### PR TITLE
feat: binary XOR readout, so LCA height is a shape

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import { BitReadout } from './hud/BitReadout'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
 import { TouchControls } from './hud/TouchControls'
@@ -49,6 +50,7 @@ export default function App(): JSX.Element {
     <div className="app">
       <Scene />
       {!crowded && <Targets targets={targets} />}
+      {!crowded && <BitReadout />}
       {panelsOpen && <Hud menuOpen={crowded} />}
       {!crowded && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
       {!crowded && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}

--- a/src/hud/BitReadout.tsx
+++ b/src/hud/BitReadout.tsx
@@ -1,0 +1,104 @@
+/**
+ * BitReadout.tsx: what the pending move costs, drawn as a shape instead of a
+ * number.
+ *
+ * Every other cost readout in this HUD is a figure you have to take on trust.
+ * This one shows the reason: three bits of the avatar's coordinate, the same
+ * three bits of the cursor's, and their XOR, per axis. The leading run of
+ * zeroes is the prefix the two share, the highest set bit is the wall being
+ * crossed, and h is that bit's index plus one. Nudge the cursor one gibson
+ * across a power of two and you watch the wall jump up the column while the
+ * distance on screen does not change at all.
+ *
+ * Columns follow the screen axes, so the leftmost column is the one W and D
+ * drive, but each is labelled with its cyberspace letter because Shift+WASD
+ * reshuffles that order.
+ */
+
+import { WINDOW_BITS, xorReadout } from '../lib/bits'
+import { useCyberspace } from '../store/useCyberspace'
+
+/**
+ * One line of a column.
+ *
+ * The two out-of-frame slots are rendered on every row, not just the XOR row,
+ * so that lighting one up cannot shift the bits sideways: a column you cannot
+ * read straight down is worse than no column.
+ */
+function Row({
+  bits,
+  above = false,
+  below = false,
+}: {
+  bits: JSX.Element | string
+  above?: boolean
+  below?: boolean
+}): JSX.Element {
+  const slot = (on: boolean): JSX.Element => (
+    <span className={on ? 'bits__edge bits__edge--set' : 'bits__edge'}>{'…'}</span>
+  )
+  return (
+    <div>
+      {slot(above)}
+      {bits}
+      {slot(below)}
+    </div>
+  )
+}
+
+export function BitReadout(): JSX.Element {
+  const position = useCyberspace((s) => s.position)
+  const cursor = useCyberspace((s) => s.cursor)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const axes = useCyberspace((s) => s.axes())
+  const columns = xorReadout(position, cursor, axes, scaleExp)
+
+  return (
+    <section className="panel">
+      <header className="panel__head">
+        <h2>XOR readout</h2>
+        <span className="tag">
+          BITS {scaleExp}..{scaleExp + WINDOW_BITS - 1}
+        </span>
+      </header>
+
+      <div className="bits">
+        <div className="bits__col">
+          <div className="bits__head">{' '}</div>
+          <div>pos</div>
+          <div>cur</div>
+          <div>xor</div>
+          <div className="bits__head">{' '}</div>
+        </div>
+
+        {columns.map((c) => (
+          <div className="bits__col" key={c.axis}>
+            <div className="bits__head">{c.axis.toUpperCase()}</div>
+            <Row bits={c.avatar} />
+            <Row bits={c.cursor} />
+            <Row
+              above={c.hiddenAbove}
+              below={c.hiddenBelow}
+              bits={
+                <>
+                  <span className="bits__matched">{c.matched}</span>
+                  <span className="bits__wall">{c.wall}</span>
+                  {c.rest}
+                </>
+              }
+            />
+            <div className="bits__head">h={c.height}</div>
+          </div>
+        ))}
+      </div>
+
+      <p className="legend__note">
+        Window low bit sits at the current scale, because the cursor only moves
+        in steps of 2^{scaleExp}. Dim zeroes are the shared prefix; the bright
+        bit is the wall, costing 2^h - 1 pairings to cross. A lit ellipsis means
+        the coordinates also differ off the right (below this scale) or off the
+        left (above the {WINDOW_BITS}-bit compute ceiling, so a sidestep).
+      </p>
+    </section>
+  )
+}

--- a/src/hud/BitReadout.tsx
+++ b/src/hud/BitReadout.tsx
@@ -3,12 +3,17 @@
  * number.
  *
  * Every other cost readout in this HUD is a figure you have to take on trust.
- * This one shows the reason: three bits of the avatar's coordinate, the same
- * three bits of the cursor's, and their XOR, per axis. The leading run of
+ * This one shows the reason: twenty bits of the avatar's coordinate, the same
+ * twenty bits of the cursor's, and their XOR, per axis. The leading run of
  * zeroes is the prefix the two share, the highest set bit is the wall being
  * crossed, and h is that bit's index plus one. Nudge the cursor one gibson
  * across a power of two and you watch the wall jump up the column while the
  * distance on screen does not change at all.
+ *
+ * It rides on the scene rather than sitting in a panel, because it is an
+ * instrument you read while driving, not a fact you look up. That is also why
+ * it survives the hamburger: hiding the panels to see the space should not take
+ * away the one readout that explains what the space costs.
  *
  * Columns follow the screen axes, so the leftmost column is the one W and D
  * drive, but each is labelled with its cyberspace letter because Shift+WASD
@@ -54,21 +59,18 @@ export function BitReadout(): JSX.Element {
   const columns = xorReadout(position, cursor, axes, scaleExp)
 
   return (
-    <section className="panel">
-      <header className="panel__head">
-        <h2>XOR readout</h2>
-        <span className="tag">
-          BITS {scaleExp}..{scaleExp + WINDOW_BITS - 1}
-        </span>
-      </header>
+    <div className="bits">
+      <div className="bits__title">
+        XOR BITS {scaleExp}..{scaleExp + WINDOW_BITS - 1}
+      </div>
 
-      <div className="bits">
+      <div className="bits__grid">
         <div className="bits__col">
-          <div className="bits__head">{' '}</div>
+          <div className="bits__head">{' '}</div>
           <div>pos</div>
           <div>cur</div>
           <div>xor</div>
-          <div className="bits__head">{' '}</div>
+          <div className="bits__head">{' '}</div>
         </div>
 
         {columns.map((c) => (
@@ -91,14 +93,6 @@ export function BitReadout(): JSX.Element {
           </div>
         ))}
       </div>
-
-      <p className="legend__note">
-        Window low bit sits at the current scale, because the cursor only moves
-        in steps of 2^{scaleExp}. Dim zeroes are the shared prefix; the bright
-        bit is the wall, costing 2^h - 1 pairings to cross. A lit ellipsis means
-        the coordinates also differ off the right (below this scale) or off the
-        left (above the {WINDOW_BITS}-bit compute ceiling, so a sidestep).
-      </p>
-    </section>
+    </div>
   )
 }

--- a/src/hud/BitReadout.tsx
+++ b/src/hud/BitReadout.tsx
@@ -4,9 +4,9 @@
  *
  * Every other cost readout in this HUD is a figure you have to take on trust.
  * This one shows the reason: twenty bits of the avatar's coordinate, the same
- * twenty bits of the cursor's, and their XOR, per axis. The leading run of
+ * twenty bits of the target's, and their XOR, per axis. The leading run of
  * zeroes is the prefix the two share, the highest set bit is the wall being
- * crossed, and h is that bit's index plus one. Nudge the cursor one gibson
+ * crossed, and h is that bit's index plus one. Nudge the target one gibson
  * across a power of two and you watch the wall jump up the column while the
  * distance on screen does not change at all.
  *
@@ -15,20 +15,26 @@
  * it survives the hamburger: hiding the panels to see the space should not take
  * away the one readout that explains what the space costs.
  *
- * Columns follow the screen axes, so the leftmost column is the one W and D
- * drive, but each is labelled with its cyberspace letter because Shift+WASD
- * reshuffles that order.
+ * Columns follow the screen axes, so the first column is the one W and D drive,
+ * but each is labelled with its cyberspace letter because Shift+WASD reshuffles
+ * that order. Whether those columns sit side by side or stack is a question of
+ * room, so the stylesheet owns it; the markup is the same either way.
  */
 
 import { WINDOW_BITS, xorReadout } from '../lib/bits'
 import { useCyberspace } from '../store/useCyberspace'
 
+/** The row labels, which double as the palette hook for each row's tone. */
+type Tone = 'pos' | 'trg' | 'xor'
+
 /**
  * One line of a column.
  *
- * The two out-of-frame slots are rendered on every row, not just the XOR row,
- * so that lighting one up cannot shift the bits sideways: a column you cannot
- * read straight down is worse than no column.
+ * Both out-of-frame slots are rendered on every row, not just the XOR row, so
+ * that lighting one up cannot shift the bits sideways: a column you cannot read
+ * straight down is worse than no column. The row label is drawn per column and
+ * hidden by CSS in every column but the first, which is what lets the same
+ * markup stack on a phone, where each column needs its own labels back.
  */
 function Row({
   tone,
@@ -36,21 +42,24 @@ function Row({
   above = false,
   below = false,
 }: {
-  tone: 'pos' | 'cur' | 'xor'
+  tone: Tone
   bits: JSX.Element | string
   above?: boolean
   below?: boolean
 }): JSX.Element {
-  const slot = (on: boolean): JSX.Element => (
-    <span className={on ? 'bits__edge bits__edge--set' : 'bits__edge'}>{'…'}</span>
-  )
   return (
     <div className={`bits__row--${tone}`}>
-      {slot(above)}
+      <span className="bits__key">{`${tone} `}</span>
+      <Slot on={above} />
       {bits}
-      {slot(below)}
+      <Slot on={below} />
     </div>
   )
+}
+
+/** An out-of-frame marker: one cell wide always, lit only when it means something. */
+function Slot({ on = false }: { on?: boolean }): JSX.Element {
+  return <span className={on ? 'bits__edge bits__edge--set' : 'bits__edge'}>{'…'}</span>
 }
 
 export function BitReadout(): JSX.Element {
@@ -67,19 +76,18 @@ export function BitReadout(): JSX.Element {
       </div>
 
       <div className="bits__grid">
-        <div className="bits__col">
-          <div className="bits__head">{' '}</div>
-          <div className="bits__row--pos">pos</div>
-          <div className="bits__row--cur">cur</div>
-          <div className="bits__row--xor">xor</div>
-          <div className="bits__head">{' '}</div>
-        </div>
-
         {columns.map((c) => (
           <div className="bits__col" key={c.axis}>
-            <div className="bits__head">{c.axis.toUpperCase()}</div>
+            {/* The heading carries the same two lead-ins as the rows below it,
+                empty, so the axis letter sits over its own first bit instead of
+                floating a cell to the left of the column. */}
+            <div className="bits__head">
+              <span className="bits__key">{'    '}</span>
+              <Slot />
+              {c.axis.toUpperCase()} h={c.height}
+            </div>
             <Row tone="pos" bits={c.avatar} />
-            <Row tone="cur" bits={c.cursor} />
+            <Row tone="trg" bits={c.cursor} />
             <Row
               tone="xor"
               above={c.hiddenAbove}
@@ -92,7 +100,6 @@ export function BitReadout(): JSX.Element {
                 </>
               }
             />
-            <div className="bits__head">h={c.height}</div>
           </div>
         ))}
       </div>

--- a/src/hud/BitReadout.tsx
+++ b/src/hud/BitReadout.tsx
@@ -31,10 +31,12 @@ import { useCyberspace } from '../store/useCyberspace'
  * read straight down is worse than no column.
  */
 function Row({
+  tone,
   bits,
   above = false,
   below = false,
 }: {
+  tone: 'pos' | 'cur' | 'xor'
   bits: JSX.Element | string
   above?: boolean
   below?: boolean
@@ -43,7 +45,7 @@ function Row({
     <span className={on ? 'bits__edge bits__edge--set' : 'bits__edge'}>{'…'}</span>
   )
   return (
-    <div>
+    <div className={`bits__row--${tone}`}>
       {slot(above)}
       {bits}
       {slot(below)}
@@ -67,18 +69,19 @@ export function BitReadout(): JSX.Element {
       <div className="bits__grid">
         <div className="bits__col">
           <div className="bits__head">{' '}</div>
-          <div>pos</div>
-          <div>cur</div>
-          <div>xor</div>
+          <div className="bits__row--pos">pos</div>
+          <div className="bits__row--cur">cur</div>
+          <div className="bits__row--xor">xor</div>
           <div className="bits__head">{' '}</div>
         </div>
 
         {columns.map((c) => (
           <div className="bits__col" key={c.axis}>
             <div className="bits__head">{c.axis.toUpperCase()}</div>
-            <Row bits={c.avatar} />
-            <Row bits={c.cursor} />
+            <Row tone="pos" bits={c.avatar} />
+            <Row tone="cur" bits={c.cursor} />
             <Row
+              tone="xor"
               above={c.hiddenAbove}
               below={c.hiddenBelow}
               bits={

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -5,7 +5,6 @@
 
 import { formatBig, formatStep } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
-import { BitReadout } from './BitReadout'
 import { ChainPanel } from './ChainPanel'
 import { Legend } from './Legend'
 import { ScaleLadder } from './ScaleLadder'
@@ -196,7 +195,6 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <Brand />
         <IdentityPanel />
         <PositionPanel />
-        <BitReadout />
         <ScalePanel />
         <LinksPanel />
       </div>

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -5,6 +5,7 @@
 
 import { formatBig, formatStep } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
+import { BitReadout } from './BitReadout'
 import { ChainPanel } from './ChainPanel'
 import { Legend } from './Legend'
 import { ScaleLadder } from './ScaleLadder'
@@ -195,6 +196,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <Brand />
         <IdentityPanel />
         <PositionPanel />
+        <BitReadout />
         <ScalePanel />
         <LinksPanel />
       </div>

--- a/src/lib/bits.test.ts
+++ b/src/lib/bits.test.ts
@@ -1,0 +1,272 @@
+/**
+ * bits.test.ts: pins the XOR readout to the protocol.
+ *
+ * The readout exists to make LCA height legible, so the failure that matters is
+ * not a crash, it is a picture that quietly disagrees with what the mover
+ * actually charges. Every test here compares the drawn window against
+ * findLcaHeight, which is the function the proof worker itself uses.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { AXIS_MAX, findLcaHeight } from 'cyberspace-core'
+import { WINDOW_BITS, axisReadout, xorReadout } from './bits'
+import { canonicalQuaternion, viewAxes, type Position } from './space'
+
+/** The readout for one pair, on an arbitrary axis, at a given window floor. */
+function read(a: bigint, b: bigint, scaleExp = 0) {
+  return axisReadout('x', a, b, scaleExp)
+}
+
+/**
+ * Deterministic 85-bit pairs. A seeded LCG rather than Math.random so a failure
+ * is reproducible, and built from three 32-bit draws because the range is wider
+ * than a double can address exactly.
+ */
+function* randomPairs(count: number): Generator<[bigint, bigint]> {
+  let seed = 0x9e3779b9
+  const next32 = (): bigint => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+    return BigInt(seed)
+  }
+  const draw = (): bigint => ((next32() << 64n) | (next32() << 32n) | next32()) % (AXIS_MAX + 1n)
+  for (let i = 0; i < count; i++) yield [draw(), draw()]
+}
+
+describe('the wall is the LCA height', () => {
+  it('puts the wall at findLcaHeight - 1 across the whole 85-bit range', () => {
+    for (const [a, b] of randomPairs(400)) {
+      const h = findLcaHeight(a, b)
+      // Anchor the window so the wall lands inside it, which is the case the
+      // property is about; the out-of-window cases have their own tests.
+      const scaleExp = Math.max(0, Math.min(h - 1, 85 - WINDOW_BITS))
+      const r = read(a, b, scaleExp)
+      expect(r.height).toBe(h)
+      expect(r.wallBit).toBe(h === 0 ? null : h - 1)
+      if (h > 0) expect(r.wall).toBe('1')
+    }
+  })
+
+  it('reports no wall at all when the coordinates are identical', () => {
+    for (const v of [0n, 1n, 12345n, AXIS_MAX]) {
+      const r = read(v, v)
+      expect(findLcaHeight(v, v)).toBe(0)
+      expect(r.wallBit).toBeNull()
+      expect(r.height).toBe(0)
+      expect(r.wall).toBe('')
+      expect(r.xor).toBe('0'.repeat(WINDOW_BITS))
+      // Nothing differs anywhere, so the entire window is shared structure.
+      expect(r.matched.length).toBe(WINDOW_BITS)
+    }
+  })
+
+  it('finds a wall at bit 0', () => {
+    const r = read(1n << 40n, (1n << 40n) | 1n)
+    expect(r.wallBit).toBe(0)
+    expect(r.height).toBe(findLcaHeight(1n << 40n, (1n << 40n) | 1n))
+    expect(r.height).toBe(1)
+    expect(r.matched).toBe('0'.repeat(WINDOW_BITS - 1))
+    expect(r.rest).toBe('')
+  })
+
+  it('finds a wall at bit 84, the top of the axis', () => {
+    const a = 5n
+    const b = (1n << 84n) | 5n
+    // The window has to be lifted to see it; at scale 0 the wall is far above.
+    const r = read(a, b, 84 - WINDOW_BITS + 1)
+    expect(r.wallBit).toBe(84)
+    expect(r.height).toBe(findLcaHeight(a, b))
+    expect(r.height).toBe(85)
+    expect(r.wall).toBe('1')
+    expect(r.matched).toBe('')
+  })
+
+  it('teaches 4 -> 5 against 7 -> 8', () => {
+    const cheap = read(4n, 5n)
+    const dear = read(7n, 8n)
+
+    // One step each. The bits are the explanation the numbers cannot give.
+    expect(cheap.xor.endsWith('0001')).toBe(true)
+    expect(dear.xor.endsWith('1111')).toBe(true)
+    expect(cheap.height).toBe(1)
+    expect(dear.height).toBe(4)
+    // A tree sixteen times the size: 1 pairing against 15.
+    expect(2 ** cheap.height - 1).toBe(1)
+    expect(2 ** dear.height - 1).toBe(15)
+
+    // Only the top bit of 0b1111 is the wall. The three below it are inside the
+    // differing region: drawing them as shared would say the two coordinates
+    // agree on three bits they do not agree on.
+    expect(dear.matched.length).toBe(WINDOW_BITS - 4)
+    expect(dear.wall).toBe('1')
+    expect(dear.rest).toBe('111')
+  })
+
+  it('keeps interior zeroes out of the matched run', () => {
+    // 0b1001: h is 4, and the two interior bits are zero without being shared.
+    const r = read(0n, 0b1001n)
+    expect(r.height).toBe(findLcaHeight(0n, 0b1001n))
+    expect(r.matched.length).toBe(WINDOW_BITS - 4)
+    expect(r.rest).toBe('001')
+    expect(r.matched.includes('1')).toBe(false)
+  })
+})
+
+describe('window edges', () => {
+  const scaleExp = 10
+  const low = scaleExp
+  const high = scaleExp + WINDOW_BITS - 1
+
+  it('shows a wall sitting exactly on the window floor', () => {
+    const a = 0n
+    const b = 1n << BigInt(low)
+    const r = read(a, b, scaleExp)
+    expect(findLcaHeight(a, b)).toBe(low + 1)
+    expect(r.wallBit).toBe(low)
+    expect(r.matched.length).toBe(WINDOW_BITS - 1)
+    expect(r.wall).toBe('1')
+    expect(r.hiddenBelow).toBe(false)
+  })
+
+  it('shows a wall sitting exactly on the window ceiling', () => {
+    const a = 0n
+    const b = 1n << BigInt(high)
+    const r = read(a, b, scaleExp)
+    expect(findLcaHeight(a, b)).toBe(high + 1)
+    expect(r.wallBit).toBe(high)
+    expect(r.matched).toBe('')
+    expect(r.wall).toBe('1')
+    expect(r.hiddenAbove).toBe(false)
+  })
+
+  it('marks a wall one bit above the ceiling as out of frame', () => {
+    // Above the window is above MAX_COMPUTE_HEIGHT relative to the floor, so
+    // this is a sidestep, and the window would otherwise read as a clean match.
+    const a = 0n
+    const b = 1n << BigInt(high + 1)
+    const r = read(a, b, scaleExp)
+    expect(r.wallBit).toBe(high + 1)
+    expect(r.hiddenAbove).toBe(true)
+    expect(r.xor).toBe('0'.repeat(WINDOW_BITS))
+    // Not one bit of it is shared structure, despite being all zeroes.
+    expect(r.matched).toBe('')
+    expect(r.rest).toBe('0'.repeat(WINDOW_BITS))
+  })
+
+  it('marks a wall one bit below the floor as out of frame', () => {
+    const a = 0n
+    const b = 1n << BigInt(low - 1)
+    const r = read(a, b, scaleExp)
+    expect(r.wallBit).toBe(low - 1)
+    expect(r.hiddenBelow).toBe(true)
+    expect(r.hiddenAbove).toBe(false)
+    expect(r.xor).toBe('0'.repeat(WINDOW_BITS))
+    // Every drawn bit really is above the divergence, so the run is genuine.
+    expect(r.matched.length).toBe(WINDOW_BITS)
+  })
+})
+
+describe('divergence hidden below the window', () => {
+  it('catches the nudge-then-zoom case', () => {
+    // One gibson apart at scale 0, then zoomed out to 2^10: bit 0 is set and
+    // the window starts at bit 10, so nothing of the difference is drawable.
+    const a = 4096n
+    const b = 4097n
+    expect(read(a, b, 0).hiddenBelow).toBe(false)
+    const zoomed = read(a, b, 10)
+    expect(zoomed.hiddenBelow).toBe(true)
+    // The cost is unchanged by zooming. Only the visibility changed.
+    expect(zoomed.height).toBe(findLcaHeight(a, b))
+    expect(zoomed.height).toBe(1)
+  })
+
+  it('does not change the height when a taller wall is in frame', () => {
+    const a = 0n
+    const b = (1n << 15n) | 1n
+    const r = read(a, b, 10)
+    expect(r.hiddenBelow).toBe(true)
+    expect(r.height).toBe(findLcaHeight(a, b))
+    expect(r.height).toBe(16)
+    expect(r.wall).toBe('1')
+  })
+
+  it('never fires when the window is anchored at bit 0', () => {
+    for (const [a, b] of randomPairs(60)) {
+      expect(read(a, b, 0).hiddenBelow).toBe(false)
+    }
+  })
+
+  it('fires exactly once the window floor rises past the difference', () => {
+    const a = 0n
+    const b = 1n << 5n
+    for (let scaleExp = 0; scaleExp <= 12; scaleExp++) {
+      expect(read(a, b, scaleExp).hiddenBelow).toBe(scaleExp > 5)
+    }
+  })
+})
+
+describe('readout invariants', () => {
+  it('draws exactly WINDOW_BITS columns, whatever the values', () => {
+    for (const [a, b] of randomPairs(120)) {
+      for (const scaleExp of [0, 7, 40, 84]) {
+        const r = read(a, b, scaleExp)
+        expect(r.avatar.length).toBe(WINDOW_BITS)
+        expect(r.cursor.length).toBe(WINDOW_BITS)
+        expect(r.xor.length).toBe(WINDOW_BITS)
+        expect(r.matched + r.wall + r.rest).toBe(r.xor)
+      }
+    }
+  })
+
+  it('renders rows that XOR back to the XOR row', () => {
+    for (const [a, b] of randomPairs(120)) {
+      const scaleExp = 12
+      const r = read(a, b, scaleExp)
+      const bits = (s: string): bigint => BigInt(`0b${s}`)
+      expect(bits(r.avatar) ^ bits(r.cursor)).toBe(bits(r.xor))
+    }
+  })
+
+  it('ties the matched run to the height: matched = scaleExp + WINDOW_BITS - h', () => {
+    for (const [a, b] of randomPairs(400)) {
+      for (const scaleExp of [0, 13, 44, 65]) {
+        const h = findLcaHeight(a, b)
+        const r = read(a, b, scaleExp)
+        const inWindow = h - 1 >= scaleExp && h - 1 <= scaleExp + WINDOW_BITS - 1
+        if (!inWindow) continue
+        expect(r.matched.length).toBe(scaleExp + WINDOW_BITS - h)
+        // And it really is the run of leading zeroes, not just a count.
+        expect(r.matched).toBe('0'.repeat(r.matched.length))
+        expect(r.wall).toBe('1')
+      }
+    }
+  })
+
+  it('never claims shared structure above a wall that is out of frame', () => {
+    for (const [a, b] of randomPairs(200)) {
+      const r = read(a, b, 0)
+      if (r.hiddenAbove) expect(r.matched).toBe('')
+    }
+  })
+})
+
+describe('column order', () => {
+  const avatar: Position = { x: 1n, y: 2n, z: 3n }
+  const cursor: Position = { x: 9n, y: 9n, z: 9n }
+
+  it('follows the screen axes, each labelled with its own letter', () => {
+    // Canonical view (spec section 11.3): +X right, +Y up, -Z out.
+    const cols = xorReadout(avatar, cursor, viewAxes(canonicalQuaternion()), 0)
+    expect(cols.map((c) => c.axis)).toEqual(['x', 'y', 'z'])
+    // Each column reads the axis it is labelled with, not the one at its index.
+    for (const c of cols) {
+      expect(c.height).toBe(findLcaHeight(avatar[c.axis], cursor[c.axis]))
+    }
+  })
+
+  it('reshuffles when the view rotates, which is why the labels exist', () => {
+    const rotated = viewAxes(canonicalQuaternion())
+    const swapped = { right: rotated.up, up: rotated.right, out: rotated.out }
+    const cols = xorReadout(avatar, cursor, swapped, 0)
+    expect(cols.map((c) => c.axis)).toEqual(['y', 'x', 'z'])
+  })
+})

--- a/src/lib/bits.ts
+++ b/src/lib/bits.ts
@@ -1,0 +1,133 @@
+/**
+ * bits.ts: the arithmetic behind the XOR readout, kept out of the component so
+ * the one claim it makes can be checked against the protocol's own LCA function.
+ *
+ * Cost here is not distance. A move between two coordinates costs 2^h - 1
+ * Cantor pairings, where h = bit_length(v1 XOR v2), so the price is set entirely
+ * by the highest bit at which the two values disagree. That is why 7 to 8 costs
+ * sixteen times what 4 to 5 costs despite both being one step: 7 XOR 8 is
+ * 0b1111 (h = 4) while 4 XOR 5 is 0b0001 (h = 1).
+ *
+ * A cost readout in digits cannot show why. A bit pattern can, which is what
+ * this module prepares: the XOR split into the leading run of zeroes (the prefix
+ * the two coordinates share, the subtree you never have to leave) and the
+ * highest set bit (the wall you are paying to cross).
+ *
+ * The leading run is the only part that means "shared". Zeroes below the highest
+ * set bit are inside the differing region and buy nothing: 0b00001001 has three
+ * interior zeroes and h is still 4. Colouring all zeroes alike would draw that
+ * pattern as mostly-matched when it is nothing of the sort.
+ */
+
+import type { AxisName, Position, ViewAxes } from './space'
+
+/**
+ * Width of the readout window, in bits.
+ *
+ * Matched to MAX_COMPUTE_HEIGHT (the Cantor ceiling) so the window sorts moves
+ * into the two categories the app already distinguishes: a wall inside it is a
+ * hop you can afford, and a wall above it is sidestep territory. Any other width
+ * would be an arbitrary number of columns.
+ *
+ * Deliberately not imported from the store. This module has to stay loadable
+ * without zustand and localStorage, which is what makes it testable at all.
+ */
+export const WINDOW_BITS = 20
+
+const WINDOW_MASK = (1n << BigInt(WINDOW_BITS)) - 1n
+
+/** The window's bits, MSB first, zero padded to WINDOW_BITS characters. */
+function windowOf(v: bigint, low: number): string {
+  return ((v >> BigInt(low)) & WINDOW_MASK).toString(2).padStart(WINDOW_BITS, '0')
+}
+
+export interface AxisReadout {
+  /** Which cyberspace axis this is, since screen order changes as you rotate. */
+  axis: AxisName
+  /** Avatar bits in the window, MSB first. */
+  avatar: string
+  /** Cursor bits in the window, MSB first. */
+  cursor: string
+  /** XOR of the two, MSB first. Always `matched + wall + rest`. */
+  xor: string
+  /** Leading run of zeroes: the prefix both coordinates share. */
+  matched: string
+  /** The highest set bit, or '' when the wall is not inside the window. */
+  wall: string
+  /** Everything below the wall. Diverged territory, whatever its bits say. */
+  rest: string
+  /** Absolute index of the highest set XOR bit, or null when they are equal. */
+  wallBit: number | null
+  /** LCA height for this axis, so cost is 2^height - 1 pairings. */
+  height: number
+  /** A set XOR bit below the window, too fine to be reachable at this scale. */
+  hiddenBelow: boolean
+  /** The wall itself is above the window, so the window shows only the tail. */
+  hiddenAbove: boolean
+}
+
+/**
+ * Split one axis pair into the window the HUD draws.
+ *
+ * `low` is the current scaleExp, so the window covers bits
+ * [low, low + WINDOW_BITS - 1]. Bits under it are inert while you drive, because
+ * the cursor only moves in steps of 2^scaleExp, but they are not always zero:
+ * nudge a gibson at scale 0 and then zoom out and the divergence you created
+ * drops out of sight. It still sets the cost when nothing above it differs, so
+ * it is reported rather than quietly dropped.
+ */
+export function axisReadout(
+  axis: AxisName,
+  avatar: bigint,
+  cursor: bigint,
+  low: number,
+): AxisReadout {
+  const high = low + WINDOW_BITS - 1
+  const diff = avatar ^ cursor
+
+  // Bit length via the binary string: bigint has no clz, and toString(2) never
+  // emits leading zeroes, so its length is exactly the highest set bit plus one.
+  // Computed here rather than borrowed from findLcaHeight so that the test
+  // comparing the two is an actual cross-check instead of a tautology.
+  const wallBit = diff === 0n ? null : diff.toString(2).length - 1
+  const xor = windowOf(diff, low)
+
+  // Window bits sitting strictly above the wall, clamped at both ends: a wall
+  // below the window leaves the whole window shared, a wall above it leaves none
+  // of the window shared, because every bit drawn is then below the divergence.
+  const matchedLength =
+    wallBit === null ? WINDOW_BITS : Math.min(Math.max(high - wallBit, 0), WINDOW_BITS)
+  const inside = wallBit !== null && wallBit >= low && wallBit <= high
+
+  return {
+    axis,
+    avatar: windowOf(avatar, low),
+    cursor: windowOf(cursor, low),
+    xor,
+    matched: xor.slice(0, matchedLength),
+    wall: inside ? xor[matchedLength] : '',
+    rest: xor.slice(matchedLength + (inside ? 1 : 0)),
+    wallBit,
+    height: wallBit === null ? 0 : wallBit + 1,
+    hiddenBelow: (diff & ((1n << BigInt(low)) - 1n)) !== 0n,
+    hiddenAbove: wallBit !== null && wallBit > high,
+  }
+}
+
+/**
+ * The three columns of the readout, in screen order: right, up, then out.
+ *
+ * Screen order rather than x/y/z so a column lines up with the direction the key
+ * you press moves the cursor. Rotating the view reshuffles them, which is why
+ * every column carries its axis letter.
+ */
+export function xorReadout(
+  avatar: Position,
+  cursor: Position,
+  axes: ViewAxes,
+  scaleExp: number,
+): AxisReadout[] {
+  return [axes.right, axes.up, axes.out].map((a) =>
+    axisReadout(a.axis, avatar[a.axis], cursor[a.axis], scaleExp),
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -413,6 +413,51 @@ body {
   border-left: 2px solid var(--danger);
 }
 
+/* ---------- XOR bit readout ---------- */
+
+.bits {
+  display: flex;
+  gap: 3px;
+  /* 69 characters (three 22-wide columns plus the row labels) have to sit
+   * inside a 320px HUD column, which sets the size. overflow-x is the safety
+   * net for the day someone bumps the font. */
+  font-size: 7.5px;
+  line-height: 1.6;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.bits__col {
+  display: flex;
+  flex-direction: column;
+}
+
+.bits__head {
+  color: var(--dim);
+  letter-spacing: 0.14em;
+}
+
+/* The three things the XOR row has to keep apart: shared prefix, wall, and
+ * divergence that fell outside the window. Everything else is diverged
+ * territory and stays plain. */
+.bits__matched {
+  color: var(--dim);
+}
+
+.bits__wall {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.bits__edge {
+  opacity: 0;
+}
+
+.bits__edge--set {
+  opacity: 1;
+  color: var(--warn);
+}
+
 /* ---------- Legend ---------- */
 
 .legend__row {

--- a/src/styles.css
+++ b/src/styles.css
@@ -415,16 +415,33 @@ body {
 
 /* ---------- XOR bit readout ---------- */
 
+/* Sits on the scene, not in a panel: an instrument you read while driving. Top
+ * centre is the one band of screen that stays clear at every width, with the
+ * panel columns either side of it and the compass below. */
 .bits {
-  display: flex;
-  gap: 3px;
-  /* 69 characters (three 22-wide columns plus the row labels) have to sit
-   * inside a 320px HUD column, which sets the size. overflow-x is the safety
-   * net for the day someone bumps the font. */
-  font-size: 7.5px;
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  pointer-events: none;
+  font-size: 9px;
   line-height: 1.6;
+  /* No panel behind it, so the point field has to be pushed off the glyphs the
+   * same way the target markers do it. */
+  text-shadow: 0 0 5px var(--bg), 0 0 3px var(--bg);
+}
+
+.bits__title {
+  color: var(--accent);
+  letter-spacing: 0.2em;
+  margin-bottom: 3px;
+}
+
+.bits__grid {
+  display: flex;
+  gap: 6px;
   white-space: pre;
-  overflow-x: auto;
 }
 
 .bits__col {

--- a/src/styles.css
+++ b/src/styles.css
@@ -415,8 +415,22 @@ body {
 
 /* ---------- XOR bit readout ---------- */
 
+/*
+ * The in-world labels are drawn in Monaspace Krypton by troika (see lib/font.ts)
+ * and the readout is painted into the same layer, so it takes the same typeface
+ * from the same file rather than the HUD's system stack. One voice for
+ * everything that sits on the scene, and one download shared with the 3D text.
+ */
+@font-face {
+  font-family: 'Monaspace Krypton';
+  src: url('/fonts/MonaspaceKrypton-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
 /* Sits on the scene, not in a panel: an instrument you read while driving. Top
- * centre is the one band of screen that stays clear at every width, with the
+ * centre is the one band of screen that stays clear at this width, with the
  * panel columns either side of it and the compass below. */
 .bits {
   position: absolute;
@@ -425,11 +439,25 @@ body {
   transform: translateX(-50%);
   z-index: 2;
   pointer-events: none;
-  font-size: 9px;
+  font-family: 'Monaspace Krypton', var(--mono);
+  /*
+   * Seventy-two character cells (three 22-wide columns, the row labels, and the
+   * gaps between them) have to fit whatever the viewport is, and a phone is
+   * 360px. Krypton's advance is 0.6em, so the block is 43.2em, and 2.1vw leaves
+   * a margin on the narrowest phone while the cap stops it growing past
+   * readable on a desktop. Clipped bits are worse than small ones: a truncated
+   * column silently changes which bit you think you are looking at.
+   */
+  font-size: min(9px, 2.1vw);
   line-height: 1.6;
-  /* No panel behind it, so the point field has to be pushed off the glyphs the
-   * same way the target markers do it. */
-  text-shadow: 0 0 5px var(--bg), 0 0 3px var(--bg);
+  color: var(--fg);
+  /*
+   * Nothing behind it but the point field, so every glyph carries its own
+   * lighting: a tight dark halo for contrast against whatever it lands on, then
+   * a wider bloom in currentColor, which means each row and the wall glow their
+   * own colour without this rule having to know the palette.
+   */
+  text-shadow: 0 0 3px var(--bg), 0 0 4px currentColor, 0 0 12px currentColor;
 }
 
 .bits__title {
@@ -440,7 +468,7 @@ body {
 
 .bits__grid {
   display: flex;
-  gap: 6px;
+  gap: 0.6em; /* One character cell, so the whole block scales as one. */
   white-space: pre;
 }
 
@@ -450,20 +478,37 @@ body {
 }
 
 .bits__head {
-  color: var(--dim);
+  color: rgba(0, 229, 255, 0.55);
   letter-spacing: 0.14em;
+}
+
+/*
+ * One hue for the whole readout, so the eye reads brightness rather than
+ * colour: where you stand is low key, where you are pointing is live, and the
+ * difference between them sits in between. The only warm thing on the block is
+ * the wall, which is the one thing that costs money.
+ */
+.bits__row--pos {
+  color: #4a8fb5;
+}
+
+.bits__row--cur {
+  color: var(--accent);
+}
+
+.bits__row--xor {
+  color: #78d5f5;
 }
 
 /* The three things the XOR row has to keep apart: shared prefix, wall, and
  * divergence that fell outside the window. Everything else is diverged
- * territory and stays plain. */
+ * territory and stays the row's own colour. */
 .bits__matched {
-  color: var(--dim);
+  color: #2c5670;
 }
 
 .bits__wall {
   color: var(--danger);
-  font-weight: 700;
 }
 
 .bits__edge {
@@ -874,6 +919,16 @@ kbd {
     transform: none;
     width: 84px;
     height: 84px;
+  }
+
+  /* The compass has the top right corner at this width, and centring the
+   * readout would run its last column under the cube. Full width is worth more
+   * to it than the middle of the screen, so it drops below instead: any
+   * narrower and the type has to shrink to stay unclipped. */
+  .bits {
+    top: 104px;
+    left: 8px;
+    transform: none;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -429,26 +429,23 @@ body {
   font-display: swap;
 }
 
-/* Sits on the scene, not in a panel: an instrument you read while driving. Top
- * centre is the one band of screen that stays clear at this width, with the
- * panel columns either side of it and the compass below. */
+/*
+ * Sits on the scene, not in a panel: an instrument you read while driving.
+ *
+ * Flush left and level with the compass, so the two instruments share a band
+ * instead of stacking down the centre line of the screen. Not quite the
+ * compass's own baseline: the hamburger owns the bottom left corner (24px in,
+ * 56px across), and a button drawn over the first ten characters of every row
+ * would cost more than the 68px of height it takes to clear it.
+ */
 .bits {
   position: absolute;
-  top: 16px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 16px;
+  bottom: 88px;
   z-index: 2;
   pointer-events: none;
   font-family: 'Monaspace Krypton', var(--mono);
-  /*
-   * Seventy-two character cells (three 22-wide columns, the row labels, and the
-   * gaps between them) have to fit whatever the viewport is, and a phone is
-   * 360px. Krypton's advance is 0.6em, so the block is 43.2em, and 2.1vw leaves
-   * a margin on the narrowest phone while the cap stops it growing past
-   * readable on a desktop. Clipped bits are worse than small ones: a truncated
-   * column silently changes which bit you think you are looking at.
-   */
-  font-size: min(9px, 2.1vw);
+  font-size: 9px;
   line-height: 1.6;
   color: var(--fg);
   /*
@@ -477,9 +474,23 @@ body {
   flex-direction: column;
 }
 
+/*
+ * Side by side the row labels only need saying once, and the columns are close
+ * enough to read across. Stacked they have to come back, which is why every
+ * column carries its own and all but the first are hidden here rather than
+ * being absent from the markup.
+ *
+ * Three columns abreast is 71 cells, about 400px, and the compass is centred, so
+ * they cannot reach it before the 1100px breakpoint stacks them anyway: the
+ * overlap rule and the breakpoint happen to be the same line. Grow the type and
+ * that stops being true.
+ */
+.bits__col:not(:first-child) .bits__key {
+  display: none;
+}
+
 .bits__head {
   color: rgba(0, 229, 255, 0.55);
-  letter-spacing: 0.14em;
 }
 
 /*
@@ -492,12 +503,16 @@ body {
   color: #4a8fb5;
 }
 
-.bits__row--cur {
+.bits__row--trg {
   color: var(--accent);
 }
 
 .bits__row--xor {
   color: #78d5f5;
+}
+
+.bits__key {
+  color: rgba(0, 229, 255, 0.55);
 }
 
 /* The three things the XOR row has to keep apart: shared prefix, wall, and
@@ -921,14 +936,26 @@ kbd {
     height: 84px;
   }
 
-  /* The compass has the top right corner at this width, and centring the
-   * readout would run its last column under the cube. Full width is worth more
-   * to it than the middle of the screen, so it drops below instead: any
-   * narrower and the type has to shrink to stay unclipped. */
+  /*
+   * The compass takes the top right corner at this width, so the readout goes
+   * to the top left to stay level with it. Three columns abreast would run
+   * under the cube on a phone, so they stack: one column of twenty bits is 26
+   * cells, which fits the narrowest phone at full size, where shrinking the
+   * type to keep them abreast would not have.
+   */
   .bits {
-    top: 104px;
+    top: 12px;
+    bottom: auto;
     left: 8px;
-    transform: none;
+  }
+
+  .bits__grid {
+    flex-direction: column;
+  }
+
+  /* Stacked, every column is on its own again and needs its labels back. */
+  .bits__col:not(:first-child) .bits__key {
+    display: inline;
   }
 }
 


### PR DESCRIPTION
## What

A per-axis binary XOR readout on the scene, so LCA height is a shape rather than a number you take on trust.

Twenty bits of the avatar's coordinate, twenty of the target's, and their XOR, per axis. The leading run of zeroes is the prefix the two share, the highest set bit is the wall being crossed, and h is that bit's index plus one. Nudging one gibson across a power of two makes the wall jump up the column while nothing on screen moves.

## How it reads

- Window is exactly 20 bits with its low bit anchored at the current `scaleExp`, matching `MAX_COMPUTE_HEIGHT`: a wall inside the window is a hop you can afford, a wall above it is a sidestep.
- Only the LEADING run of zeroes is drawn as shared structure. A zero below the wall is inside the differing region and buys nothing: `0b1001` has two interior zeroes and still costs h = 4.
- Divergence that falls off either end of the window lights an ellipsis, so an all-zero row never implies a clean match it has not earned. Both cases are one keypress away (nudge, then zoom).
- Columns follow the screen axes and carry their cyberspace letter, because Shift+WASD reshuffles them.

## Where the maths lives

`src/lib/bits.ts`, away from the component, so the claim it makes can be tested: the wall's bit index is `findLcaHeight` minus one, checked against the protocol's own function across the 85-bit range, at both window edges, and on the 4 to 5 against 7 to 8 teaching pair. Bit length is recomputed locally rather than borrowed from `findLcaHeight`, which keeps that test a cross-check instead of a tautology. 20 tests.

## Layout

Flush left and level with the compass: bottom left on a desktop, top left on a phone. Three columns abreast where there is room, stacked below 1100px where there is not. Drawn in Monaspace Krypton from the same file troika loads, so it matches the in-world labels rather than the HUD's system stack.

Known: with panels open on a desktop it draws over the left panel column. Moving it clear is a one-line change to `left` if that is not wanted.

## Verified

`npm run typecheck` and `npm test` both exit 0 (66 tests) on the merged tree. Rendering, both out-of-frame markers, and the label alignment checked in a real browser at 320, 369, 412, 820, 1400 and 1920 wide, including that the above-window marker lights at the same moment the proof panel flips to SIDESTEP READY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
