### PR TITLE
feat: the chain is real, and Live puts it on the relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,23 @@ up, and both turn red when the hop is beyond the compute ceiling. Position
 only advances when a committed proof completes, so the movement chain shown in
 the HUD is contiguous by construction.
 
-**You spawn at your pubkey.** Each session generates an ephemeral keypair, and
-per spec section 8.3 the spawn coordinate IS the pubkey: the 256-bit key
-decodes directly to x / y / z / plane.
+**You spawn at your pubkey.** The first visit generates a keypair and keeps it
+in localStorage, and per spec section 8.3 the spawn coordinate IS the pubkey:
+the 256-bit key decodes directly to x / y / z / plane.
+
+**The chain is real.** Spawning signs a `kind:3333` spawn event, and every
+committed hop or sidestep is signed into its own event the moment the proof
+lands, naming the spawn as `genesis` and the previous event as `previous`
+(spec section 8). The next proof's temporal work is bound to that event's id,
+exactly as a verifier recomputes it. The chain persists as those events, so a
+reload reads position, plane and history back out of them.
+
+**Local / Live.** The switch under RECALL and COMMIT decides whether events
+leave the device. Live (the default) publishes each one to
+`wss://cyberspace.nostr1.com` as it is signed, in chain order, and the proof
+chain panel shows how many the relay has acknowledged. Local keeps them here;
+switching to Live later publishes the whole backlog, oldest first, so every
+prefix the relay holds is itself a valid chain.
 
 ## What you are looking at
 
@@ -109,6 +123,9 @@ Two consequences worth knowing:
 src/
   lib/space.ts        coordinate <-> render-space maths, view orientation
   lib/palette.ts      the two visual encodings (terrain fill, boundary lines)
+  lib/events.ts       kind:3333 builders, parser, chain reassembly (spec 8, 10)
+  lib/relay.ts        the one relay, publish / query / subscribe
+  lib/publisher.ts    drains unpublished events in chain order while Live
   lib/workers.ts      worker singletons
   store/              zustand store: position, scale, view, proof telemetry
   workers/            proof and terrain sampling, off the main thread

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { BitReadout } from './hud/BitReadout'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
@@ -11,6 +11,7 @@ import { useKeyboard } from './hooks/useKeyboard'
 import { useProofListener } from './hooks/useProofListener'
 import { useIsMobile } from './hooks/useIsMobile'
 import { useTargets } from './hooks/useTargets'
