### PR TITLE
feat: spectate any avatar, with their chain in the explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ shows what that hop cost); what came after is drawn faint. Off the head the
 movement controls stand down and RETURN TO LIVE brings them back. The same
 instrument walks any other avatar's chain while spectating.
 
+**Spectating.** The Avatars panel lists every pubkey with a v2 action on the
+relay, newest first, with a field for any npub. SPECTATE anchors the scene on
+that avatar's chain head (their terrain, their rooms, their trail, their spawn
+marker), keeps their hops arriving live, hands the chain explorer their
+history, and points a YOU marker back at your own avatar. The panels lock, the
+movement controls stand down, the compass and view controls stay, and END
+SPECTATION brings you home.
+
 **The spawn marker.** v1's spawn model (`public/spawn.glb`: three hexagonal
 rings, a hollow cube, six radiating bars) stands at the pubkey coordinate,
 sized in cells like the avatar so it marks the spawn cell at any scale.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { BitReadout } from './hud/BitReadout'
 import { ChainExplorer } from './hud/ChainExplorer'
+import { SpectateBar } from './hud/SpectateBar'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
 import { TouchControls } from './hud/TouchControls'
@@ -25,19 +26,23 @@ export default function App(): JSX.Element {
   useEffect(() => startPublisher(), [])
   const isMobile = useIsMobile()
   const targets = useTargets()
-  // Off the head there is nothing to drive: the movement controls stand down
-  // and the explorer's RETURN TO LIVE is the way back.
-  const atHead = useCyberspace((s) => s.exploreIndex === null)
+  // Off your own head there is nothing to drive: the movement controls stand
+  // down and the explorer's RETURN TO LIVE is the way back.
+  const atHead = useCyberspace((s) => s.atHead())
+  // Spectating locks the panels: they describe you, and the scene is not about
+  // you right now. The bar carries what matters and the way out.
+  const spectating = useCyberspace((s) => s.spectate !== null)
 
   // Panels start open on a desktop and closed on a phone, and after that the
   // hamburger owns it on both. It used to be derived from the breakpoint, which
   // was necessary while the hamburger only existed on mobile: a stored `false`
   // would have stranded a desktop HUD with no control to bring it back.
   const [panelsOpen, setPanelsOpen] = useState(!isMobile)
+  const showPanels = panelsOpen && !spectating
 
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.
-  const crowded = isMobile && panelsOpen
+  const crowded = isMobile && showPanels
 
   const [padOpen, setPadOpen] = useState(true)
   const [viewMenuOpen, setViewMenuOpen] = useState(false)
@@ -64,7 +69,8 @@ export default function App(): JSX.Element {
           <ChainExplorer />
         </div>
       )}
-      {panelsOpen && <Hud menuOpen={crowded} />}
+      {showPanels && <Hud menuOpen={crowded} />}
+      <SpectateBar />
       {!crowded && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
       {!crowded && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && <TouchControls onDismiss={() => setPadOpen(false)} />}
@@ -81,7 +87,8 @@ export default function App(): JSX.Element {
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}
         onClick={() => setPanelsOpen((open) => !open)}
-        aria-label={panelsOpen ? 'Hide panels' : 'Show panels'}
+        disabled={spectating}
+        aria-label={spectating ? 'Panels locked while spectating' : panelsOpen ? 'Hide panels' : 'Show panels'}
       >
         <span className={`hamburger-icon ${panelsOpen ? 'hamburger-icon--open' : ''}`}>
           <span></span>

--- a/src/hooks/useRecentAvatars.ts
+++ b/src/hooks/useRecentAvatars.ts
@@ -1,0 +1,42 @@
+/**
+ * useRecentAvatars.ts — who has moved lately, newest first.
+ *
+ * One query for the newest v2 actions on the relay, folded to the newest per
+ * pubkey, then a live subscription so anyone who hops while the panel is open
+ * rises to the top. The relay cannot group by author, so the fold is ours;
+ * the limit is generous because one busy avatar can own most of the newest
+ * few hundred events.
+ */
+
+import { useEffect, useState } from 'react'
+import { fetchRecent, latestByPubkey, mergeEvents, watchRecent } from '../lib/chains'
+import type { ActionEvent, NostrEvent } from '../lib/events'
+
+export interface RecentAvatars {
+  avatars: ActionEvent[]
+  status: 'loading' | 'ready' | 'error'
+}
+
+export function useRecentAvatars(): RecentAvatars {
+  const [events, setEvents] = useState<NostrEvent[]>([])
+  const [status, setStatus] = useState<RecentAvatars['status']>('loading')
+
+  useEffect(() => {
+    let alive = true
+    const since = Math.floor(Date.now() / 1000) - 60
+    const close = watchRecent(since, (ev) => {
+      if (alive) setEvents((prev) => mergeEvents(prev, [ev]))
+    })
+    fetchRecent(400).then(
+      (fetched) => {
+        if (!alive) return
+        setEvents((prev) => mergeEvents(fetched, prev))
+        setStatus('ready')
+      },
+      () => { if (alive) setStatus('error') },
+    )
+    return () => { alive = false; close() }
+  }, [])
+
+  return { avatars: latestByPubkey(events), status }
+}

--- a/src/hooks/useTargets.ts
+++ b/src/hooks/useTargets.ts
@@ -12,15 +12,23 @@ import { EARTH } from '../lib/palette'
 import type { CyberTarget } from '../lib/targets'
 import { useCyberspace } from '../store/useCyberspace'
 
+/** The avatar's own red, so the marker for you is the colour you are drawn in. */
+const YOU = '#ff2323'
+
 /** §9.7: dataspace is centred on the half-axis point, 1 km = 1000 * 2^33. */
 const EARTH_CENTRE = 1n << 84n
 const EARTH_RADIUS = 6371n * 1000n * (1n << 33n)
 
 export function useTargets(): CyberTarget[] {
-  const plane = useCyberspace((s) => s.plane)
+  const plane = useCyberspace((s) => s.anchorPlane)
+  const spectating = useCyberspace((s) => s.spectate !== null)
+  const position = useCyberspace((s) => s.position)
 
   return useMemo(() => {
     const out: CyberTarget[] = []
+    // While you are looking through someone else's eyes, the way home is a
+    // thing worth pointing at from anywhere.
+    if (spectating) out.push({ id: 'you', label: 'YOU', color: YOU, at: position })
     // Ideaspace has no physical mapping, so there is no planet in it to point at.
     if (plane === 0) {
       out.push({
@@ -32,5 +40,5 @@ export function useTargets(): CyberTarget[] {
       })
     }
     return out
-  }, [plane])
+  }, [plane, spectating, position])
 }

