### PR TITLE
feat: the shard workshop, and three ways to draw one

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ shows what that hop cost); what came after is drawn faint. Off the head the
 movement controls stand down and RETURN TO LIVE brings them back. The same
 instrument walks any other avatar's chain while spectating.
 
+**Shards.** The Shards panel opens the workshop: a full-screen bench where a
+shard is built from coloured vertices on an integer grid. ADD places a vertex
+where you tap, at the current level; SELECT picks one for the nudge pad
+(a unit along X, Y or Z), the colour input and DELETE; FACE joins three taps
+into a triangle. A shard renders SOLID (triangles, colours blended across
+faces), POINTS (every vertex a light) or LINES (a polyline through the
+vertices, colours blending along it), chosen per shard and previewed live.
+`unit` says what one grid unit is in gibsons (2^unit). Shards persist in
+localStorage. Keys on the bench: WASD / RF or arrows nudge, Del deletes,
+1 2 3 pick tools, [ ] change the level, Esc deselects then closes.
+
 **Targets.** The Targets panel points at any number of pubkeys the way the
 HUD points at Earth: a reticle in frame, a chevron on the nearest edge out of
 frame, the distance either way, and the avatar itself (a wireframe icosahedron

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { BitReadout } from './hud/BitReadout'
 import { ChainExplorer } from './hud/ChainExplorer'
 import { SpectateBar } from './hud/SpectateBar'
+import { Workshop } from './workshop/Workshop'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
 import { TouchControls } from './hud/TouchControls'
@@ -85,6 +86,7 @@ export default function App(): JSX.Element {
         >CONTROLS</button>
       )}
       {crowded && <div className="mobile-overlay" />}
+      <Workshop />
       <button
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -9,6 +9,7 @@
 
 import { useEffect } from 'react'
 import { useCyberspace } from '../store/useCyberspace'
+import { useWorkshop } from '../store/useWorkshop'
 import { moveDirection, type MoveName } from '../lib/moves'
 import type { RotateDirection } from '../lib/space'
 
