### PR TITLE
feat: profiles — names and faces for pubkeys

### DIFF
--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,15 @@
+/**
+ * useProfile.ts — a pubkey's profile, requested and reactive.
+ *
+ * Reads from the shared profile cache and asks it to fetch on first sight.
+ * Returns undefined while unknown, null when fetched-but-none, or the profile.
+ */
+
+import { useEffect } from 'react'
+import { useProfiles, type Profile } from '../store/useProfiles'
+
+export function useProfile(pubkey: string | null | undefined): Profile | null | undefined {
+  const profile = useProfiles((s) => (pubkey ? s.profiles[pubkey] : undefined))
+  useEffect(() => { if (pubkey) useProfiles.getState().request(pubkey) }, [pubkey])
+  return profile
+}

--- a/src/hud/AvatarsPanel.tsx
+++ b/src/hud/AvatarsPanel.tsx
@@ -13,16 +13,10 @@ import { useRecentAvatars } from '../hooks/useRecentAvatars'
 import { parsePubkey } from '../lib/chains'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { spectate } from '../lib/spectator'
+import { ProfileBadge } from './ProfileBadge'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
-import { nip19 } from 'nostr-tools'
-
-/** Enough to tell keys apart; the title carries the whole npub. */
-function shortNpub(pubkey: string): string {
-  const npub = nip19.npubEncode(pubkey)
-  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
-}
 
 export function AvatarsPanel(): JSX.Element {
   const { avatars, status } = useRecentAvatars()
@@ -73,7 +67,7 @@ export function AvatarsPanel(): JSX.Element {
           const on = !!targets[a.pubkey]
           return (
             <li key={a.pubkey} className="avatars__row">
-              <span className="avatars__who" title={nip19.npubEncode(a.pubkey)}>{shortNpub(a.pubkey)}</span>
+              <ProfileBadge pubkey={a.pubkey} />
               <span className={`avatars__type avatars__type--${a.type}`}>{a.type.toUpperCase()}</span>
               <span className="avatars__when" title={formatStamp(a.createdAt)}>{formatAgo(a.createdAt, now)}</span>
               {you ? (

--- a/src/hud/ProfileBadge.tsx
+++ b/src/hud/ProfileBadge.tsx
@@ -1,0 +1,51 @@
+/**
+ * ProfileBadge.tsx — a pubkey as a face and a name.
+ *
+ * A round avatar (the kind:0 picture, or a colour-from-the-key fallback with an
+ * initial) and the name, or a shortened npub until the profile arrives. One
+ * component so every list — follows, avatars, targets, a secret's creator —
+ * shows a person the same way.
+ */
+
+import { useState } from 'react'
+import { nip19 } from 'nostr-tools'
+import { targetColor } from '../lib/targets'
+import { profileLabel } from '../store/useProfiles'
+import { useProfile } from '../hooks/useProfile'
+
+export function ProfilePic({ pubkey, size = 22 }: { pubkey: string; size?: number }): JSX.Element {
+  const profile = useProfile(pubkey)
+  const [broken, setBroken] = useState(false)
+  const npub = nip19.npubEncode(pubkey)
+  const initial = (profile?.name ?? npub.slice(4, 5)).slice(0, 1).toUpperCase()
+  const style = { width: size, height: size, minWidth: size } as const
+
+  if (profile?.picture && !broken) {
+    return <img className="pfp" style={style} src={profile.picture} alt="" loading="lazy" referrerPolicy="no-referrer" onError={() => setBroken(true)} />
+  }
+  return (
+    <span className="pfp pfp--fallback" style={{ ...style, background: targetColor(pubkey), fontSize: size * 0.5 }} aria-hidden="true">
+      {initial}
+    </span>
+  )
+}
+
+interface BadgeProps {
+  pubkey: string
+  /** A petname from a contact list, shown when the profile has no name yet. */
+  fallbackName?: string | null
+  size?: number
+  className?: string
+}
+
+export function ProfileBadge({ pubkey, fallbackName, size = 22, className = '' }: BadgeProps): JSX.Element {
+  const profile = useProfile(pubkey)
+  const npub = nip19.npubEncode(pubkey)
+  const name = profile?.name ?? fallbackName ?? profileLabel(profile, npub)
+  return (
+    <span className={`badge ${className}`} title={npub}>
+      <ProfilePic pubkey={pubkey} size={size} />
+      <span className="badge__name">{name}</span>
+    </span>
+  )
+}

--- a/src/hud/SpectateBar.tsx
+++ b/src/hud/SpectateBar.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react'
 import { stopSpectating } from '../lib/spectator'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
+import { ProfileBadge } from './ProfileBadge'
 
 export function SpectateBar(): JSX.Element | null {
   const spectate = useCyberspace((s) => s.spectate)
@@ -22,7 +23,6 @@ export function SpectateBar(): JSX.Element | null {
 
   if (!spectate) return null
 
-  const short = `${spectate.npub.slice(0, 12)}…${spectate.npub.slice(-6)}`
   const status =
     spectate.status === 'loading' ? 'FETCHING CHAIN'
       : spectate.status === 'error' ? 'RELAY UNREACHABLE'
@@ -34,7 +34,7 @@ export function SpectateBar(): JSX.Element | null {
       <span className="spectate__eye" aria-hidden="true">◉</span>
       <span className="spectate__text">
         <span className="spectate__label">SPECTATING</span>
-        <span className="spectate__who" title={spectate.npub}>{short}</span>
+        <ProfileBadge pubkey={spectate.pubkey} className="spectate__badge" />
         <span className="spectate__meta">
           {spectate.lastActive !== null && (
             <span title={formatStamp(spectate.lastActive)}>LAST ACTIVE {formatAgo(spectate.lastActive, now).toUpperCase()} · </span>

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -10,17 +10,13 @@
  */
 
 import { useEffect, useState } from 'react'
-import { nip19 } from 'nostr-tools'
 import { parsePubkey } from '../lib/chains'
 import { fetchContacts, GENERAL_RELAYS, type Contact } from '../lib/contacts'
 import { spectate } from '../lib/spectator'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
-
-function shortNpub(npub: string): string {
-  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
-}
+import { ProfileBadge } from './ProfileBadge'
 
 export function TargetsPanel(): JSX.Element {
   const targets = useCyberspace((s) => s.targets)
@@ -67,7 +63,7 @@ export function TargetsPanel(): JSX.Element {
         {list.map((t) => (
           <li key={t.pubkey} className="targets__row">
             <span className="targets__dot" style={{ background: targetColor(t.pubkey), boxShadow: `0 0 6px ${targetColor(t.pubkey)}` }} />
-            <span className="avatars__who" title={t.npub}>{t.name ?? shortNpub(t.npub)}</span>
+            <ProfileBadge pubkey={t.pubkey} fallbackName={t.name} />
             <span className={`targets__status targets__status--${t.status}`} title={t.lastActive ? formatStamp(t.lastActive) : undefined}>
               {t.status === 'live' && t.lastActive ? formatAgo(t.lastActive, now)
                 : t.status === 'resolving' ? 'FINDING'
@@ -97,7 +93,7 @@ export function TargetsPanel(): JSX.Element {
               const on = !!targets[c.pubkey]
               return (
                 <li key={c.pubkey} className="targets__row targets__row--contact">
-                  <span className="avatars__who" title={nip19.npubEncode(c.pubkey)}>{c.name ?? shortNpub(nip19.npubEncode(c.pubkey))}</span>
+                  <ProfileBadge pubkey={c.pubkey} fallbackName={c.name} />
                   <button
                     className={`targets__toggle ${on ? 'is-on' : ''}`}
                     style={on ? { color: targetColor(c.pubkey), borderColor: targetColor(c.pubkey) } : undefined}

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -62,13 +62,20 @@ interface AuthRelay {
  * and re-auths on its own when a reconnect brings a fresh challenge.
  */
 const authedFor = new Map<string, string>()
+const noChallenge = new Set<string>()
 async function authRelay(url: string): Promise<void> {
+  // A relay that never challenged before will not now: skip the wait.
+  if (noChallenge.has(url)) return
   try {
     const relay = (await getPool().ensureRelay(url)) as unknown as AuthRelay
-    for (let i = 0; i < 20 && !relay.challenge; i++) await new Promise((r) => setTimeout(r, 50))
-    if (relay.challenge && authedFor.get(url) !== relay.challenge) {
-      await relay.auth(authSign)
-      authedFor.set(url, relay.challenge)
+    for (let i = 0; i < 10 && !relay.challenge; i++) await new Promise((r) => setTimeout(r, 40))
+    if (relay.challenge) {
+      if (authedFor.get(url) !== relay.challenge) {
+        await relay.auth(authSign)
+        authedFor.set(url, relay.challenge)
+      }
+    } else {
+      noChallenge.add(url)
     }
   } catch { /* relay down, or does not require auth */ }
 }
@@ -109,7 +116,7 @@ export function publish(event: NostrEvent): Promise<PublishResult> {
  * `onauth`: the relay now requires NIP-42 auth for reads, so a query has to be
  * able to answer the challenge and retry, or it comes back empty.
  */
-async function collect(relays: string[], filter: Filter): Promise<NostrEvent[]> {
+async function collect(relays: string[], filter: Filter, maxWait = MAX_WAIT_MS): Promise<NostrEvent[]> {
   await authAll(relays)
   return new Promise((resolve) => {
     const events = new Map<string, NostrEvent>()
@@ -121,12 +128,12 @@ async function collect(relays: string[], filter: Filter): Promise<NostrEvent[]> 
       try { sub.close() } catch { /* already closed */ }
       resolve([...events.values()])
     }
-    const timer = setTimeout(done, MAX_WAIT_MS + 2000)
+    const timer = setTimeout(done, maxWait + 500)
     const sub = getPool().subscribeEose(relays, filter, {
       onevent: (e) => events.set(e.id, e),
       onclose: done,
       onauth: authSign,
-      maxWait: MAX_WAIT_MS,
+      maxWait,
     })
   })
 }
@@ -137,8 +144,8 @@ export function query(filter: Filter): Promise<NostrEvent[]> {
 }
 
 /** Query an explicit set, for the few things that live elsewhere (contact lists). */
-export function queryAny(relays: string[], filter: Filter): Promise<NostrEvent[]> {
-  return collect(relays, filter)
+export function queryAny(relays: string[], filter: Filter, maxWait?: number): Promise<NostrEvent[]> {
+  return collect(relays, filter, maxWait)
 }
 
 /** A live subscription across the configured relays; the returned function closes it. */

--- a/src/store/useProfiles.ts
+++ b/src/store/useProfiles.ts
@@ -1,0 +1,148 @@
+/**
+ * useProfiles.ts — who a pubkey is, cached.
+ *
+ * A pubkey is intelligible only with its kind:0: a name, a picture, maybe a
+ * nip05. Components ask for one by pubkey; this batches the misses into a
+ * single relay query, caches what comes back, and keeps it in localStorage so
+ * a reload does not refetch the world. Profiles live on the general relays
+ * (purplepag.es aggregates them), so it asks those alongside ours.
+ *
+ * The whole cache is one reactive record: a component that reads get(pubkey)
+ * re-renders when that profile arrives, without every row holding a
+ * subscription of its own.
+ */
+
+import { create } from 'zustand'
+import { queryAny } from '../lib/relay'
+import { GENERAL_RELAYS } from '../lib/contacts'
+import type { NostrEvent } from '../lib/events'
+
+export interface Profile {
+  pubkey: string
+  name: string | null
+  picture: string | null
+  about: string | null
+  nip05: string | null
+  /** created_at of the kind:0 we parsed, so a newer one wins. */
+  at: number
+}
+
+interface ProfilesState {
+  /** null = fetched, none found; undefined = not fetched. */
+  profiles: Record<string, Profile | null>
+  /** Ask for a profile; a miss is queued and fetched in the next batch. */
+  request: (pubkey: string) => void
+  get: (pubkey: string) => Profile | null | undefined
+}
+
+const STORAGE = 'onosendai:profiles'
+const HEX = /^[0-9a-f]{64}$/
+/** Refetch a cached profile after this, in case it changed. */
+const TTL_MS = 24 * 60 * 60 * 1000
+/** How many authors to ask for in one query. */
+const CHUNK = 100
+const FLUSH_MS = 250
+/** Profiles live on the general relays; the cyberspace relay is auth-gated and
+ * slow, and rarely holds kind:0, so a short wait on the general set is enough. */
+const PROFILE_WAIT_MS = 4000
+
+function loadCache(): Record<string, Profile | null> {
+  try {
+    const raw = localStorage.getItem(STORAGE)
+    const data = raw ? JSON.parse(raw) : {}
+    return data && typeof data === 'object' ? data : {}
+  } catch { return {} }
+}
+
+let saveHandle: number | null = null
+function saveCacheSoon(cache: Record<string, Profile | null>): void {
+  if (saveHandle !== null) return
+  saveHandle = window.setTimeout(() => {
+    saveHandle = null
+    try {
+      // Only real profiles are worth persisting; misses can be retried.
+      const keep: Record<string, Profile> = {}
+      for (const [pk, p] of Object.entries(cache)) if (p) keep[pk] = p
+      localStorage.setItem(STORAGE, JSON.stringify(keep))
+    } catch { /* quota or private mode */ }
+  }, 1000)
+}
+
+/** Parse a kind:0 into a Profile; null if the content is not usable JSON. */
+export function parseProfile(ev: NostrEvent): Profile | null {
+  try {
+    const meta = JSON.parse(ev.content) as Record<string, unknown>
+    const str = (v: unknown): string | null => (typeof v === 'string' && v.trim() ? v.trim() : null)
+    return {
+      pubkey: ev.pubkey,
+      name: str(meta.display_name) ?? str(meta.name),
+      picture: str(meta.picture),
+      about: str(meta.about),
+      nip05: str(meta.nip05),
+      at: ev.created_at,
+    }
+  } catch { return null }
+}
+
+const pending = new Set<string>()
+let flushHandle: number | null = null
+
+export const useProfiles = create<ProfilesState>((set, get) => {
+  const initial = loadCache()
+
+  async function flush(): Promise<void> {
+    flushHandle = null
+    const want = [...pending]
+    pending.clear()
+    if (want.length === 0) return
+
+    for (let i = 0; i < want.length; i += CHUNK) {
+      const authors = want.slice(i, i + CHUNK)
+      let events: NostrEvent[] = []
+      try {
+        events = await queryAny(GENERAL_RELAYS, { kinds: [0], authors }, PROFILE_WAIT_MS)
+      } catch { /* relays down */ }
+
+      const newest = new Map<string, Profile>()
+      for (const ev of events) {
+        const p = parseProfile(ev)
+        if (p && (!newest.has(p.pubkey) || p.at > newest.get(p.pubkey)!.at)) newest.set(p.pubkey, p)
+      }
+      const next = { ...get().profiles }
+      for (const pk of authors) next[pk] = newest.get(pk) ?? null
+      set({ profiles: next })
+      saveCacheSoon(next)
+    }
+  }
+
+  return {
+    profiles: initial,
+
+    request: (pubkey) => {
+      if (!HEX.test(pubkey)) return
+      const have = get().profiles[pubkey]
+      const stamp = withStamp.get(pubkey)
+      const fresh = have && stamp !== undefined && Date.now() - stamp < TTL_MS
+      if (fresh || pending.has(pubkey)) return
+      pending.add(pubkey)
+      if (flushHandle === null) flushHandle = window.setTimeout(() => void flush(), FLUSH_MS)
+    },
+
+    get: (pubkey) => get().profiles[pubkey],
+  }
+})
+
+if (import.meta.env.DEV && typeof window !== "undefined") { (window as unknown as { __profiles?: unknown }).__profiles = useProfiles }
+
+/** When each profile was fetched, so the TTL can refetch a stale one. */
+const withStamp = new Map<string, number>()
+useProfiles.subscribe((s, prev) => {
+  if (s.profiles === prev.profiles) return
+  const now = Date.now()
+  for (const pk of Object.keys(s.profiles)) if (s.profiles[pk] !== prev.profiles[pk]) withStamp.set(pk, now)
+})
+
+/** A short, human label for a pubkey: its name, or a shortened npub. */
+export function profileLabel(profile: Profile | null | undefined, npub: string): string {
+  return profile?.name ?? `${npub.slice(0, 12)}…${npub.slice(-4)}`
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -864,6 +864,51 @@ kbd {
   white-space: nowrap;
 }
 
+/* ---------- Profile badge (face + name) ---------- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.badge__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pfp {
+  border-radius: 50%;
+  object-fit: cover;
+  flex: none;
+  display: inline-block;
+  background: rgba(0, 229, 255, 0.1);
+}
+
+.pfp--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #05070d;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.spectate__badge .badge__name {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+/* The avatars/targets/follows rows hold a badge where a bare name used to sit;
+ * the badge is the flexible column that ellipsizes. */
+.avatars__row .badge,
+.targets__row .badge,
+.targets__row--contact .badge {
+  min-width: 0;
+}
+
 /* ---------- Avatars ---------- */
 
 .avatars__find {


### PR DESCRIPTION
First of three (base: `v2`). Makes follows/avatars/targets/spectate intelligible; the creator data the secret-detail modal will need.

## What changes

- **`store/useProfiles.ts`**: batched, cached kind:0 store (localStorage-persisted, TTL refetch). Profiles from the general relays (purplepag.es et al.); cyberspace relay skipped (auth-gated, rarely holds kind:0).
- **`ProfileBadge` / `ProfilePic` + `useProfile`**: a pubkey as avatar + name, with a colour-from-key identicon fallback (and on-404 fallback). Wired into the follows list, Avatars, Targets, and the spectate bar.
- **Relay-read speedups** (profiles fetch a lot): `authAll` caches relays that never challenge and stops waiting on them; `collect`/`queryAny` take a shorter timeout for profile batches.

## Verification

Browser: fiatjaf's follows resolve to real names + pictures (10/10 sampled, 185 avatars), targeting arkinox shows "arkinox", dead picture URL falls back cleanly. Tests unchanged; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)