### PR TITLE
feat: deploy a shard hidden at a location, and discover others'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ vertices, colours blending along it), chosen per shard and previewed live.
 localStorage. Keys on the bench: WASD / RF or arrows nudge, Del deletes,
 1 2 3 pick tools, [ ] change the level, Esc deselects then closes.
 
+**Deploying a shard.** DEPLOY on the bench, or from the Shards panel, enters
+deploy mode: aim the movement cursor at where it should go (it ghosts there at
+its true size), pick a height to hide it at, and place (DEPLOY, Space, or the
+PLACE button). Height is the discovery radius (spec section 7.3): 0 is a single
+gibson, each step up doubles the aligned cube it hides in. What is published is
+a location-encrypted `kind:33330` event (spec section 8.6): the shard, its
+coordinate and plane are AES-256-GCM encrypted to the region key
+`sha256(region_bytes)`, and only the `lookup_id = sha256(key)` is public, so
+the coordinate never leaves in the clear. The derivation is spec section 7.2
+exactly, so a shard hidden here is one the reference CLI can find and open.
+
+**Discovery.** A background scan derives the region keys for heights 0 to 12 at
+wherever the scene is anchored (in a worker, since that is the O(2^h) work the
+protocol says looking must cost), asks the relay for content under those lookup
+ids, and renders whatever decrypts. Your own deployments always render; others'
+appear when you are near enough to compute their region. The scan only re-runs
+when you cross a region boundary (spec section 7.5).
+
 **Targets.** The Targets panel points at any number of pubkeys the way the
 HUD points at Earth: a reticle in frame, a chevron on the nearest edge out of
 frame, the distance either way, and the avatar itself (a wireframe icosahedron

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ vertices, colours blending along it), chosen per shard and previewed live.
 localStorage. Keys on the bench: WASD / RF or arrows nudge, Del deletes,
 1 2 3 pick tools, [ ] change the level, Esc deselects then closes.
 