@@ -33,6 +34,10 @@ export function useKeyboard(): void {
     const onKeyDown = (event: KeyboardEvent) => {
       // Let the browser keep its own shortcuts.
       if (event.metaKey || event.ctrlKey || event.altKey) return
+      // Typing into a field, or building on the bench: not ours.
+      const tag = (event.target as HTMLElement | null)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      if (useWorkshop.getState().open) return
 
       const store = useCyberspace.getState()
       // What is on screen, which under free orbit is not the snapped frame.

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -9,6 +9,7 @@ import { AvatarsPanel } from './AvatarsPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
 import { TargetsPanel } from './TargetsPanel'
+import { ShardsPanel } from './ShardsPanel'
 import { Legend } from './Legend'
 import { ScaleLadder } from './ScaleLadder'
 import { ProofPanel } from './ProofPanel'
@@ -213,6 +214,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <ProofPanel />
         <ChainPanel />
         <Legend />
+        <ShardsPanel />
         <Controls />
         <DerezzPanel />
       </div>

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -1,0 +1,41 @@
+/**
+ * ShardsPanel.tsx — your shards, and the door to the workshop.
+ */
+
+import { useWorkshop } from '../store/useWorkshop'
+
+export function ShardsPanel(): JSX.Element {
+  const shards = useWorkshop((s) => s.shards)
+
+  return (
+    <section className="panel panel--shards">
+      <header className="panel__head">
+        <h2>Shards</h2>
+        <span className="tag">{shards.length} BUILT</span>
+      </header>
+
+      <ul className="avatars__list shards__list">
+        {shards.map((s) => (
+          <li key={s.id} className="shards__row">
+            <button className="shards__open" onClick={() => useWorkshop.getState().openWorkshop(s.id)} title="Open in the workshop">
+              <span className="avatars__who">{s.name}</span>
+              <span className="shards__meta">{s.vertices.length} v · {s.faces.length} f · {s.mode.toUpperCase()} · 2^{s.unit}</span>
+            </button>
+          </li>
+        ))}
+        {shards.length === 0 && <li className="avatars__empty">Nothing built yet.</li>}
+      </ul>
+
+      <div className="shards__actions">
+        <button className="avatars__go" onClick={() => useWorkshop.getState().openWorkshop()}>OPEN WORKSHOP</button>
+        <button className="avatars__go" onClick={() => { useWorkshop.getState().create(); useWorkshop.getState().openWorkshop() }}>NEW SHARD</button>
+      </div>
+
+      <p className="legend__note">
+        A shard is a small object of coloured vertices: triangles in SOLID
+        mode, lights in POINTS mode, a polyline in LINES mode. Built on an
+        integer grid and kept on this device until deployed.
+      </p>
+    </section>
+  )
+}

--- a/src/lib/shards.test.ts
+++ b/src/lib/shards.test.ts
@@ -1,0 +1,69 @@
+/**
+ * shards.test.ts - the wire form round-trips, and refuses what would crash a
+ * drawer.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { flatten, fromPayload, newShard, toPayload, validFace, validPoint, type ShardModel } from './shards'
+
+const tri: ShardModel = {
+  ...newShard('tri'),
+  mode: 'solid',
+  unit: 3,
+  vertices: [
+    { p: [0, 0, 0], c: [1, 0, 0] },
+    { p: [2, 0, 0], c: [0, 1, 0] },
+    { p: [0, 2, 0], c: [0, 0, 1] },
+  ],
+  faces: [[0, 1, 2]],
+}
+
+describe('payload', () => {
+  it('round-trips', () => {
+    const back = fromPayload(JSON.parse(JSON.stringify(toPayload(tri))), 'x')
+    expect(back).not.toBeNull()
+    expect(back!.vertices).toEqual(tri.vertices)
+    expect(back!.faces).toEqual(tri.faces)
+    expect(back!.mode).toBe('solid')
+    expect(back!.unit).toBe(3)
+    expect(back!.name).toBe('tri')
+  })
+
+  it('refuses a face that points past the vertices', () => {
+    const p = toPayload(tri)
+    expect(fromPayload({ ...p, faces: [[0, 1, 9]] }, 'x')).toBeNull()
+  })
+
+  it('refuses mismatched colours, unknown modes, bad units and other types', () => {
+    const p = toPayload(tri)
+    expect(fromPayload({ ...p, colors: p.colors.slice(1) }, 'x')).toBeNull()
+    expect(fromPayload({ ...p, mode: 'voxels' }, 'x')).toBeNull()
+    expect(fromPayload({ ...p, unit: 99 }, 'x')).toBeNull()
+    expect(fromPayload({ ...p, type: 'note' }, 'x')).toBeNull()
+    expect(fromPayload('nope', 'x')).toBeNull()
+  })
+
+  it('clamps colours into 0..1', () => {
+    const p = toPayload(tri)
+    const back = fromPayload({ ...p, colors: [[2, -1, 0.5], [0, 0, 0], [0, 0, 0]] }, 'x')
+    expect(back!.vertices[0].c).toEqual([1, 0, 0.5])
+  })
+})
+
+describe('geometry', () => {
+  it('flattens vertices and faces in order', () => {
+    const f = flatten(tri)
+    expect(Array.from(f.positions)).toEqual([0, 0, 0, 2, 0, 0, 0, 2, 0])
+    expect(Array.from(f.colors)).toEqual([1, 0, 0, 0, 1, 0, 0, 0, 1])
+    expect(f.index).toEqual([0, 1, 2])
+  })
+
+  it('validates points and faces', () => {
+    expect(validPoint([1, -8, 8])).toBe(true)
+    expect(validPoint([9, 0, 0])).toBe(false)
+    expect(validPoint([0.5, 0, 0])).toBe(false)
+    expect(validFace([0, 1, 2], 3)).toBe(true)
+    expect(validFace([0, 1, 1], 3)).toBe(false)
+    expect(validFace([0, 1, 3], 3)).toBe(false)
+  })
+})

--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -1,0 +1,162 @@
+/**
+ * shards.ts — the shape of a shard, and nothing about where it goes.
+ *
+ * A shard is a small 3D object: vertices with colours, optional triangles,
+ * and a render mode. The mesh is only one way to draw it. Vertices alone can
+ * be lights, and a polyline through them blends their colours along the line
+ * the way a mesh blends across a face, so the same vertex list carries all
+ * three and the mode is a property of the shard, not of the viewer.
+ *
+ * Vertices sit on an integer grid in model units, and a shard carries the
+ * exponent that says what one unit is in gibsons, so a gibson-sized trinket
+ * and a sector-sized monument are the same data at different `unit`. Integers
+ * because precision is the whole point of this client: a vertex is at a
+ * coordinate, not near one.
+ *
+ * Pure. The builder store mutates copies of these; the world draws them.
+ */
+
+export type ShardMode = 'solid' | 'points' | 'lines'
+
+export interface ShardVertex {
+  /** Model units, integers. */
+  p: [number, number, number]
+  /** 0..1 per channel. */
+  c: [number, number, number]
+}
+
+export interface ShardModel {
+  id: string
+  name: string
+  /** One model unit is 2^unit gibsons. */
+  unit: number
+  mode: ShardMode
+  vertices: ShardVertex[]
+  /** Triangles as vertex indices; drawn in `solid` mode only. */
+  faces: Array<[number, number, number]>
+  updatedAt: number
+}
+
+/** Wire form: what goes in an event's content, public or decrypted. */
+export interface ShardPayload {
+  v: 1
+  type: 'shard'
+  name: string
+  unit: number
+  mode: ShardMode
+  vertices: Array<[number, number, number]>
+  colors: Array<[number, number, number]>
+  faces: Array<[number, number, number]>
+}
+
+export const MODES: ShardMode[] = ['solid', 'points', 'lines']
+
+/** Half-width of the build grid, in units. */
+export const GRID_HALF = 8
+
+export const MAX_VERTICES = 512
+export const MAX_FACES = 1024
+
+export function newShard(name = 'Untitled shard'): ShardModel {
+  return { id: uuid(), name, unit: 0, mode: 'solid', vertices: [], faces: [], updatedAt: Date.now() }
+}
+
+export function uuid(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID()
+  return Array.from({ length: 32 }, () => Math.floor(Math.random() * 16).toString(16)).join('')
+}
+
+/** Integers inside the grid; anything else is not a vertex. */
+export function validPoint(p: [number, number, number]): boolean {
+  return p.every((v) => Number.isInteger(v) && Math.abs(v) <= GRID_HALF)
+}
+
+export function clampColor(c: [number, number, number]): [number, number, number] {
+  return c.map((v) => Math.min(1, Math.max(0, Number.isFinite(v) ? v : 0))) as [number, number, number]
+}
+
+/** A face needs three distinct vertices that exist. */
+export function validFace(f: [number, number, number], count: number): boolean {
+  return f.every((i) => Number.isInteger(i) && i >= 0 && i < count) && new Set(f).size === 3
+}
+
+export function toPayload(s: ShardModel): ShardPayload {
+  return {
+    v: 1,
+    type: 'shard',
+    name: s.name,
+    unit: s.unit,
+    mode: s.mode,
+    vertices: s.vertices.map((v) => v.p),
+    colors: s.vertices.map((v) => v.c),
+    faces: s.faces,
+  }
+}
+
+/**
+ * Strict on shape, forgiving on nothing: a payload is what the wire gives
+ * back, and a shard with a face pointing at a vertex it does not have would
+ * throw inside three.js at draw time, far from anything that could explain it.
+ */
+export function fromPayload(raw: unknown, id: string): ShardModel | null {
+  if (!raw || typeof raw !== 'object') return null
+  const p = raw as Partial<ShardPayload>
+  if (p.v !== 1 || p.type !== 'shard') return null
+  if (!Array.isArray(p.vertices) || !Array.isArray(p.colors) || !Array.isArray(p.faces)) return null
+  if (p.vertices.length !== p.colors.length || p.vertices.length > MAX_VERTICES || p.faces.length > MAX_FACES) return null
+  if (!MODES.includes(p.mode as ShardMode)) return null
+  if (!Number.isInteger(p.unit) || (p.unit as number) < 0 || (p.unit as number) > 84) return null
+  const vertices: ShardVertex[] = []
+  for (let i = 0; i < p.vertices.length; i++) {
+    const pt = p.vertices[i], c = p.colors[i]
+    if (!Array.isArray(pt) || pt.length !== 3 || !Array.isArray(c) || c.length !== 3) return null
+    const point = pt.map(Number) as [number, number, number]
+    if (!point.every(Number.isFinite)) return null
+    vertices.push({ p: point, c: clampColor(c.map(Number) as [number, number, number]) })
+  }
+  const faces: Array<[number, number, number]> = []
+  for (const f of p.faces) {
+    if (!Array.isArray(f) || f.length !== 3) return null
+    const face = f.map(Number) as [number, number, number]
+    if (!validFace(face, vertices.length)) return null
+    faces.push(face)
+  }
+  return {
+    id,
+    name: typeof p.name === 'string' ? p.name.slice(0, 64) : 'shard',
+    unit: p.unit as number,
+    mode: p.mode as ShardMode,
+    vertices,
+    faces,
+    updatedAt: Date.now(),
+  }
+}
+
+/** The flat arrays three.js wants, in one place so every drawer agrees. */
+export function flatten(s: ShardModel): { positions: Float32Array; colors: Float32Array; index: number[] } {
+  const positions = new Float32Array(s.vertices.length * 3)
+  const colors = new Float32Array(s.vertices.length * 3)
+  s.vertices.forEach((v, i) => {
+    positions.set(v.p, i * 3)
+    colors.set(v.c, i * 3)
+  })
+  return { positions, colors, index: s.faces.flat() }
+}
+
+/** Where the shard's vertices sit on average: what the workshop orbits. */
+export function centroid(s: ShardModel): [number, number, number] {
+  if (s.vertices.length === 0) return [0, 0, 0]
+  const sum = [0, 0, 0]
+  for (const v of s.vertices) for (let i = 0; i < 3; i++) sum[i] += v.p[i]
+  return sum.map((x) => x / s.vertices.length) as [number, number, number]
+}
+
+/** Hex <-> 0..1 triple, for the colour input. */
+export function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.replace('#', ''), 16)
+  return [((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255]
+}
+
+export function rgbToHex(c: [number, number, number]): string {
+  return '#' + c.map((v) => Math.round(Math.min(1, Math.max(0, v)) * 255).toString(16).padStart(2, '0')).join('')
+}

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -1,0 +1,86 @@
+/**
+ * ShardMesh.tsx — one shard, drawn in its mode.
+ *
+ * Shared by the workshop bench and the world, so what you build is exactly
+ * what gets placed. Three modes off one vertex list:
+ *
+ * - solid: the triangles, vertex colours blended across each face, unlit and
+ *   double-sided so it reads as drawn light under bloom like everything else.
+ * - points: every vertex is a light. Additive, depth-write off, so lights in
+ *   front of lights add up instead of occluding.
+ * - lines: a polyline through the vertices in order, the colours blending
+ *   along each segment the way they do across a face.
+ */
+
+import { useMemo } from 'react'
+import {
+  AdditiveBlending,
+  BufferGeometry,
+  DoubleSide,
+  Float32BufferAttribute,
+  Line,
+  LineBasicMaterial,
+} from 'three'
+import { flatten, type ShardModel } from '../lib/shards'
+
+interface Props {
+  shard: ShardModel
+  /** Render units per model unit. */
+  scale?: number
+  /** Dimmed, for a preview that is not yet real. */
+  ghost?: boolean
+}
+
+export function ShardMesh({ shard, scale = 1, ghost = false }: Props): JSX.Element | null {
+  const { positions, colors, index } = useMemo(() => flatten(shard), [shard.vertices, shard.faces])
+
+  // Two geometries off one buffer pair: the mesh needs the index, the points
+  // and the line must not have it (an indexed Line draws the index order).
+  const plain = useMemo(() => {
+    const g = new BufferGeometry()
+    g.setAttribute('position', new Float32BufferAttribute(positions, 3))
+    g.setAttribute('color', new Float32BufferAttribute(colors, 3))
+    return g
+  }, [positions, colors])
+
+  const indexed = useMemo(() => {
+    const g = plain.clone()
+    g.setIndex(index)
+    g.computeVertexNormals()
+    return g
+  }, [plain, index])
+
+  const line = useMemo(() => {
+    const l = new Line(plain, new LineBasicMaterial({ vertexColors: true, toneMapped: false, transparent: true, opacity: ghost ? 0.45 : 1 }))
+    l.frustumCulled = false
+    return l
+  }, [plain, ghost])
+
+  if (shard.vertices.length === 0) return null
+  const opacity = ghost ? 0.45 : 1
+
+  return (
+    <group scale={scale}>
+      {shard.mode === 'solid' && index.length > 0 && (
+        <mesh geometry={indexed} frustumCulled={false}>
+          <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} />
+        </mesh>
+      )}
+      {shard.mode === 'lines' && shard.vertices.length > 1 && <primitive object={line} />}
+      {(shard.mode === 'points' || shard.mode === 'solid' || shard.mode === 'lines') && (
+        <points geometry={plain} frustumCulled={false}>
+          <pointsMaterial
+            vertexColors
+            size={shard.mode === 'points' ? 0.6 : 0.16}
+            sizeAttenuation
+            transparent
+            opacity={shard.mode === 'points' ? opacity : opacity * 0.9}
+            blending={AdditiveBlending}
+            depthWrite={false}
+            toneMapped={false}
+          />
+        </points>
+      )}
+    </group>
+  )
+}

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -1,0 +1,77 @@
+/**
+ * useWorkshop.test.ts - edits keep the shard consistent: no two vertices on a
+ * point, faces follow their vertices through deletions, duplicates are copies.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWorkshop } from './useWorkshop'
+
+const w = () => useWorkshop.getState()
+
+describe('workshop', () => {
+  beforeEach(() => {
+    useWorkshop.setState({ shards: [], currentId: null, selected: null, facePick: [], level: 0 })
+    w().create('t')
+  })
+
+  it('adds vertices at the level, never twice on one point, and selects them', () => {
+    w().setLevel(2)
+    w().addVertex([1, 2, 3])
+    w().addVertex([1, 2, 3])
+    expect(w().current()!.vertices).toHaveLength(1)
+    expect(w().current()!.vertices[0].p).toEqual([1, 2, 3])
+    expect(w().selected).toBe(0)
+    w().addVertex([9, 0, 0])
+    expect(w().current()!.vertices).toHaveLength(1)
+  })
+
+  it('nudges the selection and refuses to land on another vertex or leave the grid', () => {
+    w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0])
+    w().selectVertex(0)
+    w().moveSelected(0, 1)
+    expect(w().current()!.vertices[0].p).toEqual([0, 0, 0])
+    w().moveSelected(1, 1)
+    expect(w().current()!.vertices[0].p).toEqual([0, 1, 0])
+    w().selectVertex(1)
+    for (let i = 0; i < 20; i++) w().moveSelected(0, 1)
+    expect(w().current()!.vertices[1].p[0]).toBe(8)
+  })
+
+  it('builds a face from three picks, ignores duplicates, and reindexes on delete', () => {
+    w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0]); w().addVertex([0, 0, 1]); w().addVertex([2, 0, 2])
+    w().setTool('face')
+    w().pickForFace(1); w().pickForFace(2); w().pickForFace(3)
+    expect(w().current()!.faces).toEqual([[1, 2, 3]])
+    w().pickForFace(3); w().pickForFace(1); w().pickForFace(2)
+    expect(w().current()!.faces).toHaveLength(1)
+    w().pickForFace(0); w().pickForFace(1); w().pickForFace(2)
+    expect(w().current()!.faces).toHaveLength(2)
+    // Delete vertex 0: the face using it goes, the other shifts down.
+    w().setTool('select'); w().selectVertex(0); w().deleteSelected()
+    expect(w().current()!.vertices).toHaveLength(3)
+    expect(w().current()!.faces).toEqual([[0, 1, 2]])
+    expect(w().selected).toBeNull()
+  })
+
+  it('colours the selection or everything', () => {
+    w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0])
+    w().selectVertex(1); w().colorSelected([1, 0, 0])
+    expect(w().current()!.vertices[1].c).toEqual([1, 0, 0])
+    expect(w().current()!.vertices[0].c).not.toEqual([1, 0, 0])
+    w().colorAll([0, 1, 0])
+    expect(w().current()!.vertices.every((v) => v.c.join() === '0,1,0')).toBe(true)
+  })
+
+  it('duplicates as an independent copy and removes', () => {
+    w().addVertex([0, 0, 0])
+    const src = w().currentId!
+    const copy = w().duplicate(src)
+    expect(copy).not.toBe(src)
+    w().addVertex([1, 1, 1])
+    expect(w().shards.find((s) => s.id === src)!.vertices).toHaveLength(1)
+    expect(w().shards.find((s) => s.id === copy)!.vertices).toHaveLength(2)
+    w().remove(copy)
+    expect(w().shards.map((s) => s.id)).toEqual([src])
+    expect(w().currentId).toBe(src)
+  })
+})

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -1,0 +1,243 @@
+/**
+ * useWorkshop.ts — the shards you are building, and the one on the bench.
+ *
+ * Everything here is local: shards persist in localStorage until deployed,
+ * and a deployed shard stays here too, so it can be deployed again somewhere
+ * else or edited into a new one. The editing model is deliberately small:
+ * select a vertex, nudge it a unit along an axis, colour it, join three into
+ * a face. It fits a thumb, and it is exact.
+ */
+
+import { create } from 'zustand'
+import {
+  GRID_HALF,
+  clampColor,
+  newShard,
+  uuid,
+  validFace,
+  validPoint,
+  type ShardMode,
+  type ShardModel,
+  type ShardVertex,
+} from '../lib/shards'
+
+export type Tool = 'add' | 'select' | 'face'
+
+const STORAGE = 'onosendai:shards'
+
+export interface WorkshopState {
+  shards: ShardModel[]
+  currentId: string | null
+  /** The workshop overlay is up. */
+  open: boolean
+  tool: Tool
+  /** Selected vertex index, for moving, colouring and deleting. */
+  selected: number | null
+  /** Vertices picked so far for the next face. */
+  facePick: number[]
+  /** The Y the add tool places on: the grid plane moves up and down. */
+  level: number
+  /** The colour new vertices get, and the colour input shows. */
+  color: [number, number, number]
+
+  openWorkshop: (id?: string) => void
+  closeWorkshop: () => void
+  create: (name?: string) => string
+  select: (id: string | null) => void
+  rename: (id: string, name: string) => void
+  duplicate: (id: string) => string
+  remove: (id: string) => void
+  setMode: (mode: ShardMode) => void
+  setUnit: (unit: number) => void
+  setTool: (tool: Tool) => void
+  setLevel: (level: number) => void
+  setColor: (c: [number, number, number]) => void
+  addVertex: (p: [number, number, number]) => void
+  selectVertex: (index: number | null) => void
+  moveSelected: (axis: 0 | 1 | 2, delta: number) => void
+  colorSelected: (c: [number, number, number]) => void
+  colorAll: (c: [number, number, number]) => void
+  deleteSelected: () => void
+  pickForFace: (index: number) => void
+  clearFacePick: () => void
+  removeLastFace: () => void
+  removeFace: (index: number) => void
+  clearShard: () => void
+  current: () => ShardModel | null
+}
+
+function load(): ShardModel[] {
+  try {
+    const raw = localStorage.getItem(STORAGE)
+    if (!raw) return []
+    const list = JSON.parse(raw)
+    return Array.isArray(list) ? list.filter((s) => s && typeof s.id === 'string' && Array.isArray(s.vertices)) : []
+  } catch { return [] }
+}
+
+function save(shards: ShardModel[]): void {
+  try { localStorage.setItem(STORAGE, JSON.stringify(shards)) } catch { /* quota or private mode */ }
+}
+
+export const useWorkshop = create<WorkshopState>((set, get) => {
+  /** Apply an edit to the current shard, stamp it, persist. */
+  const edit = (fn: (s: ShardModel) => ShardModel | null): void => {
+    const { shards, currentId } = get()
+    const i = shards.findIndex((s) => s.id === currentId)
+    if (i < 0) return
+    const next = fn(shards[i])
+    if (!next) return
+    const list = shards.slice()
+    list[i] = { ...next, updatedAt: Date.now() }
+    set({ shards: list })
+    save(list)
+  }
+
+  return {
+    shards: load(),
+    currentId: null,
+    open: false,
+    tool: 'add',
+    selected: null,
+    facePick: [],
+    level: 0,
+    color: [0, 0.9, 1],
+
+    openWorkshop: (id) => {
+      const { shards } = get()
+      const currentId = id ?? get().currentId ?? shards[0]?.id ?? get().create()
+      set({ open: true, currentId, selected: null, facePick: [], tool: 'add' })
+    },
+
+    closeWorkshop: () => set({ open: false, selected: null, facePick: [] }),
+
+    create: (name) => {
+      const s = newShard(name ?? `Shard ${get().shards.length + 1}`)
+      const list = [...get().shards, s]
+      set({ shards: list, currentId: s.id, selected: null, facePick: [] })
+      save(list)
+      return s.id
+    },
+
+    select: (id) => set({ currentId: id, selected: null, facePick: [] }),
+
+    rename: (id, name) => {
+      const list = get().shards.map((s) => (s.id === id ? { ...s, name: name.slice(0, 64), updatedAt: Date.now() } : s))
+      set({ shards: list }); save(list)
+    },
+
+    duplicate: (id) => {
+      const src = get().shards.find((s) => s.id === id)
+      if (!src) return id
+      const copy: ShardModel = { ...src, id: uuid(), name: `${src.name} copy`, vertices: src.vertices.map((v) => ({ p: [...v.p] as ShardVertex['p'], c: [...v.c] as ShardVertex['c'] })), faces: src.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
+      const list = [...get().shards, copy]
+      set({ shards: list, currentId: copy.id, selected: null, facePick: [] }); save(list)
+      return copy.id
+    },
+
+    remove: (id) => {
+      const list = get().shards.filter((s) => s.id !== id)
+      const currentId = get().currentId === id ? (list[0]?.id ?? null) : get().currentId
+      set({ shards: list, currentId, selected: null, facePick: [] }); save(list)
+    },
+
+    setMode: (mode) => edit((s) => ({ ...s, mode })),
+    setUnit: (unit) => edit((s) => ({ ...s, unit: Math.max(0, Math.min(84, Math.round(unit))) })),
+    setTool: (tool) => set({ tool, facePick: [] }),
+    setLevel: (level) => set({ level: Math.max(-GRID_HALF, Math.min(GRID_HALF, Math.round(level))) }),
+    setColor: (c) => set({ color: clampColor(c) }),
+
+    addVertex: (p) => {
+      if (!validPoint(p)) return
+      let added = -1
+      edit((s) => {
+        // One vertex per point: adding where one already is selects it instead.
+        const existing = s.vertices.findIndex((v) => v.p[0] === p[0] && v.p[1] === p[1] && v.p[2] === p[2])
+        if (existing >= 0) { added = existing; return null }
+        added = s.vertices.length
+        return { ...s, vertices: [...s.vertices, { p: [...p] as ShardVertex['p'], c: [...get().color] as ShardVertex['c'] }] }
+      })
+      if (added >= 0) set({ selected: added })
+    },
+
+    selectVertex: (index) => set({ selected: index }),
+
+    moveSelected: (axis, delta) => {
+      const { selected } = get()
+      if (selected === null) return
+      edit((s) => {
+        const v = s.vertices[selected]
+        if (!v) return null
+        const p = [...v.p] as ShardVertex['p']
+        p[axis] += delta
+        if (!validPoint(p)) return null
+        // Never two vertices on one point.
+        if (s.vertices.some((o, i) => i !== selected && o.p[0] === p[0] && o.p[1] === p[1] && o.p[2] === p[2])) return null
+        const vertices = s.vertices.slice()
+        vertices[selected] = { ...v, p }
+        return { ...s, vertices }
+      })
+    },
+
+    colorSelected: (c) => {
+      const { selected } = get()
+      set({ color: clampColor(c) })
+      if (selected === null) return
+      edit((s) => {
+        const vertices = s.vertices.slice()
+        if (!vertices[selected]) return null
+        vertices[selected] = { ...vertices[selected], c: clampColor(c) }
+        return { ...s, vertices }
+      })
+    },
+
+    colorAll: (c) => {
+      set({ color: clampColor(c) })
+      edit((s) => ({ ...s, vertices: s.vertices.map((v) => ({ ...v, c: clampColor(c) })) }))
+    },
+
+    deleteSelected: () => {
+      const { selected } = get()
+      if (selected === null) return
+      edit((s) => {
+        if (!s.vertices[selected]) return null
+        // Faces that used it go; faces above it shift down one.
+        const faces = s.faces
+          .filter((f) => !f.includes(selected))
+          .map((f) => f.map((i) => (i > selected ? i - 1 : i)) as [number, number, number])
+        return { ...s, vertices: s.vertices.filter((_, i) => i !== selected), faces }
+      })
+      set({ selected: null, facePick: [] })
+    },
+
+    pickForFace: (index) => {
+      const { facePick } = get()
+      if (facePick.includes(index)) { set({ facePick: facePick.filter((i) => i !== index) }); return }
+      const pick = [...facePick, index]
+      if (pick.length < 3) { set({ facePick: pick }); return }
+      const face = pick as [number, number, number]
+      edit((s) => {
+        if (!validFace(face, s.vertices.length)) return null
+        // The same three vertices in any order is the same face.
+        const key = [...face].sort().join(',')
+        if (s.faces.some((f) => [...f].sort().join(',') === key)) return null
+        return { ...s, faces: [...s.faces, face] }
+      })
+      set({ facePick: [] })
+    },
+
+    clearFacePick: () => set({ facePick: [] }),
+
+    removeLastFace: () => edit((s) => (s.faces.length ? { ...s, faces: s.faces.slice(0, -1) } : null)),
+
+    removeFace: (index) => edit((s) => (s.faces[index] ? { ...s, faces: s.faces.filter((_, i) => i !== index) } : null)),
+
+    clearShard: () => { edit((s) => ({ ...s, vertices: [], faces: [] })); set({ selected: null, facePick: [] }) },
+
+    current: () => get().shards.find((s) => s.id === get().currentId) ?? null,
+  }
+})
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __workshop?: unknown }).__workshop = useWorkshop
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1162,6 +1162,320 @@ kbd {
   transform: none;
 }
 
