### PR TITLE
feat: tap a hidden thing to see it and its creator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { SpectateBar } from './hud/SpectateBar'
 import { Workshop } from './workshop/Workshop'
 import { DeployBar } from './hud/DeployBar'
 import { DeploymentDetail } from './hud/DeploymentDetail'
+import { SecretModal } from './hud/SecretModal'
 import { useDiscovery } from './hooks/useDiscovery'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
@@ -105,6 +106,7 @@ export default function App(): JSX.Element {
       <Workshop />
       <DeployBar />
       <DeploymentDetail />
+      <SecretModal />
       <button
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,15 @@
+/**
+ * useProfile.ts — a pubkey's profile, requested and reactive.
+ *
+ * Reads from the shared profile cache and asks it to fetch on first sight.
+ * Returns undefined while unknown, null when fetched-but-none, or the profile.
+ */
+
+import { useEffect } from 'react'
+import { useProfiles, type Profile } from '../store/useProfiles'
+
+export function useProfile(pubkey: string | null | undefined): Profile | null | undefined {
+  const profile = useProfiles((s) => (pubkey ? s.profiles[pubkey] : undefined))
+  useEffect(() => { if (pubkey) useProfiles.getState().request(pubkey) }, [pubkey])
+  return profile
+}

--- a/src/hud/AvatarsPanel.tsx
+++ b/src/hud/AvatarsPanel.tsx
@@ -13,16 +13,10 @@ import { useRecentAvatars } from '../hooks/useRecentAvatars'
 import { parsePubkey } from '../lib/chains'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { spectate } from '../lib/spectator'
+import { ProfileBadge } from './ProfileBadge'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
-import { nip19 } from 'nostr-tools'
-
-/** Enough to tell keys apart; the title carries the whole npub. */
-function shortNpub(pubkey: string): string {
-  const npub = nip19.npubEncode(pubkey)
-  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
-}
 
 export function AvatarsPanel(): JSX.Element {
   const { avatars, status } = useRecentAvatars()
@@ -73,7 +67,7 @@ export function AvatarsPanel(): JSX.Element {
           const on = !!targets[a.pubkey]
           return (
             <li key={a.pubkey} className="avatars__row">
-              <span className="avatars__who" title={nip19.npubEncode(a.pubkey)}>{shortNpub(a.pubkey)}</span>
+              <ProfileBadge pubkey={a.pubkey} />
               <span className={`avatars__type avatars__type--${a.type}`}>{a.type.toUpperCase()}</span>
               <span className="avatars__when" title={formatStamp(a.createdAt)}>{formatAgo(a.createdAt, now)}</span>
               {you ? (

--- a/src/hud/ProfileBadge.tsx
+++ b/src/hud/ProfileBadge.tsx
@@ -1,0 +1,51 @@
+/**
+ * ProfileBadge.tsx — a pubkey as a face and a name.
+ *
+ * A round avatar (the kind:0 picture, or a colour-from-the-key fallback with an
+ * initial) and the name, or a shortened npub until the profile arrives. One
+ * component so every list — follows, avatars, targets, a secret's creator —
+ * shows a person the same way.
+ */
+
+import { useState } from 'react'
+import { nip19 } from 'nostr-tools'
+import { targetColor } from '../lib/targets'
+import { profileLabel } from '../store/useProfiles'
+import { useProfile } from '../hooks/useProfile'
+
+export function ProfilePic({ pubkey, size = 22 }: { pubkey: string; size?: number }): JSX.Element {
+  const profile = useProfile(pubkey)
+  const [broken, setBroken] = useState(false)
+  const npub = nip19.npubEncode(pubkey)
+  const initial = (profile?.name ?? npub.slice(4, 5)).slice(0, 1).toUpperCase()
+  const style = { width: size, height: size, minWidth: size } as const
+
+  if (profile?.picture && !broken) {
+    return <img className="pfp" style={style} src={profile.picture} alt="" loading="lazy" referrerPolicy="no-referrer" onError={() => setBroken(true)} />
+  }
+  return (
+    <span className="pfp pfp--fallback" style={{ ...style, background: targetColor(pubkey), fontSize: size * 0.5 }} aria-hidden="true">
+      {initial}
+    </span>
+  )
+}
+
+interface BadgeProps {
+  pubkey: string
+  /** A petname from a contact list, shown when the profile has no name yet. */
+  fallbackName?: string | null
+  size?: number
+  className?: string
+}
+
+export function ProfileBadge({ pubkey, fallbackName, size = 22, className = '' }: BadgeProps): JSX.Element {
+  const profile = useProfile(pubkey)
+  const npub = nip19.npubEncode(pubkey)
+  const name = profile?.name ?? fallbackName ?? profileLabel(profile, npub)
+  return (
+    <span className={`badge ${className}`} title={npub}>
+      <ProfilePic pubkey={pubkey} size={size} />
+      <span className="badge__name">{name}</span>
+    </span>
+  )
+}

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -1,0 +1,102 @@
+/**
+ * SecretModal.tsx — tapping a hidden thing in the world.
+ *
+ * A shard or a message you found (or left) opens this: what it is, what it
+ * says or looks like, who made it — with their profile — when and where, and
+ * what you can do about the person: point at them, watch them, or go stand
+ * where their content sits. Your own also offers to delete it.
+ *
+ * This is the "who is this and what do I do about them" view. The Shards panel's
+ * deployment detail is the "manage my own on the wire" view; the two are
+ * reached differently and answer different questions.
+ */
+
+import { useEffect } from 'react'
+import { nip19 } from 'nostr-tools'
+import { formatCellSize } from '../lib/scale'
+import { formatAgo, formatStamp, shortHex } from '../lib/time'
+import { spectate } from '../lib/spectator'
+import { ProfilePic } from './ProfileBadge'
+import { useProfile } from '../hooks/useProfile'
+import { profileLabel } from '../store/useProfiles'
+import { useCyberspace } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+
+export function SecretModal(): JSX.Element | null {
+  const selected = useShards((s) => s.selectedSecret)
+  const item = useShards((s) => (s.selectedSecret ? s.secretByEvent(s.selectedSecret) : null))
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const targeted = useCyberspace((s) => (item?.author ? !!s.targets[item.author] : false))
+  const author = item?.author ?? ''
+  const profile = useProfile(author || null)
+
+  // A selection that no longer resolves (deleted, scrolled out) closes itself.
+  useEffect(() => { if (selected && !item) useShards.getState().selectSecret(null) }, [selected, item])
+
+  if (!item || !author) return null
+
+  const npub = nip19.npubEncode(author)
+  const name = profileLabel(profile, npub)
+  const mine = item.author === me
+  const close = (): void => useShards.getState().selectSecret(null)
+
+  const goTo = (): void => {
+    close()
+    useCyberspace.getState().focusOn(item.at, item.plane, item.type === 'message' ? name : item.shard?.name ?? 'shard', item.type === 'shard' ? item.shard?.unit ?? 0 : 0)
+  }
+  const watch = (): void => { close(); void spectate(author) }
+  const target = (): void => useCyberspace.getState().toggleTarget(author, profile?.name ?? null)
+
+  return (
+    <div className="modal" role="dialog" aria-modal="true" aria-label="Hidden content" onPointerDown={close}>
+      <div className="modal__card secret" onPointerDown={(e) => e.stopPropagation()}>
+        <div className="secret__head">
+          <span className={`secret__badge secret__badge--${item.type}`}>{item.type === 'message' ? '✎ MESSAGE' : '◇ SHARD'}</span>
+          {mine && <span className="secret__mine">YOURS</span>}
+          <button className="secret__close" onClick={close} aria-label="Close">✕</button>
+        </div>
+
+        {item.type === 'message' ? (
+          <blockquote className="secret__message">{item.text}</blockquote>
+        ) : (
+          <div className="secret__shard">
+            <span className="secret__shard-name">{item.shard?.name}</span>
+            <span className="secret__shard-meta">{item.shard?.vertices.length} v · {item.shard?.faces.length} f · {item.shard?.mode.toUpperCase()} · unit 2^{item.shard?.unit}</span>
+          </div>
+        )}
+
+        <div className="secret__creator">
+          <span className="secret__label">Left by</span>
+          <div className="secret__person">
+            <ProfilePic pubkey={author} size={40} />
+            <div className="secret__person-text">
+              <span className="secret__name">{name}{mine ? ' (you)' : ''}</span>
+              {profile?.nip05 && <span className="secret__nip05">{profile.nip05.replace(/^_@/, '')}</span>}
+              <span className="secret__npub" title={npub}>{shortHex(npub, 14, 8)}</span>
+            </div>
+          </div>
+          {profile?.about && <p className="secret__about">{profile.about}</p>}
+        </div>
+
+        <dl className="secret__facts">
+          <div><dt>Placed</dt><dd title={item.createdAt ? formatStamp(item.createdAt) : ''}>{item.createdAt ? formatAgo(item.createdAt) : 'unknown'}</dd></div>
+          <div><dt>Hidden at</dt><dd>{item.height === 0 ? 'exact gibson' : `within ${formatCellSize(item.height)}`}</dd></div>
+          <div><dt>Plane</dt><dd>{item.plane === 0 ? 'dataspace' : 'ideaspace'}</dd></div>
+        </dl>
+
+        <div className="secret__actions">
+          <button className="secret__act" onClick={goTo}>GO TO IT</button>
+          {!mine && (
+            <>
+              <button className={`secret__act ${targeted ? 'is-on' : ''}`} onClick={target}>{targeted ? 'TARGETED' : 'TARGET'} CREATOR</button>
+              <button className="secret__act" onClick={watch}>SPECTATE</button>
+            </>
+          )}
+          {mine && (
+            <button className="secret__act secret__act--danger" onClick={() => { close(); void useShards.getState().deleteInstance(item.key) }}>DELETE</button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hud/SpectateBar.tsx
+++ b/src/hud/SpectateBar.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react'
 import { stopSpectating } from '../lib/spectator'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
+import { ProfileBadge } from './ProfileBadge'
 
 export function SpectateBar(): JSX.Element | null {
   const spectate = useCyberspace((s) => s.spectate)
@@ -22,7 +23,6 @@ export function SpectateBar(): JSX.Element | null {
 
   if (!spectate) return null
 
-  const short = `${spectate.npub.slice(0, 12)}…${spectate.npub.slice(-6)}`
   const status =
     spectate.status === 'loading' ? 'FETCHING CHAIN'
       : spectate.status === 'error' ? 'RELAY UNREACHABLE'
@@ -34,7 +34,7 @@ export function SpectateBar(): JSX.Element | null {
       <span className="spectate__eye" aria-hidden="true">◉</span>
       <span className="spectate__text">
         <span className="spectate__label">SPECTATING</span>
-        <span className="spectate__who" title={spectate.npub}>{short}</span>
+        <ProfileBadge pubkey={spectate.pubkey} className="spectate__badge" />
         <span className="spectate__meta">
           {spectate.lastActive !== null && (
             <span title={formatStamp(spectate.lastActive)}>LAST ACTIVE {formatAgo(spectate.lastActive, now).toUpperCase()} · </span>

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -10,17 +10,13 @@
  */
 
 import { useEffect, useState } from 'react'
-import { nip19 } from 'nostr-tools'
 import { parsePubkey } from '../lib/chains'
 import { fetchContacts, GENERAL_RELAYS, type Contact } from '../lib/contacts'
 import { spectate } from '../lib/spectator'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
-
-function shortNpub(npub: string): string {
-  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
-}
+import { ProfileBadge } from './ProfileBadge'
 
 export function TargetsPanel(): JSX.Element {
   const targets = useCyberspace((s) => s.targets)
@@ -67,7 +63,7 @@ export function TargetsPanel(): JSX.Element {
         {list.map((t) => (
           <li key={t.pubkey} className="targets__row">
             <span className="targets__dot" style={{ background: targetColor(t.pubkey), boxShadow: `0 0 6px ${targetColor(t.pubkey)}` }} />
-            <span className="avatars__who" title={t.npub}>{t.name ?? shortNpub(t.npub)}</span>
+            <ProfileBadge pubkey={t.pubkey} fallbackName={t.name} />
             <span className={`targets__status targets__status--${t.status}`} title={t.lastActive ? formatStamp(t.lastActive) : undefined}>
               {t.status === 'live' && t.lastActive ? formatAgo(t.lastActive, now)
                 : t.status === 'resolving' ? 'FINDING'
@@ -97,7 +93,7 @@ export function TargetsPanel(): JSX.Element {
               const on = !!targets[c.pubkey]
               return (
                 <li key={c.pubkey} className="targets__row targets__row--contact">
-                  <span className="avatars__who" title={nip19.npubEncode(c.pubkey)}>{c.name ?? shortNpub(nip19.npubEncode(c.pubkey))}</span>
+                  <ProfileBadge pubkey={c.pubkey} fallbackName={c.name} />
                   <button
                     className={`targets__toggle ${on ? 'is-on' : ''}`}
                     style={on ? { color: targetColor(c.pubkey), borderColor: targetColor(c.pubkey) } : undefined}

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -62,13 +62,20 @@ interface AuthRelay {
  * and re-auths on its own when a reconnect brings a fresh challenge.
  */
 const authedFor = new Map<string, string>()
+const noChallenge = new Set<string>()
 async function authRelay(url: string): Promise<void> {
+  // A relay that never challenged before will not now: skip the wait.
+  if (noChallenge.has(url)) return
   try {
     const relay = (await getPool().ensureRelay(url)) as unknown as AuthRelay
-    for (let i = 0; i < 20 && !relay.challenge; i++) await new Promise((r) => setTimeout(r, 50))
-    if (relay.challenge && authedFor.get(url) !== relay.challenge) {
-      await relay.auth(authSign)
-      authedFor.set(url, relay.challenge)
+    for (let i = 0; i < 10 && !relay.challenge; i++) await new Promise((r) => setTimeout(r, 40))
+    if (relay.challenge) {
+      if (authedFor.get(url) !== relay.challenge) {
+        await relay.auth(authSign)
+        authedFor.set(url, relay.challenge)
+      }
+    } else {
+      noChallenge.add(url)
     }
   } catch { /* relay down, or does not require auth */ }
 }
@@ -109,7 +116,7 @@ export function publish(event: NostrEvent): Promise<PublishResult> {
  * `onauth`: the relay now requires NIP-42 auth for reads, so a query has to be
  * able to answer the challenge and retry, or it comes back empty.
  */
-async function collect(relays: string[], filter: Filter): Promise<NostrEvent[]> {
+async function collect(relays: string[], filter: Filter, maxWait = MAX_WAIT_MS): Promise<NostrEvent[]> {
   await authAll(relays)
   return new Promise((resolve) => {
     const events = new Map<string, NostrEvent>()
@@ -121,12 +128,12 @@ async function collect(relays: string[], filter: Filter): Promise<NostrEvent[]> 
       try { sub.close() } catch { /* already closed */ }
       resolve([...events.values()])
     }
-    const timer = setTimeout(done, MAX_WAIT_MS + 2000)
+    const timer = setTimeout(done, maxWait + 500)
     const sub = getPool().subscribeEose(relays, filter, {
       onevent: (e) => events.set(e.id, e),
       onclose: done,
       onauth: authSign,
-      maxWait: MAX_WAIT_MS,
+      maxWait,
     })
   })
 }
@@ -137,8 +144,8 @@ export function query(filter: Filter): Promise<NostrEvent[]> {
 }
 
 /** Query an explicit set, for the few things that live elsewhere (contact lists). */
-export function queryAny(relays: string[], filter: Filter): Promise<NostrEvent[]> {
-  return collect(relays, filter)
+export function queryAny(relays: string[], filter: Filter, maxWait?: number): Promise<NostrEvent[]> {
+  return collect(relays, filter, maxWait)
 }
 
 /** A live subscription across the configured relays; the returned function closes it. */

--- a/src/scene/WorldMessages.tsx
+++ b/src/scene/WorldMessages.tsx
@@ -10,10 +10,13 @@
 import { useMemo } from 'react'
 import { nip19 } from 'nostr-tools'
 import { ACCENT } from '../lib/palette'
+import type { ThreeEvent } from '@react-three/fiber'
 import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
 import { WorldLabel } from './WorldLabel'
+
+const TAP_SLOP = 8
 
 const REACH = GRID_RADIUS * 8
 /** The message colour: a warm note against the cool field. */
@@ -66,12 +69,23 @@ export function WorldMessages({ axes }: Props): JSX.Element | null {
 
   return (
     <>
-      {placed.map((w) => (
-        <group key={w.key}>
-          <WorldLabel text={wrap(w.text)} color={NOTE} at={w.centre} align="center" px={13} />
-          <WorldLabel text={`— ${shortAuthor(w.author, w.mine)}`} color={ACCENT} at={[w.centre[0], w.centre[1] - 0.9, w.centre[2]]} align="center" px={9} opacity={0.7} />
-        </group>
-      ))}
+      {placed.map((w) => {
+        const open = (e: ThreeEvent<MouseEvent>): void => {
+          if (e.delta > TAP_SLOP) return
+          e.stopPropagation()
+          useShards.getState().selectSecret(w.key)
+        }
+        return (
+          <group key={w.key}>
+            <WorldLabel text={wrap(w.text)} color={NOTE} at={w.centre} align="center" px={13} />
+            <WorldLabel text={`— ${shortAuthor(w.author, w.mine)}`} color={ACCENT} at={[w.centre[0], w.centre[1] - 0.9, w.centre[2]]} align="center" px={9} opacity={0.7} />
+            <mesh position={w.centre} onClick={open}>
+              <sphereGeometry args={[1, 8, 8]} />
+              <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+            </mesh>
+          </group>
+        )
+      })}
     </>
   )
 }

--- a/src/scene/WorldShards.tsx
+++ b/src/scene/WorldShards.tsx
@@ -9,10 +9,14 @@
  */
 
 import { useMemo } from 'react'
+import type { ThreeEvent } from '@react-three/fiber'
 import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
 import { ShardMesh } from './ShardMesh'
+
+/** A press that travels further than this is an orbit, not a tap. */
+const TAP_SLOP = 8
 
 const REACH = GRID_RADIUS * 8
 
@@ -50,11 +54,24 @@ export function WorldShards({ axes }: Props): JSX.Element | null {
 
   return (
     <>
-      {placed.map((w) => (
-        <group key={w.key} position={w.centre}>
-          <ShardMesh shard={w.shard} scale={w.scale} />
-        </group>
-      ))}
+      {placed.map((w) => {
+        const hit = Math.max(0.6, w.scale * 2)
+        const open = (e: ThreeEvent<MouseEvent>): void => {
+          if (e.delta > TAP_SLOP) return
+          e.stopPropagation()
+          useShards.getState().selectSecret(w.key)
+        }
+        return (
+          <group key={w.key} position={w.centre}>
+            <ShardMesh shard={w.shard} scale={w.scale} />
+            {/* An invisible, generous tap target: shards can be a few pixels. */}
+            <mesh onClick={open}>
+              <sphereGeometry args={[hit, 8, 8]} />
+              <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+            </mesh>
+          </group>
+        )
+      })}
     </>
   )
 }

--- a/src/store/useProfiles.ts
+++ b/src/store/useProfiles.ts
@@ -1,0 +1,148 @@
+/**
+ * useProfiles.ts — who a pubkey is, cached.
+ *
+ * A pubkey is intelligible only with its kind:0: a name, a picture, maybe a
+ * nip05. Components ask for one by pubkey; this batches the misses into a
+ * single relay query, caches what comes back, and keeps it in localStorage so
+ * a reload does not refetch the world. Profiles live on the general relays
+ * (purplepag.es aggregates them), so it asks those alongside ours.
+ *
+ * The whole cache is one reactive record: a component that reads get(pubkey)
+ * re-renders when that profile arrives, without every row holding a
+ * subscription of its own.
+ */
+
+import { create } from 'zustand'
+import { queryAny } from '../lib/relay'
+import { GENERAL_RELAYS } from '../lib/contacts'
+import type { NostrEvent } from '../lib/events'
+
+export interface Profile {
+  pubkey: string
+  name: string | null
+  picture: string | null
+  about: string | null
+  nip05: string | null
+  /** created_at of the kind:0 we parsed, so a newer one wins. */
+  at: number
+}
+
+interface ProfilesState {
+  /** null = fetched, none found; undefined = not fetched. */
+  profiles: Record<string, Profile | null>
+  /** Ask for a profile; a miss is queued and fetched in the next batch. */
+  request: (pubkey: string) => void
+  get: (pubkey: string) => Profile | null | undefined
+}
+
+const STORAGE = 'onosendai:profiles'
+const HEX = /^[0-9a-f]{64}$/
+/** Refetch a cached profile after this, in case it changed. */
+const TTL_MS = 24 * 60 * 60 * 1000
+/** How many authors to ask for in one query. */
+const CHUNK = 100
+const FLUSH_MS = 250
+/** Profiles live on the general relays; the cyberspace relay is auth-gated and
+ * slow, and rarely holds kind:0, so a short wait on the general set is enough. */
+const PROFILE_WAIT_MS = 4000
+
+function loadCache(): Record<string, Profile | null> {
+  try {
+    const raw = localStorage.getItem(STORAGE)
+    const data = raw ? JSON.parse(raw) : {}
+    return data && typeof data === 'object' ? data : {}
+  } catch { return {} }
+}
+
+let saveHandle: number | null = null
+function saveCacheSoon(cache: Record<string, Profile | null>): void {
+  if (saveHandle !== null) return
+  saveHandle = window.setTimeout(() => {
+    saveHandle = null
+    try {
+      // Only real profiles are worth persisting; misses can be retried.
+      const keep: Record<string, Profile> = {}
+      for (const [pk, p] of Object.entries(cache)) if (p) keep[pk] = p
+      localStorage.setItem(STORAGE, JSON.stringify(keep))
+    } catch { /* quota or private mode */ }
+  }, 1000)
+}
+
+/** Parse a kind:0 into a Profile; null if the content is not usable JSON. */
+export function parseProfile(ev: NostrEvent): Profile | null {
+  try {
+    const meta = JSON.parse(ev.content) as Record<string, unknown>
+    const str = (v: unknown): string | null => (typeof v === 'string' && v.trim() ? v.trim() : null)
+    return {
+      pubkey: ev.pubkey,
+      name: str(meta.display_name) ?? str(meta.name),
+      picture: str(meta.picture),
+      about: str(meta.about),
+      nip05: str(meta.nip05),
+      at: ev.created_at,
+    }
+  } catch { return null }
+}
+
+const pending = new Set<string>()
+let flushHandle: number | null = null
+
+export const useProfiles = create<ProfilesState>((set, get) => {
+  const initial = loadCache()
+
+  async function flush(): Promise<void> {
+    flushHandle = null
+    const want = [...pending]
+    pending.clear()
+    if (want.length === 0) return
+
+    for (let i = 0; i < want.length; i += CHUNK) {
+      const authors = want.slice(i, i + CHUNK)
+      let events: NostrEvent[] = []
+      try {
+        events = await queryAny(GENERAL_RELAYS, { kinds: [0], authors }, PROFILE_WAIT_MS)
+      } catch { /* relays down */ }
+
+      const newest = new Map<string, Profile>()
+      for (const ev of events) {
+        const p = parseProfile(ev)
+        if (p && (!newest.has(p.pubkey) || p.at > newest.get(p.pubkey)!.at)) newest.set(p.pubkey, p)
+      }
+      const next = { ...get().profiles }
+      for (const pk of authors) next[pk] = newest.get(pk) ?? null
+      set({ profiles: next })
+      saveCacheSoon(next)
+    }
+  }
+
+  return {
+    profiles: initial,
+
+    request: (pubkey) => {
+      if (!HEX.test(pubkey)) return
+      const have = get().profiles[pubkey]
+      const stamp = withStamp.get(pubkey)
+      const fresh = have && stamp !== undefined && Date.now() - stamp < TTL_MS
+      if (fresh || pending.has(pubkey)) return
+      pending.add(pubkey)
+      if (flushHandle === null) flushHandle = window.setTimeout(() => void flush(), FLUSH_MS)
+    },
+
+    get: (pubkey) => get().profiles[pubkey],
+  }
+})
+
+if (import.meta.env.DEV && typeof window !== "undefined") { (window as unknown as { __profiles?: unknown }).__profiles = useProfiles }
+
+/** When each profile was fetched, so the TTL can refetch a stale one. */
+const withStamp = new Map<string, number>()
+useProfiles.subscribe((s, prev) => {
+  if (s.profiles === prev.profiles) return
+  const now = Date.now()
+  for (const pk of Object.keys(s.profiles)) if (s.profiles[pk] !== prev.profiles[pk]) withStamp.set(pk, now)
+})
+
+/** A short, human label for a pubkey: its name, or a shortened npub. */
+export function profileLabel(profile: Profile | null | undefined, npub: string): string {
+  return profile?.name ?? `${npub.slice(0, 12)}…${npub.slice(-4)}`
+}

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -66,6 +66,7 @@ export interface WorldItem {
   author?: string
   shard?: ShardModel
   text?: string
+  createdAt?: number
 }
 
 /** What a deploy is placing, before it lands. */
@@ -88,6 +89,8 @@ interface ShardsState {
   deleted: Record<string, true>
   inspecting: string | null
   scanning: boolean
+  /** A world item clicked open, by its inner event id. */
+  selectedSecret: string | null
 
   startDeployShard: (shardId: string) => void
   startDeployMessage: (text: string) => void
@@ -96,11 +99,14 @@ interface ShardsState {
   deploy: () => Promise<void>
   deleteInstance: (eventId: string) => Promise<void>
   inspect: (eventId: string | null) => void
+  selectSecret: (eventId: string | null) => void
   addDiscovered: (items: Hidden[]) => void
   setScanning: (scanning: boolean) => void
   testDiscovery: (eventId: string) => Promise<boolean>
   pendingShard: () => ShardModel | null
   worldItems: () => WorldItem[]
+  /** The clicked item, mine or discovered, as one shape. */
+  secretByEvent: (eventId: string) => WorldItem | null
 }
 
 const MINE_KEY = 'onosendai:deployments'
@@ -194,6 +200,7 @@ export const useShards = create<ShardsState>((set, get) => {
     deleted: loadDeleted(),
     inspecting: null,
     scanning: false,
+    selectedSecret: null,
 
     startDeployShard: (shardId) => set({ pending: { type: 'shard', shardId }, deployStatus: 'idle', deployError: null }),
     startDeployMessage: (text) => set({ pending: { type: 'message', text }, deployStatus: 'idle', deployError: null }),
@@ -297,6 +304,8 @@ export const useShards = create<ShardsState>((set, get) => {
 
     inspect: (eventId) => set({ inspecting: eventId }),
 
+    selectSecret: (eventId) => set({ selectedSecret: eventId }),
+
     addDiscovered: (items) => {
       if (items.length === 0) return
       const { deleted } = get()
@@ -330,16 +339,19 @@ export const useShards = create<ShardsState>((set, get) => {
     worldItems: () => {
       const out: WorldItem[] = []
       const seen = new Set<string>()
+      const me = useCyberspace.getState().identity.pubkey
       for (const d of get().mine) {
         seen.add(d.eventId)
-        out.push({ key: d.eventId, type: d.type, at: positionOf(d), plane: d.plane, height: d.height, mine: true, shard: d.shard, text: d.text })
+        out.push({ key: d.eventId, type: d.type, at: positionOf(d), plane: d.plane, height: d.height, mine: true, author: me, shard: d.shard, text: d.text, createdAt: d.createdAt })
       }
       for (const h of Object.values(get().discovered)) {
         if (seen.has(h.eventId)) continue
-        out.push({ key: h.eventId, type: h.type, at: h.at, plane: h.plane, height: h.height, mine: false, author: h.author, shard: h.shard, text: h.text })
+        out.push({ key: h.eventId, type: h.type, at: h.at, plane: h.plane, height: h.height, mine: false, author: h.author, shard: h.shard, text: h.text, createdAt: h.createdAt })
       }
       return out
     },
+
+    secretByEvent: (eventId) => get().worldItems().find((w) => w.key === eventId) ?? null,
   }
 })
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -864,6 +864,51 @@ kbd {
   white-space: nowrap;
 }
 
+/* ---------- Profile badge (face + name) ---------- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.badge__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pfp {
+  border-radius: 50%;
+  object-fit: cover;
+  flex: none;
+  display: inline-block;
+  background: rgba(0, 229, 255, 0.1);
+}
+
+.pfp--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #05070d;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.spectate__badge .badge__name {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+/* The avatars/targets/follows rows hold a badge where a bare name used to sit;
+ * the badge is the flexible column that ellipsizes. */
+.avatars__row .badge,
+.targets__row .badge,
+.targets__row--contact .badge {
+  min-width: 0;
+}
+
 /* ---------- Avatars ---------- */
 
 .avatars__find {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1183,6 +1183,168 @@ kbd {
   border-color: var(--danger);
 }
 
+/* ---------- Secret modal (a hidden thing, tapped in the world) ---------- */
+.modal__card.secret {
+  border-color: rgba(0, 229, 255, 0.5);
+  max-width: 440px;
+}
+
+.secret__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.secret__badge {
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+}
+
+.secret__badge--message { color: #ffd27d; }
+
+.secret__mine {
+  font-size: 8px;
+  letter-spacing: 0.16em;
+  color: #05070d;
+  background: var(--ok);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-weight: 700;
+}
+
+.secret__close {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 12px;
+  width: 26px;
+  height: 26px;
+  border-radius: 4px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.2);
+  cursor: pointer;
+}
+
+.secret__message {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #ffd27d;
+  background: rgba(255, 210, 125, 0.08);
+  border-left: 3px solid #ffd27d;
+  border-radius: 3px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.secret__shard {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  background: rgba(0, 229, 255, 0.06);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+}
+
+.secret__shard-name { font-size: 14px; color: var(--fg); }
+.secret__shard-meta { font-size: 10px; letter-spacing: 0.06em; color: var(--dim); }
+
+.secret__creator {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(0, 229, 255, 0.14);
+}
+
+.secret__label {
+  font-size: 8px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+
+.secret__person {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.secret__person-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.secret__name { font-size: 13px; color: var(--fg); }
+.secret__nip05 { font-size: 10px; color: var(--accent); }
+.secret__npub { font-size: 9px; color: var(--dim); }
+
+.secret__about {
+  margin: 8px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--dim);
+  max-height: 60px;
+  overflow-y: auto;
+}
+
+.secret__facts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.secret__facts dt {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dim);
+  margin-bottom: 2px;
+}
+
+.secret__facts dd { margin: 0; font-size: 11px; color: var(--fg); }
+
+.secret__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.secret__act {
+  flex: 1;
+  min-width: 100px;
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  height: 34px;
+  border-radius: 6px;
+  color: var(--accent);
+  background: rgba(0, 229, 255, 0.06);
+  border: 1px solid rgba(0, 229, 255, 0.4);
+  cursor: pointer;
+}
+
+.secret__act:hover { background: rgba(0, 229, 255, 0.16); }
+
+.secret__act.is-on {
+  color: #05070d;
+  background: var(--accent);
+  font-weight: 700;
+}
+
+.secret__act--danger {
+  color: var(--danger);
+  border-color: rgba(255, 59, 107, 0.5);
+  background: rgba(255, 59, 107, 0.08);
+}
+
 /* ---------- Deployment detail overlay ----------
  *
  * The wire record of a deployed shard, up while the scene is flown to it. Left


### PR DESCRIPTION
Second of three (base: `feat/profiles`, PR #28).

## What changes

- **World items are clickable.** `WorldShards` and `WorldMessages` each carry an invisible, generous tap target; a tap (not an orbit — checked via pointer travel) sets `selectedSecret` in the store.
- **`SecretModal`**: what it is (message text, or shard name/mode/vertices), **who left it** as a profile (avatar, name, nip05, npub, about — via the profile cache), when/height/plane, and actions: GO TO IT (fly the scene), TARGET creator, SPECTATE; DELETE for your own.
- Store: `selectedSecret` + `secretByEvent()`; `worldItems()` now carries `author` (you, for your own) and `createdAt`.

## Verification

Browser: real click on a deployed shard opens the modal naming it; message modal shows text + creator profile (name + nip05); GO TO IT flies + closes; DELETE removes an own item. Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)