--- a/src/hud/AvatarsPanel.tsx
+++ b/src/hud/AvatarsPanel.tsx
@@ -1,0 +1,96 @@
+/**
+ * AvatarsPanel.tsx — everyone else, by how recently they moved.
+ *
+ * Each row is a pubkey and its newest action on the relay. SPECTATE anchors
+ * the scene on that avatar's chain head and hands the explorer their history;
+ * the field above takes any npub or hex key, for someone who has not moved
+ * lately or is not on this relay's feed at all. Your own key is listed when it
+ * has published, marked YOU, since spectating yourself is just being here.
+ */
+
+import { useEffect, useState } from 'react'
+import { useRecentAvatars } from '../hooks/useRecentAvatars'
+import { parsePubkey } from '../lib/chains'
+import { CYBERSPACE_RELAY } from '../lib/relay'
+import { spectate } from '../lib/spectator'
+import { formatAgo, formatStamp } from '../lib/time'
+import { useCyberspace } from '../store/useCyberspace'
+import { nip19 } from 'nostr-tools'
+
+/** Enough to tell keys apart; the title carries the whole npub. */
+function shortNpub(pubkey: string): string {
+  const npub = nip19.npubEncode(pubkey)
+  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
+}
+
+export function AvatarsPanel(): JSX.Element {
+  const { avatars, status } = useRecentAvatars()
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const [input, setInput] = useState('')
+  const [now, setNow] = useState(() => Date.now() / 1000)
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now() / 1000), 10_000)
+    return () => window.clearInterval(t)
+  }, [])
+
+  const typed = parsePubkey(input)
+
+  const go = (pubkey: string): void => {
+    setInput('')
+    void spectate(pubkey)
+  }
+
+  return (
+    <section className="panel panel--avatars">
+      <header className="panel__head">
+        <h2>Avatars</h2>
+        <span className="tag">{status === 'loading' ? 'LOADING' : `${avatars.length} SEEN`}</span>
+      </header>
+
+      <form
+        className="avatars__find"
+        onSubmit={(e) => { e.preventDefault(); if (typed) go(typed) }}
+      >
+        <input
+          className="avatars__input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="npub or hex pubkey"
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="Pubkey to spectate"
+        />
+        <button className="avatars__go" type="submit" disabled={!typed}>SPECTATE</button>
+      </form>
+
+      {status === 'error' && <p className="notice">Could not reach {CYBERSPACE_RELAY.replace('wss://', '')}.</p>}
+
+      <ul className="avatars__list">
+        {avatars.map((a) => {
+          const you = a.pubkey === me
+          return (
+            <li key={a.pubkey} className="avatars__row">
+              <span className="avatars__who" title={nip19.npubEncode(a.pubkey)}>{shortNpub(a.pubkey)}</span>
+              <span className={`avatars__type avatars__type--${a.type}`}>{a.type.toUpperCase()}</span>
+              <span className="avatars__when" title={formatStamp(a.createdAt)}>{formatAgo(a.createdAt, now)}</span>
+              {you ? (
+                <span className="avatars__you">YOU</span>
+              ) : (
+                <button className="avatars__spectate" onClick={() => go(a.pubkey)}>SPECTATE</button>
+              )}
+            </li>
+          )
+        })}
+        {status === 'ready' && avatars.length === 0 && (
+          <li className="avatars__empty">No v2 actions on the relay yet.</li>
+        )}
+      </ul>
+
+      <p className="legend__note">
+        Newest kind:3333 action per pubkey on {CYBERSPACE_RELAY.replace('wss://', '')}.
+        Spectating anchors the scene on their chain head and gives the chain
+        explorer their history; the controls stand down until you end it.
+      </p>
+    </section>
+  )
+}

--- a/src/hud/ChainExplorer.tsx
+++ b/src/hud/ChainExplorer.tsx
@@ -26,9 +26,10 @@ const MAX_TICKS = 96
 
 export function ChainExplorer(): JSX.Element {
   const events = useCyberspace((s) => s.events)
+  const spectate = useCyberspace((s) => s.spectate)
   const exploreIndex = useCyberspace((s) => s.exploreIndex)
   // Parsed once per chain change; the store caches, this just subscribes.
-  const actions = useMemo(() => useCyberspace.getState().actions(), [events])
+  const actions = useMemo(() => useCyberspace.getState().focusChain(), [events, spectate])
   const last = actions.length - 1
   const index = exploreIndex ?? last
   const action = actions[index]
@@ -58,6 +59,9 @@ export function ChainExplorer(): JSX.Element {
 
   const fraction = last <= 0 ? 1 : index / last
   const ticks = last + 1 <= MAX_TICKS ? actions.map((_, i) => (last === 0 ? 1 : i / last)) : []
+
+  // A spectated pubkey with nothing on the relay has no chain to walk.
+  if (actions.length === 0) return <></>
 
   return (
     <div className="explorer">
@@ -114,10 +118,10 @@ export function ChainExplorer(): JSX.Element {
             <span className={`explorer__type explorer__type--${action.type}`}>{action.type.toUpperCase()}</span>
             <span className="explorer__when" title={formatStamp(action.createdAt)}>{formatAgo(action.createdAt, now)}</span>
             {atHead ? (
-              <span className="explorer__live">LIVE</span>
+              <span className="explorer__live">{spectate ? 'THEIR HEAD' : 'LIVE'}</span>
             ) : (
               <button className="explorer__return" {...noCallout}
-                onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); go(null) }}>RETURN TO LIVE</button>
+                onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); go(null) }}>{spectate ? 'TO THEIR HEAD' : 'RETURN TO LIVE'}</button>
             )}
           </div>
 

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -5,6 +5,7 @@
 
 import { formatBig, formatStep } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
+import { AvatarsPanel } from './AvatarsPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
 import { Legend } from './Legend'
@@ -202,6 +203,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <Brand />
         <IdentityPanel />
         <PositionPanel />
+        <AvatarsPanel />
         <ScalePanel />
         <LinksPanel />
       </div>

