### PR TITLE
feat: the chain explorer, and a scene that can stand anywhere on a chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ cd ../cyberspace-cli-js && npm install && npm run build
 | `R` / `F` | cursor along the axis into / out of the screen |
 | `C` | canonical view ("facing the black sun") |
 | `P` | toggle dataspace and ideaspace |
+| `[` / `]` | chain explorer: one action back / forward (hold to repeat) |
+| `Home` / `End` | chain explorer: the spawn / the live head |
 
 Movement is expressed in screen directions and resolved to world axes through
 the current view, so `W` is always "away from you" in any of the 24 reachable
@@ -62,6 +64,13 @@ lands, naming the spawn as `genesis` and the previous event as `previous`
 (spec section 8). The next proof's temporal work is bound to that event's id,
 exactly as a verifier recomputes it. The chain persists as those events, so a
 reload reads position, plane and history back out of them.
+
+**The chain explorer.** Under the XOR readout, the CHAIN instrument walks the
+chain: back, forward, spawn, head, or scrub the rail. The scene re-anchors on
+the action shown (avatar, trail, terrain, rooms, and the readout, which then
+shows what that hop cost); what came after is drawn faint. Off the head the
+movement controls stand down and RETURN TO LIVE brings them back. The same
+instrument walks any other avatar's chain while spectating.
 
 **The spawn marker.** v1's spawn model (`public/spawn.glb`: three hexagonal
 rings, a hollow cube, six radiating bars) stands at the pubkey coordinate,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { BitReadout } from './hud/BitReadout'
+import { ChainExplorer } from './hud/ChainExplorer'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
 import { TouchControls } from './hud/TouchControls'
@@ -12,6 +13,7 @@ import { useProofListener } from './hooks/useProofListener'
 import { useIsMobile } from './hooks/useIsMobile'
 import { useTargets } from './hooks/useTargets'
 import { startPublisher } from './lib/publisher'
