### PR TITLE
feat: derezz, which abandons the chain and rezzes at the pubkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ lands, naming the spawn as `genesis` and the previous event as `previous`
 exactly as a verifier recomputes it. The chain persists as those events, so a
 reload reads position, plane and history back out of them.
 
+**Derezz.** The last panel in the HUD abandons the chain: a new spawn event is
+signed (and published, when Live), which per spec section 3.2 retires every
+action before it, and the avatar is back at its pubkey with nothing behind it.
+It arms a warning first, in v1's words, because it cannot be undone.
+
 **Local / Live.** The switch under RECALL and COMMIT decides whether events
 leave the device. Live (the default) publishes each one to
 `wss://cyberspace.nostr1.com` as it is signed, in chain order, and the proof

--- a/src/hud/DerezzPanel.tsx
+++ b/src/hud/DerezzPanel.tsx
@@ -1,0 +1,64 @@
+/**
+ * DerezzPanel.tsx - abandon the chain and rez again at the pubkey.
+ *
+ * Spec §3.2: a keypair may respawn at any time by publishing a new spawn
+ * event, which by being newer retires every prior action. The old events stay
+ * on relays; they just no longer lead anywhere. So this is the one control in
+ * the HUD that throws away work, and it is buried at the bottom of the panels,
+ * behind a warning, in red, the way v1 buried it behind DEREZZ.
+ *
+ * The copy is v1's, because v1 had the tone right: a respawn is a small death,
+ * and a machine that asks you to remove your neuroactive interfaces first is
+ * not joking about the part that matters.
+ */
+
+import { useState } from 'react'
+import { useCyberspace } from '../store/useCyberspace'
+
+export function DerezzPanel(): JSX.Element {
+  const [armed, setArmed] = useState(false)
+  const chain = useCyberspace((s) => s.chain)
+  const live = useCyberspace((s) => s.live)
+  const actions = chain.hops + chain.sidesteps
+
+  const derezz = (): void => {
+    useCyberspace.getState().respawn()
+    setArmed(false)
+  }
+
+  return (
+    <section className={`panel panel--derezz ${armed ? 'is-armed' : ''}`}>
+      <header className="panel__head">
+        <h2>Derezz</h2>
+        <span className="tag tag--danger">{actions} ACTION{actions === 1 ? '' : 'S'}</span>
+      </header>
+
+      {armed ? (
+        <>
+          <p className="derezz__warning">
+            DISCARD CURRENT PROOF CHAIN OF {actions} ACTION{actions === 1 ? '' : 'S'} AND
+            REZ AT PUBKEY COORDINATE? (THIS CANNOT BE UNDONE)
+          </p>
+          <p className="derezz__fine">
+            TO AVOID INJURY OR BRAIN DEATH, PLEASE REMOVE NEUROACTIVE INTERFACES
+            BEFORE CONTINUING
+          </p>
+          <div className="derezz__row">
+            <button className="derezz__cancel" onClick={() => setArmed(false)}>CANCEL</button>
+            <button className="derezz__now" onClick={derezz}>DEREZZ NOW</button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="legend__note">
+            Abandon this chain and spawn again at your pubkey. A new spawn event
+            {live ? ' is published and ' : ' '}retires every action before it
+            (spec section 3.2). Your identity and the relay's copy of the old
+            chain are untouched.
+          </p>
+          <button className="derezz__arm" onClick={() => setArmed(true)}>DEREZZ</button>
+        </>
+      )}
+    </section>
+  )
+}

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -6,6 +6,7 @@
 import { formatBig, formatStep } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
 import { ChainPanel } from './ChainPanel'
+import { DerezzPanel } from './DerezzPanel'
 import { Legend } from './Legend'
 import { ScaleLadder } from './ScaleLadder'
 import { ProofPanel } from './ProofPanel'
@@ -207,6 +208,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <ChainPanel />
         <Legend />
         <Controls />