--- a/src/hud/SpectateBar.tsx
+++ b/src/hud/SpectateBar.tsx
@@ -1,0 +1,48 @@
+/**
+ * SpectateBar.tsx — what is true while you are looking through someone else.
+ *
+ * Whose chain this is, when they last moved, and the one way out. It stays
+ * on screen the whole time the panels are locked, because a scene anchored on
+ * a stranger with nothing saying so would read as a bug: your avatar gone,
+ * your controls gone, the terrain unfamiliar.
+ */
+
+import { useEffect, useState } from 'react'
+import { stopSpectating } from '../lib/spectator'
+import { formatAgo, formatStamp } from '../lib/time'
+import { useCyberspace } from '../store/useCyberspace'
+
+export function SpectateBar(): JSX.Element | null {
+  const spectate = useCyberspace((s) => s.spectate)
+  const [now, setNow] = useState(() => Date.now() / 1000)
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now() / 1000), 5_000)
+    return () => window.clearInterval(t)
+  }, [])
+
+  if (!spectate) return null
+
+  const short = `${spectate.npub.slice(0, 12)}…${spectate.npub.slice(-6)}`
+  const status =
+    spectate.status === 'loading' ? 'FETCHING CHAIN'
+      : spectate.status === 'error' ? 'RELAY UNREACHABLE'
+        : spectate.status === 'empty' ? 'NO CHAIN ON RELAY, AT PUBKEY COORDINATE'
+          : `${spectate.actions.length} ACTION${spectate.actions.length === 1 ? '' : 'S'}`
+
+  return (
+    <div className="spectate" role="status">
+      <span className="spectate__eye" aria-hidden="true">◉</span>
+      <span className="spectate__text">
+        <span className="spectate__label">SPECTATING</span>
+        <span className="spectate__who" title={spectate.npub}>{short}</span>
+        <span className="spectate__meta">
+          {spectate.lastActive !== null && (
+            <span title={formatStamp(spectate.lastActive)}>LAST ACTIVE {formatAgo(spectate.lastActive, now).toUpperCase()} · </span>
+          )}
+          {status}
+        </span>
+      </span>
+      <button className="spectate__end" onClick={stopSpectating}>END SPECTATION</button>
+    </div>
+  )
+}

--- a/src/lib/chains.test.ts
+++ b/src/lib/chains.test.ts
@@ -1,0 +1,49 @@
+/**
+ * chains.test.ts - the relay feed is folded client-side, so the fold is tested.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { nip19 } from 'nostr-tools'
+import { hopTemplate, spawnTemplate, type NostrEvent } from './events'
+import { latestByPubkey, mergeEvents, parsePubkey } from './chains'
+
+const a = generateSecretKey(), b = generateSecretKey()
+const pa = getPublicKey(a), pb = getPublicKey(b)
+const spawnA = finalizeEvent(spawnTemplate(pa, 100), a)
+const spawnB = finalizeEvent(spawnTemplate(pb, 150), b)
+const hopA = finalizeEvent(hopTemplate({
+  createdAt: 200, genesisId: spawnA.id, previousId: spawnA.id, prevCoordHex: pa,
+  to: { x: 1n, y: 2n, z: 3n }, plane: 0, proofHash: '0'.repeat(64),
+}), a)
+const v1: NostrEvent = { ...spawnB, id: 'f'.repeat(64), tags: [['A', 'drift'], ['C', pb]], created_at: 999 }
+
+describe('latestByPubkey', () => {
+  it('keeps the newest action per pubkey, newest pubkey first', () => {
+    const out = latestByPubkey([spawnA, spawnB, hopA])
+    expect(out.map((e) => [e.pubkey, e.type])).toEqual([[pa, 'hop'], [pb, 'spawn']])
+  })
+
+  it('ignores v1 and malformed events', () => {
+    const out = latestByPubkey([v1, spawnB])
+    expect(out).toHaveLength(1)
+    expect(out[0].id).toBe(spawnB.id)
+  })
+})
+
+describe('mergeEvents', () => {
+  it('unions by id and keeps the first order', () => {
+    const out = mergeEvents([spawnA], [hopA, spawnA, hopA])
+    expect(out.map((e) => e.id)).toEqual([spawnA.id, hopA.id])
+  })
+})
+
+describe('parsePubkey', () => {
+  it('accepts hex and npub, rejects the rest', () => {
+    expect(parsePubkey(pa)).toBe(pa)
+    expect(parsePubkey(pa.toUpperCase())).toBe(pa)
+    expect(parsePubkey(`  ${nip19.npubEncode(pa)} `)).toBe(pa)
+    expect(parsePubkey('npub1notakey')).toBeNull()
+    expect(parsePubkey('xyz')).toBeNull()
+  })
+})

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -1,0 +1,85 @@
+/**
+ * chains.ts — other people's chains, from the relay.
+ *
+ * The relay holds every kind:3333 ever published to it, and almost all of it
+ * is v1: drift and noop actions from the proof-of-work era, which this client
+ * cannot place. Every query here filters the `A` tag to the v2 actions, which
+ * is what keeps a v1 avatar's ten thousand drifts from swamping the feed the
+ * moment an old client comes back online.
+ *
+ * Pure helpers first, so the ordering and merging rules can be tested without
+ * a socket; the relay calls below are thin.
+ */
+
+import { buildChain, parseAction, type ActionEvent, type NostrEvent } from './events'
+import { nip19 } from 'nostr-tools'
+import { query, subscribe } from './relay'
+
+/** The actions this client understands, and therefore the only ones it asks for. */
+export const V2_ACTIONS = ['spawn', 'hop', 'sidestep']
+
+const KIND = 3333
+
+/** The newest v2 action per pubkey, newest pubkey first. */
+export function latestByPubkey(events: NostrEvent[]): ActionEvent[] {
+  const best = new Map<string, ActionEvent>()
+  for (const ev of events) {
+    const a = parseAction(ev)
+    if (!a) continue
+    const cur = best.get(a.pubkey)
+    if (!cur || a.createdAt > cur.createdAt || (a.createdAt === cur.createdAt && a.id > cur.id)) {
+      best.set(a.pubkey, a)
+    }
+  }
+  return [...best.values()].sort((x, y) => y.createdAt - x.createdAt || (x.id < y.id ? 1 : -1))
+}
+
+/** Union by id, order preserved: what was there first stays first. */
+export function mergeEvents(existing: NostrEvent[], incoming: NostrEvent[]): NostrEvent[] {
+  const seen = new Set(existing.map((e) => e.id))
+  const out = existing.slice()
+  for (const e of incoming) {
+    if (seen.has(e.id)) continue
+    seen.add(e.id)
+    out.push(e)
+  }
+  return out
+}
+
+/** Everything the relay has for one pubkey's v2 chain, raw. */
+export function fetchChainEvents(pubkey: string): Promise<NostrEvent[]> {
+  return query({ kinds: [KIND], authors: [pubkey], '#A': V2_ACTIONS })
+}
+
+/** The same, assembled. */
+export async function fetchChain(pubkey: string): Promise<ActionEvent[]> {
+  return buildChain(await fetchChainEvents(pubkey))
+}
+
+/** The newest v2 actions on the relay, any author. */
+export function fetchRecent(limit = 400): Promise<NostrEvent[]> {
+  return query({ kinds: [KIND], '#A': V2_ACTIONS, limit })
+}
+
+/** New v2 actions from anyone, from `since` on. */
+export function watchRecent(since: number, onEvent: (ev: NostrEvent) => void): () => void {
+  return subscribe({ kinds: [KIND], '#A': V2_ACTIONS, since }, onEvent)
+}
+
+/** New v2 actions from one author, from `since` on. */
+export function watchAuthor(pubkey: string, since: number, onEvent: (ev: NostrEvent) => void): () => void {
+  return subscribe({ kinds: [KIND], authors: [pubkey], '#A': V2_ACTIONS, since }, onEvent)
+}
+
+/** Accepts an npub or 64-char hex; returns hex, or null when it is neither. */
+export function parsePubkey(input: string): string | null {
+  const v = input.trim()
+  if (/^[0-9a-f]{64}$/i.test(v)) return v.toLowerCase()
+  if (!/^npub1/i.test(v)) return null
+  try {
+    const decoded = nip19.decode(v.toLowerCase())
+    return decoded.type === 'npub' ? decoded.data : null
+  } catch {
+    return null
+  }
+}