+import { useCyberspace } from './store/useCyberspace'
 
 export default function App(): JSX.Element {
   // The keyboard is unconditional. The on-screen controls are a second way in,
@@ -23,6 +25,9 @@ export default function App(): JSX.Element {
   useEffect(() => startPublisher(), [])
   const isMobile = useIsMobile()
   const targets = useTargets()
+  // Off the head there is nothing to drive: the movement controls stand down
+  // and the explorer's RETURN TO LIVE is the way back.
+  const atHead = useCyberspace((s) => s.exploreIndex === null)
 
   // Panels start open on a desktop and closed on a phone, and after that the
   // hamburger owns it on both. It used to be derived from the breakpoint, which
@@ -36,7 +41,7 @@ export default function App(): JSX.Element {
 
   const [padOpen, setPadOpen] = useState(true)
   const [viewMenuOpen, setViewMenuOpen] = useState(false)
-  const showPad = padOpen && !crowded
+  const showPad = padOpen && !crowded && atHead
 
   const onSceneTap = useCallback(() => {
     // A tap while the view menu is up dismisses that first, so one gesture never
@@ -53,12 +58,17 @@ export default function App(): JSX.Element {
     <div className="app">
       <Scene />
       {!crowded && <Targets targets={targets} />}
-      {!crowded && <BitReadout />}
+      {!crowded && (
+        <div className="instruments">
+          <BitReadout />
+          <ChainExplorer />
+        </div>
+      )}
       {panelsOpen && <Hud menuOpen={crowded} />}
       {!crowded && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
       {!crowded && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && <TouchControls onDismiss={() => setPadOpen(false)} />}
-      {!crowded && !padOpen && (
+      {!crowded && !padOpen && atHead && (
         <button
           className="chip touchhint"
           onContextMenu={(e) => e.preventDefault()}

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -45,6 +45,25 @@ export function useKeyboard(): void {
         return
       }
 
+      // The chain explorer: one action back or forward, held keys repeat
+      // through the keyboard's own repeat; Home and End are the spawn and the
+      // head. These work wherever the scene is anchored, head included.
+      if (event.code === 'BracketLeft' || event.code === 'BracketRight') {
+        event.preventDefault()
+        store.exploreStep(event.code === 'BracketLeft' ? -1 : 1)
+        return
+      }
+      if (event.code === 'Home') {
+        event.preventDefault()
+        store.explore(0)
+        return
+      }
+      if (event.code === 'End') {
+        event.preventDefault()
+        store.explore(null)
+        return
+      }
+
       if (event.code === 'Escape') {
         event.preventDefault()
         store.resetView()

--- a/src/hooks/useRepeatable.ts
+++ b/src/hooks/useRepeatable.ts
@@ -1,0 +1,69 @@
+/**
+ * useRepeatable.ts — press once, then repeat while held.
+ *
+ * Shared by the movement pad and the chain explorer. Crossing a lot of gibsons
+ * one tap at a time would be miserable, and so would stepping through a
+ * thousand-hop chain; holding is what the keyboard gives you for free through
+ * key repeat, and this is the same thing for a button.
+ */
+
+import { useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Suppress the long-press callout.
+ *
+ * Holding a direction is a first-class gesture here, it is how you cross more
+ * than a few gibsons, and on a touch device a long press is also how you ask for
+ * a context menu. So the very thing the pad is designed for is what pops a
+ * "copy / share" sheet over it on Android and a magnifier on iOS. The CSS half
+ * of this lives in `-webkit-touch-callout: none`; this is the half that stops
+ * the event a desktop right-click would raise on the same element.
+ */
+export const noCallout = { onContextMenu: (e: React.MouseEvent) => e.preventDefault() }
+
+/** Delay before a held button starts repeating, then the repeat period. */
+const HOLD_DELAY = 380
+const REPEAT_MS = 110
+
+/**
+ * Fire on press, then repeat while held.
+ *
+ * Crossing a lot of gibsons one tap at a time would be miserable, and holding
+ * is what the keyboard gives you for free through key repeat.
+ */
+export function useRepeatable(): (action: () => void) => {
+  onPointerDown: (e: React.PointerEvent) => void
+  onPointerUp: () => void
+  onPointerCancel: () => void
+  onPointerLeave: () => void
+  onContextMenu: (e: React.MouseEvent) => void
+} {
+  const timers = useRef<{ delay?: number; repeat?: number }>({})
+
+  const stop = useCallback(() => {
+    if (timers.current.delay) clearTimeout(timers.current.delay)
+    if (timers.current.repeat) clearInterval(timers.current.repeat)
+    timers.current = {}
+  }, [])
+
+  useEffect(() => stop, [stop])
+
+  return useCallback((action: () => void) => ({
+    onPointerDown: (e: React.PointerEvent) => {
+      // Keeps the press off the canvas and stops it becoming a scroll or a
+      // synthetic click that would fire the action twice.
+      e.preventDefault()
+      e.stopPropagation()
+      stop()
+      action()
+      timers.current.delay = window.setTimeout(() => {
+        timers.current.repeat = window.setInterval(action, REPEAT_MS)
+      }, HOLD_DELAY)
+    },
+    onPointerUp: stop,
+    onPointerCancel: stop,
+    onPointerLeave: stop,
+    ...noCallout,
+  }), [stop])
+}
+

--- a/src/hooks/useTerrainVolume.ts
+++ b/src/hooks/useTerrainVolume.ts
@@ -65,9 +65,10 @@ function cellAt(
 }
 
 export function useTerrainVolume(win: ViewWindow, axes: ViewAxes): TerrainVolume {
-  const position = useCyberspace((s) => s.position)
+  // The anchor: the terrain is around whoever the scene is anchored on.
+  const position = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
-  const plane: Plane = useCyberspace((s) => s.plane)
+  const plane: Plane = useCyberspace((s) => s.anchorPlane)
 
   const [dataVersion, setDataVersion] = useState(0)
   const flushHandle = useRef<number | null>(null)

--- a/src/hooks/useViewWindow.ts
+++ b/src/hooks/useViewWindow.ts
@@ -37,7 +37,8 @@ const SETTLE_MS = 90
 
 export function useViewWindow(): ViewWindow {
   const cursor = useCyberspace((s) => s.cursor)
-  const position = useCyberspace((s) => s.position)
+  const anchor = useCyberspace((s) => s.anchor)
+  const exploreIndex = useCyberspace((s) => s.exploreIndex)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const view = useCyberspace((s) => s.view)
 
@@ -61,9 +62,9 @@ export function useViewWindow(): ViewWindow {
     return () => {
       if (handle.current !== null) clearTimeout(handle.current)
     }
-    // cursorOffset derives from exactly these four.
+    // cursorOffset derives from exactly these five.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cursor, position, scaleExp, view])
+  }, [cursor, anchor, exploreIndex, scaleExp, view])
 
   return win
 }

--- a/src/hud/BitReadout.tsx
+++ b/src/hud/BitReadout.tsx
@@ -73,11 +73,12 @@ export function BitReadout(): JSX.Element {
   // Open by default: it is the readout that explains what everything else on
   // screen costs, so it has to be seen before anyone would think to dismiss it.
   const [open, setOpen] = useState(true)
-  const position = useCyberspace((s) => s.position)
-  const cursor = useCyberspace((s) => s.cursor)
+  // At the head: you and the cursor. In history: the hop into the action
+  // shown, so scrubbing the chain reads each crossing's cost off the bits.
+  const [from, to] = useCyberspace((s) => s.readoutPair())
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const axes = useCyberspace((s) => s.axes())
-  const columns = xorReadout(position, cursor, axes, scaleExp)
+  const columns = xorReadout(from, to, axes, scaleExp)
 
   return (
     <div className="bits">

--- a/src/hud/ChainExplorer.tsx
+++ b/src/hud/ChainExplorer.tsx
@@ -1,0 +1,137 @@
+/**
+ * ChainExplorer.tsx — walk the chain, yours or anyone's.
+ *
+ * Every avatar is a line of signed actions, and the scene can stand at any
+ * point on that line: this is the instrument that moves you along it. Step
+ * back and forward, jump to the spawn or the head, or scrub the rail, and the
+ * whole scene re-anchors on that action: the avatar, the trail up to it, the
+ * terrain around it, the rooms, the XOR readout showing what that hop cost.
+ *
+ * It rides on the scene under the XOR readout rather than in a panel, for the
+ * same reason the readout does: it is something you work while looking at the
+ * space, not a fact you look up. Its heading is the chip that folds it away.
+ *
+ * Off the head the controls are withdrawn, because nothing in history is a
+ * place you can move from; LIVE brings them back. Held buttons rapid-fire, and
+ * [ ] Home End do the same from the keyboard.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { noCallout, useRepeatable } from '../hooks/useRepeatable'
+import { formatAgo, formatStamp, shortHex } from '../lib/time'
+import { useCyberspace } from '../store/useCyberspace'
+
+/** Past this many actions the rail stops drawing a tick per action. */
+const MAX_TICKS = 96
+
+export function ChainExplorer(): JSX.Element {
+  const events = useCyberspace((s) => s.events)
+  const exploreIndex = useCyberspace((s) => s.exploreIndex)
+  // Parsed once per chain change; the store caches, this just subscribes.
+  const actions = useMemo(() => useCyberspace.getState().actions(), [events])
+  const last = actions.length - 1
+  const index = exploreIndex ?? last
+  const action = actions[index]
+  const atHead = exploreIndex === null
+
+  const [open, setOpen] = useState(true)
+  // Relative times drift; refresh them on a slow clock rather than per frame.
+  const [now, setNow] = useState(() => Date.now() / 1000)
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now() / 1000), 10_000)
+    return () => window.clearInterval(t)
+  }, [])
+
+  const bind = useRepeatable()
+  const go = (i: number | null): void => useCyberspace.getState().explore(i)
+  const step = (d: number) => () => useCyberspace.getState().exploreStep(d)
+
+  // The rail: press or drag anywhere on it to land on the nearest action.
+  const rail = useRef<HTMLDivElement>(null)
+  const dragging = useRef(false)
+  const scrubTo = (clientX: number): void => {
+    const r = rail.current?.getBoundingClientRect()
+    if (!r || r.width === 0 || last <= 0) return
+    const t = Math.min(1, Math.max(0, (clientX - r.left) / r.width))
+    go(Math.round(t * last))
+  }
+
+  const fraction = last <= 0 ? 1 : index / last
+  const ticks = last + 1 <= MAX_TICKS ? actions.map((_, i) => (last === 0 ? 1 : i / last)) : []
+
+  return (
+    <div className="explorer">
+      <button
+        className="chip explorer__toggle"
+        {...noCallout}
+        onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); setOpen((v) => !v) }}
+        aria-label={open ? 'Hide chain explorer' : 'Show chain explorer'}
+        aria-pressed={open}
+      >
+        CHAIN {index + 1}/{actions.length}{atHead ? '' : ' HISTORY'}
+      </button>
+
+      {open && action && (
+        <div className={`explorer__body ${atHead ? '' : 'is-history'}`}>
+          <div className="explorer__row">
+            <button className="explorer__btn" title="Spawn (Home)" aria-label="Go to spawn" disabled={index === 0} {...noCallout}
+              onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); go(0) }}>|◀</button>
+            <button className="explorer__btn" title="Back (hold to repeat, [ key)" aria-label="Back one action" disabled={index === 0} {...bind(step(-1))}>◀</button>
+
+            <div
+              className="explorer__rail"
+              ref={rail}
+              role="slider"
+              aria-label="Chain position"
+              aria-valuemin={1}
+              aria-valuemax={actions.length}
+              aria-valuenow={index + 1}
+              {...noCallout}
+              onPointerDown={(e) => {
+                e.preventDefault(); e.stopPropagation()
+                dragging.current = true
+                ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+                scrubTo(e.clientX)
+              }}
+              onPointerMove={(e) => { if (dragging.current) scrubTo(e.clientX) }}
+              onPointerUp={() => { dragging.current = false }}
+              onPointerCancel={() => { dragging.current = false }}
+            >
+              <span className="explorer__line" />
+              <span className="explorer__walked" style={{ width: `${fraction * 100}%` }} />
+              {ticks.map((t, i) => (
+                <span key={i} className={`explorer__tick ${i === 0 ? 'explorer__tick--spawn' : ''}`} style={{ left: `${t * 100}%` }} />
+              ))}
+              <span className="explorer__mark" style={{ left: `${fraction * 100}%` }} />
+            </div>
+
+            <button className="explorer__btn" title="Forward (hold to repeat, ] key)" aria-label="Forward one action" disabled={index >= last} {...bind(step(1))}>▶</button>
+            <button className="explorer__btn" title="Head (End)" aria-label="Go to head" disabled={index >= last} {...noCallout}
+              onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); go(null) }}>▶|</button>
+          </div>
+
+          <div className="explorer__meta">
+            <span className={`explorer__type explorer__type--${action.type}`}>{action.type.toUpperCase()}</span>
+            <span className="explorer__when" title={formatStamp(action.createdAt)}>{formatAgo(action.createdAt, now)}</span>
+            {atHead ? (
+              <span className="explorer__live">LIVE</span>
+            ) : (
+              <button className="explorer__return" {...noCallout}
+                onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); go(null) }}>RETURN TO LIVE</button>
+            )}
+          </div>
+
+          <div className="explorer__detail" title={action.coordHex}>
+            <span className="explorer__key">C </span>{shortHex(action.coordHex, 10, 8)}
+            <span className="explorer__key">  S </span>{action.sector}
+          </div>
+          {action.proofHash && (
+            <div className="explorer__detail" title={action.proofHash}>
+              <span className="explorer__key">proof </span>{shortHex(action.proofHash, 10, 8)}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -172,6 +172,8 @@ function Controls(): JSX.Element {
     ['Q / E', 'scale step up / down (zoom out / in)'],
     ['R / F', 'cursor along depth axis'],
     ['P', 'toggle plane'],
+    ['[ / ]', 'chain explorer: back / forward one action'],
+    ['Home / End', 'chain explorer: spawn / live head'],
   ]
 
   return (

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -15,68 +15,10 @@
  * way WASD does and the two can never disagree about which way is up.
  */
 
-import { useCallback, useEffect, useRef } from 'react'
 import { useCyberspace } from '../store/useCyberspace'
 import { moveDirection, type MoveName } from '../lib/moves'
 import { MAX_SCALE_EXP } from '../lib/space'
-
-/**
- * Suppress the long-press callout.
- *
- * Holding a direction is a first-class gesture here, it is how you cross more
- * than a few gibsons, and on a touch device a long press is also how you ask for
- * a context menu. So the very thing the pad is designed for is what pops a
- * "copy / share" sheet over it on Android and a magnifier on iOS. The CSS half
- * of this lives in `-webkit-touch-callout: none`; this is the half that stops
- * the event a desktop right-click would raise on the same element.
- */
-const noCallout = { onContextMenu: (e: React.MouseEvent) => e.preventDefault() }
-
-/** Delay before a held button starts repeating, then the repeat period. */
-const HOLD_DELAY = 380
-const REPEAT_MS = 110
-
-/**
- * Fire on press, then repeat while held.
- *
- * Crossing a lot of gibsons one tap at a time would be miserable, and holding
- * is what the keyboard gives you for free through key repeat.
- */
-function useRepeatable(): (action: () => void) => {
-  onPointerDown: (e: React.PointerEvent) => void
-  onPointerUp: () => void
-  onPointerCancel: () => void
-  onPointerLeave: () => void
-  onContextMenu: (e: React.MouseEvent) => void
-} {
-  const timers = useRef<{ delay?: number; repeat?: number }>({})
-
-  const stop = useCallback(() => {
-    if (timers.current.delay) clearTimeout(timers.current.delay)
-    if (timers.current.repeat) clearInterval(timers.current.repeat)
-    timers.current = {}
-  }, [])
-
-  useEffect(() => stop, [stop])
-
-  return useCallback((action: () => void) => ({
-    onPointerDown: (e: React.PointerEvent) => {
-      // Keeps the press off the canvas and stops it becoming a scroll or a
-      // synthetic click that would fire the action twice.
-      e.preventDefault()
-      e.stopPropagation()
-      stop()
-      action()
-      timers.current.delay = window.setTimeout(() => {
-        timers.current.repeat = window.setInterval(action, REPEAT_MS)
-      }, HOLD_DELAY)
-    },
-    onPointerUp: stop,
-    onPointerCancel: stop,
-    onPointerLeave: stop,
-    ...noCallout,
-  }), [stop])
-}
+import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 
 export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Element {
   const proof = useCyberspace((s) => s.proof)

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,30 @@
+/**
+ * time.ts — when something happened, as a person would say it.
+ *
+ * Relative for the glance ("3 min ago"), with the caller free to put the exact
+ * stamp in a title. Coarse on purpose: the chain explorer and the avatar list
+ * are read while doing something else, and "47 minutes ago" is not a number
+ * anyone wanted.
+ */
+
+/** `at` and `now` in seconds since the epoch. */
+export function formatAgo(at: number, now: number = Date.now() / 1000): string {
+  const d = Math.max(0, Math.floor(now - at))
+  if (d < 5) return 'just now'
+  if (d < 60) return `${d} s ago`
+  if (d < 3600) return `${Math.floor(d / 60)} min ago`
+  if (d < 86400) return `${Math.floor(d / 3600)} h ago`
+  if (d < 86400 * 30) return `${Math.floor(d / 86400)} d ago`
+  return `${Math.floor(d / (86400 * 30))} mo ago`
+}
+
+/** Exact, for a title: local time, ISO-like, no milliseconds. */
+export function formatStamp(at: number): string {
+  return new Date(at * 1000).toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')
+}
+
+/** Short form of a 64-char hex id for a label, first and last few chars. */
+export function shortHex(hex: string, head = 8, tail = 6): string {
+  if (hex.length <= head + tail + 1) return hex
+  return `${hex.slice(0, head)}…${hex.slice(-tail)}`
+}

--- a/src/scene/CoveringBox.tsx
+++ b/src/scene/CoveringBox.tsx
@@ -39,10 +39,14 @@ export function CoveringBox({ axes }: Props): JSX.Element | null {
   const pendingTarget = useCyberspace((s) => s.pendingTarget)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const plane = useCyberspace((s) => s.plane)
+  const atHead = useCyberspace((s) => s.exploreIndex === null)
 
   const target = pendingTarget ?? cursor
 
   const box = useMemo(() => {
+    // In history nothing is being lined up, and the box would be drawn against
+    // an origin that is not the avatar's.
+    if (!atHead) return null
     const origin = alignedOrigin(position, scaleExp)
     const c = coveringBox(position, target, origin, scaleExp, axes, MAX_CELLS)
     // Nothing is being crossed while the cursor sits on the avatar, and a box
@@ -115,7 +119,7 @@ export function CoveringBox({ axes }: Props): JSX.Element | null {
       // and the two would otherwise print over each other.
       at: cellCentre(target, origin, scaleExp, axes),
     }
-  }, [position, target, scaleExp, plane, axes])
+  }, [position, target, scaleExp, plane, axes, atHead])
 
   if (!box) return null
 

--- a/src/scene/CrossingFlash.tsx
+++ b/src/scene/CrossingFlash.tsx
@@ -78,6 +78,9 @@ export function CrossingFlash({ axes }: Props): JSX.Element | null {
     const from = previous.current
     previous.current = position
     if (from.x === position.x && from.y === position.y && from.z === position.z) return
+    // A commit that lands while you are looking at history would flash in a
+    // frame anchored somewhere else entirely.
+    if (useCyberspace.getState().exploreIndex !== null) return
 
     const next = buildFlash(from, position, scaleExp, axes)
     setFlash((old) => {

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -84,9 +84,13 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const pendingTarget = useCyberspace((s) => s.pendingTarget)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const plane = useCyberspace((s) => s.plane)
+  const anchor = useCyberspace((s) => s.anchor)
+  const atHead = useCyberspace((s) => s.exploreIndex === null)
 
-  const target = pendingTarget ?? cursor
-  const active = !samePosition(position, target)
+  // In history there is no move being lined up, so no tether and no target
+  // cell. The scale label stays, riding the anchor instead of the cursor.
+  const target = atHead ? (pendingTarget ?? cursor) : anchor
+  const active = atHead && !samePosition(position, target)
 
   // The action being lined up: null legs when inactive; a landing splits the
   // journey when the direct hop is beyond the Cantor ceiling.
@@ -119,7 +123,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   // at its centre. The offset is 0.5 - 0.5/step, so it is invisible at scaleExp
   // 0 and grows to nearly half a cell by scaleExp 14.
   const points = useMemo(() => {
-    const origin = alignedOrigin(position, scaleExp)
+    const origin = alignedOrigin(anchor, scaleExp)
     const centre = (p: Position) => cellCentre(p, origin, scaleExp, axes)
     const b = centre(target)
     return {
@@ -128,7 +132,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
       landing: plan?.landing ? centre(plan.landing) : null,
       targetCell: b,
     }
-  }, [position, target, plan, scaleExp, axes])
+  }, [position, target, plan, scaleExp, axes, anchor])
 
   const leg1Geometry = useMemo(() => new BufferGeometry(), [])
   const leg2Geometry = useMemo(() => new BufferGeometry(), [])
@@ -168,8 +172,8 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const outline = useRef<LineSegments>(null)
   useFrame(() => {
     const s = useCyberspace.getState()
-    const live = s.pendingTarget ?? s.cursor
-    const b = cellCentre(live, alignedOrigin(s.position, s.scaleExp), s.scaleExp, axes)
+    const live = s.exploreIndex === null ? (s.pendingTarget ?? s.cursor) : s.anchor
+    const b = cellCentre(live, alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes)
     if (outline.current) outline.current.position.set(b[0], b[1], b[2])
     setSegmentEnd(leg2.visible ? leg2 : leg1, leg2.visible ? leg2Geometry : leg1Geometry, b)
   })
@@ -193,8 +197,8 @@ export function Cursor({ axes }: Props): JSX.Element | null {
         follow={() => {
           const s = useCyberspace.getState()
           return cellCentre(
-            s.pendingTarget ?? s.cursor,
-            alignedOrigin(s.position, s.scaleExp), s.scaleExp, axes,
+            s.exploreIndex === null ? (s.pendingTarget ?? s.cursor) : s.anchor,
+            alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes,
           )
         }}
       />

--- a/src/scene/Earth.tsx
+++ b/src/scene/Earth.tsx
@@ -53,9 +53,9 @@ function inCells(value: bigint, step: bigint): number {
 }
 
 export function Earth({ axes }: Props): JSX.Element | null {
-  const position = useCyberspace((s) => s.position)
+  const position = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
-  const plane = useCyberspace((s) => s.plane)
+  const plane = useCyberspace((s) => s.anchorPlane)
 
   const globe = useMemo(() => {
     // Ideaspace has no physical mapping at all (§9.1), so there is no planet in

--- a/src/scene/PathTrail.tsx
+++ b/src/scene/PathTrail.tsx
@@ -1,8 +1,10 @@
 /**
- * PathTrail.tsx - renders red lines connecting all committed positions.
+ * PathTrail.tsx - renders the chain as a line through cyberspace.
  *
- * Shows the movement chain as a visible trail through cyberspace.
- * Each segment connects consecutive positions in the history array.
+ * Each segment connects consecutive committed positions. When the scene is
+ * anchored on an earlier action, the trail up to that action is drawn in full
+ * and what came after it is drawn faint: the chain is the same object, you are
+ * just standing somewhere along it, and the faint part is where it goes next.
  */
 
 import { useMemo, useRef } from 'react'
@@ -20,38 +22,49 @@ interface Props {
 
 export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
   const positionHistory = useCyberspace((s) => s.positionHistory)
-  const position = useCyberspace((s) => s.position)
+  const anchor = useCyberspace((s) => s.anchor)
+  const exploreIndex = useCyberspace((s) => s.exploreIndex)
+
+  const split = exploreIndex ?? positionHistory.length - 1
 
   const geometry = useMemo(() => {
     if (positionHistory.length < 2) return null
 
-    const origin = alignedOrigin(position, scaleExp)
-    const vertices: number[] = []
+    const origin = alignedOrigin(anchor, scaleExp)
+    const walked: number[] = []
+    const ahead: number[] = []
 
     // All three axes. The trail used to map right and up only and pin depth to a
     // constant, so it drew a flat shadow of a 3D path: every out-axis hop
     // collapsed to nothing, and rotating the view changed which axis was being
     // flattened, so the shape changed with the view. Cell centres, matching the
     // cursor and the avatar, so a segment ends where its gibson is drawn.
-    const centre = (p: typeof position): [number, number, number] =>
+    const centre = (p: typeof anchor): [number, number, number] =>
       cellCentre(p, origin, scaleExp, axes)
 
     for (let i = 0; i < positionHistory.length - 1; i++) {
-      vertices.push(...centre(positionHistory[i]), ...centre(positionHistory[i + 1]))
+      const into = i < split ? walked : ahead
+      into.push(...centre(positionHistory[i]), ...centre(positionHistory[i + 1]))
     }
 
-    const geom = new BufferGeometry()
-    geom.setAttribute('position', new Float32BufferAttribute(vertices, 3))
-    return geom
-  }, [positionHistory, axes, scaleExp, position])
+    const make = (v: number[]): BufferGeometry | null => {
+      if (v.length === 0) return null
+      const geom = new BufferGeometry()
+      geom.setAttribute('position', new Float32BufferAttribute(v, 3))
+      return geom
+    }
+    return { walked: make(walked), ahead: make(ahead) }
+  }, [positionHistory, axes, scaleExp, anchor, split])
 
   // The newest segment ends on the avatar, which is drawn trailing behind its
   // committed cell for a moment after a commit. Left alone, the trail would
   // reach the destination while you were still visibly travelling to it, so the
-  // line would lead you there. Its final vertex rides the same offset.
+  // line would lead you there. Its final vertex rides the same offset. Only at
+  // the head: in history nothing is travelling.
   const lastVertex = useRef<Float32Array | null>(null)
   useFrame(() => {
-    const attr = geometry?.attributes.position
+    if (exploreIndex !== null) return
+    const attr = geometry?.walked?.attributes.position
     if (!attr) return
     const arr = attr.array as Float32Array
     const n = arr.length
@@ -66,8 +79,17 @@ export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
   if (!geometry) return null
 
   return (
-    <lineSegments geometry={geometry} frustumCulled={false}>
-      <lineBasicMaterial color="#ff0000" linewidth={2} toneMapped={false} />
-    </lineSegments>
+    <>
+      {geometry.walked && (
+        <lineSegments geometry={geometry.walked} frustumCulled={false}>
+          <lineBasicMaterial color="#ff0000" linewidth={2} toneMapped={false} />
+        </lineSegments>
+      )}
+      {geometry.ahead && (
+        <lineSegments geometry={geometry.ahead} frustumCulled={false}>
+          <lineBasicMaterial color="#ff0000" transparent opacity={0.22} toneMapped={false} />
+        </lineSegments>
+      )}
+    </>
   )
 }

--- a/src/scene/Rooms.tsx
+++ b/src/scene/Rooms.tsx
@@ -139,7 +139,7 @@ function gridGeometry(
 }
 
 export function Rooms({ axes }: Props): JSX.Element {
-  const position = useCyberspace((s) => s.position)
+  const position = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
 
   const levels = useMemo(() => {

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -214,7 +214,10 @@ function Rig(): JSX.Element {
     const c = controls.current
     if (!c) return
     const s = useCyberspace.getState()
-    const origin = alignedOrigin(s.position, s.scaleExp)
+    // The anchor, not the position: in history the scene is drawn from the
+    // action being looked at, and the camera has to ride that the same way it
+    // rides a commit.
+    const origin = alignedOrigin(s.anchor, s.scaleExp)
 
     // A commit re-anchors render space to the new avatar cell, so every
     // coordinate in the scene shifts at once. That is a change of frame, not

--- a/src/scene/SectorBox.tsx
+++ b/src/scene/SectorBox.tsx
@@ -19,7 +19,7 @@
 
 import { useMemo } from 'react'
 import { BoxGeometry, EdgesGeometry } from 'three'
-import { SECTOR_BITS_DEFAULT } from 'cyberspace-core'
+import { sectorTag, xyzToSectorId, SECTOR_BITS_DEFAULT } from 'cyberspace-core'
 import { GRID_RADIUS, cellDelta, type ViewAxes } from '../lib/space'
 import { SECTOR } from '../lib/palette'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
@@ -30,9 +30,9 @@ interface Props {
 }
 
 export function SectorBox({ axes }: Props): JSX.Element | null {
-  const position = useCyberspace((s) => s.position)
+  const position = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
-  const sectorId = useCyberspace((s) => s.sector())
+  const sectorId = sectorTag(xyzToSectorId(position.x, position.y, position.z))
 
   const box = useMemo(() => {
     // Cells across, at the current zoom. Fractional above scaleExp 30, where a

--- a/src/scene/SpawnMarker.tsx
+++ b/src/scene/SpawnMarker.tsx
@@ -59,7 +59,7 @@ interface Props {
 }
 
 function Model({ pubkey, axes }: Props): JSX.Element | null {
-  const position = useCyberspace((s) => s.position)
+  const position = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const gltf = useGLTF(MODEL) as unknown as {
     nodes: Record<string, Mesh>

--- a/src/scene/TargetProjector.tsx
+++ b/src/scene/TargetProjector.tsx
@@ -31,7 +31,9 @@ export function TargetProjector({ axes, targets }: Props): null {
 
   useFrame((state) => {
     const s = useCyberspace.getState()
-    const origin = alignedOrigin(s.position, s.scaleExp)
+    // Everything is measured from the anchor: the avatar being looked at, which
+    // is you at the head and whoever or whenever else the scene is anchored on.
+    const origin = alignedOrigin(s.anchor, s.scaleExp)
     const step = stepFor(s.scaleExp)
     const cam = state.camera as unknown as { fov?: number; position: Vector3 }
     state.camera.getWorldDirection(forward)
@@ -66,7 +68,7 @@ export function TargetProjector({ axes, targets }: Props): null {
       const sy = behind ? -scratch.y : scratch.y
 
       const dist = (a: 'x' | 'y' | 'z'): bigint => {
-        const d = t.at[a] - s.position[a]
+        const d = t.at[a] - s.anchor[a]
         return d < 0n ? -d : d
       }
       // Chebyshev rather than Euclidean: no bigint square root, and for "how far

--- a/src/store/explore.test.ts
+++ b/src/store/explore.test.ts
@@ -1,0 +1,95 @@
+/**
+ * explore.test.ts - the anchor follows the explored action, and only that.
+ *
+ * What would fail silently: the anchor staying on the live position while the
+ * index moves (the scene would not change), the camera offset still tracking a
+ * cursor that is not drawn, or a commit landing while you are in history and
+ * dragging the anchor to the new head.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import { SPAWN, useCyberspace } from './useCyberspace'
+
+function land(dx: bigint): void {
+  const s = useCyberspace.getState()
+  useCyberspace.setState({ pendingTarget: { ...s.position, x: s.position.x + dx } })
+  s.applyProofMessage({
+    type: 'done', id: 0, mode: 'hop', elapsedMs: 1, proofHash: 'ab'.repeat(32),
+    regionN: '1', terrainK: 8, lca: { x: 1, y: 0, z: 0 }, totalOps: 1,
+  })
+}
+
+describe('explore', () => {
+  beforeAll(() => {
+    // Three hops: the chain is spawn, +1, +2, +3.
+    land(1n); land(1n); land(1n)
+  })
+
+  it('starts at the head, anchored on the live position', () => {
+    const s = useCyberspace.getState()
+    expect(s.actions()).toHaveLength(4)
+    expect(s.exploreIndex).toBeNull()
+    expect(s.anchor).toEqual(s.position)
+    expect(s.atHead()).toBe(true)
+  })
+
+  it('anchors on the explored action and stops framing the cursor', () => {
+    useCyberspace.setState({ cursor: { ...SPAWN, x: SPAWN.x + 40n } })
+    useCyberspace.getState().explore(1)
+    const s = useCyberspace.getState()
+    expect(s.exploreIndex).toBe(1)
+    expect(s.anchor).toEqual({ ...SPAWN, x: SPAWN.x + 1n })
+    expect(s.position).toEqual({ ...SPAWN, x: SPAWN.x + 3n })
+    expect(s.atHead()).toBe(false)
+    expect(s.cursorOffset()).toEqual([0, 0, 0])
+  })
+
+  it('reads the hop into the explored action for the XOR readout', () => {
+    const [from, to] = useCyberspace.getState().readoutPair()
+    expect(from).toEqual(SPAWN)
+    expect(to).toEqual({ ...SPAWN, x: SPAWN.x + 1n })
+  })
+
+  it('steps and clamps at both ends', () => {
+    const s = useCyberspace.getState()
+    s.exploreStep(-5)
+    expect(useCyberspace.getState().exploreIndex).toBe(0)
+    expect(useCyberspace.getState().anchor).toEqual(SPAWN)
+    s.exploreStep(2)
+    expect(useCyberspace.getState().exploreIndex).toBe(2)
+    s.exploreStep(50)
+    expect(useCyberspace.getState().exploreIndex).toBeNull()
+    expect(useCyberspace.getState().atHead()).toBe(true)
+  })
+
+  it('refuses to move the cursor or commit from history', () => {
+    const s = useCyberspace.getState()
+    s.explore(0)
+    const cursor = useCyberspace.getState().cursor
+    s.moveCursor({ axis: 'x', dir: 1 })
+    expect(useCyberspace.getState().cursor).toEqual(cursor)
+    s.commit()
+    expect(useCyberspace.getState().proof.status).not.toBe('computing')
+  })
+
+  it('leaves the anchor in history when a commit lands, and follows once back at the head', () => {
+    useCyberspace.getState().explore(0)
+    land(1n)
+    let s = useCyberspace.getState()
+    expect(s.actions()).toHaveLength(5)
+    expect(s.exploreIndex).toBe(0)
+    expect(s.anchor).toEqual(SPAWN)
+    s.explore(null)
+    s = useCyberspace.getState()
+    expect(s.anchor).toEqual(s.position)
+    expect(s.position).toEqual({ ...SPAWN, x: SPAWN.x + 4n })
+  })
+
+  it('comes back to the head on a respawn', () => {
+    useCyberspace.getState().explore(2)
+    useCyberspace.getState().respawn()
+    const s = useCyberspace.getState()
+    expect(s.exploreIndex).toBeNull()
+    expect(s.anchor).toEqual(SPAWN)
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -55,6 +55,16 @@ import {
 } from '../lib/events'
 import { cancelProof, postProof, type ProofMode, type ProofResponse } from '../lib/workers'
 
+/**
+ * The explored chain, parsed once per events change rather than on every
+ * read. Every explorer selector goes through this.
+ */
+let actionsFor: { events: NostrEvent[]; actions: ActionEvent[] } | null = null
+function parsedChain(events: NostrEvent[]): ActionEvent[] {
+  if (!actionsFor || actionsFor.events !== events) actionsFor = { events, actions: buildChain(events) }
+  return actionsFor.actions
+}
+
 /** Matches cyberspace-core's DEFAULT_MAX_COMPUTE_HEIGHT. */
 export const MAX_COMPUTE_HEIGHT = 20
 
@@ -148,6 +158,20 @@ export interface CyberspaceState {
   chain: ChainStats
   /** History of all committed positions for rendering the path trail. */
   positionHistory: Position[]
+  /**
+   * Which action of the chain the scene is anchored on, or null for the head.
+   * Exploring history moves the anchor, not the avatar: nothing about the
+   * chain changes, only where you are looking from.
+   */
+  exploreIndex: number | null
+  /**
+   * The scene's render origin, materialised: the position of the action being
+   * looked at. Equal to `position` at the head. Every origin-relative thing in
+   * the scene reads this rather than `position`, which is what lets the same
+   * scene show you your own past and, later, someone else's present.
+   */
+  anchor: Position
+  anchorPlane: Plane
 
   moveCursor: (dir: AxisDirection) => void
   setCursorAtCell: (row: number, col: number) => void
@@ -169,6 +193,10 @@ export interface CyberspaceState {
    * anywhere.
    */
   respawn: () => void
+  /** Anchor the scene on action `index` of the chain; null or past the end is the head. */
+  explore: (index: number | null) => void
+  /** Step the explored index; clamps at both ends. */
+  exploreStep: (delta: number) => void
 
   axes: () => ViewAxes
   /** Axes as they appear on screen right now, including free orbit. */
@@ -179,6 +207,14 @@ export interface CyberspaceState {
   sector: () => string
   /** The chain, parsed. */
   actions: () => ActionEvent[]
+  /** True when the scene is anchored on the live head, where the controls apply. */
+  atHead: () => boolean
+  /**
+   * The two positions the XOR readout compares: at the head, where you stand
+   * and where the cursor is; in history, the action before the one shown and
+   * the one shown, so the readout explains what that hop cost.
+   */
+  readoutPair: () => [Position, Position]
   /** Which position the view centers on: cursor when active, avatar otherwise. */
   viewCenter: () => Position
   /**
@@ -314,6 +350,9 @@ function derive(saved: PersistedChain): {
   positionHistory: Position[]
   plane: Plane
   headPlane: Plane
+  exploreIndex: null
+  anchor: Position
+  anchorPlane: Plane
 } {
   const actions = buildChain(saved.events)
   const head = actions[actions.length - 1]
@@ -329,6 +368,9 @@ function derive(saved: PersistedChain): {
     positionHistory: actions.map((a) => a.position),
     plane: head.plane,
     headPlane: head.plane,
+    exploreIndex: null,
+    anchor: head.position,
+    anchorPlane: head.plane,
   }
 }
 
@@ -350,6 +392,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
 
   moveCursor: (dir) => {
     const { cursor, scaleExp } = get()
+    if (!get().atHead()) return
     const step = stepFor(scaleExp) * BigInt(dir.dir)
 
     const next: Position = { ...cursor }
@@ -384,6 +427,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     const { position, cursor, plane, headPlane, prevEventId, proof } = get()
     // One proof at a time. X cancels a commit you regret.
     if (proof.status === 'computing') return
+    // Looking at history: nothing here is a place you can move from.
+    if (!get().atHead()) return
     // Nothing lined up: same cell, same plane.
     if (samePosition(position, cursor) && plane === headPlane) return
 
@@ -526,9 +571,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     const nextEvents = [...events, event]
     const nextPublished = { ...published, [event.id]: 'queued' as const }
 
+    const following = get().exploreIndex === null
     set({
       position: newPosition,
       headPlane: plane,
+      ...(following ? { anchor: newPosition, anchorPlane: plane } : {}),
       pendingTarget: null,
       proof: {
         status: 'done',
@@ -576,6 +623,26 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     saveChain(fresh.events, fresh.published, fresh.chain)
   },
 
+  explore: (index) => {
+    const actions = get().actions()
+    const last = actions.length - 1
+    if (index === null || index >= last) {
+      const { position, headPlane } = get()
+      set({ exploreIndex: null, anchor: position, anchorPlane: headPlane })
+      return
+    }
+    const i = Math.max(0, Math.floor(index))
+    const a = actions[i]
+    set({ exploreIndex: i, anchor: a.position, anchorPlane: a.plane })
+  },
+
+  exploreStep: (delta) => {
+    const { exploreIndex } = get()
+    const last = get().actions().length - 1
+    const from = exploreIndex ?? last
+    get().explore(Math.min(last, Math.max(0, from + delta)))
+  },
+
   setPublishStatus: (id, status, reason) => {
     const { published, events, chain } = get()
     if (!(id in published)) return
@@ -609,7 +676,18 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     return sectorTag(xyzToSectorId(position.x, position.y, position.z))
   },
 
-  actions: () => buildChain(get().events),
+  actions: () => parsedChain(get().events),
+
+  atHead: () => get().exploreIndex === null,
+
+  readoutPair: () => {
+    const { exploreIndex, position, cursor } = get()
+    if (exploreIndex === null) return [position, cursor]
+    const actions = get().actions()
+    const here = actions[exploreIndex]?.position ?? position
+    const before = actions[exploreIndex - 1]?.position ?? here
+    return [before, here]
+  },
 
   /**
    * Which position the camera tracks: the cursor when it is away from the
@@ -628,9 +706,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
    * screen centre, so zooming tracks the cursor instead of the avatar.
    */
   cursorOffset: (): [number, number, number] => {
-    const { position, cursor, scaleExp, view } = get()
+    const { anchor, cursor, scaleExp, view, exploreIndex } = get()
+    // In history there is no cursor to frame; the camera sits on the anchor.
+    if (exploreIndex !== null) return [0, 0, 0]
     const axes = viewAxes(view)
-    const origin = alignedOrigin(position, scaleExp)
+    const origin = alignedOrigin(anchor, scaleExp)
     // Cell CENTRES, the same convention the cursor cube, the avatar and the path
     // trail draw with. This used to mix cellOffset on two axes with cellDelta on
     // the third, so the point field's focus, the camera target and the cursor

--- a/src/styles.css
+++ b/src/styles.css
@@ -598,6 +598,9 @@ body {
   display: flex;
   flex-direction: column;
   gap: 3px;
+  /* Never wider than the screen: on a phone the rail gives way, not the
+   * buttons, and the detail lines wrap rather than running off the edge. */
+  max-width: calc(100vw - 16px);
   padding: 6px 8px 7px;
   border-radius: 7px;
   background: rgba(6, 14, 22, 0.55);
@@ -649,7 +652,9 @@ body {
 
 .explorer__rail {
   position: relative;
-  width: 200px;
+  flex: 1 1 200px;
+  min-width: 90px;
+  max-width: 200px;
   height: 24px;
   cursor: pointer;
   touch-action: none;
@@ -716,7 +721,8 @@ body {
 .explorer__meta {
   display: flex;
   align-items: center;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 6px 10px;
   letter-spacing: 0.1em;
 }
 
@@ -758,7 +764,8 @@ body {
 
 .explorer__detail {
   color: var(--dim);
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .explorer__key {

--- a/src/styles.css
+++ b/src/styles.css
@@ -452,11 +452,19 @@ body {
  * it goes top left on every screen, opposite the compass on a phone and beside
  * the panel column on a desktop.
  */
-.bits {
+.instruments {
   position: absolute;
   top: 12px;
   left: 8px;
   z-index: 2;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.bits {
   pointer-events: none;
   display: flex;
   flex-direction: column;
@@ -562,6 +570,199 @@ body {
   .bits__col:not(:first-child) .bits__key {
     display: none;
   }
+}
+
+/* ---------- Chain explorer ----------
+ *
+ * Same voice as the readout above it: the world font, small, glowing. The rail
+ * is the one thing here that wants a finger, so it alone is generous.
+ */
+.explorer {
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-family: 'Monaspace Krypton', var(--mono);
+  font-size: 9px;
+  line-height: 1.5;
+  color: var(--fg);
+  text-shadow: 0 0 3px var(--bg), 0 0 4px currentColor, 0 0 12px currentColor;
+}
+
+.explorer__toggle {
+  pointer-events: auto;
+}
+
+.explorer__body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 6px 8px 7px;
+  border-radius: 7px;
+  background: rgba(6, 14, 22, 0.55);
+  border: 1px solid rgba(0, 229, 255, 0.18);
+  backdrop-filter: blur(6px);
+  pointer-events: auto;
+  text-shadow: none;
+}
+
+/* In history the block turns amber, the same colour the cursor goes when it is
+ * somewhere the avatar is not: you are looking at a place you are not at. */
+.explorer__body.is-history {
+  border-color: rgba(255, 176, 32, 0.45);
+}
+
+.explorer__row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.explorer__btn {
+  font-family: inherit;
+  font-size: 9px;
+  width: 26px;
+  height: 24px;
+  padding: 0;
+  border-radius: 5px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.8);
+  border: 1px solid rgba(0, 229, 255, 0.25);
+  cursor: pointer;
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.explorer__btn:active {
+  background: rgba(0, 229, 255, 0.28);
+  border-color: var(--accent);
+}
+
+.explorer__btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.explorer__rail {
+  position: relative;
+  width: 200px;
+  height: 24px;
+  cursor: pointer;
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.explorer__line,
+.explorer__walked {
+  position: absolute;
+  left: 0;
+  top: 11px;
+  height: 2px;
+  background: rgba(0, 229, 255, 0.22);
+}
+
+.explorer__line {
+  width: 100%;
+}
+
+.explorer__walked {
+  background: var(--accent);
+  box-shadow: 0 0 6px rgba(0, 229, 255, 0.6);
+}
+
+.is-history .explorer__walked {
+  background: var(--warn);
+  box-shadow: 0 0 6px rgba(255, 176, 32, 0.6);
+}
+
+.explorer__tick {
+  position: absolute;
+  top: 8px;
+  width: 1px;
+  height: 8px;
+  margin-left: -0.5px;
+  background: rgba(200, 245, 255, 0.35);
+}
+
+.explorer__tick--spawn {
+  width: 3px;
+  margin-left: -1.5px;
+  background: var(--fg);
+}
+
+.explorer__mark {
+  position: absolute;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+
+.is-history .explorer__mark {
+  background: var(--warn);
+  box-shadow: 0 0 8px var(--warn);
+}
+
+.explorer__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: 0.1em;
+}
+
+.explorer__type {
+  color: var(--accent);
+}
+
+.explorer__type--spawn {
+  color: var(--ok);
+}
+
+.explorer__type--sidestep {
+  color: var(--sidestep);
+}
+
+.explorer__when {
+  color: var(--dim);
+}
+
+.explorer__live {
+  margin-left: auto;
+  color: var(--ok);
+}
+
+.explorer__return {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  padding: 3px 7px;
+  border-radius: 5px;
+  color: #05070d;
+  background: var(--warn);
+  border: 1px solid var(--warn);
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.explorer__detail {
+  color: var(--dim);
+  white-space: pre;
+}
+
+.explorer__key {
+  color: rgba(0, 229, 255, 0.55);
 }
 
 /* ---------- Legend ---------- */
@@ -1256,7 +1457,7 @@ kbd {
    * top. It used to follow the compass to the bottom and sit above the
    * hamburger, which put the one readout you drive by in the corner you look
    * at least, behind the pad's row of buttons on a short window. */
-  .bits {
+  .instruments {
     left: 352px;
   }
 


### PR DESCRIPTION
Stack 5 (base: `feat/spawn-marker`, PR #19).

## What changes

- **Anchor.** The store materialises `anchor` / `anchorPlane`: the position of the chain action the scene is looking at (equal to `position` at the head). Every origin-relative component (rig, cursor, trail, Earth, targets, rooms, sector cage, terrain volume, spawn marker) reads the anchor instead of `position`. This is the refactor the spectate PR builds on.
- **Explore state.** `exploreIndex` (null = head), `explore(i)`, `exploreStep(d)`, `atHead()`, `readoutPair()`. Off the head: cursor moves and commits refuse, the pad and CONTROLS chip withdraw, no tether / covering box / crossing flash, camera sits on the anchor, trail is full up to the anchor and faint beyond, and the XOR readout shows the hop into the action shown.
- **Chain explorer instrument** under the XOR readout: `CHAIN n/N` chip, spawn / back / rail (press or drag) / forward / head, action type + relative time (exact in the title) + C / S / proof, `RETURN TO LIVE`. Held buttons rapid-fire via `hooks/useRepeatable` (extracted from TouchControls). Keyboard: `[` `]` `Home` `End`.

## Verification

- Tests: 118 passing (`store/explore.test.ts` new: anchoring, clamping, readout pair, controls refusing, commit landing while in history, respawn resetting).
- Browser: `[` twice anchors on action 2/4 (spawn marker at `(-1,0,0)`, pad gone, cursorOffset 0); rail drag scrubs to the spawn; `End` returns to live; held back button steps 5→4→3→2→1 at the repeat cadence; RETURN TO LIVE works; phone layout checked. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)