+/* ---------- Shards panel ---------- */
+
+.shards__row {
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+}
+
+.shards__row:first-child {
+  border-top: 0;
+}
+
+.shards__open {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  padding: 6px 4px;
+  font-family: inherit;
+  font-size: 11px;
+  color: var(--fg);
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.shards__open:hover {
+  background: rgba(0, 229, 255, 0.06);
+}
+
+.shards__meta {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+
+.shards__actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+/* ---------- Workshop ----------
+ *
+ * A full-screen bench. The bench fills what the head and the tools leave,
+ * and on a phone the tools wrap rather than scroll: every control has to be
+ * reachable with the model still in view.
+ */
+.workshop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--mono);
+}
+
+.workshop__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.workshop__list-btn,
+.workshop__close,
+.workshop__mode,
+.workshop__tool,
+.workshop__btn,
+.workshop__new,
+.workshop__mini {
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 5px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.8);
+  border: 1px solid rgba(0, 229, 255, 0.25);
+  cursor: pointer;
+  touch-action: none;
+  white-space: nowrap;
+  -webkit-touch-callout: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.workshop__btn:active:not(:disabled),
+.workshop__tool:active,
+.workshop__mode:active {
+  background: rgba(0, 229, 255, 0.28);
+}
+
+.workshop__btn:disabled,
+.workshop__tool:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.workshop__mode.is-on,
+.workshop__tool.is-on {
+  color: #05070d;
+  background: var(--accent);
+  border-color: var(--accent);
+  font-weight: 700;
+}
+
+.workshop__close {
+  margin-left: auto;
+  color: var(--dim);
+}
+
+.workshop__name {
+  flex: 1 1 120px;
+  min-width: 80px;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 6px 8px;
+  border-radius: 5px;
+  color: var(--fg);
+  background: rgba(0, 229, 255, 0.05);
+  border: 1px solid rgba(0, 229, 255, 0.22);
+}
+
+.workshop__name:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.workshop__modes {
+  display: flex;
+  gap: 3px;
+}
+
+.workshop__list {
+  position: absolute;
+  top: 48px;
+  left: 10px;
+  z-index: 1;
+  width: min(320px, calc(100vw - 20px));
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 8px;
+  border-radius: 8px;
+  background: rgba(6, 14, 22, 0.96);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+}
+
+.workshop__list ul {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+}
+
+.workshop__list li {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+}
+
+.workshop__list li.is-current .workshop__pick {
+  color: var(--accent);
+}
+
+.workshop__new {
+  width: 100%;
+  color: var(--accent);
+}
+
+.workshop__pick {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 7px 4px;
+  font-family: inherit;
+  font-size: 11px;
+  color: var(--fg);
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.workshop__pick-meta {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+
+.workshop__mini {
+  width: 30px;
+  padding: 0;
+  color: var(--dim);
+}
+
+.workshop__mini--danger:hover {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.workshop__bench {
+  position: relative;
+  min-height: 0;
+}
+
+.workshop__bench canvas {
+  display: block;
+}
+
+.workshop__stats {
+  position: absolute;
+  left: 10px;
+  bottom: 8px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+  pointer-events: none;
+  text-shadow: 0 0 4px var(--bg);
+}
+
+.workshop__tools {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.workshop__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+
+.workshop__label {
+  font-size: 8px;
+  letter-spacing: 0.16em;
+  color: var(--dim);
+  min-width: 54px;
+}
+
+.workshop__label--gap {
+  margin-left: 10px;
+}
+
+.workshop__value {
+  font-size: 11px;
+  min-width: 22px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.workshop__help {
+  flex: 1 1 200px;
+  font-size: 9px;
+  color: var(--dim);
+}
+
+.workshop__pad {
+  display: grid;
+  grid-template-columns: repeat(6, auto);
+  gap: 4px;
+}
+
+.workshop__btn--x { color: #ff4444; }
+.workshop__btn--y { color: #44ff44; }
+.workshop__btn--z { color: #4488ff; }
+
+.workshop__btn--danger {
+  color: var(--danger);
+  border-color: rgba(255, 59, 107, 0.4);
+}
+
+.workshop__color {
+  width: 38px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid rgba(0, 229, 255, 0.25);
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.workshop__swatches {
+  display: flex;
+  gap: 4px;
+}
+
+.workshop__swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  .workshop__help { display: none; }
+  .workshop__label { min-width: 0; }
+}
+
 /* ---------- Derezz ----------
  *
  * The one panel that destroys something. Red throughout, last in the column,

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -1,0 +1,188 @@
+/**
+ * Bench.tsx — the workshop's 3D view.
+ *
+ * A grid at the current level, the shard drawn live in its mode, and a handle
+ * on every vertex. Taps do the work: on the grid, the add tool places a vertex
+ * at the snapped point; on a handle, select picks it or the face tool collects
+ * it. Dragging orbits. R3F reports how far the pointer travelled between down
+ * and up, which is what separates the two, so a thumb that wobbles still taps.
+ */
+
+import { Canvas, useThree, type ThreeEvent } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { useEffect, useMemo, useRef } from 'react'
+import { Vector3 } from 'three'
+import { ACCENT, BG, WARN } from '../lib/palette'
+import { GRID_HALF, centroid } from '../lib/shards'
+import { ShardMesh } from '../scene/ShardMesh'
+import { useWorkshop } from '../store/useWorkshop'
+
+/** A press that travels further than this is an orbit, not a tap. */
+const TAP_SLOP = 8
+
+function Grid(): JSX.Element {
+  const level = useWorkshop((s) => s.level)
+  const tool = useWorkshop((s) => s.tool)
+
+  const onClick = (e: ThreeEvent<MouseEvent>): void => {
+    if (e.delta > TAP_SLOP) return
+    e.stopPropagation()
+    // Read the store at tap time rather than from the render closure: a level
+    // changed a moment ago must apply to this tap even if the bench has not
+    // re-rendered yet.
+    const w = useWorkshop.getState()
+    const p = e.point
+    w.addVertex([Math.round(p.x), w.level, Math.round(p.z)])
+  }
+
+  return (
+    <group position={[0, level, 0]}>
+      {/* The visible lattice. One cell per unit, so what you tap is what you get. */}
+      <gridHelper args={[GRID_HALF * 2, GRID_HALF * 2, ACCENT, '#1d3547']} />
+      {/*
+        The surface taps land on, in ADD mode only. In select and face mode it
+        carries no handler at all, so the raycaster ignores it: a raised grid
+        plane must not sit in front of the vertex handles and swallow the taps
+        meant for them, and an empty-space tap should reach onPointerMissed to
+        deselect rather than being caught here.
+      */}
+      {tool === 'add' && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} onClick={onClick}>
+          <planeGeometry args={[GRID_HALF * 2 + 1, GRID_HALF * 2 + 1]} />
+          <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+        </mesh>
+      )}
+    </group>
+  )
+}
+
+function Handles(): JSX.Element | null {
+  const shard = useWorkshop((s) => s.current())
+  const selected = useWorkshop((s) => s.selected)
+  const facePick = useWorkshop((s) => s.facePick)
+  const tool = useWorkshop((s) => s.tool)
+  if (!shard) return null
+
+  const onClick = (index: number) => (e: ThreeEvent<MouseEvent>): void => {
+    if (e.delta > TAP_SLOP) return
+    e.stopPropagation()
+    const w = useWorkshop.getState()
+    if (tool === 'face') w.pickForFace(index)
+    else w.selectVertex(w.selected === index ? null : index)
+  }
+
+  return (
+    <>
+      {shard.vertices.map((v, i) => {
+        const picked = facePick.indexOf(i)
+        const isSel = selected === i
+        return (
+          <group key={i} position={v.p}>
+            {/* A generous invisible hit target; the visible handle is small. */}
+            <mesh onClick={onClick(i)}>
+              <sphereGeometry args={[0.42, 10, 10]} />
+              <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+            </mesh>
+            <mesh>
+              <sphereGeometry args={[isSel || picked >= 0 ? 0.2 : 0.12, 12, 12]} />
+              <meshBasicMaterial color={isSel ? WARN : picked >= 0 ? ACCENT : `rgb(${v.c.map((x) => Math.round(x * 255)).join(',')})`} toneMapped={false} />
+            </mesh>
+            {picked >= 0 && (
+              <mesh>
+                <ringGeometry args={[0.3, 0.36, 24]} />
+                <meshBasicMaterial color={ACCENT} toneMapped={false} side={2} />
+              </mesh>
+            )}
+          </group>
+        )
+      })}
+    </>
+  )
+}
+
+/**
+ * Aim the orbit at the shard's centre when you switch to it, and only then.
+ * Re-aiming on every added vertex slid the whole view under your thumb each
+ * time you tapped, which is exactly when you are looking at where to tap next.
+ */
+function Aim(): null {
+  const id = useWorkshop((s) => s.currentId)
+  const controls = useThree((s) => s.controls) as unknown as { target: Vector3; update: () => void } | null
+  const camera = useThree((s) => s.camera)
+  useEffect(() => {
+    // The browser harness projects handle positions through this to click them.
+    if (import.meta.env.DEV) (window as unknown as { __benchCamera?: unknown }).__benchCamera = camera
+  }, [camera])
+  const target = useMemo(() => {
+    const shard = useWorkshop.getState().current()
+    return shard ? centroid(shard) : [0, 0, 0]
+  }, [id])
+  useEffect(() => {
+    if (!controls) return
+    controls.target.set(target[0], target[1], target[2])
+    controls.update()
+  }, [controls, target])
+  return null
+}
+
+/** Keyboard on the bench: nudge, delete, tools. */
+function Keys(): null {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      const tag = (e.target as HTMLElement | null)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      const w = useWorkshop.getState()
+      const nudge: Record<string, [0 | 1 | 2, number]> = {
+        ArrowRight: [0, 1], ArrowLeft: [0, -1], KeyD: [0, 1], KeyA: [0, -1],
+        ArrowUp: [2, -1], ArrowDown: [2, 1], KeyW: [2, -1], KeyS: [2, 1],
+        KeyR: [1, 1], KeyF: [1, -1],
+      }
+      if (nudge[e.code]) { e.preventDefault(); w.moveSelected(...nudge[e.code]); return }
+      if (e.code === 'Delete' || e.code === 'Backspace') { e.preventDefault(); w.deleteSelected(); return }
+      if (e.code === 'Escape') { e.preventDefault(); if (w.selected !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
+      if (e.code === 'Digit1') w.setTool('add')
+      if (e.code === 'Digit2') w.setTool('select')
+      if (e.code === 'Digit3') w.setTool('face')
+      if (e.code === 'BracketRight') w.setLevel(w.level + 1)
+      if (e.code === 'BracketLeft') w.setLevel(w.level - 1)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+  return null
+}
+
+export function Bench(): JSX.Element {
+  const shard = useWorkshop((s) => s.current())
+  const first = useRef(true)
+  useEffect(() => { first.current = false }, [])
+
+  return (
+    <Canvas
+      camera={{ fov: 50, position: [10, 9, 12], near: 0.05, far: 200 }}
+      dpr={[1, 2]}
+      gl={{ antialias: true }}
+      style={{ background: BG }}
+      // A click that hits nothing deselects and drops a half-built face. In ADD
+      // mode the grid plane catches the click first, so this fires only on true
+      // empty space; in select and face mode there is no plane, so a tap off any
+      // handle lands here.
+      onPointerMissed={(e) => {
+        if ((e as PointerEvent).button !== 0) return
+        const w = useWorkshop.getState()
+        if (w.selected !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() }
+      }}
+    >
+      <ambientLight intensity={1} />
+      <OrbitControls makeDefault enablePan={false} minDistance={3} maxDistance={60} dampingFactor={0.12} />
+      <Aim />
+      <Keys />
+      {/* Axes, in the compass's colours, so X is red here and out there. */}
+      <axesHelper args={[GRID_HALF + 1]} />
+      <Grid />
+      {shard && <ShardMesh shard={shard} />}
+      <Handles />
+    </Canvas>
+  )
+}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -1,0 +1,166 @@
+/**
+ * Workshop.tsx — where shards are made.
+ *
+ * A full-screen bench over the world. The tools are few and exact: ADD
+ * places a vertex where you tap the grid, at the current level; SELECT picks
+ * one and the pad nudges it a unit along X, Y or Z; FACE joins three taps
+ * into a triangle. Colour applies to the selection or to everything. The
+ * mode, solid, points or lines, is part of the shard and previews live.
+ *
+ * v1's modeller wanted a mouse: drag handles for every axis, bars to drag for
+ * every colour channel. This wants a thumb. Every action is a tap or a button,
+ * every position an integer, and the keyboard is a shortcut, not a requirement.
+ */
+
+import { useState } from 'react'
+import { noCallout, useRepeatable } from '../hooks/useRepeatable'
+import { GRID_HALF, MODES, hexToRgb, rgbToHex, type ShardMode } from '../lib/shards'
+import { formatCellSize } from '../lib/scale'
+import { useWorkshop, type Tool } from '../store/useWorkshop'
+import { Bench } from './Bench'
+
+const PALETTE = ['#00e5ff', '#ff2323', '#52e39f', '#ffb020', '#c07dff', '#f7931a', '#ffffff', '#2f81f7']
+
+const TOOL_HELP: Record<Tool, string> = {
+  add: 'Tap the grid to place a vertex at the current level.',
+  select: 'Tap a vertex, then nudge it with the pad, colour it, or delete it.',
+  face: 'Tap three vertices to make a triangle. Faces draw in SOLID mode.',
+}
+
+export function Workshop(): JSX.Element | null {
+  const open = useWorkshop((s) => s.open)
+  const shard = useWorkshop((s) => s.current())
+  const shards = useWorkshop((s) => s.shards)
+  const tool = useWorkshop((s) => s.tool)
+  const selected = useWorkshop((s) => s.selected)
+  const facePick = useWorkshop((s) => s.facePick)
+  const level = useWorkshop((s) => s.level)
+  const color = useWorkshop((s) => s.color)
+  const [listOpen, setListOpen] = useState(false)
+  const bind = useRepeatable()
+
+  if (!open) return null
+  const w = useWorkshop.getState
+
+  const nudge = (axis: 0 | 1 | 2, d: number) => () => w().moveSelected(axis, d)
+  const canNudge = selected !== null
+
+  return (
+    <div className="workshop" role="dialog" aria-label="Shard workshop">
+      <header className="workshop__head">
+        <button className="workshop__list-btn" onClick={() => setListOpen((v) => !v)} aria-expanded={listOpen}>
+          SHARDS ({shards.length})
+        </button>
+        {shard && (
+          <input
+            className="workshop__name"
+            value={shard.name}
+            onChange={(e) => w().rename(shard.id, e.target.value)}
+            aria-label="Shard name"
+            spellCheck={false}
+          />
+        )}
+        <div className="workshop__modes" role="group" aria-label="Render mode">
+          {MODES.map((m: ShardMode) => (
+            <button key={m} className={`workshop__mode ${shard?.mode === m ? 'is-on' : ''}`} aria-pressed={shard?.mode === m} onClick={() => w().setMode(m)}>
+              {m.toUpperCase()}
+            </button>
+          ))}
+        </div>
+        <button className="workshop__close" onClick={() => w().closeWorkshop()}>CLOSE</button>
+      </header>
+
+      {listOpen && (
+        <aside className="workshop__list">
+          <button className="workshop__new" onClick={() => { w().create(); setListOpen(false) }}>+ NEW SHARD</button>
+          <ul>
+            {shards.map((s) => (
+              <li key={s.id} className={s.id === shard?.id ? 'is-current' : ''}>
+                <button className="workshop__pick" onClick={() => { w().select(s.id); setListOpen(false) }}>
+                  <span className="workshop__pick-name">{s.name}</span>
+                  <span className="workshop__pick-meta">{s.vertices.length} v · {s.faces.length} f · {s.mode}</span>
+                </button>
+                <button className="workshop__mini" title="Duplicate" onClick={() => w().duplicate(s.id)}>⧉</button>
+                <button className="workshop__mini workshop__mini--danger" title="Delete" onClick={() => { if (window.confirm(`Delete "${s.name}"? This cannot be undone.`)) w().remove(s.id) }}>✕</button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      )}
+
+      <div className="workshop__bench">
+        <Bench />
+        {shard && (
+          <div className="workshop__stats">
+            {shard.vertices.length} vertices · {shard.faces.length} faces · unit 2^{shard.unit} = {formatCellSize(shard.unit)}
+            {selected !== null && shard.vertices[selected] && (
+              <> · selected #{selected} at ({shard.vertices[selected].p.join(', ')})</>
+            )}
+            {tool === 'face' && facePick.length > 0 && <> · face {facePick.length}/3</>}
+          </div>
+        )}
+      </div>
+
+      <div className="workshop__tools">
+        <div className="workshop__row" role="group" aria-label="Tool">
+          {(['add', 'select', 'face'] as Tool[]).map((t, i) => (
+            <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => w().setTool(t)} title={`${t} (${i + 1})`}>
+              {t.toUpperCase()}
+            </button>
+          ))}
+          <span className="workshop__help">{TOOL_HELP[tool]}</span>
+        </div>
+
+        <div className="workshop__row">
+          <span className="workshop__label">LEVEL Y</span>
+          <button className="workshop__btn" {...bind(() => w().setLevel(w().level - 1))} disabled={level <= -GRID_HALF} aria-label="Level down">−</button>
+          <span className="workshop__value">{level}</span>
+          <button className="workshop__btn" {...bind(() => w().setLevel(w().level + 1))} disabled={level >= GRID_HALF} aria-label="Level up">+</button>
+
+          <span className="workshop__label workshop__label--gap">UNIT 2^</span>
+          <button className="workshop__btn" {...bind(() => w().setUnit((shard?.unit ?? 0) - 1))} disabled={!shard || shard.unit <= 0} aria-label="Smaller unit">−</button>
+          <span className="workshop__value">{shard?.unit ?? 0}</span>
+          <button className="workshop__btn" {...bind(() => w().setUnit((shard?.unit ?? 0) + 1))} disabled={!shard || shard.unit >= 84} aria-label="Larger unit">+</button>
+        </div>
+
+        <div className="workshop__row">
+          <span className="workshop__label">NUDGE</span>
+          <div className="workshop__pad" role="group" aria-label="Move selected vertex">
+            <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, -1))} title="−X (A)">−X</button>
+            <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, 1))} title="+X (D)">+X</button>
+            <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, -1))} title="−Y (F)">−Y</button>
+            <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, 1))} title="+Y (R)">+Y</button>
+            <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, -1))} title="−Z (W)">−Z</button>
+            <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, 1))} title="+Z (S)">+Z</button>
+          </div>
+          <button className="workshop__btn workshop__btn--danger" disabled={!canNudge} onClick={() => w().deleteSelected()} title="Delete vertex (Del)">DELETE</button>
+        </div>
+
+        <div className="workshop__row">
+          <span className="workshop__label">COLOUR</span>
+          <input
+            type="color"
+            className="workshop__color"
+            value={rgbToHex(color)}
+            onChange={(e) => w().colorSelected(hexToRgb(e.target.value))}
+            aria-label="Vertex colour"
+            {...noCallout}
+          />
+          <div className="workshop__swatches">
+            {PALETTE.map((hex) => (
+              <button key={hex} className="workshop__swatch" style={{ background: hex }} aria-label={`Colour ${hex}`} onClick={() => w().colorSelected(hexToRgb(hex))} />
+            ))}
+          </div>
+          <button className="workshop__btn" disabled={!shard || shard.vertices.length === 0} onClick={() => w().colorAll(w().color)} title="Apply the colour to every vertex">ALL</button>
+        </div>
+
+        <div className="workshop__row">
+          <span className="workshop__label">FACES</span>
+          <span className="workshop__value">{shard?.faces.length ?? 0}</span>
+          <button className="workshop__btn" disabled={!shard || shard.faces.length === 0} onClick={() => w().removeLastFace()}>UNDO LAST</button>
+          <button className="workshop__btn workshop__btn--danger" disabled={!shard || shard.vertices.length === 0} onClick={() => { if (window.confirm('Clear every vertex and face of this shard?')) w().clearShard() }}>CLEAR</button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Stack 8 (base: `feat/targets`, PR #22). First half of spec item 5; the deploy + location-hiding + world-render half is the next PR.

## What changes

- **`lib/shards.ts`**: the shard model (coloured integer-grid vertices, faces, a `unit` exponent, a mode), a strict `fromPayload` / `toPayload` wire form, and `flatten` for three.js.
- **`scene/ShardMesh.tsx`**: one renderer, three modes — SOLID (triangles, blended vertex colours), POINTS (additive lights), LINES (colour-blended polyline). Shared by the bench and (next PR) the world.
- **`store/useWorkshop.ts`**: shards persisted in localStorage; add / select / nudge / colour / face / delete / duplicate, all keeping the shard consistent (no two vertices per point, faces reindex on delete).
- **`workshop/Bench.tsx` + `Workshop.tsx`**: a full-screen thumb-friendly bench. Tap-vs-orbit by pointer travel; grid plane active in ADD only; `onPointerMissed` deselects. Keyboard shortcuts for nudge / tools / level.
- **Shards panel** (left column) opens the workshop.

## Verification

- Tests: 147 passing (`lib/shards.test.ts`, `store/useWorkshop.test.ts` new).
- Browser: grid taps place vertices; level control places above the plane; FACE builds a triangle from three handle taps; SELECT + pad nudges, swatches colour; all three modes render (screenshots); renamed 4-vertex shard persists across reload. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)