--- a/src/lib/spectator.ts
+++ b/src/lib/spectator.ts
@@ -1,0 +1,47 @@
+/**
+ * spectator.ts — follows one avatar's chain off the relay and into the store.
+ *
+ * The store holds the spectated chain and decides what the scene does with
+ * it; this is the socket side: fetch the chain, then keep a subscription open
+ * for whatever that pubkey publishes next, so their hops arrive while you
+ * watch. A module singleton, because there is one spectated avatar at a time
+ * and a subscription has to outlive any component.
+ */
+
+import { fetchChainEvents, mergeEvents, watchAuthor } from './chains'
+import { useCyberspace } from '../store/useCyberspace'
+
+let current: { pubkey: string; close: () => void } | null = null
+
+export async function spectate(pubkey: string): Promise<void> {
+  stopSpectating()
+  const store = useCyberspace.getState()
+  store.beginSpectate(pubkey)
+
+  // Anything published while the fetch is in flight is caught by the watch,
+  // which starts from a minute ago so nothing falls between the two.
+  const since = Math.floor(Date.now() / 1000) - 60
+  let events: ReturnType<typeof mergeEvents> = []
+  const close = watchAuthor(pubkey, since, (ev) => {
+    if (current?.pubkey !== pubkey) return
+    events = mergeEvents(events, [ev])
+    useCyberspace.getState().setSpectateChain(pubkey, events)
+  })
+  current = { pubkey, close }
+
+  try {
+    const fetched = await fetchChainEvents(pubkey)
+    if (current?.pubkey !== pubkey) return
+    events = mergeEvents(fetched, events)
+    useCyberspace.getState().setSpectateChain(pubkey, events)
+  } catch {
+    if (current?.pubkey !== pubkey) return
+    useCyberspace.getState().setSpectateChain(pubkey, events, 'error')
+  }
+}
+
+export function stopSpectating(): void {
+  current?.close()
+  current = null
+  if (useCyberspace.getState().spectate) useCyberspace.getState().endSpectate()
+}

