### PR TITLE
feat: targets, which point at any pubkey the way the HUD points at Earth

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ shows what that hop cost); what came after is drawn faint. Off the head the
 movement controls stand down and RETURN TO LIVE brings them back. The same
 instrument walks any other avatar's chain while spectating.
 
+**Targets.** The Targets panel points at any number of pubkeys the way the
+HUD points at Earth: a reticle in frame, a chevron on the nearest edge out of
+frame, the distance either way, and the avatar itself (a wireframe icosahedron
+in the target's own colour, named) once you are near. Add a key, toggle one
+from the Avatars list, or load a kind 3 contact list for any npub and toggle
+follows. Positions are chain heads on the relay, kept live by a per-target
+subscription; a key with no chain is pointed at its spawn coordinate. Targets
+persist across reloads.
+
 **Spectating.** The Avatars panel lists every pubkey with a v2 action on the
 relay, newest first, with a field for any npub. SPECTATE anchors the scene on
 that avatar's chain head (their terrain, their rooms, their trail, their spawn

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { useProofListener } from './hooks/useProofListener'
 import { useIsMobile } from './hooks/useIsMobile'
 import { useTargets } from './hooks/useTargets'
 import { startPublisher } from './lib/publisher'
+import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
 
 export default function App(): JSX.Element {
@@ -22,8 +23,9 @@ export default function App(): JSX.Element {
   // cannot drift apart, and nothing about having a pointer takes the keys away.
   useKeyboard()
   useProofListener()
-  // The chain drains to the relay from here on, whenever Live is on.
-  useEffect(() => startPublisher(), [])
+  // The chain drains to the relay from here on, whenever Live is on, and the
+  // targets' positions are kept current.
+  useEffect(() => { startPublisher(); startTracker() }, [])
   const isMobile = useIsMobile()
   const targets = useTargets()
   // Off your own head there is nothing to drive: the movement controls stand

--- a/src/hooks/useTargets.ts
+++ b/src/hooks/useTargets.ts
@@ -23,9 +23,14 @@ export function useTargets(): CyberTarget[] {
   const plane = useCyberspace((s) => s.anchorPlane)
   const spectating = useCyberspace((s) => s.spectate !== null)
   const position = useCyberspace((s) => s.position)
+  const tracked = useCyberspace((s) => s.targets)
+  const focus = useCyberspace((s) => s.focusPubkey())
 
   return useMemo(() => {
     const out: CyberTarget[] = []
+    // Tracked pubkeys first, except the one the scene is looking through: a
+    // marker for the avatar you are standing on would sit on your own centre.
+    for (const t of useCyberspace.getState().targetList()) if (t.id !== focus) out.push(t)
     // While you are looking through someone else's eyes, the way home is a
     // thing worth pointing at from anywhere.
     if (spectating) out.push({ id: 'you', label: 'YOU', color: YOU, at: position })
@@ -40,5 +45,7 @@ export function useTargets(): CyberTarget[] {
       })
     }
     return out
-  }, [plane, spectating, position])
+    // tracked is what targetList reads; listed so the memo follows it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plane, spectating, position, tracked, focus])
 }

--- a/src/hud/AvatarsPanel.tsx
+++ b/src/hud/AvatarsPanel.tsx
@@ -13,6 +13,7 @@ import { useRecentAvatars } from '../hooks/useRecentAvatars'
 import { parsePubkey } from '../lib/chains'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { spectate } from '../lib/spectator'
+import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
 import { nip19 } from 'nostr-tools'
@@ -26,6 +27,7 @@ function shortNpub(pubkey: string): string {
 export function AvatarsPanel(): JSX.Element {
   const { avatars, status } = useRecentAvatars()
   const me = useCyberspace((s) => s.identity.pubkey)
+  const targets = useCyberspace((s) => s.targets)
   const [input, setInput] = useState('')
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {
@@ -68,6 +70,7 @@ export function AvatarsPanel(): JSX.Element {
       <ul className="avatars__list">
         {avatars.map((a) => {
           const you = a.pubkey === me
+          const on = !!targets[a.pubkey]
           return (
             <li key={a.pubkey} className="avatars__row">
               <span className="avatars__who" title={nip19.npubEncode(a.pubkey)}>{shortNpub(a.pubkey)}</span>
@@ -76,7 +79,16 @@ export function AvatarsPanel(): JSX.Element {
               {you ? (
                 <span className="avatars__you">YOU</span>
               ) : (
-                <button className="avatars__spectate" onClick={() => go(a.pubkey)}>SPECTATE</button>
+                <span className="avatars__acts">
+                  <button
+                    className={`targets__toggle targets__toggle--mini ${on ? 'is-on' : ''}`}
+                    style={on ? { color: targetColor(a.pubkey), borderColor: targetColor(a.pubkey) } : undefined}
+                    aria-pressed={on}
+                    title={on ? 'Stop targeting' : 'Target'}
+                    onClick={() => useCyberspace.getState().toggleTarget(a.pubkey)}
+                  >◎</button>
+                  <button className="avatars__spectate" onClick={() => go(a.pubkey)}>SPECTATE</button>
+                </span>
               )}
             </li>
           )

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -8,6 +8,7 @@ import { useCyberspace } from '../store/useCyberspace'
 import { AvatarsPanel } from './AvatarsPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
+import { TargetsPanel } from './TargetsPanel'
 import { Legend } from './Legend'
 import { ScaleLadder } from './ScaleLadder'
 import { ProofPanel } from './ProofPanel'
@@ -204,6 +205,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <IdentityPanel />
         <PositionPanel />
         <AvatarsPanel />
+        <TargetsPanel />
         <ScalePanel />
         <LinksPanel />
       </div>

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -1,0 +1,124 @@
+/**
+ * TargetsPanel.tsx — who you are pointing at.
+ *
+ * A target is a pubkey whose chain head gets the Earth treatment: a reticle
+ * when it is in frame, a chevron on the nearest edge when it is not, the
+ * distance either way, and the avatar itself once you are near. Any number at
+ * once. Targets come from three places: a key typed here, the Avatars panel,
+ * and a contact list, which is fetched for any npub because the key this
+ * client spawned with has no follows of its own.
+ */
+
+import { useEffect, useState } from 'react'
+import { nip19 } from 'nostr-tools'
+import { parsePubkey } from '../lib/chains'
+import { fetchContacts, GENERAL_RELAYS, type Contact } from '../lib/contacts'
+import { spectate } from '../lib/spectator'
+import { targetColor } from '../lib/targets'
+import { formatAgo, formatStamp } from '../lib/time'
+import { useCyberspace } from '../store/useCyberspace'
+
+function shortNpub(npub: string): string {
+  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
+}
+
+export function TargetsPanel(): JSX.Element {
+  const targets = useCyberspace((s) => s.targets)
+  const me = useCyberspace((s) => s.identity)
+  const [input, setInput] = useState('')
+  const [who, setWho] = useState(me.npub)
+  const [contacts, setContacts] = useState<Contact[] | null>(null)
+  const [contactsState, setContactsState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
+  const [now, setNow] = useState(() => Date.now() / 1000)
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now() / 1000), 10_000)
+    return () => window.clearInterval(t)
+  }, [])
+
+  const typed = parsePubkey(input)
+  const whoHex = parsePubkey(who)
+  const list = Object.values(targets)
+
+  const loadContacts = async (): Promise<void> => {
+    if (!whoHex) return
+    setContactsState('loading')
+    try {
+      setContacts(await fetchContacts(whoHex))
+      setContactsState('ready')
+    } catch {
+      setContactsState('error')
+    }
+  }
+
+  return (
+    <section className="panel panel--targets">
+      <header className="panel__head">
+        <h2>Targets</h2>
+        <span className="tag">{list.length} ACTIVE</span>
+      </header>
+
+      <form className="avatars__find" onSubmit={(e) => { e.preventDefault(); if (typed) { useCyberspace.getState().addTarget(typed); setInput('') } }}>
+        <input className="avatars__input" value={input} onChange={(e) => setInput(e.target.value)}
+          placeholder="npub or hex pubkey" spellCheck={false} autoComplete="off" aria-label="Pubkey to target" />
+        <button className="avatars__go" type="submit" disabled={!typed}>TARGET</button>
+      </form>
+
+      <ul className="avatars__list targets__list">
+        {list.map((t) => (
+          <li key={t.pubkey} className="targets__row">
+            <span className="targets__dot" style={{ background: targetColor(t.pubkey), boxShadow: `0 0 6px ${targetColor(t.pubkey)}` }} />
+            <span className="avatars__who" title={t.npub}>{t.name ?? shortNpub(t.npub)}</span>
+            <span className={`targets__status targets__status--${t.status}`} title={t.lastActive ? formatStamp(t.lastActive) : undefined}>
+              {t.status === 'live' && t.lastActive ? formatAgo(t.lastActive, now)
+                : t.status === 'resolving' ? 'FINDING'
+                  : t.status === 'spawn' ? 'AT SPAWN'
+                    : 'RELAY?'}
+            </span>
+            <button className="avatars__spectate" onClick={() => void spectate(t.pubkey)} title="Spectate">SPECTATE</button>
+            <button className="targets__remove" onClick={() => useCyberspace.getState().removeTarget(t.pubkey)} aria-label="Remove target" title="Remove target">✕</button>
+          </li>
+        ))}
+        {list.length === 0 && <li className="avatars__empty">No targets. Add a key, or toggle one in Avatars.</li>}
+      </ul>
+
+      <div className="targets__follows">
+        <span className="legend__label">Follows of</span>
+        <form className="avatars__find" onSubmit={(e) => { e.preventDefault(); void loadContacts() }}>
+          <input className="avatars__input" value={who} onChange={(e) => setWho(e.target.value)}
+            placeholder="npub or hex pubkey" spellCheck={false} autoComplete="off" aria-label="Whose follows to list" />
+          <button className="avatars__go" type="submit" disabled={!whoHex || contactsState === 'loading'}>
+            {contactsState === 'loading' ? 'LOADING' : 'LOAD'}
+          </button>
+        </form>
+        {contactsState === 'error' && <p className="notice">Could not reach the contact relays.</p>}
+        {contactsState === 'ready' && contacts && (
+          <ul className="avatars__list">
+            {contacts.map((c) => {
+              const on = !!targets[c.pubkey]
+              return (
+                <li key={c.pubkey} className="targets__row targets__row--contact">
+                  <span className="avatars__who" title={nip19.npubEncode(c.pubkey)}>{c.name ?? shortNpub(nip19.npubEncode(c.pubkey))}</span>
+                  <button
+                    className={`targets__toggle ${on ? 'is-on' : ''}`}
+                    style={on ? { color: targetColor(c.pubkey), borderColor: targetColor(c.pubkey) } : undefined}
+                    aria-pressed={on}
+                    onClick={() => useCyberspace.getState().toggleTarget(c.pubkey, c.name)}
+                  >{on ? 'TARGETED' : 'TARGET'}</button>
+                </li>
+              )
+            })}
+            {contacts.length === 0 && <li className="avatars__empty">No kind 3 contact list found for that key.</li>}
+          </ul>
+        )}
+      </div>
+
+      <p className="legend__note">
+        A target is pointed at from anywhere, like Earth: reticle in frame,
+        chevron on the edge, distance either way, and the avatar itself once
+        you are near. Positions are chain heads on the relay, kept live; a key
+        with no chain is pointed at its spawn coordinate. Follows come from
+        kind 3 on {GENERAL_RELAYS.map((r) => r.replace('wss://', '')).join(', ')}.
+      </p>
+    </section>
+  )
+}

--- a/src/lib/contacts.test.ts
+++ b/src/lib/contacts.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { parseContacts } from './contacts'
+import { targetColor } from './targets'
+
+const pk = (n: number): string => n.toString(16).padStart(64, '0')
+
+describe('parseContacts', () => {
+  it('reads p tags with optional petnames, once each, in order', () => {
+    const out = parseContacts({
+      id: '', pubkey: '', created_at: 0, kind: 3, content: '', sig: '',
+      tags: [['p', pk(1), '', 'alice'], ['p', pk(2)], ['e', pk(3)], ['p', pk(1), '', 'dup'], ['p', 'nothex', '', 'x'], ['p', pk(4), 'wss://r', '  ']],
+    })
+    expect(out).toEqual([{ pubkey: pk(1), name: 'alice' }, { pubkey: pk(2), name: null }, { pubkey: pk(4), name: null }])
+  })
+})
+
+describe('targetColor', () => {
+  it('is a function of the pubkey alone', () => {
+    expect(targetColor(pk(1))).toBe(targetColor(pk(1)))
+    expect(targetColor('ffff' + '0'.repeat(60))).not.toBe(targetColor('0000' + '0'.repeat(60)))
+    expect(targetColor(pk(7))).toMatch(/^hsl\(\d+ 90% 62%\)$/)
+  })
+})

--- a/src/lib/contacts.ts
+++ b/src/lib/contacts.ts
@@ -1,0 +1,38 @@
+/**
+ * contacts.ts — a pubkey's follows, from wherever kind 3 lives.
+ *
+ * The cyberspace relay holds movement; contact lists live on the general
+ * relays, so those are asked too and the newest list wins. Pure parsing is
+ * separate from the fetch so it can be tested without a socket.
+ */
+
+import { queryAny, CYBERSPACE_RELAY } from './relay'
+import type { NostrEvent } from './events'
+
+/** Where kind 3 is most likely to be found. */
+export const GENERAL_RELAYS = ['wss://purplepag.es', 'wss://relay.damus.io', 'wss://nos.lol']
+
+export interface Contact {
+  pubkey: string
+  /** The petname from the p tag, when the list carries one. */
+  name: string | null
+}
+
+/** NIP-02: `["p", <pubkey>, <relay>, <petname>]`, deduplicated, order kept. */
+export function parseContacts(ev: NostrEvent): Contact[] {
+  const seen = new Set<string>()
+  const out: Contact[] = []
+  for (const t of ev.tags) {
+    if (t[0] !== 'p' || !/^[0-9a-f]{64}$/.test(t[1] ?? '') || seen.has(t[1])) continue
+    seen.add(t[1])
+    out.push({ pubkey: t[1], name: t[3]?.trim() ? t[3].trim() : null })
+  }
+  return out
+}
+
+/** The newest kind 3 for a pubkey across the general relays and ours. */
+export async function fetchContacts(pubkey: string): Promise<Contact[]> {
+  const events = await queryAny([...GENERAL_RELAYS, CYBERSPACE_RELAY], { kinds: [3], authors: [pubkey] })
+  const newest = events.sort((a, b) => b.created_at - a.created_at)[0]
+  return newest ? parseContacts(newest) : []
+}

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -44,6 +44,14 @@ export function query(filter: Filter): Promise<NostrEvent[]> {
   return getPool().querySync([CYBERSPACE_RELAY], filter, { maxWait: MAX_WAIT_MS })
 }
 
+/**
+ * The same against any set of relays, for the few things that do not live
+ * here: contact lists, mostly. Results are the union; callers pick.
+ */
+export function queryAny(relays: string[], filter: Filter): Promise<NostrEvent[]> {
+  return getPool().querySync(relays, filter, { maxWait: MAX_WAIT_MS })
+}
+
 /** A live subscription; the returned function closes it. */
 export function subscribe(
   filter: Filter,

--- a/src/lib/targets.ts
+++ b/src/lib/targets.ts
@@ -45,3 +45,15 @@ export interface TargetScreen {
 
 /** Written per frame inside the Canvas, read per frame by the HUD. */
 export const targetScreens: Record<string, TargetScreen> = {}
+
+/**
+ * A colour for a pubkey, from its own bits, so a target keeps its colour
+ * across sessions and devices and two targets rarely share one. Hue only;
+ * saturation and lightness are fixed so every one of them reads against the
+ * dark field and none collides with Earth's blue or the avatar's red by being
+ * a wash of either.
+ */
+export function targetColor(pubkey: string): string {
+  const hue = (parseInt(pubkey.slice(0, 4), 16) / 0xffff) * 360
+  return `hsl(${hue.toFixed(0)} 90% 62%)`
+}

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -1,0 +1,53 @@
+/**
+ * tracker.ts — keeps every target's position current.
+ *
+ * For each tracked pubkey: fetch its chain once, then hold a subscription so
+ * a hop lands in the store the moment the relay has it. The store is the
+ * list; this only reconciles against it, so adding or removing a target
+ * anywhere in the UI is enough. A module singleton, for the same reason the
+ * publisher and the spectator are: subscriptions outlive components.
+ */
+
+import { fetchChainEvents, mergeEvents, watchAuthor } from './chains'
+import type { NostrEvent } from './events'
+import { useCyberspace } from '../store/useCyberspace'
+
+const subs = new Map<string, () => void>()
+let started = false
+
+async function track(pubkey: string): Promise<void> {
+  let events: NostrEvent[] = []
+  const since = Math.floor(Date.now() / 1000) - 60
+  const close = watchAuthor(pubkey, since, (ev) => {
+    if (!subs.has(pubkey)) return
+    events = mergeEvents(events, [ev])
+    useCyberspace.getState().setTargetChain(pubkey, events)
+  })
+  subs.set(pubkey, close)
+  try {
+    const fetched = await fetchChainEvents(pubkey)
+    if (!subs.has(pubkey)) return
+    events = mergeEvents(fetched, events)
+    useCyberspace.getState().setTargetChain(pubkey, events)
+  } catch {
+    if (subs.has(pubkey)) useCyberspace.getState().setTargetChain(pubkey, events, 'error')
+  }
+}
+
+function reconcile(): void {
+  const wanted = new Set(Object.keys(useCyberspace.getState().targets))
+  for (const [pk, close] of subs) {
+    if (wanted.has(pk)) continue
+    close()
+    subs.delete(pk)
+  }
+  for (const pk of wanted) if (!subs.has(pk)) void track(pk)
+}
+
+/** Idempotent. Subscribes once for the life of the page. */
+export function startTracker(): void {
+  if (started) return
+  started = true
+  useCyberspace.subscribe((s, prev) => { if (s.targets !== prev.targets) reconcile() })
+  reconcile()
+}

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -44,6 +44,7 @@ import { Rooms } from './Rooms'
 import { SectorBox } from './SectorBox'
 import { ShaderPointField } from './ShaderPointField'
 import { SpawnMarker } from './SpawnMarker'
+import { TargetAvatars } from './TargetAvatars'
 import { TargetProjector } from './TargetProjector'
 import { Travel } from './Travel'
 
@@ -84,6 +85,7 @@ function World(): JSX.Element {
       <CrossingFlash axes={axes} />
       <PathTrail axes={axes} scaleExp={scaleExp} />
       <SpawnMarker pubkey={pubkey} axes={axes} />
+      <TargetAvatars axes={axes} />
       <Cursor axes={axes} />
       <Avatar />
     </group>

--- a/src/scene/TargetAvatars.tsx
+++ b/src/scene/TargetAvatars.tsx
@@ -1,0 +1,56 @@
+/**
+ * TargetAvatars.tsx — a targeted avatar, once you are close enough to see it.
+ *
+ * The HUD marker says where a target is from any distance; this is the thing
+ * itself when it is inside the drawn world: the same wireframe icosahedron you
+ * are drawn as, in the target's own colour, with its name over it. The
+ * position is the chain head the tracker keeps current, so a target that hops
+ * while you watch moves here the same frame its marker does.
+ */
+
+import { useMemo } from 'react'
+import { EdgesGeometry, IcosahedronGeometry } from 'three'
+import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { WorldLabel } from './WorldLabel'
+
+/** Same cull as Earth and the spawn marker. */
+const REACH = GRID_RADIUS * 8
+
+interface Props {
+  axes: ViewAxes
+}
+
+export function TargetAvatars({ axes }: Props): JSX.Element | null {
+  const targets = useCyberspace((s) => s.targets)
+  const anchor = useCyberspace((s) => s.anchor)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const focus = useCyberspace((s) => s.focusPubkey())
+  const geometry = useMemo(() => new EdgesGeometry(new IcosahedronGeometry(0.5, 1)), [])
+
+  const near = useMemo(() => {
+    const origin = alignedOrigin(anchor, scaleExp)
+    const list = useCyberspace.getState().targetList()
+    return list
+      .filter((t) => t.id !== focus)
+      .map((t) => ({ ...t, centre: cellCentre(t.at, origin, scaleExp, axes) }))
+      .filter((t) => Math.hypot(...t.centre) <= REACH)
+    // targets is what targetList reads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targets, anchor, scaleExp, axes, focus])
+
+  if (near.length === 0) return null
+
+  return (
+    <>
+      {near.map((t) => (
+        <group key={t.id} position={t.centre}>
+          <lineSegments geometry={geometry} frustumCulled={false}>
+            <lineBasicMaterial color={t.color} toneMapped={false} />
+          </lineSegments>
+          <WorldLabel text={t.label} color={t.color} at={[0, 0.9, 0]} align="center" px={11} opacity={0.9} />
+        </group>
+      ))}
+    </>
+  )
+}

--- a/src/store/targets.test.ts
+++ b/src/store/targets.test.ts
@@ -1,0 +1,58 @@
+/**
+ * targets.test.ts - a target is a pubkey with a position, resolved from its
+ * chain when it has one and its own bits when it does not.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { coordToXyz, hexToCoord } from 'cyberspace-core'
+import { hopTemplate, spawnTemplate } from '../lib/events'
+import { useCyberspace } from './useCyberspace'
+
+const sk = generateSecretKey()
+const pk = getPublicKey(sk)
+const at = coordToXyz(hexToCoord(pk))
+const spawn = finalizeEvent(spawnTemplate(pk, 100), sk)
+const hop = finalizeEvent(hopTemplate({
+  createdAt: 110, genesisId: spawn.id, previousId: spawn.id, prevCoordHex: pk,
+  to: { x: at.x + 7n, y: at.y, z: at.z }, plane: at.plane, proofHash: '2'.repeat(64),
+}), sk)
+
+describe('targets', () => {
+  it('adds a target at its spawn coordinate, resolving', () => {
+    useCyberspace.getState().addTarget(pk, 'bob')
+    const t = useCyberspace.getState().targets[pk]
+    expect(t.status).toBe('resolving')
+    expect(t.name).toBe('bob')
+    expect(t.position).toEqual({ x: at.x, y: at.y, z: at.z })
+    expect(useCyberspace.getState().targetList().map((x) => x.label)).toEqual(['BOB'])
+  })
+
+  it('moves to the chain head once the chain arrives', () => {
+    useCyberspace.getState().setTargetChain(pk, [spawn, hop])
+    const t = useCyberspace.getState().targets[pk]
+    expect(t.status).toBe('live')
+    expect(t.position.x).toBe(at.x + 7n)
+    expect(t.lastActive).toBe(110)
+  })
+
+  it('falls back to the spawn coordinate when the relay has no chain', () => {
+    useCyberspace.getState().setTargetChain(pk, [])
+    const t = useCyberspace.getState().targets[pk]
+    expect(t.status).toBe('spawn')
+    expect(t.position.x).toBe(at.x)
+  })
+
+  it('keeps a petname when re-added without one, and toggles off', () => {
+    useCyberspace.getState().addTarget(pk)
+    expect(useCyberspace.getState().targets[pk].name).toBe('bob')
+    useCyberspace.getState().toggleTarget(pk)
+    expect(useCyberspace.getState().targets[pk]).toBeUndefined()
+    expect(useCyberspace.getState().targetList()).toEqual([])
+  })
+
+  it('ignores chains for pubkeys that are not targets', () => {
+    useCyberspace.getState().setTargetChain(pk, [spawn])
+    expect(useCyberspace.getState().targets[pk]).toBeUndefined()
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -54,6 +54,7 @@ import {
   type NostrEvent,
 } from '../lib/events'
 import { cancelProof, postProof, type ProofMode, type ProofResponse } from '../lib/workers'
+import { targetColor, type CyberTarget } from '../lib/targets'
 
 /**
  * The explored chain, parsed once per events change rather than on every
@@ -136,6 +137,21 @@ const EMPTY_STATS: ChainStats = { hops: 0, sidesteps: 0, totalOps: 0, totalHashe
  */
 export type PublishStatus = 'queued' | 'sending' | 'ok' | 'failed'
 
+/**
+ * A pubkey you are pointing at. Its position is its chain head on the relay,
+ * or its spawn coordinate until the chain arrives or when there is none.
+ */
+export interface TrackedTarget {
+  pubkey: string
+  npub: string
+  /** A petname, when it came from a contact list. */
+  name: string | null
+  position: Position
+  plane: Plane
+  lastActive: number | null
+  status: 'resolving' | 'live' | 'spawn' | 'error'
+}
+
 export interface CyberspaceState {
   identity: { pubkey: string; npub: string }
   position: Position
@@ -181,6 +197,8 @@ export interface CyberspaceState {
    */
   exploreIndex: number | null
   spectate: SpectateState | null
+  /** Pubkeys being pointed at, keyed by pubkey. Persisted. */
+  targets: Record<string, TrackedTarget>
   /**
    * The scene's render origin, materialised: the position of the action being
    * looked at. Equal to `position` at the head. Every origin-relative thing in
@@ -220,6 +238,13 @@ export interface CyberspaceState {
   setSpectateChain: (pubkey: string, events: NostrEvent[], status?: 'live' | 'empty' | 'error') => void
   /** Back to your own head. */
   endSpectate: () => void
+  addTarget: (pubkey: string, name?: string | null) => void
+  removeTarget: (pubkey: string) => void
+  toggleTarget: (pubkey: string, name?: string | null) => void
+  /** A target's chain, fetched or updated: its head becomes the position. */
+  setTargetChain: (pubkey: string, events: NostrEvent[], status?: 'error') => void
+  /** The tracked targets as things the HUD can point at. */
+  targetList: () => CyberTarget[]
 
   axes: () => ViewAxes
   /** Axes as they appear on screen right now, including free orbit. */
@@ -259,6 +284,7 @@ export interface CyberspaceState {
 const STORAGE_KEY = 'onosendai:nsec'
 const CHAIN_KEY = 'onosendai:chain'
 const LIVE_KEY = 'onosendai:live'
+const TARGETS_KEY = 'onosendai:targets'
 
 /**
  * The chain on disk is the events themselves. Position, history, plane and the
@@ -322,6 +348,32 @@ function saveChain(events: NostrEvent[], published: Record<string, PublishStatus
     }
     localStorage.setItem(CHAIN_KEY, JSON.stringify(data))
   } catch { /* quota exceeded or private mode */ }
+}
+
+/** Only who and what they are called survive a reload; positions are refetched. */
+function loadTargets(): Record<string, TrackedTarget> {
+  try {
+    const raw = localStorage.getItem(TARGETS_KEY)
+    if (!raw) return {}
+    const list = JSON.parse(raw) as Array<{ pubkey: string; name?: string | null }>
+    const out: Record<string, TrackedTarget> = {}
+    for (const t of list) {
+      if (!/^[0-9a-f]{64}$/.test(t.pubkey)) continue
+      out[t.pubkey] = unresolvedTarget(t.pubkey, t.name ?? null)
+    }
+    return out
+  } catch { return {} }
+}
+
+function saveTargets(targets: Record<string, TrackedTarget>): void {
+  try {
+    localStorage.setItem(TARGETS_KEY, JSON.stringify(Object.values(targets).map((t) => ({ pubkey: t.pubkey, name: t.name }))))
+  } catch { /* private mode */ }
+}
+
+function unresolvedTarget(pubkey: string, name: string | null): TrackedTarget {
+  const spawn = spawnOf(pubkey)
+  return { pubkey, npub: nip19.npubEncode(pubkey), name, position: spawn.position, plane: spawn.plane, lastActive: null, status: 'resolving' }
 }
 
 function loadLive(): boolean {
@@ -415,6 +467,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   identity: { pubkey: pubkeyHex, npub: nip19.npubEncode(pubkeyHex) },
   ...initial,
   spectate: null,
+  targets: loadTargets(),
   cursor: initial.position,
   pendingTarget: null,
   scaleExp: 0,
@@ -722,6 +775,63 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     const { position, headPlane } = get()
     set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: headPlane })
   },
+
+  addTarget: (pubkey, name = null) => {
+    const { targets } = get()
+    if (targets[pubkey]) {
+      // Already tracked: a name from a contact list is still worth keeping.
+      if (name && !targets[pubkey].name) {
+        const next = { ...targets, [pubkey]: { ...targets[pubkey], name } }
+        set({ targets: next }); saveTargets(next)
+      }
+      return
+    }
+    const next = { ...targets, [pubkey]: unresolvedTarget(pubkey, name) }
+    set({ targets: next })
+    saveTargets(next)
+  },
+
+  removeTarget: (pubkey) => {
+    const { targets } = get()
+    if (!targets[pubkey]) return
+    const next = { ...targets }
+    delete next[pubkey]
+    set({ targets: next })
+    saveTargets(next)
+  },
+
+  toggleTarget: (pubkey, name = null) => {
+    if (get().targets[pubkey]) get().removeTarget(pubkey)
+    else get().addTarget(pubkey, name)
+  },
+
+  setTargetChain: (pubkey, events, status) => {
+    const { targets } = get()
+    const t = targets[pubkey]
+    if (!t) return
+    const head = buildChain(events)[buildChain(events).length - 1]
+    const spawn = spawnOf(pubkey)
+    set({
+      targets: {
+        ...targets,
+        [pubkey]: {
+          ...t,
+          position: head?.position ?? spawn.position,
+          plane: head?.plane ?? spawn.plane,
+          lastActive: head?.createdAt ?? null,
+          status: head ? 'live' : status ?? 'spawn',
+        },
+      },
+    })
+  },
+
+  targetList: () =>
+    Object.values(get().targets).map((t) => ({
+      id: t.pubkey,
+      label: (t.name ?? `${t.npub.slice(0, 12)}…${t.npub.slice(-4)}`).toUpperCase(),
+      color: targetColor(t.pubkey),
+      at: t.position,
+    })),
 
   setPublishStatus: (id, status, reason) => {
     const { published, events, chain } = get()

--- a/src/styles.css
+++ b/src/styles.css
@@ -964,6 +964,103 @@ kbd {
   padding: 6px 0;
 }
 
+/* ---------- Targets ---------- */
+
+.targets__row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+  font-size: 10px;
+}
+
+.targets__row:first-child {
+  border-top: 0;
+}
+
+.targets__row--contact {
+  grid-template-columns: 1fr auto;
+}
+
+.targets__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.targets__status {
+  font-size: 9px;
+  color: var(--dim);
+  white-space: nowrap;
+}
+
+.targets__status--resolving { color: var(--warn); }
+.targets__status--error { color: var(--danger); }
+
+.targets__remove {
+  font-family: inherit;
+  font-size: 10px;
+  width: 22px;
+  height: 26px;
+  padding: 0;
+  border-radius: 3px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.18);
+  cursor: pointer;
+}
+
+.targets__remove:hover {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.targets__toggle {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  height: 26px;
+  padding: 0 9px;
+  border-radius: 3px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.25);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.targets__toggle:hover {
+  color: var(--fg);
+  border-color: var(--fg);
+}
+
+/* Lit in the target's own colour, set inline, so the row and the marker on
+ * the scene agree about which one this is. */
+.targets__toggle.is-on {
+  background: rgba(200, 245, 255, 0.06);
+}
+
+.targets__toggle--mini {
+  width: 26px;
+  padding: 0;
+  font-size: 12px;
+  letter-spacing: 0;
+}
+
+.avatars__acts {
+  display: flex;
+  gap: 4px;
+}
+
+.targets__follows {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 229, 255, 0.14);
+}
+
 /* ---------- Spectate bar ----------
  *
  * Top right on a desktop, flush to the edge: the panels are locked away while


### PR DESCRIPTION
Stack 7 (base: `feat/spectate`, PR #21).

## What changes

- **Store `targets` slice** (persisted: pubkey + petname): `addTarget`, `removeTarget`, `toggleTarget`, `setTargetChain`, `targetList()`. Position = chain head on the relay, or the spawn coordinate while resolving / when there is none.
- **`lib/tracker.ts`** singleton: per-target chain fetch + live subscription, reconciled against the store.
- **`lib/contacts.ts`**: kind 3 parsing + fetch from purplepag.es / damus / nos.lol / ours (`queryAny` added to `relay.ts`).
- **HUD**: targets join `useTargets()` (same reticle / chevron / distance as Earth); `scene/TargetAvatars.tsx` draws a named icosahedron in the target's colour when it is inside the drawn world. `targetColor(pubkey)` is derived from the key.
- **Targets panel** (left column): key field, active list with status / SPECTATE / remove, and "Follows of <npub>" with a toggle per contact. The Avatars rows gain a target toggle.

## Verification

- Tests: 136 passing (`lib/contacts.test.ts`, `store/targets.test.ts` new).
- Browser against the live relay: add by npub → live head + chevron with distance; Avatars toggle off/on; arkinox's 769 follows load, first toggled on at spawn; target moved beside the avatar renders the mesh and label; two targets persist across reload. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)