### PR TITLE
feat: a relay panel, so people can add their own relays

### DIFF
--- a/src/hooks/useDiscovery.ts
+++ b/src/hooks/useDiscovery.ts
@@ -13,7 +13,7 @@
  */
 
 import { useEffect, useRef } from 'react'
-import { queryAny, SHARD_RELAYS } from '../lib/relay'
+import { query } from '../lib/relay'
 import { decodeShard, ENCRYPTED_KIND } from '../lib/shardEvents'
 import { hexToBytes } from '../lib/events'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from '../store/useCyberspace'
@@ -68,7 +68,7 @@ export function useDiscovery(): void {
       if (keys.size === 0) return
 
       // A superseded scan must not write stale finds.
-      const events = await queryAny(SHARD_RELAYS, { kinds: [ENCRYPTED_KIND], '#d': [...keys.keys()] })
+      const events = await query({ kinds: [ENCRYPTED_KIND], '#d': [...keys.keys()] })
       if (id !== reqId.current) return
 
       const found = []

--- a/src/hud/ChainPanel.tsx
+++ b/src/hud/ChainPanel.tsx
@@ -13,6 +13,7 @@
 import { formatMs, formatOps } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
 import { CYBERSPACE_RELAY } from '../lib/relay'
+import { useRelays } from '../store/useRelays'
 
 export function ChainPanel(): JSX.Element {
   const chain = useCyberspace((s) => s.chain)
@@ -22,6 +23,7 @@ export function ChainPanel(): JSX.Element {
   const published = useCyberspace((s) => s.published)
   const publishError = useCyberspace((s) => s.publishError)
   const live = useCyberspace((s) => s.live)
+  const relayCount = useRelays((s) => s.relays.length)
   const actions = chain.hops + chain.sidesteps
 
   const statuses = events.map((e) => published[e.id])
@@ -87,7 +89,7 @@ export function ChainPanel(): JSX.Element {
       <p className="legend__note">
         Every committed action is a signed kind:3333 event naming the one
         before it (spec section 8). {live
-          ? `Live publishes each one to ${CYBERSPACE_RELAY.replace('wss://', '')} as it lands.`
+          ? `Live publishes each one to your ${relayCount === 1 ? CYBERSPACE_RELAY.replace('wss://', '') : `${relayCount} relays`} as it lands.`
           : 'Local keeps them on this device; switching to Live publishes the whole chain in order.'}
       </p>
     </section>

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -8,6 +8,7 @@ import { useCyberspace } from '../store/useCyberspace'
 import { AvatarsPanel } from './AvatarsPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
+import { RelaysPanel } from './RelaysPanel'
 import { TargetsPanel } from './TargetsPanel'
 import { ShardsPanel } from './ShardsPanel'
 import { Legend } from './Legend'
@@ -217,6 +218,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <ShardsPanel />
         <Controls />
         <DerezzPanel />
+        <RelaysPanel />
       </div>
     </div>
   )

--- a/src/hud/RelaysPanel.tsx
+++ b/src/hud/RelaysPanel.tsx
@@ -1,0 +1,80 @@
+/**
+ * RelaysPanel.tsx — the relays this client fans out across.
+ *
+ * cyberspace.nostr1.com is the shared default and is pinned: everyone meets
+ * there, so it cannot be removed. Add your own below it, and movement, hidden
+ * content, discovery and everyone else's chains all ride the whole set. A dot
+ * per relay shows whether the socket is open right now.
+ */
+
+import { useEffect, useState } from 'react'
+import { connected } from '../lib/relay'
+import { getPool } from '../lib/relay'
+import { DEFAULT_RELAY, useRelays } from '../store/useRelays'
+
+export function RelaysPanel(): JSX.Element {
+  const relays = useRelays((s) => s.relays)
+  const [input, setInput] = useState('')
+  const [error, setError] = useState(false)
+  // Connection dots update on their own clock; the pool is not reactive.
+  const [, tick] = useState(0)
+  useEffect(() => {
+    const t = window.setInterval(() => tick((n) => n + 1), 2000)
+    return () => window.clearInterval(t)
+  }, [])
+  void connected
+
+  const status = getPool().listConnectionStatus?.() ?? new Map<string, boolean>()
+
+  const submit = (e: React.FormEvent): void => {
+    e.preventDefault()
+    const added = useRelays.getState().add(input)
+    if (added) { setInput(''); setError(false) } else setError(true)
+  }
+
+  return (
+    <section className="panel panel--relays">
+      <header className="panel__head">
+        <h2>Relays</h2>
+        <span className="tag">{relays.length}</span>
+      </header>
+
+      <ul className="relays__list">
+        {relays.map((r) => {
+          const open = status.get(r)
+          const pinned = r === DEFAULT_RELAY
+          return (
+            <li key={r} className="relays__row">
+              <span className={`relays__dot ${open ? 'is-on' : ''}`} title={open ? 'connected' : 'not connected'} />
+              <span className="relays__url" title={r}>{r.replace(/^wss?:\/\//, '')}</span>
+              {pinned ? (
+                <span className="relays__default" title="The shared default, always present">DEFAULT</span>
+              ) : (
+                <button className="targets__remove" onClick={() => useRelays.getState().remove(r)} aria-label="Remove relay" title="Remove relay">✕</button>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+
+      <form className="avatars__find" onSubmit={submit}>
+        <input
+          className="avatars__input"
+          value={input}
+          onChange={(e) => { setInput(e.target.value); setError(false) }}
+          placeholder="wss://relay.example.com"
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="Relay URL to add"
+        />
+        <button className="avatars__go" type="submit" disabled={!input.trim()}>ADD</button>
+      </form>
+      {error && <p className="notice">Not a valid ws:// or wss:// URL.</p>}
+
+      <p className="legend__note">
+        Everything the client does fans out across these. The default is shared
+        by everyone and stays; yours are added on top and kept on this device.
+      </p>
+    </section>
+  )
+}

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -1,9 +1,10 @@
 /**
- * relay.ts — the one relay this client talks to, and how.
+ * relay.ts — the relays this client talks to, and how.
  *
- * cyberspace.nostr1.com is where the v2 chains live. A single pool, created on
- * first use so a page that never goes live never opens a socket, and shared by
- * publishing, chain lookups and subscriptions so they all ride one connection.
+ * The set is user-configurable (see the relays store); cyberspace.nostr1.com is
+ * the default and is always in it. A single pool, created on first use so a
+ * page that never goes live never opens a socket, and shared by publishing,
+ * lookups and subscriptions so they ride the same connections.
  *
  * Publishing reports a result rather than throwing, because the caller is a
  * queue that needs to know whether to move on or try again, and a relay that
@@ -13,18 +14,10 @@
 import { SimplePool } from 'nostr-tools/pool'
 import type { Filter } from 'nostr-tools/filter'
 import type { NostrEvent } from './events'
+import { currentRelays, DEFAULT_RELAY } from '../store/useRelays'
 
-export const CYBERSPACE_RELAY = 'wss://cyberspace.nostr1.com'
-
-/**
- * Where encrypted shard content lives. The cyberspace relay accepts the
- * location-encrypted kind:33330 events (§8.6) alongside movement, so shards
- * sit on the same relay as everything else. A list rather than the constant so
- * a deploy can be fanned to more relays later without touching the callers;
- * §7.1 makes that free, since the ciphertext is public and only the region key
- * opens it.
- */
-export const SHARD_RELAYS = [CYBERSPACE_RELAY]
+/** The default relay, always present; kept here so panels can name it. */
+export const CYBERSPACE_RELAY = DEFAULT_RELAY
 
 /** How long a publish or a one-shot query waits before giving up. */
 const MAX_WAIT_MS = 8000
@@ -36,54 +29,54 @@ export function getPool(): SimplePool {
   return pool
 }
 
-export type PublishResult = { ok: true } | { ok: false; reason: string }
-
-/** Send one event and wait for the relay's OK, or its refusal. */
-export async function publish(event: NostrEvent): Promise<PublishResult> {
-  try {
-    const [promise] = getPool().publish([CYBERSPACE_RELAY], event, { maxWait: MAX_WAIT_MS })
-    await promise
-    return { ok: true }
-  } catch (err) {
-    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
-  }
+/** The relays every cyberspace read and write fans out across, right now. */
+export function relaySet(): string[] {
+  return currentRelays()
 }
 
-/** Send to several relays; ok if any accepts, the reason of the last refusal otherwise. */
+export type PublishResult = { ok: true } | { ok: false; reason: string }
+
+/** Send to a set of relays; ok if any accepts, the last refusal otherwise. */
 export async function publishMany(relays: string[], event: NostrEvent): Promise<PublishResult> {
+  if (relays.length === 0) return { ok: false, reason: 'no relays configured' }
   const results = await Promise.allSettled(getPool().publish(relays, event, { maxWait: MAX_WAIT_MS }))
   if (results.some((r) => r.status === 'fulfilled')) return { ok: true }
   const reason = results.map((r) => (r.status === 'rejected' ? String(r.reason?.message ?? r.reason) : '')).find(Boolean)
   return { ok: false, reason: reason || 'no relay accepted it' }
 }
 
-/** One-shot query: everything the relay has for the filter, then close. */
-export function query(filter: Filter): Promise<NostrEvent[]> {
-  return getPool().querySync([CYBERSPACE_RELAY], filter, { maxWait: MAX_WAIT_MS })
+/** Send one event to every configured relay. */
+export function publish(event: NostrEvent): Promise<PublishResult> {
+  return publishMany(relaySet(), event)
 }
 
-/**
- * The same against any set of relays, for the few things that do not live
- * here: contact lists, mostly. Results are the union; callers pick.
- */
+/** One-shot query across the configured relays, merged, then close. */
+export function query(filter: Filter): Promise<NostrEvent[]> {
+  return getPool().querySync(relaySet(), filter, { maxWait: MAX_WAIT_MS })
+}
+
+/** The same against an explicit set, for the few things that live elsewhere
+ * (contact lists). Results are the union; callers pick. */
 export function queryAny(relays: string[], filter: Filter): Promise<NostrEvent[]> {
   return getPool().querySync(relays, filter, { maxWait: MAX_WAIT_MS })
 }
 
-/** A live subscription; the returned function closes it. */
+/** A live subscription across the configured relays; the returned function closes it. */
 export function subscribe(
   filter: Filter,
   onEvent: (ev: NostrEvent) => void,
   onEose?: () => void,
 ): () => void {
-  const sub = getPool().subscribe([CYBERSPACE_RELAY], filter, {
+  const sub = getPool().subscribe(relaySet(), filter, {
     onevent: onEvent,
     oneose: onEose,
   })
   return () => sub.close()
 }
 
-/** Whether the socket to the relay is currently open. */
+/** Whether any configured relay is currently connected. */
 export function connected(): boolean {
-  return pool?.listConnectionStatus().get(CYBERSPACE_RELAY) ?? false
+  const status = pool?.listConnectionStatus()
+  if (!status) return false
+  return relaySet().some((r) => status.get(r))
 }

--- a/src/store/useRelays.test.ts
+++ b/src/store/useRelays.test.ts
@@ -1,0 +1,32 @@
+/**
+ * useRelays.test.ts - a relay list is a set of real ws URLs, and the default
+ * is always in it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_RELAY, normalizeRelay } from './useRelays'
+
+describe('normalizeRelay', () => {
+  it('accepts and completes real relay hosts', () => {
+    expect(normalizeRelay('relay.example.com')).toBe('wss://relay.example.com')
+    expect(normalizeRelay('wss://relay.example.com')).toBe('wss://relay.example.com')
+    expect(normalizeRelay('wss://relay.example.com/')).toBe('wss://relay.example.com')
+    expect(normalizeRelay('ws://localhost:7777')).toBe('ws://localhost:7777')
+    expect(normalizeRelay('  wss://a.b.c  ')).toBe('wss://a.b.c')
+    expect(normalizeRelay('wss://relay.example.com/inbox')).toBe('wss://relay.example.com/inbox')
+  })
+
+  it('rejects non-URLs and wrong schemes', () => {
+    expect(normalizeRelay('not a url')).toBeNull()
+    expect(normalizeRelay('')).toBeNull()
+    expect(normalizeRelay('http://relay.example.com')).toBeNull()
+    expect(normalizeRelay('wss://')).toBeNull()
+    expect(normalizeRelay('justaword')).toBeNull()
+    expect(normalizeRelay('wss://has space.com')).toBeNull()
+  })
+
+  it('has cyberspace.nostr1.com as the default', () => {
+    expect(DEFAULT_RELAY).toBe('wss://cyberspace.nostr1.com')
+    expect(normalizeRelay(DEFAULT_RELAY)).toBe(DEFAULT_RELAY)
+  })
+})

--- a/src/store/useRelays.ts
+++ b/src/store/useRelays.ts
@@ -1,0 +1,85 @@
+/**
+ * useRelays.ts — which relays this client talks to.
+ *
+ * cyberspace.nostr1.com is the default for everyone and is always present: it
+ * is where the shared world lives, so it cannot be removed. On top of it you
+ * add your own, and everything the client does — publishing movement and
+ * hidden content, discovering it, reading other chains — fans out across the
+ * whole set. Persisted locally, so your relays survive a reload.
+ */
+
+import { create } from 'zustand'
+
+/** The default for everyone; always in the list, never removed. */
+export const DEFAULT_RELAY = 'wss://cyberspace.nostr1.com'
+
+const STORAGE = 'onosendai:relays'
+
+interface RelaysState {
+  relays: string[]
+  add: (url: string) => string | null
+  remove: (url: string) => void
+  reset: () => void
+}
+
+/** ws:// or wss:// with a real host; null for anything else. */
+export function normalizeRelay(input: string): string | null {
+  const s = input.trim()
+  // A relay URL has no spaces; a "host" with one is a typo, not an address.
+  if (!s || /\s/.test(s)) return null
+  const withScheme = /^wss?:\/\//i.test(s) ? s : `wss://${s}`
+  try {
+    const u = new URL(withScheme)
+    if (u.protocol !== 'ws:' && u.protocol !== 'wss:') return null
+    // A hostname, optionally with a port: letters, digits, dots, hyphens.
+    if (!/^[a-z0-9.-]+$/i.test(u.hostname) || !u.hostname.includes('.') && u.hostname !== 'localhost') return null
+    const path = u.pathname === '/' ? '' : u.pathname
+    return `${u.protocol}//${u.host}${path}`.replace(/\/$/, '')
+  } catch {
+    return null
+  }
+}
+
+function load(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE)
+    const list = raw ? (JSON.parse(raw) as unknown) : []
+    const urls = Array.isArray(list) ? list.map((x) => (typeof x === 'string' ? normalizeRelay(x) : null)).filter((x): x is string => !!x) : []
+    // The default is always first and always present.
+    return [DEFAULT_RELAY, ...urls.filter((u) => u !== DEFAULT_RELAY)]
+  } catch {
+    return [DEFAULT_RELAY]
+  }
+}
+
+function save(relays: string[]): void {
+  try { localStorage.setItem(STORAGE, JSON.stringify(relays.filter((r) => r !== DEFAULT_RELAY))) } catch { /* private mode */ }
+}
+
+export const useRelays = create<RelaysState>((set, get) => ({
+  relays: load(),
+
+  add: (url) => {
+    const norm = normalizeRelay(url)
+    if (!norm) return null
+    if (get().relays.includes(norm)) return norm
+    const relays = [...get().relays, norm]
+    set({ relays })
+    save(relays)
+    return norm
+  },
+
+  remove: (url) => {
+    if (url === DEFAULT_RELAY) return
+    const relays = get().relays.filter((r) => r !== url)
+    set({ relays })
+    save(relays)
+  },
+
+  reset: () => { set({ relays: [DEFAULT_RELAY] }); save([DEFAULT_RELAY]) },
+}))
+
+/** The current relay set, for the non-React relay helpers. */
+export function currentRelays(): string[] {
+  return useRelays.getState().relays
+}

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -17,7 +17,7 @@
 
 import { create } from 'zustand'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
-import { publishMany, SHARD_RELAYS } from '../lib/relay'
+import { publishMany, relaySet } from '../lib/relay'
 import { ENCRYPTED_KIND } from '../lib/shardEvents'
 import { deployTemplate, type DecodedShard } from '../lib/shardEvents'
 import { bytesToHex, hexToBytes } from '../lib/events'
@@ -143,7 +143,7 @@ export const useShards = create<ShardsState>((set, get) => ({
       const { template, lookupId, key } = await deployTemplate({ shard, at, plane, height: deployHeight, createdAt, maxComputeHeight: MAX_COMPUTE_HEIGHT })
       const event = cs.sign(template)
       const live = cs.live
-      const result = live ? await publishMany(SHARD_RELAYS, event) : { ok: true as const }
+      const result = live ? await publishMany(relaySet(), event) : { ok: true as const }
 
       const deployment: MyDeployment = {
         eventId: event.id,
@@ -153,7 +153,7 @@ export const useShards = create<ShardsState>((set, get) => ({
         height: deployHeight,
         lookupId,
         keyHex: bytesToHex(key),
-        relays: SHARD_RELAYS,
+        relays: relaySet(),
         createdAt,
         published: live && result.ok,
       }
@@ -179,7 +179,7 @@ export const useShards = create<ShardsState>((set, get) => ({
         content: 'shard instance removed',
         tags: [['e', eventId], ['k', String(ENCRYPTED_KIND)]],
       })
-      try { await publishMany(dep.relays ?? SHARD_RELAYS, del) } catch { /* best effort */ }
+      try { await publishMany(dep.relays ?? relaySet(), del) } catch { /* best effort */ }
     }
     const mine = get().mine.filter((d) => d.eventId !== eventId)
     const deleted = { ...get().deleted, [eventId]: true as const }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1918,6 +1918,55 @@ kbd {
   .workshop__close { flex: 0 0 auto; margin-left: 0; }
 }
 
+/* ---------- Relays panel ---------- */
+.relays__list {
+  list-style: none;
+  margin: 0 0 8px;
+  padding: 0;
+  max-height: 160px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.relays__row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+  font-size: 10px;
+}
+
+.relays__row:first-child { border-top: 0; }
+
+.relays__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--dim);
+  opacity: 0.5;
+  flex: none;
+}
+
+.relays__dot.is-on {
+  background: var(--ok);
+  opacity: 1;
+  box-shadow: 0 0 6px var(--ok);
+}
+
+.relays__url {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.relays__default {
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+}
+
 /* ---------- Derezz ----------
  *
  * The one panel that destroys something. Red throughout, last in the column,


### PR DESCRIPTION
Stacked on #24 (base: `feat/shard-deploy`).

## What changes

- **`store/useRelays.ts`**: the configurable relay set, persisted. `cyberspace.nostr1.com` is the default, always present and unremovable; users add their own. `normalizeRelay` accepts only real `ws://` / `wss://` hosts.
- **`lib/relay.ts`** reads the set from the store instead of hardcoding one relay: `publish` sends to all (ok if any accepts), `query` / `subscribe` union across all. `queryAny` stays for the contact relays.
- **Relays panel** at the bottom of the menu: live connection dot per relay, add field, per-relay remove (default pinned).

## Verification

- Tests: 160 passing (`useRelays.test.ts` new).
- Browser: default present + pinned; add persists across reload; invalid URL refused; remove works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)