--- a/src/scene/CoveringBox.tsx
+++ b/src/scene/CoveringBox.tsx
@@ -39,7 +39,7 @@ export function CoveringBox({ axes }: Props): JSX.Element | null {
   const pendingTarget = useCyberspace((s) => s.pendingTarget)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const plane = useCyberspace((s) => s.plane)
-  const atHead = useCyberspace((s) => s.exploreIndex === null)
+  const atHead = useCyberspace((s) => s.atHead())
 
   const target = pendingTarget ?? cursor
 

--- a/src/scene/CrossingFlash.tsx
+++ b/src/scene/CrossingFlash.tsx
@@ -80,7 +80,7 @@ export function CrossingFlash({ axes }: Props): JSX.Element | null {
     if (from.x === position.x && from.y === position.y && from.z === position.z) return
     // A commit that lands while you are looking at history would flash in a
     // frame anchored somewhere else entirely.
-    if (useCyberspace.getState().exploreIndex !== null) return
+    if (!useCyberspace.getState().atHead()) return
 
     const next = buildFlash(from, position, scaleExp, axes)
     setFlash((old) => {

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -85,7 +85,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const plane = useCyberspace((s) => s.plane)
   const anchor = useCyberspace((s) => s.anchor)
-  const atHead = useCyberspace((s) => s.exploreIndex === null)
+  const atHead = useCyberspace((s) => s.atHead())
 
   // In history there is no move being lined up, so no tether and no target
   // cell. The scale label stays, riding the anchor instead of the cursor.
@@ -172,7 +172,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const outline = useRef<LineSegments>(null)
   useFrame(() => {
     const s = useCyberspace.getState()
-    const live = s.exploreIndex === null ? (s.pendingTarget ?? s.cursor) : s.anchor
+    const live = s.atHead() ? (s.pendingTarget ?? s.cursor) : s.anchor
     const b = cellCentre(live, alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes)
     if (outline.current) outline.current.position.set(b[0], b[1], b[2])
     setSegmentEnd(leg2.visible ? leg2 : leg1, leg2.visible ? leg2Geometry : leg1Geometry, b)
@@ -197,7 +197,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
         follow={() => {
           const s = useCyberspace.getState()
           return cellCentre(
-            s.exploreIndex === null ? (s.pendingTarget ?? s.cursor) : s.anchor,
+            s.atHead() ? (s.pendingTarget ?? s.cursor) : s.anchor,
             alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes,
           )
         }}

--- a/src/scene/PathTrail.tsx
+++ b/src/scene/PathTrail.tsx
@@ -21,10 +21,16 @@ interface Props {
 }
 
 export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
-  const positionHistory = useCyberspace((s) => s.positionHistory)
+  const ownHistory = useCyberspace((s) => s.positionHistory)
+  const spectate = useCyberspace((s) => s.spectate)
   const anchor = useCyberspace((s) => s.anchor)
   const exploreIndex = useCyberspace((s) => s.exploreIndex)
 
+  // Whose trail: the spectated avatar's chain, else your own.
+  const positionHistory = useMemo(
+    () => (spectate ? spectate.actions.map((a) => a.position) : ownHistory),
+    [spectate, ownHistory],
+  )
   const split = exploreIndex ?? positionHistory.length - 1
 
   const geometry = useMemo(() => {
@@ -63,7 +69,7 @@ export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
   // the head: in history nothing is travelling.
   const lastVertex = useRef<Float32Array | null>(null)
   useFrame(() => {
-    if (exploreIndex !== null) return
+    if (exploreIndex !== null || spectate) return
     const attr = geometry?.walked?.attributes.position
     if (!attr) return
     const arr = attr.array as Float32Array

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -62,7 +62,7 @@ const FOLLOW_TAU = 0.09
 function World(): JSX.Element {
   const view = useCyberspace((s) => s.view)
   const scaleExp = useCyberspace((s) => s.scaleExp)
-  const pubkey = useCyberspace((s) => s.identity.pubkey)
+  const pubkey = useCyberspace((s) => s.focusPubkey())
   const axes = useMemo(() => useCyberspace.getState().axes(), [view])
 
   const win = useViewWindow()
@@ -178,6 +178,7 @@ function CellMetric(): null {
 function Rig(): JSX.Element {
   const view = useCyberspace((s) => s.view)
   const genesisId = useCyberspace((s) => s.genesisId)
+  const focusPubkey = useCyberspace((s) => s.focusPubkey())
   const controls = useRef<{
     object: { position: Vector3 }
     target: Vector3
@@ -208,7 +209,7 @@ function Rig(): JSX.Element {
     locked.current = true
     prevOrigin.current = null
     c.update()
-  }, [view, genesisId])
+  }, [view, genesisId, focusPubkey])
 
   useFrame((_, dt) => {
     const c = controls.current

--- a/src/scene/Travel.tsx
+++ b/src/scene/Travel.tsx
@@ -1,13 +1,16 @@
 /**
- * Travel.tsx — drives the avatar's catch-up after a commit.
+ * Travel.tsx — drives the avatar's catch-up after a move.
  *
- * Watches the committed position. `position` only advances when a proof lands
- * (`applyProofMessage` sets it, and nothing else does), so this fires at exactly
- * the right moment on its own: nothing moves while the work is being done, and
- * the journey begins the instant it is paid for. That ordering is the point.
- * Sliding during the computation would imply the move was already happening,
- * when in fact the whole premise of the protocol is that it has to be earned
- * first.
+ * Watches the anchor. At your own head that advances only when a proof lands
+ * (`applyProofMessage` sets it, and nothing else does), so this fires at
+ * exactly the right moment on its own: nothing moves while the work is being
+ * done, and the journey begins the instant it is paid for. That ordering is
+ * the point. Sliding during the computation would imply the move was already
+ * happening, when in fact the whole premise of the protocol is that it has to
+ * be earned first. While spectating, the anchor advances when THEIR proof
+ * lands on the relay, and the same catch-up shows their hop.
+ *
+ * Scrubbing history and changing whose chain is shown are not moves, and snap.
  *
  * Duration scales mildly with distance so a one gibson step is a flick and a
  * long haul reads as a haul, but it is clamped: this is punctuation on a commit,
@@ -32,32 +35,33 @@ interface Props {
 }
 
 export function Travel({ axes }: Props): null {
-  const position = useCyberspace((s) => s.position)
+  const anchor = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
-  const genesisId = useCyberspace((s) => s.genesisId)
+  // A new chain (respawn) or a new avatar (spectate) is a cut, not a journey.
+  const focusKey = useCyberspace((s) => `${s.focusPubkey()}:${s.genesisId}`)
+  const exploring = useCyberspace((s) => s.exploreIndex !== null)
 
-  const previous = useRef<Position>(position)
-  const previousGenesis = useRef(genesisId)
+  const previous = useRef<Position>(anchor)
+  const previousKey = useRef(focusKey)
   const from = useRef(new Vector3())
   const duration = useRef(0)
   const startedAt = useRef<number | null>(null)
 
   useEffect(() => {
     const old = previous.current
-    previous.current = position
-    if (old.x === position.x && old.y === position.y && old.z === position.z) return
+    previous.current = anchor
+    if (old.x === anchor.x && old.y === anchor.y && old.z === anchor.z) return
 
-    // A respawn is not a move. Nothing was paid for the distance back to the
-    // pubkey, so nothing should be seen to travel it, however short it is.
-    if (previousGenesis.current !== genesisId) {
-      previousGenesis.current = genesisId
+    const cut = previousKey.current !== focusKey || exploring
+    previousKey.current = focusKey
+    if (cut) {
       travelOffset.set(0, 0, 0)
       startedAt.current = null
       return
     }
 
     // Where the avatar was, expressed against the origin it now uses.
-    const [x, y, z] = cellCentre(old, alignedOrigin(position, scaleExp), scaleExp, axes)
+    const [x, y, z] = cellCentre(old, alignedOrigin(anchor, scaleExp), scaleExp, axes)
     from.current.set(x, y, z)
 
     // A hop far enough to leave the drawn world would animate a mesh nobody can
@@ -74,7 +78,7 @@ export function Travel({ axes }: Props): null {
     // scaleExp and axes are read at commit time on purpose: a zoom or a rotation
     // mid-flight must not restart or re-aim a journey already under way.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [position, genesisId])
+  }, [anchor, focusKey])
 
   useFrame((state) => {
     if (travelOffset.lengthSq() === 0) return

--- a/src/store/spectate.test.ts
+++ b/src/store/spectate.test.ts
@@ -1,0 +1,105 @@
+/**
+ * spectate.test.ts - someone else's chain becomes the focus chain, and only
+ * the focus: your own position, cursor and chain are untouched throughout.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { coordToXyz, hexToCoord } from 'cyberspace-core'
+import { hopTemplate, spawnTemplate, type NostrEvent } from '../lib/events'
+import { SPAWN, useCyberspace } from './useCyberspace'
+
+const sk = generateSecretKey()
+const pk = getPublicKey(sk)
+const theirSpawn = coordToXyz(hexToCoord(pk))
+const spawn = finalizeEvent(spawnTemplate(pk, 100), sk)
+function hop(prev: NostrEvent, at: number, dx: bigint): NostrEvent {
+  const prevC = prev.tags.find((t) => t[0] === 'C')![1]
+  const from = coordToXyz(hexToCoord(prevC))
+  return finalizeEvent(hopTemplate({
+    createdAt: at, genesisId: spawn.id, previousId: prev.id, prevCoordHex: prevC,
+    to: { x: from.x + dx, y: from.y, z: from.z }, plane: from.plane, proofHash: '1'.repeat(64),
+  }), sk)
+}
+const h1 = hop(spawn, 110, 1n)
+const h2 = hop(h1, 120, 1n)
+
+describe('spectate', () => {
+  it('begins at their spawn coordinate while the chain loads', () => {
+    useCyberspace.getState().beginSpectate(pk)
+    const s = useCyberspace.getState()
+    expect(s.spectate?.status).toBe('loading')
+    expect(s.anchor).toEqual({ x: theirSpawn.x, y: theirSpawn.y, z: theirSpawn.z })
+    expect(s.anchorPlane).toBe(theirSpawn.plane)
+    expect(s.atHead()).toBe(false)
+    expect(s.cursorOffset()).toEqual([0, 0, 0])
+    expect(s.focusPubkey()).toBe(pk)
+  })
+
+  it('anchors on their head once the chain arrives, and the explorer walks it', () => {
+    useCyberspace.getState().setSpectateChain(pk, [h2, spawn, h1])
+    let s = useCyberspace.getState()
+    expect(s.spectate?.status).toBe('live')
+    expect(s.spectate?.lastActive).toBe(120)
+    expect(s.focusChain().map((a) => a.id)).toEqual([spawn.id, h1.id, h2.id])
+    expect(s.anchor.x).toBe(theirSpawn.x + 2n)
+    expect(s.readoutPair().map((p) => p.x)).toEqual([theirSpawn.x + 1n, theirSpawn.x + 2n])
+
+    s.explore(0)
+    s = useCyberspace.getState()
+    expect(s.anchor.x).toBe(theirSpawn.x)
+    expect(s.exploreIndex).toBe(0)
+    // Your own chain is not what is being walked.
+    expect(s.position).toEqual(SPAWN)
+  })
+
+  it('keeps the explorer parked when their chain grows, and follows at their head', () => {
+    const h3 = hop(h2, 130, 1n)
+    useCyberspace.getState().setSpectateChain(pk, [spawn, h1, h2, h3])
+    let s = useCyberspace.getState()
+    expect(s.exploreIndex).toBe(0)
+    expect(s.anchor.x).toBe(theirSpawn.x)
+    s.explore(null)
+    useCyberspace.getState().setSpectateChain(pk, [spawn, h1, h2, h3, hop(h3, 140, 1n)])
+    s = useCyberspace.getState()
+    expect(s.exploreIndex).toBeNull()
+    expect(s.anchor.x).toBe(theirSpawn.x + 4n)
+  })
+
+  it('refuses the controls and the plane toggle', () => {
+    const s = useCyberspace.getState()
+    const cursor = s.cursor
+    s.moveCursor({ axis: 'x', dir: 1 })
+    expect(useCyberspace.getState().cursor).toEqual(cursor)
+    const plane = s.plane
+    s.togglePlane()
+    expect(useCyberspace.getState().plane).toBe(plane)
+  })
+
+  it('ignores a chain for a pubkey no longer being spectated', () => {
+    useCyberspace.getState().setSpectateChain('0'.repeat(64), [spawn])
+    expect(useCyberspace.getState().spectate?.pubkey).toBe(pk)
+  })
+
+  it('ends back at your own head', () => {
+    useCyberspace.getState().endSpectate()
+    const s = useCyberspace.getState()
+    expect(s.spectate).toBeNull()
+    expect(s.exploreIndex).toBeNull()
+    expect(s.anchor).toEqual(s.position)
+    expect(s.atHead()).toBe(true)
+    expect(s.focusPubkey()).toBe(s.identity.pubkey)
+  })
+
+  it('reports an empty chain as such, anchored on the spawn coordinate', () => {
+    useCyberspace.getState().beginSpectate(pk)
+    useCyberspace.getState().setSpectateChain(pk, [])
+    const s = useCyberspace.getState()
+    expect(s.spectate?.status).toBe('empty')
+    expect(s.focusChain()).toEqual([])
+    expect(s.anchor.x).toBe(theirSpawn.x)
+    s.exploreStep(1)
+    expect(useCyberspace.getState().exploreIndex).toBeNull()
+    useCyberspace.getState().endSpectate()
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -68,6 +68,22 @@ function parsedChain(events: NostrEvent[]): ActionEvent[] {
 /** Matches cyberspace-core's DEFAULT_MAX_COMPUTE_HEIGHT. */
 export const MAX_COMPUTE_HEIGHT = 20
 
+/**
+ * Another avatar, followed. Their chain is the focus chain while this is set:
+ * the scene anchors on it, the explorer walks it, and the controls stand down
+ * because nothing here is yours to move.
+ */
+export interface SpectateState {
+  pubkey: string
+  npub: string
+  /** Raw, so new events from the relay can be merged and the chain rebuilt. */
+  events: NostrEvent[]
+  actions: ActionEvent[]
+  /** created_at of their newest action; null when the relay has none. */
+  lastActive: number | null
+  status: 'loading' | 'live' | 'empty' | 'error'
+}
+
 export type ProofStatus = 'idle' | 'computing' | 'done' | 'infeasible'
 
 export interface ProofState {
@@ -164,6 +180,7 @@ export interface CyberspaceState {
    * chain changes, only where you are looking from.
    */
   exploreIndex: number | null
+  spectate: SpectateState | null
   /**
    * The scene's render origin, materialised: the position of the action being
    * looked at. Equal to `position` at the head. Every origin-relative thing in
@@ -197,6 +214,12 @@ export interface CyberspaceState {
   explore: (index: number | null) => void
   /** Step the explored index; clamps at both ends. */
   exploreStep: (delta: number) => void
+  /** Start following a pubkey: anchors on its spawn coordinate until its chain arrives. */
+  beginSpectate: (pubkey: string) => void
+  /** The spectated chain, fetched or updated. Keeps the explored index when it still fits. */
+  setSpectateChain: (pubkey: string, events: NostrEvent[], status?: 'live' | 'empty' | 'error') => void
+  /** Back to your own head. */
+  endSpectate: () => void
 
   axes: () => ViewAxes
   /** Axes as they appear on screen right now, including free orbit. */
@@ -207,8 +230,12 @@ export interface CyberspaceState {
   sector: () => string
   /** The chain, parsed. */
   actions: () => ActionEvent[]
-  /** True when the scene is anchored on the live head, where the controls apply. */
+  /** True when the scene is anchored on YOUR live head, where the controls apply. */
   atHead: () => boolean
+  /** The chain the scene is anchored on: the spectated avatar's, else yours. */
+  focusChain: () => ActionEvent[]
+  /** Whose chain that is. */
+  focusPubkey: () => string
   /**
    * The two positions the XOR readout compares: at the head, where you stand
    * and where the cursor is; in history, the action before the one shown and
@@ -320,6 +347,12 @@ const pubkeyHex = getPublicKey(secretKey)
 const SPAWN_XYZ = coordToXyz(hexToCoord(pubkeyHex))
 const SPAWN: Position = { x: SPAWN_XYZ.x, y: SPAWN_XYZ.y, z: SPAWN_XYZ.z }
 
+/** Where any pubkey spawns: its own bits, read as a coordinate (spec §3.1). */
+function spawnOf(pubkey: string): { position: Position; plane: Plane } {
+  const { x, y, z, plane } = coordToXyz(hexToCoord(pubkey))
+  return { position: { x, y, z }, plane }
+}
+
 /** The one place the key touches an event. */
 function sign(template: EventTemplate): NostrEvent {
   return finalizeEvent(template, secretKey)
@@ -381,6 +414,7 @@ let requestId = 0
 export const useCyberspace = create<CyberspaceState>((set, get) => ({
   identity: { pubkey: pubkeyHex, npub: nip19.npubEncode(pubkeyHex) },
   ...initial,
+  spectate: null,
   cursor: initial.position,
   pendingTarget: null,
   scaleExp: 0,
@@ -512,6 +546,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   togglePlane: () => {
     // A plane flip mid-proof would desync the in-flight terrain K.
     if (get().proof.status === 'computing') return
+    // Someone else's plane is theirs; the terrain follows their chain.
+    if (get().spectate) return
     set({ plane: get().plane === 0 ? 1 : 0, proof: IDLE_PROOF })
   },
 
@@ -571,7 +607,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     const nextEvents = [...events, event]
     const nextPublished = { ...published, [event.id]: 'queued' as const }
 
-    const following = get().exploreIndex === null
+    const following = get().atHead()
     set({
       position: newPosition,
       headPlane: plane,
@@ -624,23 +660,67 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   },
 
   explore: (index) => {
-    const actions = get().actions()
-    const last = actions.length - 1
+    const chain = get().focusChain()
+    const last = chain.length - 1
+    // Nothing to walk: a spectated pubkey with no chain on the relay. The
+    // anchor stays on its spawn coordinate.
+    if (last < 0) { set({ exploreIndex: null }); return }
     if (index === null || index >= last) {
-      const { position, headPlane } = get()
-      set({ exploreIndex: null, anchor: position, anchorPlane: headPlane })
+      const a = chain[last]
+      set({ exploreIndex: null, anchor: a.position, anchorPlane: a.plane })
       return
     }
     const i = Math.max(0, Math.floor(index))
-    const a = actions[i]
+    const a = chain[i]
     set({ exploreIndex: i, anchor: a.position, anchorPlane: a.plane })
   },
 
   exploreStep: (delta) => {
     const { exploreIndex } = get()
-    const last = get().actions().length - 1
+    const last = get().focusChain().length - 1
     const from = exploreIndex ?? last
     get().explore(Math.min(last, Math.max(0, from + delta)))
+  },
+
+  beginSpectate: (pubkey) => {
+    const spawn = spawnOf(pubkey)
+    set({
+      spectate: { pubkey, npub: nip19.npubEncode(pubkey), events: [], actions: [], lastActive: null, status: 'loading' },
+      exploreIndex: null,
+      anchor: spawn.position,
+      anchorPlane: spawn.plane,
+    })
+  },
+
+  setSpectateChain: (pubkey, events, status) => {
+    const prev = get().spectate
+    if (!prev || prev.pubkey !== pubkey) return
+    const actions = buildChain(events)
+    const head = actions[actions.length - 1]
+    // A chain that grew under an explorer parked in its history leaves the
+    // explorer where it was; one that was replaced (a respawn) snaps to head.
+    const keep = get().exploreIndex !== null
+      && get().exploreIndex! < actions.length
+      && actions[get().exploreIndex!]?.id === prev.actions[get().exploreIndex!]?.id
+    const at = keep ? actions[get().exploreIndex!] : head
+    const spawn = spawnOf(pubkey)
+    set({
+      spectate: {
+        ...prev,
+        events,
+        actions,
+        lastActive: head?.createdAt ?? null,
+        status: status ?? (head ? 'live' : 'empty'),
+      },
+      exploreIndex: keep ? get().exploreIndex : null,
+      anchor: at?.position ?? spawn.position,
+      anchorPlane: at?.plane ?? spawn.plane,
+    })
+  },
+
+  endSpectate: () => {
+    const { position, headPlane } = get()
+    set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: headPlane })
   },
 
   setPublishStatus: (id, status, reason) => {
@@ -678,14 +758,22 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
 
   actions: () => parsedChain(get().events),
 
-  atHead: () => get().exploreIndex === null,
+  atHead: () => get().exploreIndex === null && get().spectate === null,
+
+  focusChain: () => {
+    const { spectate } = get()
+    return spectate ? spectate.actions : parsedChain(get().events)
+  },
+
+  focusPubkey: () => get().spectate?.pubkey ?? get().identity.pubkey,
 
   readoutPair: () => {
-    const { exploreIndex, position, cursor } = get()
-    if (exploreIndex === null) return [position, cursor]
-    const actions = get().actions()
-    const here = actions[exploreIndex]?.position ?? position
-    const before = actions[exploreIndex - 1]?.position ?? here
+    const { exploreIndex, position, cursor, anchor } = get()
+    if (get().atHead()) return [position, cursor]
+    const chain = get().focusChain()
+    const i = exploreIndex ?? chain.length - 1
+    const here = chain[i]?.position ?? anchor
+    const before = chain[i - 1]?.position ?? here
     return [before, here]
   },
 
@@ -706,9 +794,9 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
    * screen centre, so zooming tracks the cursor instead of the avatar.
    */
   cursorOffset: (): [number, number, number] => {
-    const { anchor, cursor, scaleExp, view, exploreIndex } = get()
-    // In history there is no cursor to frame; the camera sits on the anchor.
-    if (exploreIndex !== null) return [0, 0, 0]
+    const { anchor, cursor, scaleExp, view } = get()
+    // Off your own head there is no cursor to frame; the camera sits on the anchor.
+    if (!get().atHead()) return [0, 0, 0]
     const axes = viewAxes(view)
     const origin = alignedOrigin(anchor, scaleExp)
     // Cell CENTRES, the same convention the cursor cube, the avatar and the path

--- a/src/styles.css
+++ b/src/styles.css
@@ -966,13 +966,14 @@ kbd {
 
 /* ---------- Spectate bar ----------
  *
- * Top right of the scene on a desktop, beside the panel column; along the
- * bottom on a phone, where the movement pad would be if it were yours to use.
+ * Top right on a desktop, flush to the edge: the panels are locked away while
+ * this is up, so there is no column to leave room for. Along the bottom on a
+ * phone, where the movement pad would be if it were yours to use.
  */
 .spectate {
   position: fixed;
   top: 12px;
-  right: 332px;
+  right: 14px;
   z-index: 101;
   display: flex;
   align-items: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -857,6 +857,213 @@ kbd {
   white-space: nowrap;
 }
 
+/* ---------- Avatars ---------- */
+
+.avatars__find {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.avatars__input {
+  min-width: 0;
+  font-family: inherit;
+  font-size: 10px;
+  padding: 6px 8px;
+  border-radius: 3px;
+  color: var(--fg);
+  background: rgba(0, 229, 255, 0.05);
+  border: 1px solid rgba(0, 229, 255, 0.22);
+}
+
+.avatars__input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.avatars__go,
+.avatars__spectate {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  padding: 0 9px;
+  height: 26px;
+  border-radius: 3px;
+  color: var(--accent);
+  background: rgba(0, 229, 255, 0.06);
+  border: 1px solid rgba(0, 229, 255, 0.4);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.avatars__go:hover,
+.avatars__spectate:hover {
+  background: rgba(0, 229, 255, 0.18);
+}
+
+.avatars__go:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.avatars__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 190px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.avatars__row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+  font-size: 10px;
+}
+
+.avatars__row:first-child {
+  border-top: 0;
+}
+
+.avatars__who {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.avatars__type {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+}
+
+.avatars__type--spawn { color: var(--ok); }
+.avatars__type--sidestep { color: var(--sidestep); }
+
+.avatars__when {
+  font-size: 9px;
+  color: var(--dim);
+  white-space: nowrap;
+}
+
+.avatars__you {
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: #ff2323;
+  padding: 0 9px;
+}
+
+.avatars__empty {
+  font-size: 10px;
+  color: var(--dim);
+  padding: 6px 0;
+}
+
+/* ---------- Spectate bar ----------
+ *
+ * Top right of the scene on a desktop, beside the panel column; along the
+ * bottom on a phone, where the movement pad would be if it were yours to use.
+ */
+.spectate {
+  position: fixed;
+  top: 12px;
+  right: 332px;
+  z-index: 101;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px 7px 12px;
+  border-radius: 9px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.82);
+  border: 1px solid rgba(255, 35, 35, 0.45);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 0 14px rgba(255, 35, 35, 0.18);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  max-width: calc(100vw - 24px);
+}
+
+.spectate__eye {
+  color: #ff2323;
+  font-size: 13px;
+  line-height: 1;
+  animation: spectate-blink 2.4s ease-in-out infinite;
+}
+
+@keyframes spectate-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.spectate__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.spectate__label {
+  color: #ff2323;
+  font-weight: 700;
+}
+
+.spectate__who {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spectate__meta {
+  color: var(--dim);
+  white-space: nowrap;
+}
+
+.spectate__end {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 6px;
+  color: #05070d;
+  background: #ff2323;
+  border: 1px solid #ff2323;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.spectate__end:hover {
+  background: #ff5c5c;
+}
+
+@media (max-width: 1100px) {
+  .spectate {
+    top: auto;
+    right: 14px;
+    bottom: 14px;
+    left: 92px;
+  }
+
+  .spectate__meta {
+    white-space: normal;
+  }
+}
+
+.hamburger-menu:disabled {
+  opacity: 0.3;
+  cursor: default;
+  transform: none;
+}
+
 /* ---------- Derezz ----------
  *
  * The one panel that destroys something. Red throughout, last in the column,


### PR DESCRIPTION
Stack 6 (base: `feat/chain-explorer`, PR #20).

## What changes

- **Store spectate slice**: `beginSpectate`, `setSpectateChain`, `endSpectate`; `focusChain()` / `focusPubkey()`; `atHead()` is now "your own live head". The explorer, readout pair, cursor, covering box, flash, trail, spawn marker, terrain and rig all follow the focus chain.
- **Relay helpers** (`lib/chains.ts`): every query filters `#A` to `spawn|hop|sidestep` (the relay holds ~208k v1 drifts); `latestByPubkey`, `mergeEvents`, `parsePubkey`. `lib/spectator.ts` fetches a chain and keeps a per-author subscription open so their hops arrive live.
- **Avatars panel** (left column): newest v2 action per pubkey, newest first, live-updating; SPECTATE per row (YOU on your own); npub/hex field.
- **Spectate mode**: panels lock + hamburger disabled, pad / CONTROLS chip hidden, `P` refused, compass + view menu kept, YOU target points home, spectate bar (who, last active, action count, END SPECTATION; empty-chain and error states).
- `Travel` watches the anchor: spectated hops animate, scrubs and avatar changes cut.

## Verification

- Tests: 129 passing (`lib/chains.test.ts`, `store/spectate.test.ts` new).
- Browser against the live relay: list populated; spectate by key → anchored on their head, marker at their spawn, explorer `CHAIN 2/2 THEIR HEAD`, `Home` walks to their spawn; END restores everything; row spectate; unknown key → empty state at its coordinate. Desktop and phone screenshots. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)