+**Models vs instances.** A **model** is a named design that lives on this
+device (the Shards panel's Models section). A deployed **instance** is one copy
+of it placed at a coordinate and published (the Deployed section). One model can
+have many instances. Deleting a model (behind a modal) removes it from this
+device and leaves its instances alone; deleting an instance sends a NIP-09
+deletion to the relays it is on and leaves the model alone. Tapping a deployment
+flies the scene to it and opens its wire record: event id, relays, lookup id,
+coordinate, and the height it is hidden at.
+
 **Deploying a shard.** DEPLOY on the bench, or from the Shards panel, enters
 deploy mode: aim the movement cursor at where it should go (it ghosts there at
 its true size), pick a height to hide it at, and place (DEPLOY, Space, or the
@@ -92,7 +101,8 @@ a location-encrypted `kind:33330` event (spec section 8.6): the shard, its
 coordinate and plane are AES-256-GCM encrypted to the region key
 `sha256(region_bytes)`, and only the `lookup_id = sha256(key)` is public, so
 the coordinate never leaves in the clear. The derivation is spec section 7.2
-exactly, so a shard hidden here is one the reference CLI can find and open.
+exactly, so a shard hidden here is one the reference CLI can find and open. The
+events go to `wss://cyberspace.nostr1.com` alongside movement.
 
 **Discovery.** A background scan derives the region keys for heights 0 to 12 at
 wherever the scene is anchored (in a worker, since that is the O(2^h) work the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useTargets } from './hooks/useTargets'
 import { startPublisher } from './lib/publisher'
 import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
+import { useShards } from './store/useShards'
 
 export default function App(): JSX.Element {
   // The keyboard is unconditional. The on-screen controls are a second way in,
@@ -47,6 +48,16 @@ export default function App(): JSX.Element {
   // would have stranded a desktop HUD with no control to bring it back.
   const [panelsOpen, setPanelsOpen] = useState(!isMobile)
   const showPanels = panelsOpen && !spectating
+
+  // Opening a deployment's wire record flies the scene to the shard, and on a
+  // phone that overlay sits along the bottom over the hamburger. So tapping a
+  // deployment closes the panels: the shard is what you asked to look at, the
+  // overlay is how you act on it, and EXIT frees the hamburger again. Only on a
+  // phone, where the two fight for the space; a desktop shows both at once.
+  const inspecting = useShards((s) => s.inspecting !== null)
+  useEffect(() => {
+    if (inspecting && isMobile) setPanelsOpen(false)
+  }, [inspecting, isMobile])
 
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { BitReadout } from './hud/BitReadout'
 import { ChainExplorer } from './hud/ChainExplorer'
 import { SpectateBar } from './hud/SpectateBar'
 import { Workshop } from './workshop/Workshop'
+import { DeployBar } from './hud/DeployBar'
+import { useDiscovery } from './hooks/useDiscovery'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
 import { TouchControls } from './hud/TouchControls'
@@ -24,6 +26,8 @@ export default function App(): JSX.Element {
   // cannot drift apart, and nothing about having a pointer takes the keys away.
   useKeyboard()
   useProofListener()
+  // The background scan for hidden shards near where you are looking.
+  useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
   useEffect(() => { startPublisher(); startTracker() }, [])
@@ -87,6 +91,7 @@ export default function App(): JSX.Element {
       )}
       {crowded && <div className="mobile-overlay" />}
       <Workshop />
+      <DeployBar />
       <button
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ChainExplorer } from './hud/ChainExplorer'
 import { SpectateBar } from './hud/SpectateBar'
 import { Workshop } from './workshop/Workshop'
 import { DeployBar } from './hud/DeployBar'
+import { DeploymentDetail } from './hud/DeploymentDetail'
 import { useDiscovery } from './hooks/useDiscovery'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
@@ -92,6 +93,7 @@ export default function App(): JSX.Element {
       {crowded && <div className="mobile-overlay" />}
       <Workshop />
       <DeployBar />
+      <DeploymentDetail />
       <button
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}

--- a/src/hooks/useDiscovery.ts
+++ b/src/hooks/useDiscovery.ts
@@ -1,0 +1,98 @@
+/**
+ * useDiscovery.ts — scan for chalk near where you are looking.
+ *
+ * Spec §7.4: at a coordinate you scan heights, compute each region's lookup_id,
+ * and ask the relay for encrypted content published under them. The keys come
+ * from the region worker, off the frame; the relay query and the decryption
+ * are here. What decrypts goes into the shard store and appears in the world.
+ *
+ * The scan re-runs when the anchor crosses into a new region, not on every
+ * gibson: §7.5 says an aligned subtree of height h changes only when you cross
+ * a boundary at that height, so a key stays valid until you do, and there is
+ * nothing to recompute until then.
+ */
+
+import { useEffect, useRef } from 'react'
+import { queryAny, SHARD_RELAYS } from '../lib/relay'
+import { decodeShard, ENCRYPTED_KIND } from '../lib/shardEvents'
+import { hexToBytes } from '../lib/events'
+import { MAX_COMPUTE_HEIGHT, useCyberspace } from '../store/useCyberspace'
+import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
+import type { RegionRequest, RegionResponse } from '../workers/region.worker'
+
+/** The aligned base of a value at a height: what decides "same region". */
+function base(v: bigint, h: number): bigint {
+  return (v >> BigInt(h)) << BigInt(h)
+}
+
+/** A signature of which regions the current anchor sits in, all heights. */
+function regionSignature(x: bigint, y: bigint, z: bigint): string {
+  let sig = ''
+  for (let h = 0; h <= SCAN_MAX_HEIGHT; h++) sig += `${base(x, h)},${base(y, h)},${base(z, h)};`
+  return sig
+}
+
+export function useDiscovery(): void {
+  const anchor = useCyberspace((s) => s.anchor)
+  const worker = useRef<Worker | null>(null)
+  const lastSig = useRef<string | null>(null)
+  const reqId = useRef(0)
+
+  useEffect(() => {
+    worker.current = new Worker(new URL('../workers/region.worker.ts', import.meta.url), { type: 'module' })
+    return () => { worker.current?.terminate(); worker.current = null }
+  }, [])
+
+  useEffect(() => {
+    const sig = regionSignature(anchor.x, anchor.y, anchor.z)
+    if (sig === lastSig.current) return
+    lastSig.current = sig
+
+    const id = ++reqId.current
+    const w = worker.current
+    if (!w) return
+
+    // Collect this scan's keys, then query the relay once for all of them.
+    const keys = new Map<string, string>() // lookupId -> keyHex
+
+    const onMessage = (e: MessageEvent<RegionResponse>): void => { void handle(e) }
+    const handle = async (e: MessageEvent<RegionResponse>): Promise<void> => {
+      const msg = e.data
+      if (msg.id !== id) return
+      if (msg.type === 'key') {
+        keys.set(msg.key.lookupId, msg.key.keyHex)
+        return
+      }
+      if (msg.type !== 'done') return
+      w.removeEventListener('message', onMessage)
+      if (keys.size === 0) return
+
+      // A superseded scan must not write stale finds.
+      const events = await queryAny(SHARD_RELAYS, { kinds: [ENCRYPTED_KIND], '#d': [...keys.keys()] })
+      if (id !== reqId.current) return
+
+      const found = []
+      for (const ev of events) {
+        const d = ev.tags.find((t) => t[0] === 'd')?.[1]
+        const keyHex = d ? keys.get(d) : undefined
+        if (!keyHex) continue
+        const decoded = await decodeShard(ev, hexToBytes(keyHex))
+        if (decoded) found.push(decoded)
+      }
+      if (id === reqId.current) useShards.getState().addDiscovered(found)
+    }
+
+    w.addEventListener('message', onMessage)
+    const request: RegionRequest = {
+      id,
+      x: anchor.x.toString(),
+      y: anchor.y.toString(),
+      z: anchor.z.toString(),
+      heights: Array.from({ length: SCAN_MAX_HEIGHT + 1 }, (_, h) => h),
+      maxComputeHeight: MAX_COMPUTE_HEIGHT,
+    }
+    w.postMessage(request)
+
+    return () => w.removeEventListener('message', onMessage)
+  }, [anchor])
+}

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -10,6 +10,7 @@
 import { useEffect } from 'react'
 import { useCyberspace } from '../store/useCyberspace'
 import { useWorkshop } from '../store/useWorkshop'
+import { useShards } from '../store/useShards'
 import { moveDirection, type MoveName } from '../lib/moves'
 import type { RotateDirection } from '../lib/space'
 
@@ -71,14 +72,18 @@ export function useKeyboard(): void {
 
       if (event.code === 'Escape') {
         event.preventDefault()
+        // Deploying: back out of it rather than resetting the view.
+        if (useShards.getState().deployId) { useShards.getState().cancelDeploy(); return }
         store.resetView()
         return
       }
 
-      // Commit the cursor's hop: the only key that costs a proof.
+      // Commit the cursor's hop: the only key that costs a proof. While
+      // deploying, Space places the shard at the cursor instead of moving.
       if (event.code === 'Space') {
         event.preventDefault()
-        store.commit()
+        if (useShards.getState().deployId) void useShards.getState().deploy()
+        else store.commit()
         return
       }
 

--- a/src/hud/ChainExplorer.tsx
+++ b/src/hud/ChainExplorer.tsx
@@ -35,7 +35,9 @@ export function ChainExplorer(): JSX.Element {
   const action = actions[index]
   const atHead = exploreIndex === null
 
-  const [open, setOpen] = useState(true)
+  // Minimized by default: the chip alone reads "CHAIN n/N", and the panel
+  // opens on a tap when you actually want to walk the chain.
+  const [open, setOpen] = useState(false)
   // Relative times drift; refresh them on a slow clock rather than per frame.
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {
@@ -125,13 +127,17 @@ export function ChainExplorer(): JSX.Element {
             )}
           </div>
 
+          {/* One field per line, labelled in words, so the block stays narrow
+              rather than running a wide C … S … row across the scene. */}
           <div className="explorer__detail" title={action.coordHex}>
-            <span className="explorer__key">C </span>{shortHex(action.coordHex, 10, 8)}
-            <span className="explorer__key">  S </span>{action.sector}
+            <span className="explorer__key">coord </span>{shortHex(action.coordHex, 8, 6)}
+          </div>
+          <div className="explorer__detail" title={action.sector}>
+            <span className="explorer__key">sector </span>{action.sector}
           </div>
           {action.proofHash && (
             <div className="explorer__detail" title={action.proofHash}>
-              <span className="explorer__key">proof </span>{shortHex(action.proofHash, 10, 8)}
+              <span className="explorer__key">proof </span>{shortHex(action.proofHash, 8, 6)}
             </div>
           )}
         </div>

--- a/src/hud/ConfirmModal.tsx
+++ b/src/hud/ConfirmModal.tsx
@@ -1,0 +1,29 @@
+/**
+ * ConfirmModal.tsx — a centred yes/no for the few actions that destroy
+ * something. A real modal rather than window.confirm so the wording, which is
+ * the whole point here (model vs instance), can be laid out and read.
+ */
+
+interface Props {
+  title: string
+  body: string
+  confirmLabel: string
+  danger?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmModal({ title, body, confirmLabel, danger = true, onConfirm, onCancel }: Props): JSX.Element {
+  return (
+    <div className="modal" role="dialog" aria-modal="true" aria-label={title} onPointerDown={onCancel}>
+      <div className="modal__card" onPointerDown={(e) => e.stopPropagation()}>
+        <h2 className="modal__title">{title}</h2>
+        <p className="modal__body">{body}</p>
+        <div className="modal__row">
+          <button className="modal__cancel" onClick={onCancel}>CANCEL</button>
+          <button className={`modal__confirm ${danger ? 'modal__confirm--danger' : ''}`} onClick={onConfirm}>{confirmLabel}</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hud/DeployBar.tsx
+++ b/src/hud/DeployBar.tsx
@@ -1,0 +1,71 @@
+/**
+ * DeployBar.tsx — placing a shard in the world.
+ *
+ * While this is up you are aiming, not moving: the movement cursor picks the
+ * spot (WASD, the pad, all of it), the shard ghosts there, and DEPLOY hides it
+ * at the cursor. The one real choice is the height, which is the discovery
+ * radius (spec §7.3): height 0 is a single gibson, so only someone standing on
+ * that exact point finds it; each step up doubles the aligned cube it hides in
+ * and the work it costs to find. The bar spells the radius out in real units
+ * so the choice is legible rather than a bare number.
+ */
+
+import { noCallout, useRepeatable } from '../hooks/useRepeatable'
+import { formatCellSize } from '../lib/scale'
+import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
+import { useCyberspace } from '../store/useCyberspace'
+
+export function DeployBar(): JSX.Element | null {
+  const deployId = useShards((s) => s.deployId)
+  const shard = useShards((s) => (deployId ? s.deployShard() : null))
+  const height = useShards((s) => s.deployHeight)
+  const status = useShards((s) => s.deployStatus)
+  const error = useShards((s) => s.deployError)
+  const live = useCyberspace((s) => s.live)
+  const bind = useRepeatable()
+
+  if (!deployId || !shard) return null
+
+  const empty = shard.vertices.length === 0
+  const working = status === 'working'
+
+  return (
+    <div className="deploybar" role="dialog" aria-label="Deploy shard">
+      <div className="deploybar__row">
+        <span className="deploybar__eye" aria-hidden="true">◇</span>
+        <span className="deploybar__title">
+          DEPLOY <strong>{shard.name}</strong>
+        </span>
+        <button className="deploybar__cancel" onClick={() => useShards.getState().cancelDeploy()}>CANCEL</button>
+      </div>
+
+      <div className="deploybar__row deploybar__row--height">
+        <span className="deploybar__label">HIDE AT HEIGHT</span>
+        <button className="deploybar__btn" {...bind(() => useShards.getState().setDeployHeight(height - 1))} disabled={height <= 0} aria-label="Lower height">−</button>
+        <span className="deploybar__value">{height}</span>
+        <button className="deploybar__btn" {...bind(() => useShards.getState().setDeployHeight(height + 1))} disabled={height >= SCAN_MAX_HEIGHT} aria-label="Higher height">+</button>
+        <span className="deploybar__radius">
+          {height === 0 ? 'this exact gibson' : `found within ${formatCellSize(height)}`}
+        </span>
+      </div>
+
+      <div className="deploybar__row deploybar__hint">
+        Aim with the movement controls; the ghost is where it lands.
+        {height === 0
+          ? ' At height 0 only someone on this exact point can find it.'
+          : ` Anyone who computes this ${formatCellSize(height)} region can find and open it.`}
+      </div>
+
+      {error && <div className="deploybar__row notice">{error}</div>}
+
+      <button
+        className="deploybar__deploy"
+        disabled={empty || working}
+        onClick={() => void useShards.getState().deploy()}
+        {...noCallout}
+      >
+        {empty ? 'SHARD IS EMPTY' : working ? 'HIDING…' : live ? 'DEPLOY & PUBLISH' : 'DEPLOY (LOCAL)'}
+      </button>
+    </div>
+  )
+}

--- a/src/hud/DeploymentDetail.tsx
+++ b/src/hud/DeploymentDetail.tsx
@@ -1,0 +1,90 @@
+/**
+ * DeploymentDetail.tsx — a deployed instance, on the wire.
+ *
+ * Opened by tapping a row in the Shards panel, which also flies the scene to
+ * where the shard sits. This is the record that lives on relays: its event id,
+ * which relays hold it, the lookup id it is filed under, its coordinate, and
+ * the height it is hidden at. DELETE FROM CYBERSPACE sends a NIP-09 deletion to
+ * exactly those relays and drops it here; that removes the instance, not the
+ * model it was made from, which stays in the workshop.
+ */
+
+import { useEffect, useState } from 'react'
+import { formatCellSize } from '../lib/scale'
+import { shortHex } from '../lib/time'
+import { ConfirmModal } from './ConfirmModal'
+import { useCyberspace } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+
+function Field({ label, value, full }: { label: string; value: string; full?: string }): JSX.Element {
+  const [copied, setCopied] = useState(false)
+  const copy = (): void => {
+    const text = full ?? value
+    void navigator.clipboard?.writeText(text).then(() => { setCopied(true); window.setTimeout(() => setCopied(false), 1200) }).catch(() => {})
+  }
+  return (
+    <div className="detail__field">
+      <span className="detail__key">{label}</span>
+      <button className="detail__val" title={`${full ?? value} (click to copy)`} onClick={copy}>
+        {copied ? 'copied' : value}
+      </button>
+    </div>
+  )
+}
+
+export function DeploymentDetail(): JSX.Element | null {
+  const inspecting = useShards((s) => s.inspecting)
+  const dep = useShards((s) => s.mine.find((d) => d.eventId === s.inspecting) ?? null)
+  const [confirm, setConfirm] = useState(false)
+
+  // A deployment removed out from under the overlay closes it.
+  useEffect(() => { if (inspecting && !dep) useShards.getState().inspect(null) }, [inspecting, dep])
+
+  if (!dep) return null
+
+  const exit = (): void => { useShards.getState().inspect(null); useCyberspace.getState().clearFocus() }
+
+  return (
+    <div className="detail" role="dialog" aria-label={`Deployment ${dep.shard.name}`}>
+      <div className="detail__head">
+        <span className="detail__eye" aria-hidden="true">◇</span>
+        <span className="detail__title">VIEWING <strong>{dep.shard.name}</strong></span>
+        <button className="detail__exit" onClick={exit}>EXIT</button>
+      </div>
+
+      <div className="detail__grid">
+        <Field label="event" value={shortHex(dep.eventId, 10, 8)} full={dep.eventId} />
+        <Field label="lookup" value={shortHex(dep.lookupId, 10, 8)} full={dep.lookupId} />
+        <Field label="coord" value={`${shortHex(dep.at.x, 6, 4)} / ${shortHex(dep.at.y, 6, 4)} / ${shortHex(dep.at.z, 6, 4)}`} full={`${dep.at.x}\n${dep.at.y}\n${dep.at.z}`} />
+        <div className="detail__field">
+          <span className="detail__key">hidden</span>
+          <span className="detail__plain">{dep.height === 0 ? 'exact gibson (height 0)' : `within ${formatCellSize(dep.height)} (height ${dep.height})`}</span>
+        </div>
+        <div className="detail__field">
+          <span className="detail__key">plane</span>
+          <span className="detail__plain">{dep.plane === 0 ? 'dataspace' : 'ideaspace'}</span>
+        </div>
+        <div className="detail__field detail__field--relays">
+          <span className="detail__key">relays</span>
+          <span className="detail__plain">
+            {dep.published ? dep.relays.map((r) => r.replace('wss://', '')).join(', ') : 'local only — never published'}
+          </span>
+        </div>
+      </div>
+
+      <button className="detail__delete" onClick={() => setConfirm(true)}>DELETE FROM CYBERSPACE</button>
+
+      {confirm && (
+        <ConfirmModal
+          title={`Delete this instance of ${dep.shard.name}?`}
+          body={dep.published
+            ? `A deletion request goes to ${dep.relays.map((r) => r.replace('wss://', '')).join(', ')}, and this device stops showing it and re-finding it. The "${dep.shard.name}" model in your workshop is untouched — this removes only this deployed copy.`
+            : `This instance was never published, so it only exists here. Removing it leaves the "${dep.shard.name}" model in your workshop untouched.`}
+          confirmLabel="DELETE INSTANCE"
+          onConfirm={() => { setConfirm(false); void useShards.getState().deleteInstance(dep.eventId) }}
+          onCancel={() => setConfirm(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -3,9 +3,12 @@
  */
 
 import { useWorkshop } from '../store/useWorkshop'
+import { useShards } from '../store/useShards'
+import { formatCellSize } from '../lib/scale'
 
 export function ShardsPanel(): JSX.Element {
   const shards = useWorkshop((s) => s.shards)
+  const mine = useShards((s) => s.mine)
 
   return (
     <section className="panel panel--shards">
@@ -31,10 +34,26 @@ export function ShardsPanel(): JSX.Element {
         <button className="avatars__go" onClick={() => { useWorkshop.getState().create(); useWorkshop.getState().openWorkshop() }}>NEW SHARD</button>
       </div>
 
+      {mine.length > 0 && (
+        <div className="shards__deployed">
+          <span className="legend__label">Deployed</span>
+          <ul className="avatars__list">
+            {mine.map((d) => (
+              <li key={d.eventId} className="shards__row shards__row--deployed">
+                <span className="avatars__who" title={`hidden at height ${d.height}`}>{d.shard.name}</span>
+                <span className="shards__meta">{d.height === 0 ? 'exact' : formatCellSize(d.height)} · {d.published ? 'LIVE' : 'LOCAL'}</span>
+                <button className="targets__remove" onClick={() => useShards.getState().undeploy(d.eventId)} aria-label="Remove from this device" title="Remove from this device">✕</button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <p className="legend__note">
         A shard is a small object of coloured vertices: triangles in SOLID
         mode, lights in POINTS mode, a polyline in LINES mode. Built on an
-        integer grid and kept on this device until deployed.
+        integer grid, and deployed hidden at a location: found only by someone
+        who computes the region key for where it sits (spec section 7).
       </p>
     </section>
   )

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -1,48 +1,85 @@
 /**
- * ShardsPanel.tsx — your shards, and the door to the workshop.
+ * ShardsPanel.tsx — your shards, in two kinds.
+ *
+ * A MODEL is a named design that lives on this device: you open it in the
+ * workshop, edit it, and deploy copies of it. A DEPLOYED instance is one such
+ * copy placed at a coordinate and published to the relay; one model can have
+ * many. Deleting a model and deleting an instance are different acts, so they
+ * live in different sections and warn about different things: a model delete
+ * is local and forever, an instance delete reaches the relay but leaves the
+ * model be. Tapping a deployment flies the scene to it and opens its record.
  */
 
-import { useWorkshop } from '../store/useWorkshop'
-import { useShards } from '../store/useShards'
+import { useState } from 'react'
 import { formatCellSize } from '../lib/scale'
+import { ConfirmModal } from './ConfirmModal'
+import { useCyberspace } from '../store/useCyberspace'
+import { useShards, type MyDeployment } from '../store/useShards'
+import { useWorkshop } from '../store/useWorkshop'
+
+/** The coordinate a deployment sits at, from its stored strings. */
+function positionOf(d: MyDeployment): { x: bigint; y: bigint; z: bigint } {
+  return { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) }
+}
 
 export function ShardsPanel(): JSX.Element {
-  const shards = useWorkshop((s) => s.shards)
+  const models = useWorkshop((s) => s.shards)
   const mine = useShards((s) => s.mine)
+  const inspecting = useShards((s) => s.inspecting)
+  const [deleteModel, setDeleteModel] = useState<string | null>(null)
+
+  const target = models.find((m) => m.id === deleteModel)
+  const deployedCount = (id: string): number => mine.filter((d) => d.shard.id === id).length
+
+  const goTo = (d: MyDeployment): void => {
+    useShards.getState().inspect(d.eventId)
+    useCyberspace.getState().focusOn(positionOf(d), d.plane, d.shard.name, d.shard.unit)
+  }
 
   return (
     <section className="panel panel--shards">
       <header className="panel__head">
         <h2>Shards</h2>
-        <span className="tag">{shards.length} BUILT</span>
+        <span className="tag">{models.length} MODEL{models.length === 1 ? '' : 'S'}</span>
       </header>
 
-      <ul className="avatars__list shards__list">
-        {shards.map((s) => (
-          <li key={s.id} className="shards__row">
-            <button className="shards__open" onClick={() => useWorkshop.getState().openWorkshop(s.id)} title="Open in the workshop">
-              <span className="avatars__who">{s.name}</span>
-              <span className="shards__meta">{s.vertices.length} v · {s.faces.length} f · {s.mode.toUpperCase()} · 2^{s.unit}</span>
-            </button>
-          </li>
-        ))}
-        {shards.length === 0 && <li className="avatars__empty">Nothing built yet.</li>}
-      </ul>
-
-      <div className="shards__actions">
-        <button className="avatars__go" onClick={() => useWorkshop.getState().openWorkshop()}>OPEN WORKSHOP</button>
-        <button className="avatars__go" onClick={() => { useWorkshop.getState().create(); useWorkshop.getState().openWorkshop() }}>NEW SHARD</button>
+      <div className="shards__section">
+        <span className="legend__label">Models — designs on this device</span>
+        <ul className="avatars__list shards__list">
+          {models.map((m) => {
+            const n = deployedCount(m.id)
+            return (
+              <li key={m.id} className="shards__row">
+                <button className="shards__open" onClick={() => useWorkshop.getState().openWorkshop(m.id)} title="Open in the workshop">
+                  <span className="avatars__who">{m.name}</span>
+                  <span className="shards__meta">{m.vertices.length} v · {m.faces.length} f · {m.mode.toUpperCase()} · 2^{m.unit}{n > 0 ? ` · ${n} deployed` : ''}</span>
+                </button>
+                <button className="targets__remove" onClick={() => setDeleteModel(m.id)} aria-label="Delete model" title="Delete this model">✕</button>
+              </li>
+            )
+          })}
+          {models.length === 0 && <li className="avatars__empty">Nothing built yet.</li>}
+        </ul>
+        <div className="shards__actions">
+          <button className="avatars__go" onClick={() => useWorkshop.getState().openWorkshop()}>OPEN WORKSHOP</button>
+          <button className="avatars__go" onClick={() => { useWorkshop.getState().create(); useWorkshop.getState().openWorkshop() }}>NEW MODEL</button>
+        </div>
       </div>
 
       {mine.length > 0 && (
-        <div className="shards__deployed">
-          <span className="legend__label">Deployed</span>
+        <div className="shards__section">
+          <span className="legend__label">Deployed — instances in cyberspace</span>
           <ul className="avatars__list">
             {mine.map((d) => (
-              <li key={d.eventId} className="shards__row shards__row--deployed">
-                <span className="avatars__who" title={`hidden at height ${d.height}`}>{d.shard.name}</span>
-                <span className="shards__meta">{d.height === 0 ? 'exact' : formatCellSize(d.height)} · {d.published ? 'LIVE' : 'LOCAL'}</span>
-                <button className="targets__remove" onClick={() => useShards.getState().undeploy(d.eventId)} aria-label="Remove from this device" title="Remove from this device">✕</button>
+              <li key={d.eventId} className={`shards__row shards__row--deployed ${inspecting === d.eventId ? 'is-viewing' : ''}`}>
+                <button className="shards__goto" onClick={() => goTo(d)} title="Fly to it and see its wire record">
+                  <span className="avatars__who">{d.shard.name}</span>
+                  <span className="shards__meta">
+                    {d.height === 0 ? 'exact gibson' : formatCellSize(d.height)} · {d.published ? 'LIVE' : 'LOCAL'}
+                    {d.plane === 1 ? ' · ideaspace' : ''}
+                  </span>
+                </button>
+                <span className="shards__goto-hint" aria-hidden="true">▸</span>
               </li>
             ))}
           </ul>
@@ -50,11 +87,21 @@ export function ShardsPanel(): JSX.Element {
       )}
 
       <p className="legend__note">
-        A shard is a small object of coloured vertices: triangles in SOLID
-        mode, lights in POINTS mode, a polyline in LINES mode. Built on an
-        integer grid, and deployed hidden at a location: found only by someone
-        who computes the region key for where it sits (spec section 7).
+        A shard is coloured vertices: triangles in SOLID, lights in POINTS, a
+        polyline in LINES. Models stay here; a deployed instance is hidden at a
+        location and found only by someone who computes its region key (spec
+        section 7). Tap a deployment to fly to it.
       </p>
+
+      {target && (
+        <ConfirmModal
+          title={`Delete the model "${target.name}"?`}
+          body={`This removes the model and its ${target.vertices.length} vertices from this device for good — it is not the same as removing a deployed copy. ${deployedCount(target.id) > 0 ? `Its ${deployedCount(target.id)} deployed instance${deployedCount(target.id) === 1 ? ' stays' : 's stay'} in cyberspace; delete those from the Deployed list.` : 'It has no deployed instances.'}`}
+          confirmLabel="DELETE MODEL"
+          onConfirm={() => { useWorkshop.getState().remove(target.id); setDeleteModel(null) }}
+          onCancel={() => setDeleteModel(null)}
+        />
+      )}
     </section>
   )
 }

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -18,6 +18,7 @@
 import { useCyberspace } from '../store/useCyberspace'
 import { moveDirection, type MoveName } from '../lib/moves'
 import { MAX_SCALE_EXP } from '../lib/space'
+import { useShards } from '../store/useShards'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 
 export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Element {
@@ -26,6 +27,7 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
   const cursor = useCyberspace((s) => s.cursor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const live = useCyberspace((s) => s.live)
+  const deploying = useShards((s) => s.deployId !== null)
   const bind = useRepeatable()
 
   const computing = proof.status === 'computing'
@@ -103,16 +105,17 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
           {computing ? 'STOP' : 'RECALL'}
         </button>
         <button
-          className={`touchops__commit ${computing ? 'is-busy' : armed ? 'is-armed' : ''}`}
-          disabled={!armed && !computing}
-          title="Commit hop (Space)"
+          className={`touchops__commit ${deploying ? 'is-armed' : computing ? 'is-busy' : armed ? 'is-armed' : ''}`}
+          disabled={!deploying && !armed && !computing}
+          title={deploying ? 'Place shard here' : 'Commit hop (Space)'}
           {...noCallout}
           onPointerDown={(e) => {
             e.preventDefault(); e.stopPropagation()
-            useCyberspace.getState().commit()
+            if (deploying) void useShards.getState().deploy()
+            else useCyberspace.getState().commit()
           }}
         >
-          {computing ? `${Math.round(proof.progress * 100)}%` : 'COMMIT'}
+          {deploying ? 'PLACE' : computing ? `${Math.round(proof.progress * 100)}%` : 'COMMIT'}
         </button>
         {/* Whether a commit leaves the device. Under COMMIT because that is the
             only control whose meaning it changes, and a switch rather than a

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -161,6 +161,13 @@ export function bytesToHex(bytes: Uint8Array): string {
   return out
 }
 
+export function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.length % 2 ? '0' + hex : hex
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
 function tag(ev: NostrEvent, name: string): string | undefined {
   return ev.tags.find((t) => t[0] === name)?.[1]
 }

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -17,13 +17,14 @@ import type { NostrEvent } from './events'
 export const CYBERSPACE_RELAY = 'wss://cyberspace.nostr1.com'
 
 /**
- * Where encrypted shard content lives. The cyberspace relay only accepts the
- * movement kind, so location-encrypted kind:33330 events go to general relays
- * instead, which is spec-fine: §7.1 says the ciphertext is public and can sit
- * on any relay, since only the region key opens it. Several, so a deploy lands
- * even if one is unreachable, and a scan sees what any of them holds.
+ * Where encrypted shard content lives. The cyberspace relay accepts the
+ * location-encrypted kind:33330 events (§8.6) alongside movement, so shards
+ * sit on the same relay as everything else. A list rather than the constant so
+ * a deploy can be fanned to more relays later without touching the callers;
+ * §7.1 makes that free, since the ciphertext is public and only the region key
+ * opens it.
  */
-export const SHARD_RELAYS = ['wss://nos.lol', 'wss://relay.damus.io', 'wss://relay.primal.net']
+export const SHARD_RELAYS = [CYBERSPACE_RELAY]
 
 /** How long a publish or a one-shot query waits before giving up. */
 const MAX_WAIT_MS = 8000

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -16,6 +16,15 @@ import type { NostrEvent } from './events'
 
 export const CYBERSPACE_RELAY = 'wss://cyberspace.nostr1.com'
 
+/**
+ * Where encrypted shard content lives. The cyberspace relay only accepts the
+ * movement kind, so location-encrypted kind:33330 events go to general relays
+ * instead, which is spec-fine: §7.1 says the ciphertext is public and can sit
+ * on any relay, since only the region key opens it. Several, so a deploy lands
+ * even if one is unreachable, and a scan sees what any of them holds.
+ */
+export const SHARD_RELAYS = ['wss://nos.lol', 'wss://relay.damus.io', 'wss://relay.primal.net']
+
 /** How long a publish or a one-shot query waits before giving up. */
 const MAX_WAIT_MS = 8000
 
@@ -37,6 +46,14 @@ export async function publish(event: NostrEvent): Promise<PublishResult> {
   } catch (err) {
     return { ok: false, reason: err instanceof Error ? err.message : String(err) }
   }
+}
+
+/** Send to several relays; ok if any accepts, the reason of the last refusal otherwise. */
+export async function publishMany(relays: string[], event: NostrEvent): Promise<PublishResult> {
+  const results = await Promise.allSettled(getPool().publish(relays, event, { maxWait: MAX_WAIT_MS }))
+  if (results.some((r) => r.status === 'fulfilled')) return { ok: true }
+  const reason = results.map((r) => (r.status === 'rejected' ? String(r.reason?.message ?? r.reason) : '')).find(Boolean)
+  return { ok: false, reason: reason || 'no relay accepted it' }
 }
 
 /** One-shot query: everything the relay has for the filter, then close. */

--- a/src/lib/shardCrypto.test.ts
+++ b/src/lib/shardCrypto.test.ts
@@ -1,0 +1,61 @@
+/**
+ * shardCrypto.test.ts - the round trip, and the location gate.
+ *
+ * A shard hidden at a region must come back only to the same region key, and
+ * the key must be a stable function of the coordinate and height so that
+ * anyone who computes that region, however they got there, opens it. The
+ * lookup_id must reveal nothing: seeing it must not let you derive the key.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { deriveRegionKeys, deriveRegionN } from 'cyberspace-core'
+import { decryptForRegion, encryptForRegion, regionKeyAt } from './shardCrypto'
+import { bytesToHex } from './events'
+
+const here = { x: 123456n, y: 654321n, z: 999n }
+
+describe('region key (spec 7.2)', () => {
+  it('is sha256(region_bytes) with lookup = sha256(key), matching the primitives', () => {
+    const rk = regionKeyAt(here, 8, 20)
+    const rn = deriveRegionN(here.x, here.y, here.z, 8, 20)
+    const direct = deriveRegionKeys(rn)
+    expect(rk.regionN).toBe(rn)
+    expect(bytesToHex(rk.key)).toBe(bytesToHex(direct.locationDecryptionKey))
+    expect(rk.lookupId).toBe(direct.lookupIdHex)
+  })
+
+  it('is the same for any coordinate inside the aligned cube at that height', () => {
+    const a = regionKeyAt({ x: (5n << 8n), y: 0n, z: 0n }, 8, 20)
+    const b = regionKeyAt({ x: (5n << 8n) + 200n, y: 0n, z: 0n }, 8, 20)
+    expect(a.lookupId).toBe(b.lookupId)
+    const outside = regionKeyAt({ x: (6n << 8n), y: 0n, z: 0n }, 8, 20)
+    expect(outside.lookupId).not.toBe(a.lookupId)
+  })
+
+  it('does not leak the key through the lookup id', () => {
+    const rk = regionKeyAt(here, 8, 20)
+    expect(rk.lookupId).not.toBe(bytesToHex(rk.key))
+  })
+})
+
+describe('encrypt / decrypt', () => {
+  it('round-trips through the region key', async () => {
+    const rk = regionKeyAt(here, 6, 20)
+    const ct = await encryptForRegion(rk.key, 'chalk on the sidewalk')
+    expect(await decryptForRegion(rk.key, ct)).toBe('chalk on the sidewalk')
+  })
+
+  it('is unreadable to the wrong region', async () => {
+    const mine = regionKeyAt(here, 6, 20)
+    const other = regionKeyAt({ x: here.x + (1n << 6n), y: here.y, z: here.z }, 6, 20)
+    const ct = await encryptForRegion(mine.key, 'secret')
+    expect(await decryptForRegion(other.key, ct)).toBeNull()
+  })
+
+  it('uses a fresh nonce each time', async () => {
+    const rk = regionKeyAt(here, 4, 20)
+    const a = await encryptForRegion(rk.key, 'x')
+    const b = await encryptForRegion(rk.key, 'x')
+    expect(a).not.toBe(b)
+  })
+})

--- a/src/lib/shardCrypto.ts
+++ b/src/lib/shardCrypto.ts
@@ -1,0 +1,94 @@
+/**
+ * shardCrypto.ts — hiding a shard at a place.
+ *
+ * Spec §7: a region's Cantor root is a secret you can only get by doing the
+ * work of computing it, and the same work whether you walked there or computed
+ * the coordinate directly. So a shard encrypted to a region is chalk on the
+ * sidewalk: published in the open, readable only once you have paid the cost of
+ * being (or computing) where it is.
+ *
+ * The derivation is spec §7.2 exactly, via cyberspace-core, so a shard this
+ * client hides is one the reference CLI can find and open, and the reverse:
+ * `key = sha256(int_to_bytes_be_min(region_n))`, `lookup_id = sha256(key)`.
+ * The cipher is the CLI's: AES-256-GCM, a fresh 12-byte nonce prepended to the
+ * ciphertext, the whole thing base64, in an `["encrypted","aes-256-gcm",…]`
+ * tag. Only the lookup and the key are normative; the cipher is a convention
+ * this shares with the CLI so the two interoperate.
+ */
+
+import { deriveRegionKeys, deriveRegionN } from 'cyberspace-core'
+import { bytesToHex } from './events'
+import type { Position } from './space'
+
+/** The algorithm string in the `encrypted` tag; the CLI rejects any other. */
+export const ALGO = 'aes-256-gcm'
+
+/** What actually gets encrypted: the shard, where it sits, and in which plane. */
+export interface DeployedPayload {
+  shard: import('./shards').ShardPayload
+  at: { x: string; y: string; z: string }
+  plane: 0 | 1
+}
+
+export interface RegionKey {
+  regionN: bigint
+  key: Uint8Array
+  lookupId: string
+}
+
+/** The region key at a coordinate and height (spec §7.2, §7.4). */
+export function regionKeyAt(pos: Position, height: number, maxComputeHeight: number): RegionKey {
+  const regionN = deriveRegionN(pos.x, pos.y, pos.z, height, maxComputeHeight)
+  const { locationDecryptionKey, lookupIdHex } = deriveRegionKeys(regionN)
+  return { regionN, key: locationDecryptionKey, lookupId: lookupIdHex }
+}
+
+function b64encode(bytes: Uint8Array): string {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s)
+}
+
+function b64decode(s: string): Uint8Array {
+  const bin = atob(s)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+const subtle = (): SubtleCrypto => {
+  const c = (globalThis as unknown as { crypto?: Crypto }).crypto
+  if (!c?.subtle) throw new Error('WebCrypto unavailable')
+  return c.subtle
+}
+
+/** Encrypt with a region key; returns the base64 `nonce||ciphertext||tag`. */
+export async function encryptForRegion(key: Uint8Array, plaintext: string): Promise<string> {
+  const cryptoKey = await subtle().importKey('raw', key as BufferSource, 'AES-GCM', false, ['encrypt'])
+  const nonce = new Uint8Array(12)
+  ;(globalThis.crypto as Crypto).getRandomValues(nonce)
+  const ct = new Uint8Array(await subtle().encrypt({ name: 'AES-GCM', iv: nonce }, cryptoKey, new TextEncoder().encode(plaintext)))
+  const payload = new Uint8Array(nonce.length + ct.length)
+  payload.set(nonce, 0)
+  payload.set(ct, nonce.length)
+  return b64encode(payload)
+}
+
+/** Decrypt what encryptForRegion produced; null on any failure, including the
+ * wrong key, which is the common case when a lookup_id happens to collide. */
+export async function decryptForRegion(key: Uint8Array, b64: string): Promise<string | null> {
+  try {
+    const payload = b64decode(b64)
+    if (payload.length < 12 + 16) return null
+    const nonce = payload.slice(0, 12)
+    const ct = payload.slice(12)
+    const cryptoKey = await subtle().importKey('raw', key as BufferSource, 'AES-GCM', false, ['decrypt'])
+    const pt = await subtle().decrypt({ name: 'AES-GCM', iv: nonce }, cryptoKey, ct as BufferSource)
+    return new TextDecoder().decode(pt)
+  } catch {
+    return null
+  }
+}
+
+/** For a lookup_id tag, lowercase hex. Re-exported so callers need one import. */
+export { bytesToHex }

--- a/src/lib/shardEvents.test.ts
+++ b/src/lib/shardEvents.test.ts
@@ -1,0 +1,55 @@
+/**
+ * shardEvents.test.ts - a deployed shard event carries the spec tags and gives
+ * its shard back only to whoever has the region.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { finalizeEvent, generateSecretKey } from 'nostr-tools/pure'
+import { newShard, type ShardModel } from './shards'
+import { regionKeyAt } from './shardCrypto'
+import { ENCRYPTED_KIND, ciphertextOf, decodeShard, deployTemplate, heightHint } from './shardEvents'
+
+const sk = generateSecretKey()
+const at = { x: 40_000n, y: 12_000n, z: 7n }
+const shard: ShardModel = {
+  ...newShard('prism'),
+  mode: 'lines',
+  unit: 5,
+  vertices: [{ p: [0, 0, 0], c: [1, 0, 0] }, { p: [1, 1, 0], c: [0, 1, 0] }],
+  faces: [],
+}
+
+describe('deploy', () => {
+  it('builds a kind 33330 event with d = lookup_id, encrypted, version and h', async () => {
+    const { template, lookupId } = await deployTemplate({ shard, at, plane: 0, height: 6, createdAt: 1, maxComputeHeight: 20 })
+    expect(template.kind).toBe(ENCRYPTED_KIND)
+    expect(template.tags.find((t) => t[0] === 'd')).toEqual(['d', lookupId])
+    expect(template.tags.find((t) => t[0] === 'encrypted')?.[1]).toBe('aes-256-gcm')
+    expect(template.tags.find((t) => t[0] === 'version')).toEqual(['version', '2'])
+    expect(template.tags.find((t) => t[0] === 'h')).toEqual(['h', '6'])
+    expect(lookupId).toBe(regionKeyAt(at, 6, 20).lookupId)
+  })
+
+  it('comes back to a discoverer who computes the same region', async () => {
+    const { template } = await deployTemplate({ shard, at, plane: 0, height: 6, createdAt: 2, maxComputeHeight: 20 })
+    const event = finalizeEvent(template, sk)
+    expect(ciphertextOf(event)).not.toBeNull()
+    expect(heightHint(event)).toBe(6)
+    // A fresh key derived from the coordinate, as a discoverer would.
+    const discovered = regionKeyAt(at, 6, 20).key
+    const decoded = await decodeShard(event, discovered)
+    expect(decoded).not.toBeNull()
+    expect(decoded!.at).toEqual(at)
+    expect(decoded!.plane).toBe(0)
+    expect(decoded!.shard.mode).toBe('lines')
+    expect(decoded!.shard.unit).toBe(5)
+    expect(decoded!.shard.vertices).toEqual(shard.vertices)
+  })
+
+  it('stays shut to the wrong region', async () => {
+    const { template } = await deployTemplate({ shard, at, plane: 0, height: 6, createdAt: 3, maxComputeHeight: 20 })
+    const event = finalizeEvent(template, sk)
+    const wrong = regionKeyAt({ ...at, x: at.x + (1n << 6n) }, 6, 20).key
+    expect(await decodeShard(event, wrong)).toBeNull()
+  })
+})

--- a/src/lib/shardEvents.ts
+++ b/src/lib/shardEvents.ts
@@ -1,0 +1,102 @@
+/**
+ * shardEvents.ts — a deployed shard on the wire.
+ *
+ * Spec §8.6: an encrypted content event is kind 33330 with a `d` tag holding
+ * the lookup_id and an optional `h` height hint. The ciphertext carrier is the
+ * CLI's `encrypted` tag. Nothing here reveals the coordinate: the whole point
+ * is that only someone who has computed the region key can read where it is.
+ */
+
+import { ALGO, decryptForRegion, encryptForRegion, regionKeyAt } from './shardCrypto'
+import { fromPayload, toPayload, type ShardModel } from './shards'
+import type { DeployedPayload } from './shardCrypto'
+import type { EventTemplate, NostrEvent } from './events'
+import type { Plane } from 'cyberspace-core'
+import type { Position } from './space'
+
+export const ENCRYPTED_KIND = 33330
+
+export interface DeployInput {
+  shard: ShardModel
+  at: Position
+  plane: Plane
+  height: number
+  createdAt: number
+  maxComputeHeight: number
+}
+
+export interface DeployResult {
+  template: EventTemplate
+  lookupId: string
+  key: Uint8Array
+  regionN: bigint
+}
+
+/** Build the kind 33330 template for a shard hidden at a location. */
+export async function deployTemplate(i: DeployInput): Promise<DeployResult> {
+  const { key, lookupId, regionN } = regionKeyAt(i.at, i.height, i.maxComputeHeight)
+  const payload: DeployedPayload = {
+    shard: toPayload(i.shard),
+    at: { x: i.at.x.toString(), y: i.at.y.toString(), z: i.at.z.toString() },
+    plane: i.plane,
+  }
+  const ciphertext = await encryptForRegion(key, JSON.stringify(payload))
+  const template: EventTemplate = {
+    kind: ENCRYPTED_KIND,
+    created_at: i.createdAt,
+    content: '',
+    tags: [
+      ['d', lookupId],
+      ['encrypted', ALGO, ciphertext],
+      ['version', '2'],
+      ['h', String(i.height)],
+    ],
+  }
+  return { template, lookupId, key, regionN }
+}
+
+export interface DecodedShard {
+  id: string
+  shard: ShardModel
+  at: Position
+  plane: Plane
+  /** The event that carried it, for dedup and the head time. */
+  eventId: string
+  height: number
+}
+
+function tag(ev: NostrEvent, name: string): string | undefined {
+  return ev.tags.find((t) => t[0] === name)?.[1]
+}
+
+/** The ciphertext out of a kind 33330 event, or null if it is not one. */
+export function ciphertextOf(ev: NostrEvent): string | null {
+  if (ev.kind !== ENCRYPTED_KIND) return null
+  const enc = ev.tags.find((t) => t[0] === 'encrypted')
+  if (!enc || enc[1] !== ALGO || !enc[2]) return null
+  return enc[2]
+}
+
+export function heightHint(ev: NostrEvent): number | null {
+  const h = tag(ev, 'h')
+  if (h === undefined) return null
+  const n = Number(h)
+  return Number.isInteger(n) && n >= 0 ? n : null
+}
+
+/** Decrypt and parse one event with a region key; null on any mismatch. */
+export async function decodeShard(ev: NostrEvent, key: Uint8Array): Promise<DecodedShard | null> {
+  const ct = ciphertextOf(ev)
+  if (!ct) return null
+  const json = await decryptForRegion(key, ct)
+  if (!json) return null
+  try {
+    const raw = JSON.parse(json) as DeployedPayload
+    const shard = fromPayload(raw.shard, ev.id)
+    if (!shard || !raw.at) return null
+    const at = { x: BigInt(raw.at.x), y: BigInt(raw.at.y), z: BigInt(raw.at.z) }
+    return { id: ev.id, shard, at, plane: raw.plane === 1 ? 1 : 0, eventId: ev.id, height: heightHint(ev) ?? 0 }
+  } catch {
+    return null
+  }
+}

--- a/src/scene/Avatar.tsx
+++ b/src/scene/Avatar.tsx
@@ -19,9 +19,14 @@ import { useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { IcosahedronGeometry, EdgesGeometry, Group } from 'three'
 import { travelOffset } from '../lib/travel'
+import { useCyberspace } from '../store/useCyberspace'
 
-export function Avatar(): JSX.Element {
+export function Avatar(): JSX.Element | null {
   const group = useRef<Group>(null)
+  // Looking at a shard means the origin is that shard, not you: drawing your
+  // marker there would say you are standing on it. Spectating keeps the marker,
+  // where it stands in for the avatar being watched.
+  const focus = useCyberspace((s) => s.focus)
 
   const avatarGeometry = useMemo(() => {
     const geo = new IcosahedronGeometry(0.5, 1)
@@ -31,6 +36,8 @@ export function Avatar(): JSX.Element {
   useFrame(() => {
     if (group.current) group.current.position.copy(travelOffset)
   })
+
+  if (focus) return null
 
   return (
     <group ref={group} position={[0, 0, 0]}>

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -185,6 +185,7 @@ function Rig(): JSX.Element {
   const view = useCyberspace((s) => s.view)
   const genesisId = useCyberspace((s) => s.genesisId)
   const focusPubkey = useCyberspace((s) => s.focusPubkey())
+  const focusPoint = useCyberspace((s) => (s.focus ? s.focus.position.x.toString() : ''))
   const controls = useRef<{
     object: { position: Vector3 }
     target: Vector3
@@ -215,7 +216,7 @@ function Rig(): JSX.Element {
     locked.current = true
     prevOrigin.current = null
     c.update()
-  }, [view, genesisId, focusPubkey])
+  }, [view, genesisId, focusPubkey, focusPoint])
 
   useFrame((_, dt) => {
     const c = controls.current

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -45,6 +45,8 @@ import { SectorBox } from './SectorBox'
 import { ShaderPointField } from './ShaderPointField'
 import { SpawnMarker } from './SpawnMarker'
 import { TargetAvatars } from './TargetAvatars'
+import { WorldShards } from './WorldShards'
+import { ShardGhost } from './ShardGhost'
 import { TargetProjector } from './TargetProjector'
 import { Travel } from './Travel'
 
@@ -86,6 +88,8 @@ function World(): JSX.Element {
       <PathTrail axes={axes} scaleExp={scaleExp} />
       <SpawnMarker pubkey={pubkey} axes={axes} />
       <TargetAvatars axes={axes} />
+      <WorldShards axes={axes} />
+      <ShardGhost axes={axes} />
       <Cursor axes={axes} />
       <Avatar />
     </group>

--- a/src/scene/ShardGhost.tsx
+++ b/src/scene/ShardGhost.tsx
@@ -1,0 +1,49 @@
+/**
+ * ShardGhost.tsx — the shard about to be placed, at the cursor.
+ *
+ * While deploying, this draws the shard you are aiming, dimmed, exactly where
+ * and at the size it would land: at the cursor, one model unit to 2^(unit -
+ * scaleExp) render cells. Moving the cursor moves it, so you place by looking.
+ */
+
+import { useFrame } from '@react-three/fiber'
+import { useMemo, useRef } from 'react'
+import { Group } from 'three'
+import { cellCentre, type ViewAxes } from '../lib/space'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+import { ShardMesh } from './ShardMesh'
+
+interface Props {
+  axes: ViewAxes
+}
+
+export function ShardGhost({ axes }: Props): JSX.Element | null {
+  const deployId = useShards((s) => s.deployId)
+  const shard = useShards((s) => (deployId ? s.deployShard() : null))
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const group = useRef<Group>(null)
+
+  const scale = useMemo(() => {
+    if (!shard) return 1
+    const exp = shard.unit - scaleExp
+    return exp >= 0 ? Number(1n << BigInt(exp)) : 1 / Number(1n << BigInt(-exp))
+  }, [shard, scaleExp])
+
+  // Ride the live cursor, like the cursor cube does, rather than a React commit.
+  useFrame(() => {
+    const g = group.current
+    if (!g) return
+    const s = useCyberspace.getState()
+    const b = cellCentre(s.cursor, alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes)
+    g.position.set(b[0], b[1], b[2])
+  })
+
+  if (!shard || !deployId || !Number.isFinite(scale)) return null
+
+  return (
+    <group ref={group}>
+      <ShardMesh shard={shard} scale={scale} ghost />
+    </group>
+  )
+}

--- a/src/scene/Travel.tsx
+++ b/src/scene/Travel.tsx
@@ -37,8 +37,9 @@ interface Props {
 export function Travel({ axes }: Props): null {
   const anchor = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
-  // A new chain (respawn) or a new avatar (spectate) is a cut, not a journey.
-  const focusKey = useCyberspace((s) => `${s.focusPubkey()}:${s.genesisId}`)
+  // A new chain (respawn), a new avatar (spectate), or a new fixed point
+  // (looking at a shard) is a cut, not a journey.
+  const focusKey = useCyberspace((s) => `${s.focusPubkey()}:${s.genesisId}:${s.focus ? s.focus.position.x.toString() : ''}`)
   const exploring = useCyberspace((s) => s.exploreIndex !== null)
 
   const previous = useRef<Position>(anchor)

--- a/src/scene/WorldShards.tsx
+++ b/src/scene/WorldShards.tsx
@@ -1,0 +1,59 @@
+/**
+ * WorldShards.tsx — the shards placed in cyberspace, drawn where they sit.
+ *
+ * Each shard renders at its own coordinate, at its own unit scale: one model
+ * unit is 2^unit gibsons, which at the current zoom is 2^(unit - scaleExp)
+ * render cells. So a shard hidden at a fine unit is a speck until you zoom in
+ * to it, and a monument at a coarse unit fills the view from far off, which is
+ * the honest picture. Culled past the same reach as Earth and the spawn mark.
+ */
+
+import { useMemo } from 'react'
+import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+import { ShardMesh } from './ShardMesh'
+
+const REACH = GRID_RADIUS * 8
+
+interface Props {
+  axes: ViewAxes
+}
+
+export function WorldShards({ axes }: Props): JSX.Element | null {
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  // Subscribed so the set re-renders when a deploy or a discovery lands.
+  const mine = useShards((s) => s.mine)
+  const discovered = useShards((s) => s.discovered)
+
+  const placed = useMemo(() => {
+    const origin = alignedOrigin(anchor, scaleExp)
+    return useShards.getState().worldShards()
+      .filter((w) => w.plane === anchorPlane)
+      .map((w) => {
+        const centre = cellCentre(w.at, origin, scaleExp, axes)
+        // 2^(unit - scaleExp) render cells per model unit, in fixed point so
+        // the ratio survives past a double at large separations of the two.
+        const exp = w.shard.unit - scaleExp
+        const scale = exp >= 0 ? Number(1n << BigInt(exp)) : 1 / Number(1n << BigInt(-exp))
+        return { ...w, centre, scale }
+      })
+      .filter((w) => Number.isFinite(w.scale) && Math.hypot(...w.centre) <= REACH)
+    // mine and discovered are what worldShards reads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchor, anchorPlane, scaleExp, axes, mine, discovered])
+
+  if (placed.length === 0) return null
+
+  return (
+    <>
+      {placed.map((w) => (
+        <group key={w.key} position={w.centre}>
+          <ShardMesh shard={w.shard} scale={w.scale} />
+        </group>
+      ))}
+    </>
+  )
+}

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -197,6 +197,13 @@ export interface CyberspaceState {
    */
   exploreIndex: number | null
   spectate: SpectateState | null
+  /**
+   * A fixed coordinate the scene is looking at, with nothing to walk: used to
+   * fly to a deployed shard. Like spectating, it is read-only, since the point
+   * is somewhere you are not. Exclusive with spectating in practice, because
+   * the panel it is reached from is hidden while spectating.
+   */
+  focus: { position: Position; plane: Plane; label: string } | null
   /** Pubkeys being pointed at, keyed by pubkey. Persisted. */
   targets: Record<string, TrackedTarget>
   /**
@@ -238,6 +245,10 @@ export interface CyberspaceState {
   setSpectateChain: (pubkey: string, events: NostrEvent[], status?: 'live' | 'empty' | 'error') => void
   /** Back to your own head. */
   endSpectate: () => void
+  /** Look at a fixed coordinate (a deployed shard), optionally jumping the scale. */
+  focusOn: (position: Position, plane: Plane, label: string, scaleExp?: number) => void
+  /** Stop looking; the scene returns to your avatar. */
+  clearFocus: () => void
   addTarget: (pubkey: string, name?: string | null) => void
   removeTarget: (pubkey: string) => void
   toggleTarget: (pubkey: string, name?: string | null) => void
@@ -469,6 +480,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   identity: { pubkey: pubkeyHex, npub: nip19.npubEncode(pubkeyHex) },
   ...initial,
   spectate: null,
+  focus: null,
   targets: loadTargets(),
   cursor: initial.position,
   pendingTarget: null,
@@ -778,6 +790,23 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: headPlane })
   },
 
+  focusOn: (position, plane, label, scaleExp) => {
+    const next: Partial<CyberspaceState> = {
+      focus: { position: { ...position }, plane, label },
+      spectate: null,
+      exploreIndex: null,
+      anchor: { ...position },
+      anchorPlane: plane,
+    }
+    if (scaleExp !== undefined) next.scaleExp = Math.max(0, Math.min(MAX_SCALE_EXP, Math.round(scaleExp)))
+    set(next)
+  },
+
+  clearFocus: () => {
+    const { position, headPlane } = get()
+    set({ focus: null, anchor: position, anchorPlane: headPlane })
+  },
+
   addTarget: (pubkey, name = null) => {
     const { targets } = get()
     if (targets[pubkey]) {
@@ -872,7 +901,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
 
   actions: () => parsedChain(get().events),
 
-  atHead: () => get().exploreIndex === null && get().spectate === null,
+  atHead: () => get().exploreIndex === null && get().spectate === null && get().focus === null,
 
   focusChain: () => {
     const { spectate } = get()

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -245,6 +245,8 @@ export interface CyberspaceState {
   setTargetChain: (pubkey: string, events: NostrEvent[], status?: 'error') => void
   /** The tracked targets as things the HUD can point at. */
   targetList: () => CyberTarget[]
+  /** Sign a template with this identity's key. The only door to it outside this module. */
+  sign: (template: EventTemplate) => NostrEvent
 
   axes: () => ViewAxes
   /** Axes as they appear on screen right now, including free orbit. */
@@ -832,6 +834,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       color: targetColor(t.pubkey),
       at: t.position,
     })),
+
+  sign,
 
   setPublishStatus: (id, status, reason) => {
     const { published, events, chain } = get()

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -1,0 +1,179 @@
+/**
+ * useShards.ts — deploying shards, and everything visible in the world.
+ *
+ * Deploy is its own small mode: pick a shard, aim the cursor, choose a height
+ * to hide it at, and place. The height is the discovery radius (spec §7.3):
+ * height 0 is a single gibson, so only someone at that exact point finds it;
+ * higher hides it across a wider aligned cube that costs more to compute. What
+ * gets published is a kind 33330 event whose ciphertext only opens to the
+ * region key, so the coordinate never leaves this device in the clear.
+ *
+ * Two sources feed the world. `mine` is what this device deployed, kept with
+ * its key so it always renders regardless of scanning: you can always see your
+ * own chalk. `discovered` is what a background scan turned up near you and
+ * managed to decrypt. Both persist their inputs, not their positions, so a
+ * reload re-derives everything honestly.
+ */
+
+import { create } from 'zustand'
+import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
+import { publishMany, SHARD_RELAYS } from '../lib/relay'
+import { deployTemplate, type DecodedShard } from '../lib/shardEvents'
+import { bytesToHex, hexToBytes } from '../lib/events'
+import { useWorkshop } from './useWorkshop'
+import type { ShardModel } from '../lib/shards'
+import type { Plane } from 'cyberspace-core'
+import type { Position } from '../lib/space'
+
+/** What this device put out there: enough to re-render and re-publish it. */
+export interface MyDeployment {
+  eventId: string
+  shard: ShardModel
+  at: { x: string; y: string; z: string }
+  plane: Plane
+  height: number
+  lookupId: string
+  keyHex: string
+  createdAt: number
+  published: boolean
+}
+
+/** A shard placed in the world, ready to draw. */
+export interface WorldShard {
+  key: string
+  shard: ShardModel
+  at: Position
+  plane: Plane
+  height: number
+  mine: boolean
+}
+
+/** The realistic ceiling for interactive scanning (spec §7.3 says 0..16). */
+export const SCAN_MAX_HEIGHT = 12
+
+export type DeployStatus = 'idle' | 'working' | 'done' | 'error'
+
+interface ShardsState {
+  /** Which shard is being deployed, or null. */
+  deployId: string | null
+  deployHeight: number
+  deployStatus: DeployStatus
+  deployError: string | null
+  mine: MyDeployment[]
+  /** Discovered shards keyed by event id. */
+  discovered: Record<string, DecodedShard>
+
+  startDeploy: (shardId: string) => void
+  setDeployHeight: (h: number) => void
+  cancelDeploy: () => void
+  deploy: () => Promise<void>
+  undeploy: (eventId: string) => void
+  addDiscovered: (shards: DecodedShard[]) => void
+  deployShard: () => ShardModel | null
+  worldShards: () => WorldShard[]
+}
+
+const MINE_KEY = 'onosendai:deployments'
+
+function loadMine(): MyDeployment[] {
+  try {
+    const raw = localStorage.getItem(MINE_KEY)
+    if (!raw) return []
+    const list = JSON.parse(raw)
+    return Array.isArray(list) ? list.filter((d) => d && d.eventId && d.shard) : []
+  } catch { return [] }
+}
+
+function saveMine(mine: MyDeployment[]): void {
+  try { localStorage.setItem(MINE_KEY, JSON.stringify(mine)) } catch { /* quota or private mode */ }
+}
+
+export const useShards = create<ShardsState>((set, get) => ({
+  deployId: null,
+  deployHeight: 0,
+  deployStatus: 'idle',
+  deployError: null,
+  mine: loadMine(),
+  discovered: {},
+
+  startDeploy: (shardId) => set({ deployId: shardId, deployStatus: 'idle', deployError: null }),
+  setDeployHeight: (h) => set({ deployHeight: Math.max(0, Math.min(SCAN_MAX_HEIGHT, Math.round(h))) }),
+  cancelDeploy: () => set({ deployId: null, deployStatus: 'idle', deployError: null }),
+
+  deploy: async () => {
+    const { deployId, deployHeight } = get()
+    const shard = useWorkshop.getState().shards.find((s) => s.id === deployId)
+    if (!shard || shard.vertices.length === 0) return
+    set({ deployStatus: 'working', deployError: null })
+
+    const cs = useCyberspace.getState()
+    // The cursor is where you aimed; the plane is the one you are in.
+    const at: Position = { ...cs.cursor }
+    const plane = cs.plane
+    const createdAt = Math.floor(Date.now() / 1000)
+
+    try {
+      const { template, lookupId, key } = await deployTemplate({ shard, at, plane, height: deployHeight, createdAt, maxComputeHeight: MAX_COMPUTE_HEIGHT })
+      const event = cs.sign(template)
+      const live = cs.live
+      const result = live ? await publishMany(SHARD_RELAYS, event) : { ok: true as const }
+
+      const deployment: MyDeployment = {
+        eventId: event.id,
+        shard,
+        at: { x: at.x.toString(), y: at.y.toString(), z: at.z.toString() },
+        plane,
+        height: deployHeight,
+        lookupId,
+        keyHex: bytesToHex(key),
+        createdAt,
+        published: live && result.ok,
+      }
+      const mine = [...get().mine, deployment]
+      set({ mine, deployStatus: 'done', deployId: null })
+      saveMine(mine)
+    } catch (err) {
+      set({ deployStatus: 'error', deployError: err instanceof Error ? err.message : String(err) })
+    }
+  },
+
+  undeploy: (eventId) => {
+    // Local only: a published event cannot be unpublished, but it can be
+    // dropped from what this device draws and re-derives.
+    const mine = get().mine.filter((d) => d.eventId !== eventId)
+    set({ mine }); saveMine(mine)
+  },
+
+  addDiscovered: (shards) => {
+    if (shards.length === 0) return
+    const discovered = { ...get().discovered }
+    let changed = false
+    for (const s of shards) if (!discovered[s.id]) { discovered[s.id] = s; changed = true }
+    if (changed) set({ discovered })
+  },
+
+  deployShard: () => useWorkshop.getState().shards.find((s) => s.id === get().deployId) ?? null,
+
+  worldShards: () => {
+    const out: WorldShard[] = []
+    const seen = new Set<string>()
+    for (const d of get().mine) {
+      seen.add(d.eventId)
+      out.push({ key: d.eventId, shard: d.shard, at: { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) }, plane: d.plane, height: d.height, mine: true })
+    }
+    for (const d of Object.values(get().discovered)) {
+      if (seen.has(d.id)) continue
+      out.push({ key: d.id, shard: d.shard, at: d.at, plane: d.plane, height: d.height, mine: false })
+    }
+    return out
+  },
+}))
+
+/** The key bytes for one of my deployments, for republish or re-derivation. */
+export function keyBytes(hex: string): Uint8Array {
+  return hexToBytes(hex)
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __shards?: unknown }).__shards = useShards
+}

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -18,6 +18,7 @@
 import { create } from 'zustand'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
 import { publishMany, SHARD_RELAYS } from '../lib/relay'
+import { ENCRYPTED_KIND } from '../lib/shardEvents'
 import { deployTemplate, type DecodedShard } from '../lib/shardEvents'
 import { bytesToHex, hexToBytes } from '../lib/events'
 import { useWorkshop } from './useWorkshop'
@@ -34,6 +35,8 @@ export interface MyDeployment {
   height: number
   lookupId: string
   keyHex: string
+  /** The relays this instance was sent to; where a deletion has to go. */
+  relays: string[]
   createdAt: number
   published: boolean
 }
@@ -62,18 +65,25 @@ interface ShardsState {
   mine: MyDeployment[]
   /** Discovered shards keyed by event id. */
   discovered: Record<string, DecodedShard>
+  /** Deleted instance ids, so a later scan never rebuilds them. Persisted. */
+  deleted: Record<string, true>
+  /** The deployment whose wire details are open, or null. */
+  inspecting: string | null
 
   startDeploy: (shardId: string) => void
   setDeployHeight: (h: number) => void
   cancelDeploy: () => void
   deploy: () => Promise<void>
-  undeploy: (eventId: string) => void
+  /** Delete one instance: a NIP-09 deletion to its relays, and gone from here. */
+  deleteInstance: (eventId: string) => Promise<void>
+  inspect: (eventId: string | null) => void
   addDiscovered: (shards: DecodedShard[]) => void
   deployShard: () => ShardModel | null
   worldShards: () => WorldShard[]
 }
 
 const MINE_KEY = 'onosendai:deployments'
+const DELETED_KEY = 'onosendai:deployments-deleted'
 
 function loadMine(): MyDeployment[] {
   try {
@@ -88,6 +98,21 @@ function saveMine(mine: MyDeployment[]): void {
   try { localStorage.setItem(MINE_KEY, JSON.stringify(mine)) } catch { /* quota or private mode */ }
 }
 
+function loadDeleted(): Record<string, true> {
+  try {
+    const raw = localStorage.getItem(DELETED_KEY)
+    if (!raw) return {}
+    const list = JSON.parse(raw)
+    const out: Record<string, true> = {}
+    if (Array.isArray(list)) for (const id of list) if (typeof id === 'string') out[id] = true
+    return out
+  } catch { return {} }
+}
+
+function saveDeleted(deleted: Record<string, true>): void {
+  try { localStorage.setItem(DELETED_KEY, JSON.stringify(Object.keys(deleted))) } catch { /* quota or private mode */ }
+}
+
 export const useShards = create<ShardsState>((set, get) => ({
   deployId: null,
   deployHeight: 0,
@@ -95,6 +120,8 @@ export const useShards = create<ShardsState>((set, get) => ({
   deployError: null,
   mine: loadMine(),
   discovered: {},
+  deleted: loadDeleted(),
+  inspecting: null,
 
   startDeploy: (shardId) => set({ deployId: shardId, deployStatus: 'idle', deployError: null }),
   setDeployHeight: (h) => set({ deployHeight: Math.max(0, Math.min(SCAN_MAX_HEIGHT, Math.round(h))) }),
@@ -126,6 +153,7 @@ export const useShards = create<ShardsState>((set, get) => ({
         height: deployHeight,
         lookupId,
         keyHex: bytesToHex(key),
+        relays: SHARD_RELAYS,
         createdAt,
         published: live && result.ok,
       }
@@ -137,18 +165,40 @@ export const useShards = create<ShardsState>((set, get) => ({
     }
   },
 
-  undeploy: (eventId) => {
-    // Local only: a published event cannot be unpublished, but it can be
-    // dropped from what this device draws and re-derives.
+  deleteInstance: async (eventId) => {
+    const dep = get().mine.find((d) => d.eventId === eventId)
+    if (!dep) return
+    const cs = useCyberspace.getState()
+    // NIP-09: a kind 5 naming the event tells relays to drop it. Sent to the
+    // relays this instance actually went to. It only works while Live; local
+    // instances never left the device, so removing them here is the whole job.
+    if (cs.live && dep.published) {
+      const del = cs.sign({
+        kind: 5,
+        created_at: Math.floor(Date.now() / 1000),
+        content: 'shard instance removed',
+        tags: [['e', eventId], ['k', String(ENCRYPTED_KIND)]],
+      })
+      try { await publishMany(dep.relays ?? SHARD_RELAYS, del) } catch { /* best effort */ }
+    }
     const mine = get().mine.filter((d) => d.eventId !== eventId)
-    set({ mine }); saveMine(mine)
+    const deleted = { ...get().deleted, [eventId]: true as const }
+    const discovered = { ...get().discovered }
+    delete discovered[eventId]
+    const inspecting = get().inspecting === eventId ? null : get().inspecting
+    if (get().inspecting === eventId) cs.clearFocus()
+    set({ mine, deleted, discovered, inspecting })
+    saveMine(mine); saveDeleted(deleted)
   },
+
+  inspect: (eventId) => set({ inspecting: eventId }),
 
   addDiscovered: (shards) => {
     if (shards.length === 0) return
+    const { deleted } = get()
     const discovered = { ...get().discovered }
     let changed = false
-    for (const s of shards) if (!discovered[s.id]) { discovered[s.id] = s; changed = true }
+    for (const s of shards) if (!discovered[s.id] && !deleted[s.id]) { discovered[s.id] = s; changed = true }
     if (changed) set({ discovered })
   },
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1061,6 +1061,184 @@ kbd {
   border-top: 1px solid rgba(0, 229, 255, 0.14);
 }
 
+/* ---------- Deploy bar ----------
+ *
+ * Up while you are placing a shard. Bottom of the scene on a phone, above the
+ * pad; a floating card on the left on a desktop, clear of both panel columns.
+ */
+.deploybar {
+  position: fixed;
+  left: 14px;
+  bottom: 14px;
+  z-index: 101;
+  width: min(360px, calc(100vw - 28px));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px 12px;
+  border-radius: 10px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.9);
+  border: 1px solid rgba(82, 227, 159, 0.5);
+  box-shadow: 0 0 18px rgba(82, 227, 159, 0.18);
+  backdrop-filter: blur(10px);
+  font-size: 10px;
+}
+
+.deploybar__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.deploybar__eye {
+  color: var(--ok);
+  font-size: 13px;
+}
+
+.deploybar__title {
+  flex: 1;
+  letter-spacing: 0.12em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deploybar__title strong {
+  color: var(--ok);
+}
+
+.deploybar__cancel {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 5px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.25);
+  cursor: pointer;
+}
+
+.deploybar__label {
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+}
+
+.deploybar__btn {
+  font-family: inherit;
+  font-size: 12px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 5px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.8);
+  border: 1px solid rgba(0, 229, 255, 0.25);
+  cursor: pointer;
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.deploybar__btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.deploybar__value {
+  font-size: 13px;
+  min-width: 22px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.deploybar__radius {
+  color: var(--ok);
+  letter-spacing: 0.06em;
+}
+
+.deploybar__hint {
+  display: block;
+  font-size: 9px;
+  line-height: 1.5;
+  color: var(--dim);
+}
+
+.deploybar__deploy {
+  margin-top: 2px;
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  height: 38px;
+  border-radius: 8px;
+  color: #05070d;
+  background: var(--ok);
+  border: 1px solid var(--ok);
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.deploybar__deploy:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Clear of the panel columns on a desktop. */
+@media (min-width: 1101px) {
+  .deploybar {
+    left: 332px;
+    bottom: 14px;
+  }
+}
+
+/* Above the movement pad on a phone. */
+@media (max-width: 1100px) {
+  .deploybar {
+    bottom: 150px;
+  }
+}
+
+.shards__row--deployed {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 5px 0;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+  font-size: 10px;
+}
+
+.shards__deployed {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 229, 255, 0.14);
+}
+
+.workshop__deploy {
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 5px;
+  color: #05070d;
+  background: var(--ok);
+  border: 1px solid var(--ok);
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.workshop__deploy:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
 /* ---------- Spectate bar ----------
  *
  * Top right on a desktop, flush to the edge: the panels are locked away while

--- a/src/styles.css
+++ b/src/styles.css
@@ -1061,6 +1061,248 @@ kbd {
   border-top: 1px solid rgba(0, 229, 255, 0.14);
 }
 
+/* ---------- Modal (destructive confirms) ---------- */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(5, 7, 13, 0.72);
+  backdrop-filter: blur(3px);
+}
+
+.modal__card {
+  width: min(420px, 100%);
+  padding: 18px 18px 16px;
+  border-radius: 10px;
+  background: rgba(6, 14, 22, 0.98);
+  border: 1px solid rgba(255, 59, 107, 0.5);
+  box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
+}
+
+.modal__title {
+  margin: 0 0 8px;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--fg);
+}
+
+.modal__body {
+  margin: 0 0 16px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--dim);
+}
+
+.modal__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.modal__cancel,
+.modal__confirm {
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  height: 36px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.modal__cancel {
+  color: var(--fg);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.3);
+}
+
+.modal__confirm {
+  color: #05070d;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  font-weight: 700;
+}
+
+.modal__confirm--danger {
+  background: var(--danger);
+  border-color: var(--danger);
+}
+
+/* ---------- Deployment detail overlay ----------
+ *
+ * The wire record of a deployed shard, up while the scene is flown to it. Left
+ * of the panels on a desktop, along the bottom on a phone.
+ */
+.detail {
+  position: fixed;
+  left: 14px;
+  top: 14px;
+  z-index: 101;
+  width: min(320px, calc(100vw - 28px));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px 12px;
+  border-radius: 10px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.92);
+  border: 1px solid rgba(0, 229, 255, 0.4);
+  box-shadow: 0 0 18px rgba(0, 229, 255, 0.15);
+  backdrop-filter: blur(10px);
+  font-size: 10px;
+}
+
+.detail__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.detail__eye { color: var(--accent); font-size: 13px; }
+
+.detail__title {
+  flex: 1;
+  letter-spacing: 0.1em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail__title strong { color: var(--accent); }
+
+.detail__exit {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 6px;
+  color: #05070d;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.detail__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.detail__field {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.detail__field--relays { align-items: start; }
+
+.detail__key {
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+  text-transform: uppercase;
+}
+
+.detail__val {
+  font-family: inherit;
+  font-size: 10px;
+  text-align: left;
+  color: var(--fg);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+
+.detail__val:hover { color: var(--accent); }
+
+.detail__plain {
+  font-size: 10px;
+  color: var(--fg);
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.detail__delete {
+  margin-top: 2px;
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  height: 34px;
+  border-radius: 7px;
+  color: var(--danger);
+  background: rgba(255, 59, 107, 0.08);
+  border: 1px solid rgba(255, 59, 107, 0.5);
+  cursor: pointer;
+}
+
+.detail__delete:hover {
+  background: rgba(255, 59, 107, 0.18);
+}
+
+@media (max-width: 1100px) {
+  .detail {
+    top: auto;
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    width: auto;
+  }
+}
+
+/* ---------- Shards panel sections ---------- */
+.shards__section + .shards__section {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 229, 255, 0.14);
+}
+
+.shards__goto {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 6px 4px;
+  font-family: inherit;
+  font-size: 11px;
+  color: var(--fg);
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.shards__goto:hover { background: rgba(0, 229, 255, 0.06); }
+
+.shards__row--deployed {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+}
+
+.shards__row--deployed:first-child { border-top: 0; }
+
+.shards__row--deployed.is-viewing {
+  background: rgba(0, 229, 255, 0.1);
+  border-radius: 4px;
+}
+
+.shards__goto-hint {
+  color: var(--dim);
+  padding-right: 4px;
+}
+
+/* ---------- Deploy bar ----------
+
 /* ---------- Deploy bar ----------
  *
  * Up while you are placing a shard. Bottom of the scene on a phone, above the
@@ -1403,6 +1645,7 @@ kbd {
 .workshop__head {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 8px 10px;
   border-bottom: 1px solid var(--border);
@@ -1652,6 +1895,27 @@ kbd {
 @media (max-width: 600px) {
   .workshop__help { display: none; }
   .workshop__label { min-width: 0; }
+
+  /* Portrait: the header buttons overran the right edge and CLOSE fell off the
+   * screen. The name takes its own top row, and SHARDS, the modes, DEPLOY and
+   * CLOSE wrap onto rows below it, all within reach of a thumb. */
+  .workshop__name {
+    flex: 1 1 100%;
+    order: -1;
+  }
+
+  .workshop__modes {
+    flex: 1 1 100%;
+    justify-content: space-between;
+  }
+
+  .workshop__modes .workshop__mode {
+    flex: 1;
+  }
+
+  .workshop__list-btn { flex: 0 0 auto; }
+  .workshop__deploy { flex: 1; }
+  .workshop__close { flex: 0 0 auto; margin-left: 0; }
 }
 
 /* ---------- Derezz ----------

--- a/src/workers/region.worker.ts
+++ b/src/workers/region.worker.ts
@@ -1,0 +1,50 @@
+/**
+ * region.worker.ts — the cost of looking, off the main thread.
+ *
+ * Deriving a region key at height h is O(2^h) Cantor pairings per axis (spec
+ * §7.4), which is exactly the work the protocol says looking must cost. That
+ * work must not be on the frame's critical path, so it runs here: given a
+ * coordinate and a set of heights, it computes the lookup_id and key for each
+ * and posts them back. The main thread then asks the relay for those lookup
+ * ids and decrypts what comes back.
+ */
+
+import { regionKeyAt } from '../lib/shardCrypto'
+import { bytesToHex } from '../lib/events'
+
+export interface RegionRequest {
+  id: number
+  x: string
+  y: string
+  z: string
+  heights: number[]
+  maxComputeHeight: number
+}
+
+export interface RegionKeyOut {
+  height: number
+  lookupId: string
+  keyHex: string
+}
+
+export type RegionResponse =
+  | { type: 'key'; id: number; key: RegionKeyOut }
+  | { type: 'done'; id: number }
+  | { type: 'error'; id: number; message: string }
+
+self.onmessage = (event: MessageEvent<RegionRequest>) => {
+  const { id, x, y, z, heights, maxComputeHeight } = event.data
+  const pos = { x: BigInt(x), y: BigInt(y), z: BigInt(z) }
+  try {
+    // Low heights first: the near, cheap radii resolve immediately while the
+    // wider, dearer ones are still grinding.
+    for (const h of [...heights].sort((a, b) => a - b)) {
+      const rk = regionKeyAt(pos, h, maxComputeHeight)
+      const msg: RegionResponse = { type: 'key', id, key: { height: h, lookupId: rk.lookupId, keyHex: bytesToHex(rk.key) } }
+      self.postMessage(msg)
+    }
+    self.postMessage({ type: 'done', id } satisfies RegionResponse)
+  } catch (err) {
+    self.postMessage({ type: 'error', id, message: err instanceof Error ? err.message : String(err) } satisfies RegionResponse)
+  }
+}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -17,6 +17,7 @@ import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { GRID_HALF, MODES, hexToRgb, rgbToHex, type ShardMode } from '../lib/shards'
 import { formatCellSize } from '../lib/scale'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
+import { useShards } from '../store/useShards'
 import { Bench } from './Bench'
 
 const PALETTE = ['#00e5ff', '#ff2323', '#52e39f', '#ffb020', '#c07dff', '#f7931a', '#ffffff', '#2f81f7']
@@ -67,6 +68,12 @@ export function Workshop(): JSX.Element | null {
             </button>
           ))}
         </div>
+        <button
+          className="workshop__deploy"
+          disabled={!shard || shard.vertices.length === 0}
+          onClick={() => { if (shard) { useShards.getState().startDeploy(shard.id); w().closeWorkshop() } }}
+          title="Place this shard in the world"
+        >DEPLOY ▸</button>
         <button className="workshop__close" onClick={() => w().closeWorkshop()}>CLOSE</button>
       </header>
 


### PR DESCRIPTION
Stack 9 — the outermost PR (base: `feat/shard-workshop`, PR #23). Completes spec item 5 and the whole feature set.

## What changes

- **`lib/shardCrypto.ts`**: region key derivation (spec §7.2, via cyberspace-core) + AES-256-GCM encrypt/decrypt (WebCrypto), CLI-compatible (`nonce||ct||tag`, base64).
- **`lib/shardEvents.ts`**: kind 33330 build/parse (spec §8.6) — `d` = lookup id, `encrypted`, `version`, `h`.
- **`workers/region.worker.ts`**: the O(2^h) region-key derivation off the main thread.
- **`store/useShards.ts`**: deploy mode, my deployments (kept with their key, always rendered), discovered shards. Publishes to general relays (`SHARD_RELAYS`) since the cyberspace relay only accepts kind 3333.
- **`hooks/useDiscovery.ts`**: scans heights 0–12 at the anchor, queries the shard relays, decrypts; re-runs only on region-boundary crossings (§7.5).
- **Scene**: `WorldShards` (own + discovered, at true unit scale), `ShardGhost` (aim preview at the cursor).
- **UI**: `DeployBar` (height → discovery radius in real units, PLACE), workshop DEPLOY button, Shards panel deployments list. Touch COMMIT → PLACE and Space → deploy while deploying.

## Verification

- Tests: 156 passing (`shardCrypto.test.ts`, `shardEvents.test.ts` new: spec §7.2 derivation, location gate, round-trip, deploy-event tags + decode).
- Browser, two identities: A deploys a POINTS beacon hidden at height 5 → publishes, renders at the cursor cell; B (different key, anchored into A's region) discovers it off the relay and decrypts to the exact coordinate / mode / vertices; wrong region stays shut. Zero console errors.

### Relay note
`cyberspace.nostr1.com` rejects kind 33330 (its write policy accepts only the movement kind — confirmed with `nak`). Encrypted content is spec-published to any relay (§7.1), so shard events go to `nos.lol` / `relay.damus.io` / `relay.primal.net`. Movement (kind 3333) is unchanged on the cyberspace relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)