+import { startPublisher } from './lib/publisher'
 
 export default function App(): JSX.Element {
   // The keyboard is unconditional. The on-screen controls are a second way in,
@@ -18,6 +19,8 @@ export default function App(): JSX.Element {
   // cannot drift apart, and nothing about having a pointer takes the keys away.
   useKeyboard()
   useProofListener()
+  // The chain drains to the relay from here on, whenever Live is on.
+  useEffect(() => startPublisher(), [])
   const isMobile = useIsMobile()
   const targets = useTargets()
 

--- a/src/hud/ChainPanel.tsx
+++ b/src/hud/ChainPanel.tsx
@@ -2,16 +2,37 @@
  * ChainPanel.tsx - the movement chain so far.
  *
  * Position only ever advances when a proof completes, so the chain shown here
- * is contiguous by construction: hop N's proof always references hop N-1's.
+ * is contiguous by construction: hop N's event names hop N-1's id, and its
+ * proof was bound to that id before it was signed.
+ *
+ * The relay line is the one thing here that is not about cost. It says how
+ * much of the chain exists anywhere but this device, which while Live is the
+ * difference between moving and being seen to move.
  */
 
 import { formatMs, formatOps } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
+import { CYBERSPACE_RELAY } from '../lib/relay'
 
 export function ChainPanel(): JSX.Element {
   const chain = useCyberspace((s) => s.chain)
   const prevEventId = useCyberspace((s) => s.prevEventId)
+  const genesisId = useCyberspace((s) => s.genesisId)
+  const events = useCyberspace((s) => s.events)
+  const published = useCyberspace((s) => s.published)
+  const publishError = useCyberspace((s) => s.publishError)
+  const live = useCyberspace((s) => s.live)
   const actions = chain.hops + chain.sidesteps
+
+  const statuses = events.map((e) => published[e.id])
+  const sent = statuses.filter((st) => st === 'ok').length
+  const relayState = !live
+    ? 'LOCAL'
+    : statuses.includes('failed')
+      ? 'RETRYING'
+      : statuses.includes('sending')
+        ? 'SENDING'
+        : sent === events.length ? 'SYNCED' : 'QUEUED'
 
   return (
     <section className="panel">
@@ -43,16 +64,31 @@ export function ChainPanel(): JSX.Element {
           <dt>Compute time</dt>
           <dd>{formatMs(chain.totalMs)}</dd>
         </div>
+        <div>
+          <dt>Published</dt>
+          <dd>
+            {sent} / {events.length}{' '}
+            <span className={`relay relay--${relayState.toLowerCase()}`}>{relayState}</span>
+          </dd>
+        </div>
       </dl>
 
       <div className="hash">
-        <span className="hash__label">chain head</span>
-        <code>{actions === 0 ? 'spawn (nothing committed yet)' : prevEventId}</code>
+        <span className="hash__label">genesis</span>
+        <code>{genesisId}</code>
+      </div>
+      <div className="hash">
+        <span className="hash__label">chain head{actions === 0 ? ' (spawn)' : ''}</span>
+        <code>{prevEventId}</code>
       </div>
 
+      {publishError && <p className="notice">{CYBERSPACE_RELAY}: {publishError}</p>}
+
       <p className="legend__note">
-        Each committed hop chains its proof to the previous one, mirroring the
-        protocol's per-pubkey movement chain.
+        Every committed action is a signed kind:3333 event naming the one
+        before it (spec section 8). {live
+          ? `Live publishes each one to ${CYBERSPACE_RELAY.replace('wss://', '')} as it lands.`
+          : 'Local keeps them on this device; switching to Live publishes the whole chain in order.'}
       </p>
     </section>
   )

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -27,12 +27,13 @@ function Brand(): JSX.Element {
 
 function IdentityPanel(): JSX.Element {
   const identity = useCyberspace((s) => s.identity)
+  const live = useCyberspace((s) => s.live)
 
   return (
     <section className="panel">
       <header className="panel__head">
         <h2>Identity</h2>
-        <span className="tag tag--local">LOCAL</span>
+        <span className={`tag ${live ? 'tag--live' : 'tag--local'}`}>{live ? 'LIVE' : 'LOCAL'}</span>
       </header>
 
       <div className="hash">
@@ -44,6 +45,9 @@ function IdentityPanel(): JSX.Element {
         Spawned at this key's coordinate: the 256-bit pubkey decodes directly
         to x / y / z / plane (spec section 8.3). Persisted locally so
         refreshing keeps your identity and position.
+        {live
+          ? ' LIVE: every action is signed and published to cyberspace.nostr1.com as it completes.'
+          : ' LOCAL: actions are signed but stay on this device. Going live publishes the whole chain.'}
       </p>
     </section>
   )

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -83,6 +83,7 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
   const position = useCyberspace((s) => s.position)
   const cursor = useCyberspace((s) => s.cursor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
+  const live = useCyberspace((s) => s.live)
   const bind = useRepeatable()
 
   const computing = proof.status === 'computing'
@@ -171,6 +172,25 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
         >
           {computing ? `${Math.round(proof.progress * 100)}%` : 'COMMIT'}
         </button>
+        {/* Whether a commit leaves the device. Under COMMIT because that is the
+            only control whose meaning it changes, and a switch rather than a
+            toggle so the current mode is always spelled out, not implied. */}
+        <div className="touchmode" role="group" aria-label="Publishing mode">
+          <button
+            className={`touchmode__opt ${live ? '' : 'is-on'}`}
+            aria-pressed={!live}
+            title="Local: sign actions but keep them on this device"
+            {...noCallout}
+            onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); useCyberspace.getState().setLive(false) }}
+          >LOCAL</button>
+          <button
+            className={`touchmode__opt ${live ? 'is-on' : ''}`}
+            aria-pressed={live}
+            title="Live: publish every action to cyberspace.nostr1.com"
+            {...noCallout}
+            onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); useCyberspace.getState().setLive(true) }}
+          >LIVE</button>
+        </div>
       </div>
     </>
   )

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,0 +1,262 @@
+/**
+ * events.test.ts — the wire format is consensus.
+ *
+ * A tag in the wrong place, a sector with a leading zero, a spawn whose
+ * coordinate is not its pubkey: all of these would sign and publish without
+ * complaint, and every other client would then refuse the chain. So the
+ * builders are checked tag by tag against spec §8 and §10, the parser is
+ * checked to refuse exactly what the spec refuses, and chain reassembly is
+ * checked against the one rule that matters: the newest spawn wins.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { finalizeEvent, generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure'
+import { coordToXyz, hexToCoord } from 'cyberspace-core'
+import {
+  ACTION_KIND,
+  buildChain,
+  chainHead,
+  hopTemplate,
+  parseAction,
+  positionHex,
+  sectorTags,
+  sidestepTemplate,
+  spawnTemplate,
+  type NostrEvent,
+} from './events'
+
+const sk = generateSecretKey()
+const pk = getPublicKey(sk)
+const spawnAt = coordToXyz(hexToCoord(pk))
+const ZERO = '0'.repeat(64)
+
+function sign(t: ReturnType<typeof spawnTemplate>, key = sk): NostrEvent {
+  return finalizeEvent(t, key)
+}
+
+function tagsNamed(ev: { tags: string[][] }, name: string): string[][] {
+  return ev.tags.filter((t) => t[0] === name)
+}
+
+describe('sector tags (§10)', () => {
+  it('shifts each axis by 30 and formats base-10 with no padding', () => {
+    const tags = sectorTags({ x: 1n << 30n, y: 0n, z: (3n << 30n) + 12345n })
+    expect(tags).toEqual([['X', '1'], ['Y', '0'], ['Z', '3'], ['S', '1-0-3']])
+  })
+
+  it('never prints a leading plus or zero', () => {
+    for (const t of sectorTags({ x: 7n, y: 7n, z: 7n })) {
+      expect(t[1]).toMatch(/^(0|[1-9][0-9]*)(-(0|[1-9][0-9]*)){0,2}$/)
+    }
+  })
+})
+
+describe('spawn (§8.3)', () => {
+  const ev = sign(spawnTemplate(pk, 1_700_000_000))
+
+  it('is kind 3333 with A=spawn and C equal to the pubkey', () => {
+    expect(ev.kind).toBe(ACTION_KIND)
+    expect(tagsNamed(ev, 'A')).toEqual([['A', 'spawn']])
+    expect(tagsNamed(ev, 'C')).toEqual([['C', pk]])
+  })
+
+  it('carries the sector of the pubkey coordinate', () => {
+    expect(ev.tags.slice(2)).toEqual(sectorTags(spawnAt))
+  })
+
+  it('carries no chain links and no proof', () => {
+    expect(tagsNamed(ev, 'e')).toEqual([])
+    expect(tagsNamed(ev, 'c')).toEqual([])
+    expect(tagsNamed(ev, 'proof')).toEqual([])
+  })
+
+  it('signs to a verifiable event with a canonical id', () => {
+    expect(verifyEvent(ev)).toBe(true)
+    expect(ev.id).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('parses back to its own coordinate and plane', () => {
+    const a = parseAction(ev)
+    expect(a?.type).toBe('spawn')
+    expect(a?.position).toEqual({ x: spawnAt.x, y: spawnAt.y, z: spawnAt.z })
+    expect(a?.plane).toBe(spawnAt.plane)
+    expect(a?.genesisId).toBeNull()
+  })
+})
+
+describe('hop (§8.4)', () => {
+  const spawn = sign(spawnTemplate(pk, 1_700_000_000))
+  const to = { x: spawnAt.x + 5n, y: spawnAt.y, z: spawnAt.z - 1n }
+  const hop = sign(hopTemplate({
+    createdAt: 1_700_000_010,
+    genesisId: spawn.id,
+    previousId: spawn.id,
+    prevCoordHex: pk,
+    to,
+    plane: spawnAt.plane,
+    proofHash: 'ab'.repeat(32),
+  }))
+
+  it('lays the tags out in spec order', () => {
+    expect(hop.tags.map((t) => t[0])).toEqual(['A', 'e', 'e', 'c', 'C', 'proof', 'X', 'Y', 'Z', 'S'])
+  })
+
+  it('marks genesis and previous on the e tags, with an empty relay hint', () => {
+    expect(tagsNamed(hop, 'e')).toEqual([
+      ['e', spawn.id, '', 'genesis'],
+      ['e', spawn.id, '', 'previous'],
+    ])
+  })
+
+  it('names where it came from and where it went', () => {
+    expect(tagsNamed(hop, 'c')).toEqual([['c', pk]])
+    expect(tagsNamed(hop, 'C')).toEqual([['C', positionHex(to, spawnAt.plane)]])
+    expect(tagsNamed(hop, 'proof')).toEqual([['proof', 'ab'.repeat(32)]])
+  })
+
+  it('encodes the destination plane in C', () => {
+    const other = spawnAt.plane === 0 ? 1 : 0
+    const flipped = hopTemplate({
+      createdAt: 1, genesisId: ZERO, previousId: ZERO, prevCoordHex: ZERO,
+      to, plane: other, proofHash: ZERO,
+    })
+    const C = tagsNamed(flipped, 'C')[0][1]
+    expect(coordToXyz(hexToCoord(C)).plane).toBe(other)
+  })
+
+  it('parses with every link intact', () => {
+    const a = parseAction(hop)
+    expect(a).toMatchObject({
+      type: 'hop',
+      genesisId: spawn.id,
+      previousId: spawn.id,
+      prevCoordHex: pk,
+      proofHash: 'ab'.repeat(32),
+      position: to,
+    })
+  })
+})
+
+describe('sidestep (§8.5)', () => {
+  const ss = sidestepTemplate({
+    createdAt: 1, genesisId: ZERO, previousId: ZERO, prevCoordHex: ZERO,
+    to: { x: 8n, y: 0n, z: 0n }, plane: 0, proofHash: ZERO,
+    merkleRoots: ['11'.repeat(32), '22'.repeat(32), '33'.repeat(32)],
+    inclusionProofs: ['aa'.repeat(32) + 'bb'.repeat(32), '', ''],
+    lcaHeights: [2, 0, 0],
+  })
+
+  it('carries the merkle tags after the proof and before the sector', () => {
+    expect(ss.tags.map((t) => t[0])).toEqual([
+      'A', 'e', 'e', 'c', 'C', 'proof', 'mr', 'mp', 'hx', 'hy', 'hz', 'X', 'Y', 'Z', 'S',
+    ])
+    expect(tagsNamed(ss, 'A')).toEqual([['A', 'sidestep']])
+  })
+
+  it('joins per-axis roots and proofs with colons, empty for still axes', () => {
+    expect(tagsNamed(ss, 'mr')[0][1].split(':').map((s) => s.length)).toEqual([64, 64, 64])
+    const mp = tagsNamed(ss, 'mp')[0][1].split(':')
+    expect(mp[0].length).toBe(64 * 2)
+    expect(mp[1]).toBe('')
+    expect(mp[2]).toBe('')
+  })
+
+  it('writes the heights as decimal strings', () => {
+    expect(tagsNamed(ss, 'hx')).toEqual([['hx', '2']])
+    expect(tagsNamed(ss, 'hy')).toEqual([['hy', '0']])
+    expect(tagsNamed(ss, 'hz')).toEqual([['hz', '0']])
+  })
+})
+
+describe('parseAction refuses what the spec refuses', () => {
+  const good = sign(spawnTemplate(pk, 1))
+
+  it('the wrong kind', () => {
+    expect(parseAction({ ...good, kind: 1 })).toBeNull()
+  })
+
+  it('an unknown action', () => {
+    expect(parseAction({ ...good, tags: [['A', 'teleport'], ...good.tags.slice(1)] })).toBeNull()
+  })
+
+  it('a spawn that is not at its pubkey', () => {
+    const other = getPublicKey(generateSecretKey())
+    expect(parseAction({ ...good, tags: [['A', 'spawn'], ['C', other], ...good.tags.slice(2)] })).toBeNull()
+  })
+
+  it('a hop missing a link', () => {
+    const hop = sign(hopTemplate({
+      createdAt: 2, genesisId: good.id, previousId: good.id, prevCoordHex: pk,
+      to: spawnAt, plane: 0, proofHash: ZERO,
+    }))
+    const noPrev = { ...hop, tags: hop.tags.filter((t) => t[3] !== 'previous') }
+    expect(parseAction(noPrev)).toBeNull()
+  })
+
+  it('a sidestep missing its merkle tags', () => {
+    const hop = sign(hopTemplate({
+      createdAt: 2, genesisId: good.id, previousId: good.id, prevCoordHex: pk,
+      to: spawnAt, plane: 0, proofHash: ZERO,
+    }))
+    expect(parseAction({ ...hop, tags: [['A', 'sidestep'], ...hop.tags.slice(1)] })).toBeNull()
+  })
+})
+
+describe('buildChain (§3.2: the newest spawn wins)', () => {
+  function link(prev: NostrEvent, genesis: NostrEvent, at: number, dx: bigint): NostrEvent {
+    const from = parseAction(prev)!
+    return sign(hopTemplate({
+      createdAt: at,
+      genesisId: genesis.id,
+      previousId: prev.id,
+      prevCoordHex: from.coordHex,
+      to: { ...from.position, x: from.position.x + dx },
+      plane: from.plane,
+      proofHash: ZERO,
+    }))
+  }
+
+  const spawnA = sign(spawnTemplate(pk, 100))
+  const a1 = link(spawnA, spawnA, 110, 1n)
+  const a2 = link(a1, spawnA, 120, 1n)
+  const spawnB = sign(spawnTemplate(pk, 200))
+  const b1 = link(spawnB, spawnB, 210, 1n)
+
+  it('follows the previous links from the latest spawn, in order', () => {
+    const chain = buildChain([b1, a2, spawnA, spawnB, a1])
+    expect(chain.map((e) => e.id)).toEqual([spawnB.id, b1.id])
+    expect(chainHead(chain)?.position.x).toBe(spawnAt.x + 1n)
+  })
+
+  it('leaves the abandoned chain behind even though its links are valid', () => {
+    const chain = buildChain([spawnA, a1, a2, spawnB])
+    expect(chain.map((e) => e.id)).toEqual([spawnB.id])
+  })
+
+  it('reassembles a full chain when there is only one spawn', () => {
+    expect(buildChain([a2, a1, spawnA]).map((e) => e.id)).toEqual([spawnA.id, a1.id, a2.id])
+  })
+
+  it('ignores a hop whose genesis is a different spawn', () => {
+    // Claims B's chain but descends from A's spawn: a link into the wrong tree.
+    const stray = sign(hopTemplate({
+      createdAt: 220, genesisId: spawnA.id, previousId: b1.id, prevCoordHex: pk,
+      to: spawnAt, plane: spawnAt.plane, proofHash: ZERO,
+    }))
+    expect(buildChain([spawnB, b1, stray]).map((e) => e.id)).toEqual([spawnB.id, b1.id])
+  })
+
+  it('takes the older branch at a fork', () => {
+    const early = link(b1, spawnB, 220, 1n)
+    const late = link(b1, spawnB, 230, 2n)
+    expect(buildChain([spawnB, b1, late, early]).map((e) => e.id)).toEqual([spawnB.id, b1.id, early.id])
+  })
+
+  it('is empty without a spawn', () => {
+    expect(buildChain([a1, a2])).toEqual([])
+  })
+
+  it('drops malformed events without losing the rest', () => {
+    expect(buildChain([spawnB, { ...b1, kind: 1 }]).map((e) => e.id)).toEqual([spawnB.id])
+  })
+})

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,271 @@
+/**
+ * events.ts — the movement chain as it goes on the wire.
+ *
+ * Everything the app knows about where an avatar is comes down to a per-pubkey
+ * linear chain of signed kind:3333 events (spec §8): one spawn, then hops and
+ * sidesteps, each naming the one before it. Until now the proof hash stood in
+ * for the previous event id, which kept the temporal work honest but produced
+ * nothing anyone else could read or verify. These builders produce the real
+ * thing, so the same chain that drives the avatar is the chain that gets
+ * published, and the same parser that reads our own events reads everyone
+ * else's.
+ *
+ * Pure. Signing happens in the store, which is the only place the key lives;
+ * this file only ever sees templates and finished events.
+ */
+
+import {
+  coordToHex,
+  coordToXyz,
+  hexToCoord,
+  sectorTag,
+  xyzToCoord,
+  xyzToSectorId,
+  type Plane,
+} from 'cyberspace-core'
+import type { Position } from './space'
+
+/** §8.1: every movement action, spawn included, is this one kind. */
+export const ACTION_KIND = 3333
+
+export type ActionType = 'spawn' | 'hop' | 'sidestep'
+
+/** The shape nostr-tools signs and relays return; named here so nothing in
+ * the app has to import it from the library to talk about an event. */
+export interface NostrEvent {
+  id: string
+  pubkey: string
+  created_at: number
+  kind: number
+  tags: string[][]
+  content: string
+  sig: string
+}
+
+export type EventTemplate = Pick<NostrEvent, 'kind' | 'tags' | 'content' | 'created_at'>
+
+/** A kind:3333 event with its tags read back into what they mean. */
+export interface ActionEvent {
+  id: string
+  pubkey: string
+  createdAt: number
+  type: ActionType
+  /** The `C` tag: where this action put the avatar. */
+  coordHex: string
+  position: Position
+  plane: Plane
+  /** The `c` tag; null on a spawn, which comes from nowhere. */
+  prevCoordHex: string | null
+  /** `e` tags with the `genesis` and `previous` markers; null on a spawn. */
+  genesisId: string | null
+  previousId: string | null
+  /** The `proof` tag; null on a spawn, which carries no work. */
+  proofHash: string | null
+  /** The `S` tag, as written. */
+  sector: string
+}
+
+const HEX_64 = /^[0-9a-f]{64}$/
+
+/** §10: per-axis sector tags plus the combined one, all base-10, no padding. */
+export function sectorTags(p: Position): string[][] {
+  const sid = xyzToSectorId(p.x, p.y, p.z)
+  return [
+    ['X', sid.sx.toString()],
+    ['Y', sid.sy.toString()],
+    ['Z', sid.sz.toString()],
+    ['S', sectorTag(sid)],
+  ]
+}
+
+/** 64-char lowercase hex for a position in a plane. */
+export function positionHex(p: Position, plane: Plane): string {
+  return coordToHex(xyzToCoord(p.x, p.y, p.z, plane))
+}
+
+/**
+ * §8.3. The coordinate IS the pubkey, so there is nothing to choose: the only
+ * input besides identity is when.
+ */
+export function spawnTemplate(pubkey: string, createdAt: number): EventTemplate {
+  const at = coordToXyz(hexToCoord(pubkey))
+  return {
+    kind: ACTION_KIND,
+    created_at: createdAt,
+    content: '',
+    tags: [['A', 'spawn'], ['C', pubkey], ...sectorTags(at)],
+  }
+}
+
+export interface HopInput {
+  createdAt: number
+  genesisId: string
+  previousId: string
+  /** Taken from the previous event's `C` tag, never recomputed, so the chain
+   * cannot disagree with itself about where it was. */
+  prevCoordHex: string
+  to: Position
+  plane: Plane
+  proofHash: string
+}
+
+/** §8.4. */
+export function hopTemplate(i: HopInput): EventTemplate {
+  return {
+    kind: ACTION_KIND,
+    created_at: i.createdAt,
+    content: '',
+    tags: [
+      ['A', 'hop'],
+      ['e', i.genesisId, '', 'genesis'],
+      ['e', i.previousId, '', 'previous'],
+      ['c', i.prevCoordHex],
+      ['C', positionHex(i.to, i.plane)],
+      ['proof', i.proofHash],
+      ...sectorTags(i.to),
+    ],
+  }
+}
+
+export interface SidestepInput extends HopInput {
+  /** Per-axis Merkle roots, 64 hex chars each. */
+  merkleRoots: [string, string, string]
+  /** Per-axis inclusion proofs, sibling hashes concatenated leaf-first; an
+   * axis that did not move contributes an empty string. */
+  inclusionProofs: [string, string, string]
+  lcaHeights: [number, number, number]
+}
+
+/** §8.5. */
+export function sidestepTemplate(i: SidestepInput): EventTemplate {
+  const hop = hopTemplate(i)
+  const [hx, hy, hz] = i.lcaHeights
+  return {
+    ...hop,
+    tags: [
+      ['A', 'sidestep'],
+      ...hop.tags.slice(1, 6),
+      ['mr', i.merkleRoots.join(':')],
+      ['mp', i.inclusionProofs.join(':')],
+      ['hx', String(hx)],
+      ['hy', String(hy)],
+      ['hz', String(hz)],
+      ...sectorTags(i.to),
+    ],
+  }
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+function tag(ev: NostrEvent, name: string): string | undefined {
+  return ev.tags.find((t) => t[0] === name)?.[1]
+}
+
+function marked(ev: NostrEvent, marker: string): string | undefined {
+  return ev.tags.find((t) => t[0] === 'e' && t[3] === marker)?.[1]
+}
+
+/**
+ * Read a kind:3333 event, or refuse it.
+ *
+ * Strict about shape and silent about everything else: a malformed event is
+ * dropped rather than thrown, because relays return whatever they were given
+ * and one bad event must not take down a chain. Proofs are not checked here;
+ * that is a verifier's job, and this client is a viewer.
+ */
+export function parseAction(ev: NostrEvent): ActionEvent | null {
+  if (ev.kind !== ACTION_KIND) return null
+  const type = tag(ev, 'A')
+  if (type !== 'spawn' && type !== 'hop' && type !== 'sidestep') return null
+  const coordHex = tag(ev, 'C')
+  if (!coordHex || !HEX_64.test(coordHex)) return null
+  const sector = tag(ev, 'S')
+  if (!sector) return null
+
+  const { x, y, z, plane } = coordToXyz(hexToCoord(coordHex))
+  const base = {
+    id: ev.id,
+    pubkey: ev.pubkey,
+    createdAt: ev.created_at,
+    coordHex,
+    position: { x, y, z },
+    plane,
+    sector,
+  }
+
+  if (type === 'spawn') {
+    // §8.3: a spawn that is not at its own pubkey is not a spawn.
+    if (coordHex !== ev.pubkey) return null
+    return { ...base, type, prevCoordHex: null, genesisId: null, previousId: null, proofHash: null }
+  }
+
+  const prevCoordHex = tag(ev, 'c')
+  const genesisId = marked(ev, 'genesis')
+  const previousId = marked(ev, 'previous')
+  const proofHash = tag(ev, 'proof')
+  if (!prevCoordHex || !HEX_64.test(prevCoordHex)) return null
+  if (!genesisId || !HEX_64.test(genesisId)) return null
+  if (!previousId || !HEX_64.test(previousId)) return null
+  if (!proofHash || !HEX_64.test(proofHash)) return null
+  if (type === 'sidestep') {
+    for (const t of ['mr', 'mp', 'hx', 'hy', 'hz']) if (tag(ev, t) === undefined) return null
+  }
+  return { ...base, type, prevCoordHex, genesisId, previousId, proofHash }
+}
+
+/** Newest first, ties broken by id, the NIP-01 ordering. */
+function newer(a: { createdAt: number; id: string }, b: { createdAt: number; id: string }): number {
+  if (a.createdAt !== b.createdAt) return b.createdAt - a.createdAt
+  return a.id < b.id ? 1 : a.id > b.id ? -1 : 0
+}
+
+/**
+ * Reassemble one pubkey's active chain from whatever the relay handed back.
+ *
+ * §3.2: the newest spawn wins, and everything that does not descend from it is
+ * history. From that spawn the chain is followed forward through `previous`
+ * links; a fork (two events naming the same predecessor, which a valid chain
+ * never has) takes the older branch, so a later attempt to rewrite cannot
+ * displace what was there first. Events whose `genesis` names another spawn
+ * are ignored even if their `previous` link would fit.
+ *
+ * Returns the spawn alone when nothing follows it, and nothing when there is
+ * no spawn at all: a hop without a genesis is not a position.
+ */
+export function buildChain(events: NostrEvent[]): ActionEvent[] {
+  const parsed = events.map(parseAction).filter((e): e is ActionEvent => e !== null)
+  const spawns = parsed.filter((e) => e.type === 'spawn').sort(newer)
+  const spawn = spawns[0]
+  if (!spawn) return []
+
+  const byPrev = new Map<string, ActionEvent[]>()
+  for (const e of parsed) {
+    if (e.type === 'spawn' || e.genesisId !== spawn.id || !e.previousId) continue
+    const list = byPrev.get(e.previousId) ?? []
+    list.push(e)
+    byPrev.set(e.previousId, list)
+  }
+
+  const chain = [spawn]
+  const seen = new Set([spawn.id])
+  let head = spawn
+  for (;;) {
+    const next = (byPrev.get(head.id) ?? [])
+      .filter((e) => !seen.has(e.id))
+      .sort((a, b) => -newer(a, b))[0]
+    if (!next) break
+    chain.push(next)
+    seen.add(next.id)
+    head = next
+  }
+  return chain
+}
+
+/** Where a chain currently puts its avatar. */
+export function chainHead(chain: ActionEvent[]): ActionEvent | null {
+  return chain.length ? chain[chain.length - 1] : null
+}

--- a/src/lib/publisher.ts
+++ b/src/lib/publisher.ts
@@ -1,0 +1,80 @@
+/**
+ * publisher.ts — drains the chain onto the relay, in order, while Live.
+ *
+ * One event at a time, oldest unpublished first. Order matters: a hop names
+ * its predecessor, and a relay that sees the hop before the spawn will still
+ * store it, but anyone reassembling the chain in between sees a hop with no
+ * genesis. Sending them in chain order means every prefix the relay holds is
+ * itself a valid chain.
+ *
+ * A module singleton rather than an effect, because React's dev double-mount
+ * would otherwise start two drains, and because a publish that is already in
+ * flight when the component goes away should still land and be recorded. The
+ * store is the queue: an event's status is the only state, so there is nothing
+ * here to get out of sync with it.
+ */
+
+import { publish } from './relay'
+import { useCyberspace } from '../store/useCyberspace'
+
+/** First retry after a refusal or a dead socket; doubles up to the cap. */
+const RETRY_MS = 4000
+const RETRY_MAX_MS = 60_000
+
+let started = false
+let inFlight = false
+let retryHandle: number | null = null
+let backoff = RETRY_MS
+
+async function pump(): Promise<void> {
+  if (inFlight) return
+  const s = useCyberspace.getState()
+  if (!s.live) return
+  const next = s.events.find((e) => s.published[e.id] !== 'ok')
+  if (!next) return
+
+  inFlight = true
+  s.setPublishStatus(next.id, 'sending')
+  const result = await publish(next)
+  inFlight = false
+
+  // Re-read: Live may have been switched off, or the chain respawned, while
+  // the socket was waiting. A result for an event no longer in the chain is
+  // dropped by setPublishStatus itself.
+  const now = useCyberspace.getState()
+  if (result.ok) {
+    now.setPublishStatus(next.id, 'ok')
+    backoff = RETRY_MS
+    if (now.live) void pump()
+    return
+  }
+
+  now.setPublishStatus(next.id, 'failed', result.reason)
+  if (!now.live) return
+  retryHandle = window.setTimeout(() => {
+    retryHandle = null
+    backoff = Math.min(backoff * 2, RETRY_MAX_MS)
+    void pump()
+  }, backoff)
+}
+
+/** Idempotent. Subscribes once for the life of the page. */
+export function startPublisher(): void {
+  if (started) return
+  started = true
+
+  useCyberspace.subscribe((s, prev) => {
+    if (s.live === prev.live && s.events === prev.events) return
+    if (!s.live) {
+      // Switching off stops retrying. An in-flight send is allowed to finish.
+      if (retryHandle !== null) { clearTimeout(retryHandle); retryHandle = null }
+      return
+    }
+    // Switching on, or a new event: try now rather than waiting out a backoff.
+    if (retryHandle !== null) { clearTimeout(retryHandle); retryHandle = null }
+    backoff = RETRY_MS
+    void pump()
+  })
+
+  void pump()
+}

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -1,0 +1,63 @@
+/**
+ * relay.ts — the one relay this client talks to, and how.
+ *
+ * cyberspace.nostr1.com is where the v2 chains live. A single pool, created on
+ * first use so a page that never goes live never opens a socket, and shared by
+ * publishing, chain lookups and subscriptions so they all ride one connection.
+ *
+ * Publishing reports a result rather than throwing, because the caller is a
+ * queue that needs to know whether to move on or try again, and a relay that
+ * is down is a normal condition, not an exception.
+ */
+
+import { SimplePool } from 'nostr-tools/pool'
+import type { Filter } from 'nostr-tools/filter'
+import type { NostrEvent } from './events'
+
+export const CYBERSPACE_RELAY = 'wss://cyberspace.nostr1.com'
+
+/** How long a publish or a one-shot query waits before giving up. */
+const MAX_WAIT_MS = 8000
+
+let pool: SimplePool | null = null
+
+export function getPool(): SimplePool {
+  if (!pool) pool = new SimplePool()
+  return pool
+}
+
+export type PublishResult = { ok: true } | { ok: false; reason: string }
+
+/** Send one event and wait for the relay's OK, or its refusal. */
+export async function publish(event: NostrEvent): Promise<PublishResult> {
+  try {
+    const [promise] = getPool().publish([CYBERSPACE_RELAY], event, { maxWait: MAX_WAIT_MS })
+    await promise
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/** One-shot query: everything the relay has for the filter, then close. */
+export function query(filter: Filter): Promise<NostrEvent[]> {
+  return getPool().querySync([CYBERSPACE_RELAY], filter, { maxWait: MAX_WAIT_MS })
+}
+
+/** A live subscription; the returned function closes it. */
+export function subscribe(
+  filter: Filter,
+  onEvent: (ev: NostrEvent) => void,
+  onEose?: () => void,
+): () => void {
+  const sub = getPool().subscribe([CYBERSPACE_RELAY], filter, {
+    onevent: onEvent,
+    oneose: onEose,
+  })
+  return () => sub.close()
+}
+
+/** Whether the socket to the relay is currently open. */
+export function connected(): boolean {
+  return pool?.listConnectionStatus().get(CYBERSPACE_RELAY) ?? false
+}

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -4,22 +4,28 @@
  *
  * Movement is two-phase: WASD noodles a free cursor, Space commits the hop.
  * Only a commit computes a proof, and position advances only when that proof
- * lands, so the prevEventId chain stays contiguous: every position the avatar
- * has ever occupied is covered by a completed proof.
+ * lands, so the chain stays contiguous: every position the avatar has ever
+ * occupied is covered by a completed proof.
+ *
+ * The chain is real. Every committed action is signed into a kind:3333 event
+ * (spec §8) the moment its proof lands, and the NEXT proof's temporal work is
+ * bound to that event's id, exactly as a verifier will recompute it. Local or
+ * Live only decides whether those events leave the device; the chain itself
+ * is identical either way, so switching to Live later publishes the same
+ * history you would have had from the start.
  */
 
 import { create } from 'zustand'
 import { Quaternion } from 'three'
-import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools'
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { nip19 } from 'nostr-tools'
 import {
-  coordToHex,
   coordToXyz,
   estimateHopCost,
   findLcaHeight,
   hexToCoord,
   sectorTag,
   sidestepLanding,
-  xyzToCoord,
   xyzToSectorId,
   type Plane,
 } from 'cyberspace-core'
@@ -38,12 +44,19 @@ import {
   type RotateDirection,
   type ViewAxes,
 } from '../lib/space'
+import {
+  buildChain,
+  hopTemplate,
+  sidestepTemplate,
+  spawnTemplate,
+  type ActionEvent,
+  type EventTemplate,
+  type NostrEvent,
+} from '../lib/events'
 import { cancelProof, postProof, type ProofMode, type ProofResponse } from '../lib/workers'
 
 /** Matches cyberspace-core's DEFAULT_MAX_COMPUTE_HEIGHT. */
 export const MAX_COMPUTE_HEIGHT = 20
-
-const ZERO_EVENT_ID = '0'.repeat(64)
 
 export type ProofStatus = 'idle' | 'computing' | 'done' | 'infeasible'
 
@@ -89,6 +102,14 @@ export interface ChainStats {
   totalMs: number
 }
 
+const EMPTY_STATS: ChainStats = { hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0 }
+
+/**
+ * Where an event is on its way to the relay. `queued` is the resting state in
+ * Local mode: nothing is wrong, nothing has been sent.
+ */
+export type PublishStatus = 'queued' | 'sending' | 'ok' | 'failed'
+
 export interface CyberspaceState {
   identity: { pubkey: string; npub: string }
   position: Position
@@ -96,14 +117,34 @@ export interface CyberspaceState {
   cursor: Position
   /** Destination of the in-flight proof; null when nothing is computing. */
   pendingTarget: Position | null
+  /**
+   * The plane the next commit lands in. Part of the lined-up action, like the
+   * cursor: toggling it costs nothing until committed, and a commit with the
+   * cursor parked but the plane flipped is a valid hop in its own right.
+   */
   plane: Plane
+  /** The plane the chain head is actually in. */
+  headPlane: Plane
   scaleExp: number
   /** Current view quaternion (camera snaps instantly to this). */
   view: Quaternion
   viewHistory: Quaternion[]
   proof: ProofState
-  /** Chained from the previous hop, mirroring the protocol's prev-event link. */
+  /**
+   * The chain, as signed events, spawn first. This is what gets published and
+   * what everything else here is derived from.
+   */
+  events: NostrEvent[]
+  /** Id of the spawn event: the `genesis` every hop names. */
+  genesisId: string
+  /** Id of the chain head: what the next proof's temporal work binds to. */
   prevEventId: string
+  /** Per event id. Only `ok` survives a reload; the rest is in flight. */
+  published: Record<string, PublishStatus>
+  /** The relay's last refusal, for the panel. */
+  publishError: string | null
+  /** Live publishes the chain as it grows; Local keeps it here. */
+  live: boolean
   chain: ChainStats
   /** History of all committed positions for rendering the path trail. */
   positionHistory: Position[]
@@ -119,13 +160,18 @@ export interface CyberspaceState {
   canonicalView: () => void
   togglePlane: () => void
   applyProofMessage: (msg: ProofResponse) => void
+  setLive: (live: boolean) => void
+  setPublishStatus: (id: string, status: PublishStatus, reason?: string) => void
 
   axes: () => ViewAxes
   /** Axes as they appear on screen right now, including free orbit. */
   screenAxes: ViewAxes | null
   setScreenAxes: (a: ViewAxes) => void
+  /** The chain head's coordinate, exactly as its event carries it. */
   coordHex: () => string
   sector: () => string
+  /** The chain, parsed. */
+  actions: () => ActionEvent[]
   /** Which position the view centers on: cursor when active, avatar otherwise. */
   viewCenter: () => Position
   /**
@@ -142,12 +188,23 @@ export interface CyberspaceState {
  */
 const STORAGE_KEY = 'onosendai:nsec'
 const CHAIN_KEY = 'onosendai:chain'
+const LIVE_KEY = 'onosendai:live'
 
-interface PersistedState {
-  position: { x: string; y: string; z: string }
-  prevEventId: string
-  chain: ChainStats
-  positionHistory: Array<{ x: string; y: string; z: string }>
+/**
+ * The chain on disk is the events themselves. Position, history, plane and the
+ * previous-event link are all read back out of them, so there is exactly one
+ * thing that can be wrong and it is the thing that gets published.
+ *
+ * Version 1 stored positions with proof hashes standing in for event ids and
+ * no events at all, which nothing could verify or publish. It is not migrated:
+ * a chain that never existed on the wire restarts at spawn.
+ */
+interface PersistedChain {
+  version: 2
+  events: NostrEvent[]
+  /** Ids the relay has acknowledged. */
+  published: string[]
+  stats: ChainStats
 }
 
 function loadOrGenerateKey(): Uint8Array {
@@ -164,74 +221,116 @@ function loadOrGenerateKey(): Uint8Array {
   return fresh
 }
 
-function positionToStrings(pos: Position): { x: string; y: string; z: string } {
-  return { x: pos.x.toString(), y: pos.y.toString(), z: pos.z.toString() }
-}
-
-function stringsToPosition(s: { x: string; y: string; z: string }): Position {
-  return { x: BigInt(s.x), y: BigInt(s.y), z: BigInt(s.z) }
-}
-
-function loadPersistedState(): {
-  position: Position
-  prevEventId: string
-  chain: ChainStats
-  positionHistory: Position[]
-} | null {
+function loadChain(pubkey: string): PersistedChain | null {
   try {
     const raw = localStorage.getItem(CHAIN_KEY)
     if (!raw) return null
-    const data: PersistedState = JSON.parse(raw)
+    const data = JSON.parse(raw) as Partial<PersistedChain>
+    if (data.version !== 2 || !Array.isArray(data.events) || data.events.length === 0) return null
+    // Must reassemble to exactly what was stored, from our own key. Anything
+    // else is a chain that cannot be continued, and pretending otherwise would
+    // sign hops onto a history the relay will reject.
+    const chain = buildChain(data.events)
+    if (chain.length !== data.events.length || chain[0].pubkey !== pubkey) return null
     return {
-      position: stringsToPosition(data.position),
-      prevEventId: data.prevEventId,
-      chain: data.chain,
-      positionHistory: data.positionHistory.map(stringsToPosition),
+      version: 2,
+      events: data.events,
+      published: Array.isArray(data.published) ? data.published : [],
+      stats: { ...EMPTY_STATS, ...(data.stats ?? {}) },
     }
   } catch { /* corrupt or missing */ }
   return null
 }
 
-function savePersistedState(
-  position: Position,
-  prevEventId: string,
-  chain: ChainStats,
-  positionHistory: Position[],
-): void {
+function saveChain(events: NostrEvent[], published: Record<string, PublishStatus>, stats: ChainStats): void {
   try {
-    const data: PersistedState = {
-      position: positionToStrings(position),
-      prevEventId,
-      chain,
-      positionHistory: positionHistory.map(positionToStrings),
+    const data: PersistedChain = {
+      version: 2,
+      events,
+      published: events.map((e) => e.id).filter((id) => published[id] === 'ok'),
+      stats,
     }
     localStorage.setItem(CHAIN_KEY, JSON.stringify(data))
   } catch { /* quota exceeded or private mode */ }
 }
 
+function loadLive(): boolean {
+  try {
+    const raw = localStorage.getItem(LIVE_KEY)
+    // Live is the default: the chain is meant to be seen.
+    return raw === null ? true : raw === '1'
+  } catch { return true }
+}
+
+function saveLive(live: boolean): void {
+  try { localStorage.setItem(LIVE_KEY, live ? '1' : '0') } catch { /* private mode */ }
+}
+
+/** Seconds now, never earlier than the chain head, so the chain reads forward. */
+function nextCreatedAt(head: NostrEvent | undefined): number {
+  const now = Math.floor(Date.now() / 1000)
+  return head ? Math.max(now, head.created_at) : now
+}
+
 const secretKey = loadOrGenerateKey()
 const pubkeyHex = getPublicKey(secretKey)
-const SPAWN = coordToXyz(hexToCoord(pubkeyHex))
-const persisted = loadPersistedState()
+const SPAWN_XYZ = coordToXyz(hexToCoord(pubkeyHex))
+const SPAWN: Position = { x: SPAWN_XYZ.x, y: SPAWN_XYZ.y, z: SPAWN_XYZ.z }
 
-// Reserved for signing spawn/hop events when publishing lands.
-void secretKey
+/** The one place the key touches an event. */
+function sign(template: EventTemplate): NostrEvent {
+  return finalizeEvent(template, secretKey)
+}
+
+/** A fresh chain: one spawn, signed now, unpublished. */
+function freshSpawn(): PersistedChain {
+  return { version: 2, events: [sign(spawnTemplate(pubkeyHex, nextCreatedAt(undefined)))], published: [], stats: EMPTY_STATS }
+}
+
+/** Everything the store derives from a chain, so spawn and respawn agree. */
+function derive(saved: PersistedChain): {
+  events: NostrEvent[]
+  genesisId: string
+  prevEventId: string
+  published: Record<string, PublishStatus>
+  chain: ChainStats
+  position: Position
+  positionHistory: Position[]
+  plane: Plane
+  headPlane: Plane
+} {
+  const actions = buildChain(saved.events)
+  const head = actions[actions.length - 1]
+  const published: Record<string, PublishStatus> = {}
+  for (const e of saved.events) published[e.id] = saved.published.includes(e.id) ? 'ok' : 'queued'
+  return {
+    events: saved.events,
+    genesisId: actions[0].id,
+    prevEventId: head.id,
+    published,
+    chain: saved.stats,
+    position: head.position,
+    positionHistory: actions.map((a) => a.position),
+    plane: head.plane,
+    headPlane: head.plane,
+  }
+}
+
+const initial = derive(loadChain(pubkeyHex) ?? freshSpawn())
 
 let requestId = 0
 
 export const useCyberspace = create<CyberspaceState>((set, get) => ({
   identity: { pubkey: pubkeyHex, npub: nip19.npubEncode(pubkeyHex) },
-  position: persisted?.position ?? SPAWN,
-  cursor: persisted?.position ?? SPAWN,
+  ...initial,
+  cursor: initial.position,
   pendingTarget: null,
-  plane: 0,
   scaleExp: 0,
   view: topDownQuaternion(),
   viewHistory: [],
   proof: IDLE_PROOF,
-  prevEventId: persisted?.prevEventId ?? ZERO_EVENT_ID,
-  chain: persisted?.chain ?? { hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0 },
-  positionHistory: persisted?.positionHistory ?? [SPAWN],
+  publishError: null,
+  live: loadLive(),
 
   moveCursor: (dir) => {
     const { cursor, scaleExp } = get()
@@ -266,10 +365,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   },
 
   commit: () => {
-    const { position, cursor, plane, prevEventId, proof } = get()
+    const { position, cursor, plane, headPlane, prevEventId, proof } = get()
     // One proof at a time. X cancels a commit you regret.
     if (proof.status === 'computing') return
-    if (samePosition(position, cursor)) return
+    // Nothing lined up: same cell, same plane.
+    if (samePosition(position, cursor) && plane === headPlane) return
 
     // Route by feasibility: a hop straight to the cursor when the Cantor tree
     // fits, otherwise a Merkle sidestep across the blocking wall(s). The
@@ -283,7 +383,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     )
     const mode: ProofMode = estimate.exceedsLimit ? 'sidestep' : 'hop'
     const to = mode === 'sidestep' ? sidestepTarget(position, cursor) : { ...cursor }
-    if (samePosition(position, to)) return
+    if (samePosition(position, to) && plane === headPlane) return
 
     const id = ++requestId
     set({
@@ -303,7 +403,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   },
 
   cancel: () => {
-    const { proof, position } = get()
+    const { proof, position, headPlane } = get()
     if (proof.status === 'computing') {
       // A Cantor proof is one synchronous computation, so cancelling means
       // killing the worker thread. Position never moved; the chain is intact.
@@ -312,8 +412,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       set({ pendingTarget: null, proof: IDLE_PROOF })
       return
     }
-    // Not computing: recall the cursor to where you actually stand.
-    set({ cursor: { ...position } })
+    // Not computing: recall the cursor, plane included, to where you stand.
+    set({ cursor: { ...position }, plane: headPlane })
   },
 
   adjustScale: (delta) => {
@@ -378,12 +478,41 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       return
     }
 
-    const { pendingTarget, position, chain } = get()
+    const { pendingTarget, position, plane, chain, events, genesisId, prevEventId, published } = get()
     const newPosition = pendingTarget ?? position
+    const head = events[events.length - 1]
+
+    // The proof covers exactly position -> pendingTarget, and this event is
+    // its receipt: the hop the next proof will bind to. Signed before the
+    // position moves, so the chain and the avatar can never disagree.
+    const link = {
+      createdAt: nextCreatedAt(head),
+      genesisId,
+      previousId: prevEventId,
+      prevCoordHex: head.tags.find((t) => t[0] === 'C')?.[1] ?? '',
+      to: newPosition,
+      plane,
+      proofHash: msg.proofHash,
+    }
+    const event = sign(
+      msg.mode === 'sidestep' && msg.sidestep
+        ? sidestepTemplate({ ...link, ...msg.sidestep })
+        : hopTemplate(link),
+    )
+
+    const stats: ChainStats = {
+      hops: chain.hops + (msg.mode === 'hop' ? 1 : 0),
+      sidesteps: chain.sidesteps + (msg.mode === 'sidestep' ? 1 : 0),
+      totalOps: chain.totalOps + (msg.mode === 'hop' ? msg.totalOps : 0),
+      totalHashes: chain.totalHashes + (msg.mode === 'sidestep' ? msg.totalOps : 0),
+      totalMs: chain.totalMs + msg.elapsedMs,
+    }
+    const nextEvents = [...events, event]
+    const nextPublished = { ...published, [event.id]: 'queued' as const }
+
     set({
-      // The proof covers exactly position -> pendingTarget, so only now does
-      // the avatar arrive.
       position: newPosition,
+      headPlane: plane,
       pendingTarget: null,
       proof: {
         status: 'done',
@@ -397,25 +526,28 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
         totalOps: msg.totalOps,
         message: null,
       },
-      prevEventId: msg.proofHash,
-      chain: {
-        hops: chain.hops + (msg.mode === 'hop' ? 1 : 0),
-        sidesteps: chain.sidesteps + (msg.mode === 'sidestep' ? 1 : 0),
-        totalOps: chain.totalOps + (msg.mode === 'hop' ? msg.totalOps : 0),
-        totalHashes: chain.totalHashes + (msg.mode === 'sidestep' ? msg.totalOps : 0),
-        totalMs: chain.totalMs + msg.elapsedMs,
-      },
+      events: nextEvents,
+      prevEventId: event.id,
+      published: nextPublished,
+      chain: stats,
       positionHistory: [...get().positionHistory, newPosition],
     })
-    
-    // Persist the updated state
-    const updated = get()
-    savePersistedState(
-      updated.position,
-      updated.prevEventId,
-      updated.chain,
-      updated.positionHistory
-    )
+
+    saveChain(nextEvents, nextPublished, stats)
+  },
+
+  setLive: (live) => {
+    if (live === get().live) return
+    saveLive(live)
+    set({ live, publishError: null })
+  },
+
+  setPublishStatus: (id, status, reason) => {
+    const { published, events, chain } = get()
+    if (!(id in published)) return
+    const next = { ...published, [id]: status }
+    set({ published: next, publishError: status === 'failed' ? reason ?? 'relay refused' : null })
+    if (status === 'ok') saveChain(events, next, chain)
   },
 
   screenAxes: null,
@@ -434,14 +566,16 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   axes: () => viewAxes(get().view),
 
   coordHex: () => {
-    const { position, plane } = get()
-    return coordToHex(xyzToCoord(position.x, position.y, position.z, plane))
+    const { events } = get()
+    return events[events.length - 1].tags.find((t) => t[0] === 'C')?.[1] ?? ''
   },
 
   sector: () => {
     const { position } = get()
     return sectorTag(xyzToSectorId(position.x, position.y, position.z))
   },
+
+  actions: () => buildChain(get().events),
 
   /**
    * Which position the camera tracks: the cursor when it is away from the
@@ -482,6 +616,9 @@ if (import.meta.env.DEV && typeof window !== 'undefined') {
   // from the HUD, the same way __terrain and __screenAxes work.
   ;(window as unknown as { __store?: unknown }).__store = useCyberspace
 }
+
+/** The spawn coordinate of this identity: where every chain of its starts. */
+export { SPAWN }
 
 /** Positions are equal when all three axes match. */
 export function samePosition(a: Position, b: Position): boolean {

--- a/src/styles.css
+++ b/src/styles.css
@@ -174,9 +174,27 @@ body {
   border-color: rgba(200, 245, 255, 0.3);
 }
 
-.tag--local {
+/* Live is the state worth noticing. Local is not an error, it is just quiet. */
+.tag--live {
   color: var(--ok);
 }
+
+.tag--local {
+  color: var(--dim);
+}
+
+/* Relay state, inline after the published count. */
+.relay {
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  margin-left: 4px;
+}
+
+.relay--synced { color: var(--ok); }
+.relay--sending,
+.relay--queued { color: var(--warn); }
+.relay--retrying { color: var(--danger); }
+.relay--local { color: var(--dim); }
 
 /* ---------- Scale bar (integrated left edge) ---------- */
 
@@ -830,7 +848,7 @@ kbd {
  * has exactly nine things worth reaching: six directions, the scale readout and
  * its two steps. */
 .touchpad {
-  bottom: 62px;
+  bottom: 92px;
   display: grid;
   grid-template-columns: repeat(3, 38px);
   grid-template-rows: repeat(3, 38px);
@@ -918,8 +936,47 @@ kbd {
   bottom: 14px;
   display: grid;
   grid-template-columns: 56px 62px;
+  grid-template-rows: 40px 26px;
   gap: 4px;
   width: 122px;
+}
+
+/* Local / Live, under RECALL and COMMIT. A two-way switch, so the state that
+ * is on is always written out next to the one that is not: "LIVE" lit beside a
+ * dark "LOCAL" cannot be misread as a button that would turn live on. */
+.touchmode {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border: 1px solid var(--border, #1d3547);
+  border-radius: 9px;
+  overflow: hidden;
+  background: rgba(6, 14, 22, 0.72);
+  backdrop-filter: blur(6px);
+}
+
+.touchmode__opt {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  color: var(--dim, #7fa6bd);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.touchmode__opt.is-on {
+  color: #05070d;
+  background: var(--ok, #52e39f);
+  font-weight: 700;
+}
+
+.touchmode__opt:first-child.is-on {
+  /* Local lit is the quieter state: present, deliberately not green. */
+  color: var(--fg, #c8f5ff);
+  background: rgba(200, 245, 255, 0.16);
 }
 
 .touchops__cancel,
@@ -1127,7 +1184,7 @@ kbd {
    * 62px from the bottom. At 150 the menu covered the pad's top row. */
   .viewmenu {
     top: auto;
-    bottom: 196px;
+    bottom: 226px;
     right: 332px;
   }
 }
@@ -1158,6 +1215,7 @@ kbd {
 .touchpad__hub,
 .touchops__commit,
 .touchops__cancel,
+.touchmode__opt,
 .touchhint,
 .hamburger-menu,
 .compass-3d--tappable,

--- a/src/workers/proof.worker.ts
+++ b/src/workers/proof.worker.ts
@@ -14,6 +14,7 @@ import {
   estimateSidestepCost,
   type Plane,
 } from 'cyberspace-core'
+import { bytesToHex } from '../lib/events'
 
 export type ProofMode = 'hop' | 'sidestep'
 
@@ -25,6 +26,18 @@ export interface ProofRequest {
   plane: Plane
   prevEventId: string
   maxComputeHeight: number
+}
+
+/**
+ * What a sidestep event carries beyond the proof hash (spec §8.5): the
+ * per-axis Merkle roots, the destination leaf's inclusion path on each axis,
+ * and the LCA heights that tell a verifier how long each path should be.
+ * Already hex, so the main thread can drop them straight into tags.
+ */
+export interface SidestepTags {
+  merkleRoots: [string, string, string]
+  inclusionProofs: [string, string, string]
+  lcaHeights: [number, number, number]
 }
 
 export type ProofResponse =
@@ -40,6 +53,8 @@ export type ProofResponse =
       lca: { x: number; y: number; z: number }
       /** Cantor pairings for hops; SHA-256 evaluations for sidesteps. */
       totalOps: number
+      /** Present on sidesteps only. */
+      sidestep?: SidestepTags
     }
   | { type: 'error'; id: number; message: string; elapsedMs: number }
 
@@ -77,6 +92,9 @@ self.onmessage = (event: MessageEvent<ProofRequest>) => {
         prevEventId,
         onProgress,
       )
+      // §8.5: siblings concatenated leaf-first per axis, empty where the axis
+      // did not move.
+      const path = (siblings: Uint8Array[]): string => siblings.map(bytesToHex).join('')
       const response: ProofResponse = {
         type: 'done',
         id,
@@ -87,6 +105,15 @@ self.onmessage = (event: MessageEvent<ProofRequest>) => {
         terrainK: proof.terrainK,
         lca: { x: proof.lcaHeights[0], y: proof.lcaHeights[1], z: proof.lcaHeights[2] },
         totalOps: estimate.totalHashes,
+        sidestep: {
+          merkleRoots: [bytesToHex(proof.merkleX), bytesToHex(proof.merkleY), bytesToHex(proof.merkleZ)],
+          inclusionProofs: [
+            path(proof.inclusionProofs.x),
+            path(proof.inclusionProofs.y),
+            path(proof.inclusionProofs.z),
+          ],
+          lcaHeights: proof.lcaHeights,
+        },
       }
       self.postMessage(response)
       return


### PR DESCRIPTION
Stack 1 of N (base: `v2`). Foundation for respawn, spectating and targets.

## What changes

- **Real `kind:3333` events.** Spawning signs a spawn event; every committed hop or sidestep is signed into its own event when the proof lands, naming `genesis` and `previous` per spec §8.3 to §8.5. The next proof's temporal work binds to the real previous event id.
- **Persistence is the events.** Position, plane, history and the previous link are derived from the stored chain on load. The old proof-hash format is not migrated (it never existed on the wire), so existing local chains restart at spawn once.
- **Spawn plane is the pubkey's plane bit** (spec §8.3), not a hardcoded 0. `P` now lines up the plane for the next commit; a plane-only commit is a valid hop; `X` recalls the plane with the cursor.
- **Sidestep events carry `mr` / `mp` / `hx` / `hy` / `hz`** from the worker's Merkle roots and inclusion paths.
- **Local / Live switch** under RECALL and COMMIT, Live by default, persisted. A singleton publisher drains unpublished events oldest-first with backoff to `wss://cyberspace.nostr1.com`; switching to Live later publishes the backlog in chain order.
- HUD: identity tag reads LIVE / LOCAL; proof chain panel shows genesis, head, published count, relay state and the relay's last refusal.

## Verification

- `npm test`: 109 passing (27 new, tag-by-tag against spec §8 and §10, parser refusals, chain reassembly with newest-spawn-wins and fork handling).
- `npm run typecheck`: clean.
- Browser (Playwright): a hop signs to `A,e,e,c,C,proof,X,Y,Z,S`, chain survives reload; with Live on, spawn + hop reach the relay (`2 / 2 SYNCED`) and `nak req -i <id>` returns both from cyberspace.nostr1.com. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)