+        <DerezzPanel />
       </div>
     </div>
   )

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -174,6 +174,7 @@ function CellMetric(): null {
  */
 function Rig(): JSX.Element {
   const view = useCyberspace((s) => s.view)
+  const genesisId = useCyberspace((s) => s.genesisId)
   const controls = useRef<{
     object: { position: Vector3 }
     target: Vector3
@@ -189,6 +190,11 @@ function Rig(): JSX.Element {
   const prevOrigin = useRef<Position | null>(null)
   const prevScale = useRef(-1)
 
+  // Re-framed on an axis snap and on a respawn. A respawn moves the render
+  // origin home in one step, and the per-frame shift below would faithfully
+  // carry the camera the same distance, which is the whole width of the axis:
+  // the avatar would be at the origin and the camera 10^20 cells away. Treating
+  // it as a fresh frame, like a zoom, is what puts you back at your spawn.
   useEffect(() => {
     const c = controls.current
     if (!c) return
@@ -197,8 +203,9 @@ function Rig(): JSX.Element {
     c.target.copy(smooth.current)
     c.object.position.set(x, y, z + START_DISTANCE)
     locked.current = true
+    prevOrigin.current = null
     c.update()
-  }, [view])
+  }, [view, genesisId])
 
   useFrame((_, dt) => {
     const c = controls.current

--- a/src/scene/Travel.tsx
+++ b/src/scene/Travel.tsx
@@ -34,8 +34,10 @@ interface Props {
 export function Travel({ axes }: Props): null {
   const position = useCyberspace((s) => s.position)
   const scaleExp = useCyberspace((s) => s.scaleExp)
+  const genesisId = useCyberspace((s) => s.genesisId)
 
   const previous = useRef<Position>(position)
+  const previousGenesis = useRef(genesisId)
   const from = useRef(new Vector3())
   const duration = useRef(0)
   const startedAt = useRef<number | null>(null)
@@ -44,6 +46,15 @@ export function Travel({ axes }: Props): null {
     const old = previous.current
     previous.current = position
     if (old.x === position.x && old.y === position.y && old.z === position.z) return
+
+    // A respawn is not a move. Nothing was paid for the distance back to the
+    // pubkey, so nothing should be seen to travel it, however short it is.
+    if (previousGenesis.current !== genesisId) {
+      previousGenesis.current = genesisId
+      travelOffset.set(0, 0, 0)
+      startedAt.current = null
+      return
+    }
 
     // Where the avatar was, expressed against the origin it now uses.
     const [x, y, z] = cellCentre(old, alignedOrigin(position, scaleExp), scaleExp, axes)
@@ -63,7 +74,7 @@ export function Travel({ axes }: Props): null {
     // scaleExp and axes are read at commit time on purpose: a zoom or a rotation
     // mid-flight must not restart or re-aim a journey already under way.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [position])
+  }, [position, genesisId])
 
   useFrame((state) => {
     if (travelOffset.lengthSq() === 0) return

--- a/src/store/respawn.test.ts
+++ b/src/store/respawn.test.ts
@@ -1,0 +1,51 @@
+/**
+ * respawn.test.ts - a respawn is a new chain, not an edit to the old one.
+ *
+ * The things that would go wrong silently: the new spawn inheriting the old
+ * head as its previous link, the published map still holding the old ids so
+ * the publisher never sends the new spawn, or the position staying where the
+ * old chain left it while the events say otherwise.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseAction } from '../lib/events'
+import { SPAWN, useCyberspace } from './useCyberspace'
+
+describe('respawn', () => {
+  it('replaces the chain with a single spawn at the pubkey and resets the cursor', () => {
+    const before = useCyberspace.getState()
+    const oldGenesis = before.genesisId
+    // Pretend the chain had gone somewhere.
+    useCyberspace.setState({
+      position: { ...SPAWN, x: SPAWN.x + 5n },
+      cursor: { ...SPAWN, x: SPAWN.x + 9n },
+      chain: { hops: 3, sidesteps: 1, totalOps: 99, totalHashes: 7, totalMs: 12 },
+    })
+
+    useCyberspace.getState().respawn()
+    const s = useCyberspace.getState()
+
+    expect(s.events).toHaveLength(1)
+    const spawn = parseAction(s.events[0])
+    expect(spawn?.type).toBe('spawn')
+    expect(spawn?.pubkey).toBe(s.identity.pubkey)
+    expect(s.genesisId).toBe(s.events[0].id)
+    expect(s.prevEventId).toBe(s.events[0].id)
+    expect(s.genesisId).not.toBe(oldGenesis)
+    expect(s.position).toEqual(SPAWN)
+    expect(s.cursor).toEqual(SPAWN)
+    expect(s.positionHistory).toEqual([SPAWN])
+    expect(s.plane).toBe(spawn?.plane)
+    expect(s.headPlane).toBe(spawn?.plane)
+    expect(s.chain).toEqual({ hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0 })
+    expect(Object.keys(s.published)).toEqual([s.events[0].id])
+    expect(s.published[s.events[0].id]).toBe('queued')
+    expect(s.pendingTarget).toBeNull()
+  })
+
+  it('ignores a relay result for an event the respawn retired', () => {
+    const s = useCyberspace.getState()
+    s.setPublishStatus('0'.repeat(64), 'ok')
+    expect(useCyberspace.getState().published['0'.repeat(64)]).toBeUndefined()
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -162,6 +162,13 @@ export interface CyberspaceState {
   applyProofMessage: (msg: ProofResponse) => void
   setLive: (live: boolean) => void
   setPublishStatus: (id: string, status: PublishStatus, reason?: string) => void
+  /**
+   * §3.2: a new spawn event, which by being newer retires every prior action.
+   * The avatar is back at its pubkey with nothing behind it. Cannot be undone,
+   * because the old chain's events still exist on relays but no longer lead
+   * anywhere.
+   */
+  respawn: () => void
 
   axes: () => ViewAxes
   /** Axes as they appear on screen right now, including free orbit. */
@@ -282,9 +289,18 @@ function sign(template: EventTemplate): NostrEvent {
   return finalizeEvent(template, secretKey)
 }
 
-/** A fresh chain: one spawn, signed now, unpublished. */
-function freshSpawn(): PersistedChain {
-  return { version: 2, events: [sign(spawnTemplate(pubkeyHex, nextCreatedAt(undefined)))], published: [], stats: EMPTY_STATS }
+/**
+ * A fresh chain: one spawn, signed now, unpublished.
+ *
+ * A respawn passes the chain it retires. §3.2 makes the new spawn win by being
+ * newer, and "newer" has to be strictly so: a spawn signed in the same second
+ * as the one before it is the same bytes, the same id, and so not a new spawn
+ * at all. The timestamp therefore steps past the old head, not merely to now.
+ */
+function freshSpawn(retiring?: NostrEvent): PersistedChain {
+  const now = Math.floor(Date.now() / 1000)
+  const createdAt = retiring ? Math.max(now, retiring.created_at + 1) : now
+  return { version: 2, events: [sign(spawnTemplate(pubkeyHex, createdAt))], published: [], stats: EMPTY_STATS }
 }
 
 /** Everything the store derives from a chain, so spawn and respawn agree. */
@@ -540,6 +556,24 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     if (live === get().live) return
     saveLive(live)
     set({ live, publishError: null })
+  },
+
+  respawn: () => {
+    // A proof in flight was for a chain that is about to stop existing.
+    if (get().proof.status === 'computing') {
+      cancelProof()
+      requestId++
+    }
+    const { events } = get()
+    const fresh = derive(freshSpawn(events[events.length - 1]))
+    set({
+      ...fresh,
+      cursor: fresh.position,
+      pendingTarget: null,
+      proof: IDLE_PROOF,
+      publishError: null,
+    })
+    saveChain(fresh.events, fresh.published, fresh.chain)
   },
 
   setPublishStatus: (id, status, reason) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -649,6 +649,98 @@ kbd {
   white-space: nowrap;
 }
 
+/* ---------- Derezz ----------
+ *
+ * The one panel that destroys something. Red throughout, last in the column,
+ * and its button arms a warning rather than acting, so nothing here happens on
+ * one click.
+ */
+
+.panel--derezz {
+  border-color: rgba(255, 59, 107, 0.28);
+}
+
+.panel--derezz .panel__head {
+  border-bottom-color: rgba(255, 59, 107, 0.2);
+}
+
+.panel--derezz .panel__head h2 {
+  color: var(--danger);
+}
+
+.tag--danger {
+  color: var(--danger);
+}
+
+.panel--derezz.is-armed {
+  background: rgba(40, 6, 16, 0.88);
+  border-color: var(--danger);
+}
+
+.derezz__arm,
+.derezz__cancel,
+.derezz__now {
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  height: 30px;
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 0 12px;
+}
+
+.derezz__arm {
+  margin-top: 10px;
+  width: 100%;
+  color: var(--danger);
+  background: rgba(255, 59, 107, 0.06);
+  border: 1px solid rgba(255, 59, 107, 0.5);
+}
+
+.derezz__arm:hover {
+  background: rgba(255, 59, 107, 0.16);
+}
+
+.derezz__warning {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.06em;
+  color: var(--danger);
+}
+
+.derezz__fine {
+  margin: 8px 0 0;
+  font-size: 9px;
+  line-height: 1.5;
+  letter-spacing: 0.08em;
+  color: rgba(255, 59, 107, 0.7);
+}
+
+.derezz__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.derezz__cancel {
+  color: var(--fg);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.3);
+}
+
+.derezz__now {
+  color: #05070d;
+  background: var(--danger);
+  border: 1px solid var(--danger);
+  font-weight: 700;
+}
+
+.derezz__now:hover {
+  background: #ff5c85;
+}
+
 /* ---------- Narrow viewports ---------- */
 
 @media (max-width: 1100px) {


### PR DESCRIPTION
Stack 3 (base: `feat/chip-style`, PR #17).

## What changes

- **Derezz panel**, last in the HUD column, red, armed in two steps with v1's warning copy. Confirming calls `respawn()`.
- **`respawn()`** (spec §3.2): cancels any in-flight proof, signs a fresh spawn event with a `created_at` strictly after the retired chain's head (a same-second respawn would otherwise be the identical event, caught by the new test), and derives events / genesis / head / published / stats / position / history / plane from it. The publisher sends it while Live; relay results for retired ids are dropped.
- **Scene guards:** `Travel` snaps on a genesis change instead of animating the trip home; the `Rig` re-frames on a genesis change so the origin shift cannot fling the camera across the axis.

## Verification

- Tests: 111 passing (`store/respawn.test.ts` new).
- Browser: hop, arm, cancel, arm, confirm; chain reset to one newer spawn, position/history reset, camera stayed at its orbit, chain persisted across reload, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)