### PR TITLE
feat: choose who signs (nsec, ncryptsec, extension, or bunker)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { SpectateBar } from './hud/SpectateBar'
 import { Workshop } from './workshop/Workshop'
 import { DeployBar } from './hud/DeployBar'
 import { DeploymentDetail } from './hud/DeploymentDetail'
+import { SecretModal } from './hud/SecretModal'
 import { useDiscovery } from './hooks/useDiscovery'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
@@ -105,6 +106,7 @@ export default function App(): JSX.Element {
       <Workshop />
       <DeployBar />
       <DeploymentDetail />
+      <SecretModal />
       <button
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker() }, [])
+  useEffect(() => { startPublisher(); startTracker(); void useCyberspace.getState().initSigner() }, [])
   const isMobile = useIsMobile()
   const targets = useTargets()
   // Off your own head there is nothing to drive: the movement controls stand

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,15 @@
+/**
+ * useProfile.ts — a pubkey's profile, requested and reactive.
+ *
+ * Reads from the shared profile cache and asks it to fetch on first sight.
+ * Returns undefined while unknown, null when fetched-but-none, or the profile.
+ */
+
+import { useEffect } from 'react'
+import { useProfiles, type Profile } from '../store/useProfiles'
+
+export function useProfile(pubkey: string | null | undefined): Profile | null | undefined {
+  const profile = useProfiles((s) => (pubkey ? s.profiles[pubkey] : undefined))
+  useEffect(() => { if (pubkey) useProfiles.getState().request(pubkey) }, [pubkey])
+  return profile
+}

--- a/src/hud/AvatarsPanel.tsx
+++ b/src/hud/AvatarsPanel.tsx
@@ -13,16 +13,10 @@ import { useRecentAvatars } from '../hooks/useRecentAvatars'
 import { parsePubkey } from '../lib/chains'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { spectate } from '../lib/spectator'
+import { ProfileBadge } from './ProfileBadge'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
-import { nip19 } from 'nostr-tools'
-
-/** Enough to tell keys apart; the title carries the whole npub. */
-function shortNpub(pubkey: string): string {
-  const npub = nip19.npubEncode(pubkey)
-  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
-}
 
 export function AvatarsPanel(): JSX.Element {
   const { avatars, status } = useRecentAvatars()
@@ -73,7 +67,7 @@ export function AvatarsPanel(): JSX.Element {
           const on = !!targets[a.pubkey]
           return (
             <li key={a.pubkey} className="avatars__row">
-              <span className="avatars__who" title={nip19.npubEncode(a.pubkey)}>{shortNpub(a.pubkey)}</span>
+              <ProfileBadge pubkey={a.pubkey} />
               <span className={`avatars__type avatars__type--${a.type}`}>{a.type.toUpperCase()}</span>
               <span className="avatars__when" title={formatStamp(a.createdAt)}>{formatAgo(a.createdAt, now)}</span>
               {you ? (

--- a/src/hud/DeployBar.tsx
+++ b/src/hud/DeployBar.tsx
@@ -14,7 +14,7 @@ import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { formatCellSize } from '../lib/scale'
 import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
 import { messagePreview } from '../lib/hidden'
-import { useCyberspace } from '../store/useCyberspace'
+import { MAX_COMPUTE_HEIGHT, useCyberspace } from '../store/useCyberspace'
 
 export function DeployBar(): JSX.Element | null {
   const pending = useShards((s) => s.pending)
@@ -46,7 +46,7 @@ export function DeployBar(): JSX.Element | null {
         <span className="deploybar__label">HIDE AT HEIGHT</span>
         <button className="deploybar__btn" {...bind(() => useShards.getState().setDeployHeight(height - 1))} disabled={height <= 0} aria-label="Lower height">−</button>
         <span className="deploybar__value">{height}</span>
-        <button className="deploybar__btn" {...bind(() => useShards.getState().setDeployHeight(height + 1))} disabled={height >= SCAN_MAX_HEIGHT} aria-label="Higher height">+</button>
+        <button className="deploybar__btn" {...bind(() => useShards.getState().setDeployHeight(height + 1))} disabled={height >= MAX_COMPUTE_HEIGHT} aria-label="Higher height">+</button>
         <span className="deploybar__radius">
           {height === 0 ? 'this exact gibson' : `found within ${formatCellSize(height)}`}
         </span>
@@ -58,6 +58,12 @@ export function DeployBar(): JSX.Element | null {
           ? ' At height 0 only someone on this exact point can find it.'
           : ` Anyone who computes this ${formatCellSize(height)} region can find and open it.`}
       </div>
+
+      {height > SCAN_MAX_HEIGHT && (
+        <div className="deploybar__row deploybar__warn">
+          ⚠ Past height {SCAN_MAX_HEIGHT}, discovery will not surface this automatically. Only someone who already knows this spot and height can compute the region and open it.
+        </div>
+      )}
 
       {error && <div className="deploybar__row notice">{error}</div>}
 

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -3,8 +3,14 @@
  * would cost, and what the chain has cost so far.
  */
 
+import { useState } from 'react'
 import { formatBig, formatStep } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
+import { shortHex } from '../lib/time'
+import { ProfilePic } from './ProfileBadge'
+import { useProfile } from '../hooks/useProfile'
+import { profileLabel } from '../store/useProfiles'
+import { LoginModal } from './LoginModal'
 import { AvatarsPanel } from './AvatarsPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
@@ -30,9 +36,20 @@ function Brand(): JSX.Element {
   )
 }
 
+const SIGNER_LABEL: Record<string, string> = {
+  local: 'LOCAL KEY',
+  nip07: 'EXTENSION',
+  nip46: 'BUNKER',
+}
+
 function IdentityPanel(): JSX.Element {
   const identity = useCyberspace((s) => s.identity)
+  const signerKind = useCyberspace((s) => s.signerKind)
   const live = useCyberspace((s) => s.live)
+  const profile = useProfile(identity.pubkey)
+  const [loginOpen, setLoginOpen] = useState(false)
+
+  const name = profileLabel(profile, identity.npub)
 
   return (
     <section className="panel">
@@ -41,9 +58,14 @@ function IdentityPanel(): JSX.Element {
         <span className={`tag ${live ? 'tag--live' : 'tag--local'}`}>{live ? 'LIVE' : 'LOCAL'}</span>
       </header>
 
-      <div className="hash">
-        <span className="hash__label">npub</span>
-        <code>{identity.npub}</code>
+      <div className="identity__who">
+        <ProfilePic pubkey={identity.pubkey} size={38} />
+        <div className="identity__who-text">
+          <span className="identity__name">{name}</span>
+          <span className="identity__signer">{SIGNER_LABEL[signerKind] ?? signerKind}</span>
+          <span className="secret__npub" title={identity.npub}>{shortHex(identity.npub, 14, 8)}</span>
+        </div>
+        <button className="identity__change" onClick={() => setLoginOpen(true)}>CHANGE</button>
       </div>
 
       <p className="legend__note">
@@ -54,6 +76,8 @@ function IdentityPanel(): JSX.Element {
           ? ' LIVE: every action is signed and published to cyberspace.nostr1.com as it completes.'
           : ' LOCAL: actions are signed but stay on this device. Going live publishes the whole chain.'}
       </p>
+
+      {loginOpen && <LoginModal onClose={() => setLoginOpen(false)} />}
     </section>
   )
 }

--- a/src/hud/LoginModal.tsx
+++ b/src/hud/LoginModal.tsx
@@ -1,0 +1,165 @@
+/**
+ * LoginModal.tsx — choosing who signs.
+ *
+ * The avatar starts life as a random key so cyberspace is explorable the
+ * instant the page loads, with nothing to set up. This is where that gets
+ * overridden: bring an nsec or an encrypted ncryptsec, hand signing to a
+ * browser extension (NIP-07) or a remote bunker (NIP-46), or roll a fresh
+ * random key. Anything but the random key is a real identity, so switching to
+ * one you have moved before drops you back onto that chain; a new one spawns
+ * where its pubkey lands (spec §3.1).
+ *
+ * The store owns the actual switch and the async handshakes; this only gathers
+ * input, shows what went wrong, and closes once a switch has taken.
+ */
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { hasNip07 } from '../lib/signers'
+import { shortHex } from '../lib/time'
+import { ProfilePic } from './ProfileBadge'
+import { useProfile } from '../hooks/useProfile'
+import { profileLabel } from '../store/useProfiles'
+import { useCyberspace } from '../store/useCyberspace'
+
+const KIND_LABEL: Record<string, string> = {
+  local: 'Local key',
+  nip07: 'Browser extension',
+  nip46: 'Remote bunker',
+}
+
+export function LoginModal({ onClose }: { onClose: () => void }): JSX.Element {
+  const identity = useCyberspace((s) => s.identity)
+  const signerKind = useCyberspace((s) => s.signerKind)
+  const loginError = useCyberspace((s) => s.loginError)
+  const profile = useProfile(identity.pubkey)
+
+  const [key, setKey] = useState('')
+  const [password, setPassword] = useState('')
+  const [bunker, setBunker] = useState('')
+  // Which action is mid-flight, so its button can say so and the rest lock.
+  const [busy, setBusy] = useState<string | null>(null)
+
+  // A stale error from a previous visit should not greet the next one.
+  useEffect(() => {
+    useCyberspace.getState().clearLoginError()
+    return () => useCyberspace.getState().clearLoginError()
+  }, [])
+
+  const name = profileLabel(profile, identity.npub)
+  const encrypted = key.trim().startsWith('ncryptsec')
+  const extension = hasNip07()
+
+  // Run a store switch, then close if it took. A switch clears loginError on
+  // success and sets it on failure, so the error state is the whole verdict.
+  const run = async (id: string, fn: () => Promise<void>): Promise<void> => {
+    if (busy) return
+    setBusy(id)
+    try {
+      await fn()
+    } finally {
+      setBusy(null)
+    }
+    if (!useCyberspace.getState().loginError) onClose()
+  }
+
+  const cy = useCyberspace.getState
+  const useKey = (): Promise<void> =>
+    run('key', () => (encrypted ? cy().useNcryptsec(key, password) : cy().useNsec(key)))
+  const connectBunker = (): Promise<void> => run('bunker', () => cy().useBunker(bunker))
+  const useExtension = (): Promise<void> => run('nip07', () => cy().useExtension())
+  const generate = (): Promise<void> => run('new', () => cy().useNewKey())
+
+  const disabled = busy !== null
+  const busyLabel = (id: string, label: string): string => (busy === id ? 'WORKING…' : label)
+
+  return createPortal(
+    <div className="modal" role="dialog" aria-modal="true" aria-label="Identity" onPointerDown={onClose}>
+      <div className="modal__card login" onPointerDown={(e) => e.stopPropagation()}>
+        <div className="login__head">
+          <h2 className="modal__title">Identity</h2>
+          <button className="secret__close" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        <div className="login__current">
+          <ProfilePic pubkey={identity.pubkey} size={40} />
+          <div className="login__current-text">
+            <span className="secret__name">{name}</span>
+            <span className="login__kind">{KIND_LABEL[signerKind] ?? signerKind}</span>
+            <span className="secret__npub" title={identity.npub}>{shortHex(identity.npub, 14, 8)}</span>
+          </div>
+        </div>
+
+        <p className="login__note">
+          Switching signs a fresh spawn at the new key's coordinate. An identity
+          you have moved before returns to its own chain; a new one starts over.
+        </p>
+
+        {loginError && <p className="notice login__error">{loginError}</p>}
+
+        <div className="login__section">
+          <label className="login__label" htmlFor="login-key">Paste an nsec or ncryptsec</label>
+          <input
+            id="login-key"
+            className="avatars__input login__input"
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="nsec1… or ncryptsec1…"
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+          />
+          {encrypted && (
+            <input
+              className="avatars__input login__input"
+              type="password"
+              autoComplete="off"
+              placeholder="ncryptsec password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          )}
+          <button
+            className="secret__act login__act"
+            disabled={disabled || !key.trim() || (encrypted && !password)}
+            onClick={useKey}
+          >{busyLabel('key', 'USE THIS KEY')}</button>
+        </div>
+
+        <div className="login__section">
+          <label className="login__label" htmlFor="login-bunker">Connect a remote bunker (NIP-46)</label>
+          <input
+            id="login-bunker"
+            className="avatars__input login__input"
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="bunker://…"
+            value={bunker}
+            onChange={(e) => setBunker(e.target.value)}
+          />
+          <button
+            className="secret__act login__act"
+            disabled={disabled || !bunker.trim()}
+            onClick={connectBunker}
+          >{busyLabel('bunker', 'CONNECT BUNKER')}</button>
+        </div>
+
+        <div className="login__section login__section--row">
+          <button
+            className="secret__act login__act"
+            disabled={disabled || !extension}
+            onClick={useExtension}
+            title={extension ? '' : 'No NIP-07 extension detected'}
+          >{busyLabel('nip07', extension ? 'USE EXTENSION' : 'NO EXTENSION')}</button>
+          <button
+            className="secret__act login__act"
+            disabled={disabled}
+            onClick={generate}
+          >{busyLabel('new', 'NEW RANDOM KEY')}</button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/hud/ProfileBadge.tsx
+++ b/src/hud/ProfileBadge.tsx
@@ -13,11 +13,25 @@ import { targetColor } from '../lib/targets'
 import { profileLabel } from '../store/useProfiles'
 import { useProfile } from '../hooks/useProfile'
 
+/**
+ * npubEncode throws on anything that is not a 32-byte hex pubkey: a synthetic
+ * landmark id like "earth", a truncated key from a bad tag. A profile view is
+ * never worth taking the whole render down for, so callers that might be handed
+ * one encode through this and fall back.
+ */
+function safeNpub(pubkey: string): string | null {
+  try {
+    return nip19.npubEncode(pubkey)
+  } catch {
+    return null
+  }
+}
+
 export function ProfilePic({ pubkey, size = 22 }: { pubkey: string; size?: number }): JSX.Element {
   const profile = useProfile(pubkey)
   const [broken, setBroken] = useState(false)
-  const npub = nip19.npubEncode(pubkey)
-  const initial = (profile?.name ?? npub.slice(4, 5)).slice(0, 1).toUpperCase()
+  const npub = safeNpub(pubkey)
+  const initial = (profile?.name ?? (npub ? npub.slice(4, 5) : pubkey.slice(0, 1))).slice(0, 1).toUpperCase()
   const style = { width: size, height: size, minWidth: size } as const
 
   if (profile?.picture && !broken) {
@@ -40,10 +54,10 @@ interface BadgeProps {
 
 export function ProfileBadge({ pubkey, fallbackName, size = 22, className = '' }: BadgeProps): JSX.Element {
   const profile = useProfile(pubkey)
-  const npub = nip19.npubEncode(pubkey)
-  const name = profile?.name ?? fallbackName ?? profileLabel(profile, npub)
+  const npub = safeNpub(pubkey)
+  const name = profile?.name ?? fallbackName ?? (npub ? profileLabel(profile, npub) : pubkey.slice(0, 8))
   return (
-    <span className={`badge ${className}`} title={npub}>
+    <span className={`badge ${className}`} title={npub ?? pubkey}>
       <ProfilePic pubkey={pubkey} size={size} />
       <span className="badge__name">{name}</span>
     </span>

--- a/src/hud/ProfileBadge.tsx
+++ b/src/hud/ProfileBadge.tsx
@@ -1,0 +1,51 @@
+/**
+ * ProfileBadge.tsx — a pubkey as a face and a name.
+ *
+ * A round avatar (the kind:0 picture, or a colour-from-the-key fallback with an
+ * initial) and the name, or a shortened npub until the profile arrives. One
+ * component so every list — follows, avatars, targets, a secret's creator —
+ * shows a person the same way.
+ */
+
+import { useState } from 'react'
+import { nip19 } from 'nostr-tools'
+import { targetColor } from '../lib/targets'
+import { profileLabel } from '../store/useProfiles'
+import { useProfile } from '../hooks/useProfile'
+
+export function ProfilePic({ pubkey, size = 22 }: { pubkey: string; size?: number }): JSX.Element {
+  const profile = useProfile(pubkey)
+  const [broken, setBroken] = useState(false)
+  const npub = nip19.npubEncode(pubkey)
+  const initial = (profile?.name ?? npub.slice(4, 5)).slice(0, 1).toUpperCase()
+  const style = { width: size, height: size, minWidth: size } as const
+
+  if (profile?.picture && !broken) {
+    return <img className="pfp" style={style} src={profile.picture} alt="" loading="lazy" referrerPolicy="no-referrer" onError={() => setBroken(true)} />
+  }
+  return (
+    <span className="pfp pfp--fallback" style={{ ...style, background: targetColor(pubkey), fontSize: size * 0.5 }} aria-hidden="true">
+      {initial}
+    </span>
+  )
+}
+
+interface BadgeProps {
+  pubkey: string
+  /** A petname from a contact list, shown when the profile has no name yet. */
+  fallbackName?: string | null
+  size?: number
+  className?: string
+}
+
+export function ProfileBadge({ pubkey, fallbackName, size = 22, className = '' }: BadgeProps): JSX.Element {
+  const profile = useProfile(pubkey)
+  const npub = nip19.npubEncode(pubkey)
+  const name = profile?.name ?? fallbackName ?? profileLabel(profile, npub)
+  return (
+    <span className={`badge ${className}`} title={npub}>
+      <ProfilePic pubkey={pubkey} size={size} />
+      <span className="badge__name">{name}</span>
+    </span>
+  )
+}

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -1,0 +1,102 @@
+/**
+ * SecretModal.tsx — tapping a hidden thing in the world.
+ *
+ * A shard or a message you found (or left) opens this: what it is, what it
+ * says or looks like, who made it — with their profile — when and where, and
+ * what you can do about the person: point at them, watch them, or go stand
+ * where their content sits. Your own also offers to delete it.
+ *
+ * This is the "who is this and what do I do about them" view. The Shards panel's
+ * deployment detail is the "manage my own on the wire" view; the two are
+ * reached differently and answer different questions.
+ */
+
+import { useEffect } from 'react'
+import { nip19 } from 'nostr-tools'
+import { formatCellSize } from '../lib/scale'
+import { formatAgo, formatStamp, shortHex } from '../lib/time'
+import { spectate } from '../lib/spectator'
+import { ProfilePic } from './ProfileBadge'
+import { useProfile } from '../hooks/useProfile'
+import { profileLabel } from '../store/useProfiles'
+import { useCyberspace } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+
+export function SecretModal(): JSX.Element | null {
+  const selected = useShards((s) => s.selectedSecret)
+  const item = useShards((s) => (s.selectedSecret ? s.secretByEvent(s.selectedSecret) : null))
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const targeted = useCyberspace((s) => (item?.author ? !!s.targets[item.author] : false))
+  const author = item?.author ?? ''
+  const profile = useProfile(author || null)
+
+  // A selection that no longer resolves (deleted, scrolled out) closes itself.
+  useEffect(() => { if (selected && !item) useShards.getState().selectSecret(null) }, [selected, item])
+
+  if (!item || !author) return null
+
+  const npub = nip19.npubEncode(author)
+  const name = profileLabel(profile, npub)
+  const mine = item.author === me
+  const close = (): void => useShards.getState().selectSecret(null)
+
+  const goTo = (): void => {
+    close()
+    useCyberspace.getState().focusOn(item.at, item.plane, item.type === 'message' ? name : item.shard?.name ?? 'shard', item.type === 'shard' ? item.shard?.unit ?? 0 : 0)
+  }
+  const watch = (): void => { close(); void spectate(author) }
+  const target = (): void => useCyberspace.getState().toggleTarget(author, profile?.name ?? null)
+
+  return (
+    <div className="modal" role="dialog" aria-modal="true" aria-label="Hidden content" onPointerDown={close}>
+      <div className="modal__card secret" onPointerDown={(e) => e.stopPropagation()}>
+        <div className="secret__head">
+          <span className={`secret__badge secret__badge--${item.type}`}>{item.type === 'message' ? '✎ MESSAGE' : '◇ SHARD'}</span>
+          {mine && <span className="secret__mine">YOURS</span>}
+          <button className="secret__close" onClick={close} aria-label="Close">✕</button>
+        </div>
+
+        {item.type === 'message' ? (
+          <blockquote className="secret__message">{item.text}</blockquote>
+        ) : (
+          <div className="secret__shard">
+            <span className="secret__shard-name">{item.shard?.name}</span>
+            <span className="secret__shard-meta">{item.shard?.vertices.length} v · {item.shard?.faces.length} f · {item.shard?.mode.toUpperCase()} · unit 2^{item.shard?.unit}</span>
+          </div>
+        )}
+
+        <div className="secret__creator">
+          <span className="secret__label">Left by</span>
+          <div className="secret__person">
+            <ProfilePic pubkey={author} size={40} />
+            <div className="secret__person-text">
+              <span className="secret__name">{name}{mine ? ' (you)' : ''}</span>
+              {profile?.nip05 && <span className="secret__nip05">{profile.nip05.replace(/^_@/, '')}</span>}
+              <span className="secret__npub" title={npub}>{shortHex(npub, 14, 8)}</span>
+            </div>
+          </div>
+          {profile?.about && <p className="secret__about">{profile.about}</p>}
+        </div>
+
+        <dl className="secret__facts">
+          <div><dt>Placed</dt><dd title={item.createdAt ? formatStamp(item.createdAt) : ''}>{item.createdAt ? formatAgo(item.createdAt) : 'unknown'}</dd></div>
+          <div><dt>Hidden at</dt><dd>{item.height === 0 ? 'exact gibson' : `within ${formatCellSize(item.height)}`}</dd></div>
+          <div><dt>Plane</dt><dd>{item.plane === 0 ? 'dataspace' : 'ideaspace'}</dd></div>
+        </dl>
+
+        <div className="secret__actions">
+          <button className="secret__act" onClick={goTo}>GO TO IT</button>
+          {!mine && (
+            <>
+              <button className={`secret__act ${targeted ? 'is-on' : ''}`} onClick={target}>{targeted ? 'TARGETED' : 'TARGET'} CREATOR</button>
+              <button className="secret__act" onClick={watch}>SPECTATE</button>
+            </>
+          )}
+          {mine && (
+            <button className="secret__act secret__act--danger" onClick={() => { close(); void useShards.getState().deleteInstance(item.key) }}>DELETE</button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hud/SpectateBar.tsx
+++ b/src/hud/SpectateBar.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react'
 import { stopSpectating } from '../lib/spectator'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
+import { ProfileBadge } from './ProfileBadge'
 
 export function SpectateBar(): JSX.Element | null {
   const spectate = useCyberspace((s) => s.spectate)
@@ -22,7 +23,6 @@ export function SpectateBar(): JSX.Element | null {
 
   if (!spectate) return null
 
-  const short = `${spectate.npub.slice(0, 12)}…${spectate.npub.slice(-6)}`
   const status =
     spectate.status === 'loading' ? 'FETCHING CHAIN'
       : spectate.status === 'error' ? 'RELAY UNREACHABLE'
@@ -34,7 +34,7 @@ export function SpectateBar(): JSX.Element | null {
       <span className="spectate__eye" aria-hidden="true">◉</span>
       <span className="spectate__text">
         <span className="spectate__label">SPECTATING</span>
-        <span className="spectate__who" title={spectate.npub}>{short}</span>
+        <ProfileBadge pubkey={spectate.pubkey} className="spectate__badge" />
         <span className="spectate__meta">
           {spectate.lastActive !== null && (
             <span title={formatStamp(spectate.lastActive)}>LAST ACTIVE {formatAgo(spectate.lastActive, now).toUpperCase()} · </span>

--- a/src/hud/Targets.tsx
+++ b/src/hud/Targets.tsx
@@ -15,6 +15,8 @@
 import { useEffect, useRef } from 'react'
 import { formatDistance } from '../lib/scale'
 import { targetScreens, type CyberTarget } from '../lib/targets'
+import { useProfile } from '../hooks/useProfile'
+import { ProfilePic } from './ProfileBadge'
 
 /** Keep chevrons off the very edge, where they get clipped. */
 const EDGE_INSET = 26
@@ -94,18 +96,36 @@ export function Targets({ targets }: Props): JSX.Element {
   return (
     <div className="targets" ref={host}>
       {targets.map((t) => (
-        <div key={t.id} className="target" data-target={t.id} style={{ color: t.color }}>
-          <span className="target__ring" />
-          {/* Points along +x unrotated, so a rotation by the screen bearing
-              aims it at the target. The previous glyph pointed up and left,
-              which put every chevron 135 degrees off. */}
-          <span className="target__arrow">➤</span>
-          <span className="target__text">
-            <span className="target__label">{t.label}</span>
-            <span className="target__dist" />
-          </span>
-        </div>
+        <TargetMarker key={t.id} target={t} />
       ))}
+    </div>
+  )
+}
+
+/**
+ * One marker. Its position, distance, ring and chevron are driven imperatively
+ * by the parent's animation frame (which finds it by data-target and reaches
+ * the spans by class), so those stay in the DOM exactly where the loop expects.
+ * The name and face are the reactive part: the profile arrives from the cache,
+ * so a target that started as a wall of hex becomes a person without a reload.
+ */
+function TargetMarker({ target }: { target: CyberTarget }): JSX.Element {
+  const profile = useProfile(target.id)
+  const name = profile?.name ?? target.label
+  return (
+    <div className="target" data-target={target.id} style={{ color: target.color }}>
+      <span className="target__ring" />
+      {/* Points along +x unrotated, so a rotation by the screen bearing aims it
+          at the target. The previous glyph pointed up and left, which put every
+          chevron 135 degrees off. */}
+      <span className="target__arrow">➤</span>
+      <span className="target__body">
+        <ProfilePic pubkey={target.id} size={18} />
+        <span className="target__text">
+          <span className="target__label">{name}</span>
+          <span className="target__dist" />
+        </span>
+      </span>
     </div>
   )
 }

--- a/src/hud/Targets.tsx
+++ b/src/hud/Targets.tsx
@@ -109,9 +109,14 @@ export function Targets({ targets }: Props): JSX.Element {
  * The name and face are the reactive part: the profile arrives from the cache,
  * so a target that started as a wall of hex becomes a person without a reload.
  */
+/** Real people have a 32-byte hex id; landmarks like Earth or the YOU marker
+ * carry a plain word, which has no profile and no avatar. */
+const IS_PUBKEY = /^[0-9a-f]{64}$/i
+
 function TargetMarker({ target }: { target: CyberTarget }): JSX.Element {
-  const profile = useProfile(target.id)
-  const name = profile?.name ?? target.label
+  const person = IS_PUBKEY.test(target.id)
+  const profile = useProfile(person ? target.id : null)
+  const name = (person && profile?.name) || target.label
   return (
     <div className="target" data-target={target.id} style={{ color: target.color }}>
       <span className="target__ring" />
@@ -120,7 +125,7 @@ function TargetMarker({ target }: { target: CyberTarget }): JSX.Element {
           chevron 135 degrees off. */}
       <span className="target__arrow">➤</span>
       <span className="target__body">
-        <ProfilePic pubkey={target.id} size={18} />
+        {person && <ProfilePic pubkey={target.id} size={18} />}
         <span className="target__text">
           <span className="target__label">{name}</span>
           <span className="target__dist" />

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -10,17 +10,13 @@
  */
 
 import { useEffect, useState } from 'react'
-import { nip19 } from 'nostr-tools'
 import { parsePubkey } from '../lib/chains'
 import { fetchContacts, GENERAL_RELAYS, type Contact } from '../lib/contacts'
 import { spectate } from '../lib/spectator'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
-
-function shortNpub(npub: string): string {
-  return `${npub.slice(0, 12)}…${npub.slice(-6)}`
-}
+import { ProfileBadge } from './ProfileBadge'
 
 export function TargetsPanel(): JSX.Element {
   const targets = useCyberspace((s) => s.targets)
@@ -67,7 +63,7 @@ export function TargetsPanel(): JSX.Element {
         {list.map((t) => (
           <li key={t.pubkey} className="targets__row">
             <span className="targets__dot" style={{ background: targetColor(t.pubkey), boxShadow: `0 0 6px ${targetColor(t.pubkey)}` }} />
-            <span className="avatars__who" title={t.npub}>{t.name ?? shortNpub(t.npub)}</span>
+            <ProfileBadge pubkey={t.pubkey} fallbackName={t.name} />
             <span className={`targets__status targets__status--${t.status}`} title={t.lastActive ? formatStamp(t.lastActive) : undefined}>
               {t.status === 'live' && t.lastActive ? formatAgo(t.lastActive, now)
                 : t.status === 'resolving' ? 'FINDING'
@@ -97,7 +93,7 @@ export function TargetsPanel(): JSX.Element {
               const on = !!targets[c.pubkey]
               return (
                 <li key={c.pubkey} className="targets__row targets__row--contact">
-                  <span className="avatars__who" title={nip19.npubEncode(c.pubkey)}>{c.name ?? shortNpub(nip19.npubEncode(c.pubkey))}</span>
+                  <ProfileBadge pubkey={c.pubkey} fallbackName={c.name} />
                   <button
                     className={`targets__toggle ${on ? 'is-on' : ''}`}
                     style={on ? { color: targetColor(c.pubkey), borderColor: targetColor(c.pubkey) } : undefined}

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -31,6 +31,15 @@ export function TargetsPanel(): JSX.Element {
     return () => window.clearInterval(t)
   }, [])
 
+  // Logging in is a new identity: point "Follows of" at it, and drop the old
+  // identity's contacts so the list never shows one key's follows under
+  // another's npub.
+  useEffect(() => {
+    setWho(me.npub)
+    setContacts(null)
+    setContactsState('idle')
+  }, [me.npub])
+
   const typed = parsePubkey(input)
   const whoHex = parsePubkey(who)
   const list = Object.values(targets)

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -33,7 +33,7 @@ let pool: SimplePool | null = null
  * write them.
  */
 function authSign(template: EventTemplate): Promise<VerifiedEvent> {
-  return Promise.resolve(useCyberspace.getState().sign(template) as unknown as VerifiedEvent)
+  return useCyberspace.getState().signEvent(template) as unknown as Promise<VerifiedEvent>
 }
 
 export function getPool(): SimplePool {

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -62,13 +62,20 @@ interface AuthRelay {
  * and re-auths on its own when a reconnect brings a fresh challenge.
  */
 const authedFor = new Map<string, string>()
+const noChallenge = new Set<string>()
 async function authRelay(url: string): Promise<void> {
+  // A relay that never challenged before will not now: skip the wait.
+  if (noChallenge.has(url)) return
   try {
     const relay = (await getPool().ensureRelay(url)) as unknown as AuthRelay
-    for (let i = 0; i < 20 && !relay.challenge; i++) await new Promise((r) => setTimeout(r, 50))
-    if (relay.challenge && authedFor.get(url) !== relay.challenge) {
-      await relay.auth(authSign)
-      authedFor.set(url, relay.challenge)
+    for (let i = 0; i < 10 && !relay.challenge; i++) await new Promise((r) => setTimeout(r, 40))
+    if (relay.challenge) {
+      if (authedFor.get(url) !== relay.challenge) {
+        await relay.auth(authSign)
+        authedFor.set(url, relay.challenge)
+      }
+    } else {
+      noChallenge.add(url)
     }
   } catch { /* relay down, or does not require auth */ }
 }
@@ -109,7 +116,7 @@ export function publish(event: NostrEvent): Promise<PublishResult> {
  * `onauth`: the relay now requires NIP-42 auth for reads, so a query has to be
  * able to answer the challenge and retry, or it comes back empty.
  */
-async function collect(relays: string[], filter: Filter): Promise<NostrEvent[]> {
+async function collect(relays: string[], filter: Filter, maxWait = MAX_WAIT_MS): Promise<NostrEvent[]> {
   await authAll(relays)
   return new Promise((resolve) => {
     const events = new Map<string, NostrEvent>()
@@ -121,12 +128,12 @@ async function collect(relays: string[], filter: Filter): Promise<NostrEvent[]> 
       try { sub.close() } catch { /* already closed */ }
       resolve([...events.values()])
     }
-    const timer = setTimeout(done, MAX_WAIT_MS + 2000)
+    const timer = setTimeout(done, maxWait + 500)
     const sub = getPool().subscribeEose(relays, filter, {
       onevent: (e) => events.set(e.id, e),
       onclose: done,
       onauth: authSign,
-      maxWait: MAX_WAIT_MS,
+      maxWait,
     })
   })
 }
@@ -137,8 +144,8 @@ export function query(filter: Filter): Promise<NostrEvent[]> {
 }
 
 /** Query an explicit set, for the few things that live elsewhere (contact lists). */
-export function queryAny(relays: string[], filter: Filter): Promise<NostrEvent[]> {
-  return collect(relays, filter)
+export function queryAny(relays: string[], filter: Filter, maxWait?: number): Promise<NostrEvent[]> {
+  return collect(relays, filter, maxWait)
 }
 
 /** A live subscription across the configured relays; the returned function closes it. */

--- a/src/lib/signers.ts
+++ b/src/lib/signers.ts
@@ -1,0 +1,192 @@
+/**
+ * signers.ts — who holds the key.
+ *
+ * Cyberspace signs a lot: every hop, every hidden thing, every relay auth. The
+ * key doing it can be a local secret (a random one, or an nsec/ncryptsec you
+ * bring), a browser extension (NIP-07), or a remote bunker (NIP-46). They only
+ * differ in how signEvent works and whether the pubkey is known at once, so
+ * the rest of the app talks to this one shape and awaits every signature.
+ *
+ * Local signing is synchronous under the hood, wrapped in a resolved promise,
+ * so the common path costs nothing; extension and bunker are genuinely async.
+ */
+
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { nip19 } from 'nostr-tools'
+import * as nip46 from 'nostr-tools/nip46'
+import * as nip49 from 'nostr-tools/nip49'
+import { getPool } from './relay'
+import type { EventTemplate, NostrEvent } from './events'
+
+export type SignerKind = 'local' | 'nip07' | 'nip46'
+
+export interface Signer {
+  kind: SignerKind
+  pubkey: string
+  signEvent: (template: EventTemplate) => Promise<NostrEvent>
+  /** Present only for local signers, so the key can be persisted. */
+  secretKey?: Uint8Array
+  /** For a bunker: what to persist to reconnect it. */
+  bunkerUri?: string
+  clientSecretKey?: Uint8Array
+  close?: () => Promise<void>
+  /** For a deferred signer: force the reconnection and return the real one. */
+  reconnect?: () => Promise<Signer>
+}
+
+/** The browser extension, if one is installed. */
+interface WindowNostr {
+  getPublicKey(): Promise<string>
+  signEvent(event: EventTemplate): Promise<NostrEvent>
+}
+function windowNostr(): WindowNostr | null {
+  return (window as unknown as { nostr?: WindowNostr }).nostr ?? null
+}
+export function hasNip07(): boolean {
+  return typeof window !== 'undefined' && !!windowNostr()
+}
+
+/** A local key: the default random one, or one you brought. */
+export function localSigner(secretKey: Uint8Array): Signer {
+  const pubkey = getPublicKey(secretKey)
+  return {
+    kind: 'local',
+    pubkey,
+    secretKey,
+    signEvent: (template) => Promise.resolve(finalizeEvent(template, secretKey) as unknown as NostrEvent),
+  }
+}
+
+/** A fresh random local key. */
+export function randomSigner(): Signer {
+  return localSigner(generateSecretKey())
+}
+
+/** An nsec you paste. Throws a readable error if it is not a valid nsec. */
+export function signerFromNsec(nsec: string): Signer {
+  let decoded
+  try {
+    decoded = nip19.decode(nsec.trim())
+  } catch {
+    throw new Error('That is not a valid nsec. Check you copied the whole key.')
+  }
+  if (decoded.type !== 'nsec') throw new Error(`Expected an nsec, got ${decoded.type}.`)
+  return localSigner(decoded.data)
+}
+
+/** An ncryptsec (NIP-49) plus its password. Throws a readable error if either is wrong. */
+export function signerFromNcryptsec(ncryptsec: string, password: string): Signer {
+  let sk
+  try {
+    sk = nip49.decrypt(ncryptsec.trim(), password)
+  } catch {
+    throw new Error('Could not decrypt. Wrong password, or not a valid ncryptsec.')
+  }
+  return localSigner(sk)
+}
+
+/** The browser extension. Throws if none is present or it refuses. */
+export async function nip07Signer(): Promise<Signer> {
+  const ext = windowNostr()
+  if (!ext) throw new Error('No NIP-07 extension found')
+  const pubkey = await ext.getPublicKey()
+  return {
+    kind: 'nip07',
+    pubkey,
+    signEvent: (template) => ext.signEvent(template),
+  }
+}
+
+/**
+ * A remote bunker (NIP-46). Takes a `bunker://…` URI (or a nostrconnect one),
+ * and an optional client secret key so a reconnect keeps the same client
+ * identity. Connects, learns the remote pubkey, and signs through it.
+ */
+export async function nip46Signer(bunkerUri: string, clientSecretKey?: Uint8Array): Promise<Signer> {
+  const clientSk = clientSecretKey ?? generateSecretKey()
+  const bp = await nip46.parseBunkerInput(bunkerUri.trim())
+  if (!bp) throw new Error('Not a valid bunker URI')
+  const bunker = nip46.BunkerSigner.fromBunker(clientSk, bp, { pool: getPool() as never })
+  await bunker.connect()
+  const pubkey = await bunker.getPublicKey()
+  return {
+    kind: 'nip46',
+    pubkey,
+    bunkerUri,
+    clientSecretKey: clientSk,
+    signEvent: (template) => bunker.signEvent(template) as unknown as Promise<NostrEvent>,
+    close: () => bunker.close(),
+  }
+}
+
+/** What we persist to bring a signer back on reload. */
+export interface SignerPref {
+  kind: SignerKind
+  pubkey: string
+  /** local only. */
+  nsec?: string
+  /** nip46 only. */
+  bunkerUri?: string
+  clientNsec?: string
+}
+
+export function prefOf(signer: Signer): SignerPref {
+  const base: SignerPref = { kind: signer.kind, pubkey: signer.pubkey }
+  if (signer.kind === 'local' && signer.secretKey) base.nsec = nip19.nsecEncode(signer.secretKey)
+  if (signer.kind === 'nip46') {
+    base.bunkerUri = signer.bunkerUri
+    if (signer.clientSecretKey) base.clientNsec = nip19.nsecEncode(signer.clientSecretKey)
+  }
+  return base
+}
+
+/** Rebuild a signer from a persisted preference. Local is instant; the others reconnect. */
+export async function signerFromPref(pref: SignerPref): Promise<Signer> {
+  if (pref.kind === 'local' && pref.nsec) return signerFromNsec(pref.nsec)
+  if (pref.kind === 'nip07') return nip07Signer()
+  if (pref.kind === 'nip46' && pref.bunkerUri) {
+    const clientSk = pref.clientNsec ? (nip19.decode(pref.clientNsec).data as Uint8Array) : undefined
+    return nip46Signer(pref.bunkerUri, clientSk)
+  }
+  throw new Error('Unusable signer preference')
+}
+
+/** Where the signer preference lives across reloads. */
+const PREF_KEY = 'onosendai:signer'
+
+export function loadSignerPref(): SignerPref | null {
+  try {
+    const raw = localStorage.getItem(PREF_KEY)
+    return raw ? (JSON.parse(raw) as SignerPref) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveSignerPref(pref: SignerPref): void {
+  try {
+    localStorage.setItem(PREF_KEY, JSON.stringify(pref))
+  } catch {
+    /* private mode, quota: the session still works, it just will not persist. */
+  }
+}
+
+/**
+ * A signer for an extension/bunker identity we already know the pubkey of but
+ * have not reconnected yet. Its pubkey is available at once so the chain loads;
+ * the first signature (or an explicit reconnect()) does the real handshake,
+ * memoised, and hands the live signer to onReady so the store can swap it in.
+ */
+export function deferredReconnect(pref: SignerPref, onReady: (s: Signer) => void): Signer {
+  let pending: Promise<Signer> | null = null
+  const ensure = (): Promise<Signer> => {
+    if (!pending) pending = signerFromPref(pref).then((s) => { onReady(s); return s })
+    return pending
+  }
+  return {
+    kind: pref.kind,
+    pubkey: pref.pubkey,
+    signEvent: (template) => ensure().then((s) => s.signEvent(template)),
+    reconnect: ensure,
+  }
+}

--- a/src/scene/SpawnMarker.tsx
+++ b/src/scene/SpawnMarker.tsx
@@ -24,11 +24,18 @@ import { coordToXyz, hexToCoord } from 'cyberspace-core'
 import type { Material, Mesh, MeshStandardMaterial } from 'three'
 import { GRID_RADIUS, cellCentre, type Position, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { WorldLabel } from './WorldLabel'
 
 const MODEL = '/spawn.glb'
 
 /** v1 drew it at three times model scale, and the model's rings are radius 1. */
 const SCALE = 3
+
+/** The warm red of the marker's radiating bars, so the label reads as part of it. */
+const LABEL_COLOR = '#ff7a90'
+
+/** Below the marker's lowest bar, in cells, clear of the mesh at any zoom. */
+const LABEL_DROP = 4.5
 
 /** Beyond this it would be drawn somewhere nobody can see. Same cull as Earth. */
 const REACH = GRID_RADIUS * 8
@@ -91,13 +98,19 @@ function Model({ pubkey, axes }: Props): JSX.Element | null {
   if (!at) return null
 
   return (
-    <group name="spawn-marker" position={at} scale={SCALE} dispose={null}>
-      {PARTS.map(([node, material]) => {
-        const mesh = gltf.nodes[node]
-        if (!mesh) return null
-        return <mesh key={node} geometry={mesh.geometry} material={materials[material]} frustumCulled={false} />
-      })}
-    </group>
+    <>
+      <group name="spawn-marker" position={at} scale={SCALE} dispose={null}>
+        {PARTS.map(([node, material]) => {
+          const mesh = gltf.nodes[node]
+          if (!mesh) return null
+          return <mesh key={node} geometry={mesh.geometry} material={materials[material]} frustumCulled={false} />
+        })}
+      </group>
+      {/* A sibling, not a child: the marker group is scaled x3, and the label
+          holds its own constant pixel height, so it must sit outside that scale.
+          Dropped below the mesh so it never overlaps the rings and bars. */}
+      <WorldLabel text="SPAWN POINT" color={LABEL_COLOR} at={at} offset={[0, -LABEL_DROP, 0]} align="center" px={11} opacity={0.85} />
+    </>
   )
 }
 

--- a/src/scene/WorldMessages.tsx
+++ b/src/scene/WorldMessages.tsx
@@ -10,10 +10,13 @@
 import { useMemo } from 'react'
 import { nip19 } from 'nostr-tools'
 import { ACCENT } from '../lib/palette'
+import type { ThreeEvent } from '@react-three/fiber'
 import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
 import { WorldLabel } from './WorldLabel'
+
+const TAP_SLOP = 8
 
 const REACH = GRID_RADIUS * 8
 /** The message colour: a warm note against the cool field. */
@@ -66,12 +69,23 @@ export function WorldMessages({ axes }: Props): JSX.Element | null {
 
   return (
     <>
-      {placed.map((w) => (
-        <group key={w.key}>
-          <WorldLabel text={wrap(w.text)} color={NOTE} at={w.centre} align="center" px={13} />
-          <WorldLabel text={`— ${shortAuthor(w.author, w.mine)}`} color={ACCENT} at={[w.centre[0], w.centre[1] - 0.9, w.centre[2]]} align="center" px={9} opacity={0.7} />
-        </group>
-      ))}
+      {placed.map((w) => {
+        const open = (e: ThreeEvent<MouseEvent>): void => {
+          if (e.delta > TAP_SLOP) return
+          e.stopPropagation()
+          useShards.getState().selectSecret(w.key)
+        }
+        return (
+          <group key={w.key}>
+            <WorldLabel text={wrap(w.text)} color={NOTE} at={w.centre} align="center" px={13} />
+            <WorldLabel text={`— ${shortAuthor(w.author, w.mine)}`} color={ACCENT} at={[w.centre[0], w.centre[1] - 0.9, w.centre[2]]} align="center" px={9} opacity={0.7} />
+            <mesh position={w.centre} onClick={open}>
+              <sphereGeometry args={[1, 8, 8]} />
+              <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+            </mesh>
+          </group>
+        )
+      })}
     </>
   )
 }

--- a/src/scene/WorldShards.tsx
+++ b/src/scene/WorldShards.tsx
@@ -9,10 +9,14 @@
  */
 
 import { useMemo } from 'react'
+import type { ThreeEvent } from '@react-three/fiber'
 import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
 import { ShardMesh } from './ShardMesh'
+
+/** A press that travels further than this is an orbit, not a tap. */
+const TAP_SLOP = 8
 
 const REACH = GRID_RADIUS * 8
 
@@ -50,11 +54,24 @@ export function WorldShards({ axes }: Props): JSX.Element | null {
 
   return (
     <>
-      {placed.map((w) => (
-        <group key={w.key} position={w.centre}>
-          <ShardMesh shard={w.shard} scale={w.scale} />
-        </group>
-      ))}
+      {placed.map((w) => {
+        const hit = Math.max(0.6, w.scale * 2)
+        const open = (e: ThreeEvent<MouseEvent>): void => {
+          if (e.delta > TAP_SLOP) return
+          e.stopPropagation()
+          useShards.getState().selectSecret(w.key)
+        }
+        return (
+          <group key={w.key} position={w.centre}>
+            <ShardMesh shard={w.shard} scale={w.scale} />
+            {/* An invisible, generous tap target: shards can be a few pixels. */}
+            <mesh onClick={open}>
+              <sphereGeometry args={[hit, 8, 8]} />
+              <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+            </mesh>
+          </group>
+        )
+      })}
     </>
   )
 }

--- a/src/store/explore.test.ts
+++ b/src/store/explore.test.ts
@@ -10,19 +10,19 @@
 import { describe, it, expect, beforeAll } from 'vitest'
 import { SPAWN, useCyberspace } from './useCyberspace'
 
-function land(dx: bigint): void {
+async function land(dx: bigint): Promise<void> {
   const s = useCyberspace.getState()
   useCyberspace.setState({ pendingTarget: { ...s.position, x: s.position.x + dx } })
-  s.applyProofMessage({
+  await s.applyProofMessage({
     type: 'done', id: 0, mode: 'hop', elapsedMs: 1, proofHash: 'ab'.repeat(32),
     regionN: '1', terrainK: 8, lca: { x: 1, y: 0, z: 0 }, totalOps: 1,
   })
 }
 
 describe('explore', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     // Three hops: the chain is spawn, +1, +2, +3.
-    land(1n); land(1n); land(1n)
+    await land(1n); await land(1n); await land(1n)
   })
 
   it('starts at the head, anchored on the live position', () => {
@@ -72,9 +72,9 @@ describe('explore', () => {
     expect(useCyberspace.getState().proof.status).not.toBe('computing')
   })
 
-  it('leaves the anchor in history when a commit lands, and follows once back at the head', () => {
+  it('leaves the anchor in history when a commit lands, and follows once back at the head', async () => {
     useCyberspace.getState().explore(0)
-    land(1n)
+    await land(1n)
     let s = useCyberspace.getState()
     expect(s.actions()).toHaveLength(5)
     expect(s.exploreIndex).toBe(0)
@@ -85,9 +85,9 @@ describe('explore', () => {
     expect(s.position).toEqual({ ...SPAWN, x: SPAWN.x + 4n })
   })
 
-  it('comes back to the head on a respawn', () => {
+  it('comes back to the head on a respawn', async () => {
     useCyberspace.getState().explore(2)
-    useCyberspace.getState().respawn()
+    await useCyberspace.getState().respawn()
     const s = useCyberspace.getState()
     expect(s.exploreIndex).toBeNull()
     expect(s.anchor).toEqual(SPAWN)

--- a/src/store/respawn.test.ts
+++ b/src/store/respawn.test.ts
@@ -12,7 +12,7 @@ import { parseAction } from '../lib/events'
 import { SPAWN, useCyberspace } from './useCyberspace'
 
 describe('respawn', () => {
-  it('replaces the chain with a single spawn at the pubkey and resets the cursor', () => {
+  it('replaces the chain with a single spawn at the pubkey and resets the cursor', async () => {
     const before = useCyberspace.getState()
     const oldGenesis = before.genesisId
     // Pretend the chain had gone somewhere.
@@ -22,7 +22,7 @@ describe('respawn', () => {
       chain: { hops: 3, sidesteps: 1, totalOps: 99, totalHashes: 7, totalMs: 12 },
     })
 
-    useCyberspace.getState().respawn()
+    await useCyberspace.getState().respawn()
     const s = useCyberspace.getState()
 
     expect(s.events).toHaveLength(1)

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -17,8 +17,23 @@
 
 import { create } from 'zustand'
 import { Quaternion } from 'three'
-import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { finalizeEvent, generateSecretKey } from 'nostr-tools/pure'
 import { nip19 } from 'nostr-tools'
+import {
+  deferredReconnect,
+  localSigner,
+  randomSigner,
+  signerFromNcryptsec,
+  signerFromNsec,
+  signerFromPref,
+  nip07Signer,
+  nip46Signer,
+  prefOf,
+  loadSignerPref,
+  saveSignerPref,
+  type Signer,
+  type SignerKind,
+} from '../lib/signers'
 import {
   coordToXyz,
   estimateHopCost,
@@ -256,8 +271,28 @@ export interface CyberspaceState {
   setTargetChain: (pubkey: string, events: NostrEvent[], status?: 'error') => void
   /** The tracked targets as things the HUD can point at. */
   targetList: () => CyberTarget[]
-  /** Sign a template with this identity's key. The only door to it outside this module. */
-  sign: (template: EventTemplate) => NostrEvent
+  /** Sign a template with this identity's active signer. Async because an
+   * extension or a bunker is genuinely remote. The only door to it outside this module. */
+  signEvent: (template: EventTemplate) => Promise<NostrEvent>
+
+  /** How the current identity signs: a local key, an extension, or a bunker. */
+  signerKind: SignerKind
+  /** The last login attempt's failure, shown in the identity panel; null when clear. */
+  loginError: string | null
+  /** Reconnect a stored extension/bunker signer on startup, if there is one. */
+  initSigner: () => Promise<void>
+  /** Replace the identity with a fresh random key, spawning anew. */
+  useNewKey: () => Promise<void>
+  /** Replace the identity from a pasted nsec. */
+  useNsec: (nsec: string) => Promise<void>
+  /** Replace the identity from an ncryptsec and its password. */
+  useNcryptsec: (ncryptsec: string, password: string) => Promise<void>
+  /** Switch to the browser extension (NIP-07). */
+  useExtension: () => Promise<void>
+  /** Switch to a remote bunker (NIP-46) from its bunker:// URI. */
+  useBunker: (uri: string) => Promise<void>
+  /** Clear a shown login error. */
+  clearLoginError: () => void
 
   axes: () => ViewAxes
   /** Axes as they appear on screen right now, including free orbit. */
@@ -296,6 +331,13 @@ export interface CyberspaceState {
  */
 const STORAGE_KEY = 'onosendai:nsec'
 const CHAIN_KEY = 'onosendai:chain'
+
+/** Chains are stored per identity, so switching keys and back keeps each one's
+ * local history. The bare CHAIN_KEY is the pre-multi-identity slot, migrated in
+ * on first load for whichever identity it belonged to. */
+function chainKeyFor(pubkey: string): string {
+  return `${CHAIN_KEY}:${pubkey}`
+}
 const LIVE_KEY = 'onosendai:live'
 const TARGETS_KEY = 'onosendai:targets'
 
@@ -332,7 +374,15 @@ function loadOrGenerateKey(): Uint8Array {
 
 function loadChain(pubkey: string): PersistedChain | null {
   try {
-    const raw = localStorage.getItem(CHAIN_KEY)
+    let raw = localStorage.getItem(chainKeyFor(pubkey))
+    if (!raw) {
+      // Migrate the single legacy chain, but only for the identity that wrote it.
+      const legacy = localStorage.getItem(CHAIN_KEY)
+      if (legacy) {
+        const d = JSON.parse(legacy) as Partial<PersistedChain>
+        if (Array.isArray(d.events) && d.events[0]?.pubkey === pubkey) raw = legacy
+      }
+    }
     if (!raw) return null
     const data = JSON.parse(raw) as Partial<PersistedChain>
     if (data.version !== 2 || !Array.isArray(data.events) || data.events.length === 0) return null
@@ -352,6 +402,8 @@ function loadChain(pubkey: string): PersistedChain | null {
 }
 
 function saveChain(events: NostrEvent[], published: Record<string, PublishStatus>, stats: ChainStats): void {
+  const pubkey = events[0]?.pubkey
+  if (!pubkey) return
   try {
     const data: PersistedChain = {
       version: 2,
@@ -359,7 +411,7 @@ function saveChain(events: NostrEvent[], published: Record<string, PublishStatus
       published: events.map((e) => e.id).filter((id) => published[id] === 'ok'),
       stats,
     }
-    localStorage.setItem(CHAIN_KEY, JSON.stringify(data))
+    localStorage.setItem(chainKeyFor(pubkey), JSON.stringify(data))
   } catch { /* quota exceeded or private mode */ }
 }
 
@@ -407,20 +459,53 @@ function nextCreatedAt(head: NostrEvent | undefined): number {
   return head ? Math.max(now, head.created_at) : now
 }
 
-const secretKey = loadOrGenerateKey()
-const pubkeyHex = getPublicKey(secretKey)
-const SPAWN_XYZ = coordToXyz(hexToCoord(pubkeyHex))
-const SPAWN: Position = { x: SPAWN_XYZ.x, y: SPAWN_XYZ.y, z: SPAWN_XYZ.z }
-
 /** Where any pubkey spawns: its own bits, read as a coordinate (spec §3.1). */
 function spawnOf(pubkey: string): { position: Position; plane: Plane } {
   const { x, y, z, plane } = coordToXyz(hexToCoord(pubkey))
   return { position: { x, y, z }, plane }
 }
 
-/** The one place the key touches an event. */
-function sign(template: EventTemplate): NostrEvent {
-  return finalizeEvent(template, secretKey)
+/**
+ * The signer in use. Mutable, because you can switch from the default random
+ * key to an nsec, an extension, or a bunker. Everything signs through it and
+ * awaits it: local keys resolve at once, the others are genuinely remote.
+ */
+let currentSigner: Signer = pickInitialSigner()
+
+function pickInitialSigner(): Signer {
+  const pref = loadSignerPref()
+  // A stored extension/bunker identity whose chain we already hold: reconnect
+  // lazily, keeping its pubkey so the chain loads now.
+  if (pref && pref.kind !== 'local' && loadChain(pref.pubkey)) {
+    return deferredReconnect(pref, (s) => { currentSigner = s })
+  }
+  if (pref?.nsec) { try { return signerFromNsec(pref.nsec) } catch { /* corrupt */ } }
+  return localSigner(loadOrGenerateKey())
+}
+
+function signEvent(template: EventTemplate): Promise<NostrEvent> {
+  return currentSigner.signEvent(template)
+}
+
+const pubkeyHex = currentSigner.pubkey
+const SPAWN_XYZ = coordToXyz(hexToCoord(pubkeyHex))
+const SPAWN: Position = { x: SPAWN_XYZ.x, y: SPAWN_XYZ.y, z: SPAWN_XYZ.z }
+
+/** A fresh spawn signed synchronously: only possible with a local key, which is
+ * the only case module init ever needs one (see pickInitialSigner). */
+function freshSpawnSync(signer: Signer): PersistedChain {
+  if (!signer.secretKey) throw new Error('cannot spawn without a local key at init')
+  const createdAt = Math.floor(Date.now() / 1000)
+  const spawn = finalizeEvent(spawnTemplate(signer.pubkey, createdAt), signer.secretKey) as unknown as NostrEvent
+  return { version: 2, events: [spawn], published: [], stats: EMPTY_STATS }
+}
+
+/** A fresh spawn signed through whatever signer is active (may be remote). */
+async function freshSpawnAsync(signer: Signer, retiring?: NostrEvent): Promise<PersistedChain> {
+  const now = Math.floor(Date.now() / 1000)
+  const createdAt = retiring ? Math.max(now, retiring.created_at + 1) : now
+  const spawn = await signer.signEvent(spawnTemplate(signer.pubkey, createdAt))
+  return { version: 2, events: [spawn], published: [], stats: EMPTY_STATS }
 }
 
 /**
@@ -431,12 +516,6 @@ function sign(template: EventTemplate): NostrEvent {
  * as the one before it is the same bytes, the same id, and so not a new spawn
  * at all. The timestamp therefore steps past the old head, not merely to now.
  */
-function freshSpawn(retiring?: NostrEvent): PersistedChain {
-  const now = Math.floor(Date.now() / 1000)
-  const createdAt = retiring ? Math.max(now, retiring.created_at + 1) : now
-  return { version: 2, events: [sign(spawnTemplate(pubkeyHex, createdAt))], published: [], stats: EMPTY_STATS }
-}
-
 /** Everything the store derives from a chain, so spawn and respawn agree. */
 function derive(saved: PersistedChain): {
   events: NostrEvent[]
@@ -472,11 +551,37 @@ function derive(saved: PersistedChain): {
   }
 }
 
-const initial = derive(loadChain(pubkeyHex) ?? freshSpawn())
+const initial = derive(loadChain(pubkeyHex) ?? freshSpawnSync(currentSigner))
 
 let requestId = 0
 
-export const useCyberspace = create<CyberspaceState>((set, get) => ({
+export const useCyberspace = create<CyberspaceState>((set, get) => {
+  /**
+   * Replace the active identity. A known pubkey keeps its stored chain; a new
+   * one spawns where its own bits land (spec §3.1). Either way the scene lets
+   * go of whatever it was spectating and returns to the new head.
+   */
+  const switchTo = async (signer: Signer): Promise<void> => {
+    currentSigner = signer
+    saveSignerPref(prefOf(signer))
+    const saved = loadChain(signer.pubkey) ?? (await freshSpawnAsync(signer))
+    const d = derive(saved)
+    set({
+      identity: { pubkey: signer.pubkey, npub: nip19.npubEncode(signer.pubkey) },
+      signerKind: signer.kind,
+      loginError: null,
+      ...d,
+      cursor: d.position,
+      pendingTarget: null,
+      proof: IDLE_PROOF,
+      publishError: null,
+      spectate: null,
+      focus: null,
+    })
+    saveChain(d.events, d.published, d.chain)
+  }
+
+  return {
   identity: { pubkey: pubkeyHex, npub: nip19.npubEncode(pubkeyHex) },
   ...initial,
   spectate: null,
@@ -490,6 +595,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
   proof: IDLE_PROOF,
   publishError: null,
   live: loadLive(),
+  signerKind: currentSigner.kind,
+  loginError: null,
 
   moveCursor: (dir) => {
     const { cursor, scaleExp } = get()
@@ -618,7 +725,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     set({ plane: get().plane === 0 ? 1 : 0, proof: IDLE_PROOF })
   },
 
-  applyProofMessage: (msg) => {
+  applyProofMessage: async (msg) => {
     // Stale responses from a cancelled commit must not overwrite fresh state.
     if (msg.id !== requestId) return
 
@@ -642,7 +749,10 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       return
     }
 
-    const { pendingTarget, position, plane, chain, events, genesisId, prevEventId, published } = get()
+    // Capture the chain we are extending. A cancel or a respawn bumps requestId,
+    // so for this id events/head stay valid across the await; only `published`
+    // moves under us as the publisher drains, so that is re-read after signing.
+    const { pendingTarget, position, plane, events, genesisId, prevEventId } = get()
     const newPosition = pendingTarget ?? position
     const head = events[events.length - 1]
 
@@ -658,23 +768,46 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       plane,
       proofHash: msg.proofHash,
     }
-    const event = sign(
-      msg.mode === 'sidestep' && msg.sidestep
-        ? sidestepTemplate({ ...link, ...msg.sidestep })
-        : hopTemplate(link),
-    )
 
-    const stats: ChainStats = {
-      hops: chain.hops + (msg.mode === 'hop' ? 1 : 0),
-      sidesteps: chain.sidesteps + (msg.mode === 'sidestep' ? 1 : 0),
-      totalOps: chain.totalOps + (msg.mode === 'hop' ? msg.totalOps : 0),
-      totalHashes: chain.totalHashes + (msg.mode === 'sidestep' ? msg.totalOps : 0),
-      totalMs: chain.totalMs + msg.elapsedMs,
+    let event: NostrEvent
+    try {
+      event = await signEvent(
+        msg.mode === 'sidestep' && msg.sidestep
+          ? sidestepTemplate({ ...link, ...msg.sidestep })
+          : hopTemplate(link),
+      )
+    } catch (err) {
+      // The signer refused, or a bunker dropped mid-handshake: the move does not
+      // commit, and the avatar stays where the last committed hop left it.
+      if (msg.id !== requestId) return
+      set({
+        pendingTarget: null,
+        proof: {
+          ...IDLE_PROOF,
+          status: 'infeasible',
+          elapsedMs: msg.elapsedMs,
+          message: `Signing failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      })
+      return
     }
-    const nextEvents = [...events, event]
-    const nextPublished = { ...published, [event.id]: 'queued' as const }
 
-    const following = get().atHead()
+    // A remote signer can take seconds; a cancel or respawn may have landed
+    // while it was thinking. If so this receipt is for a chain that is gone.
+    if (msg.id !== requestId) return
+
+    const now = get()
+    const stats: ChainStats = {
+      hops: now.chain.hops + (msg.mode === 'hop' ? 1 : 0),
+      sidesteps: now.chain.sidesteps + (msg.mode === 'sidestep' ? 1 : 0),
+      totalOps: now.chain.totalOps + (msg.mode === 'hop' ? msg.totalOps : 0),
+      totalHashes: now.chain.totalHashes + (msg.mode === 'sidestep' ? msg.totalOps : 0),
+      totalMs: now.chain.totalMs + msg.elapsedMs,
+    }
+    const nextEvents = [...now.events, event]
+    const nextPublished = { ...now.published, [event.id]: 'queued' as const }
+
+    const following = now.atHead()
     set({
       position: newPosition,
       headPlane: plane,
@@ -696,7 +829,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       prevEventId: event.id,
       published: nextPublished,
       chain: stats,
-      positionHistory: [...get().positionHistory, newPosition],
+      positionHistory: [...now.positionHistory, newPosition],
     })
 
     saveChain(nextEvents, nextPublished, stats)
@@ -708,14 +841,14 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
     set({ live, publishError: null })
   },
 
-  respawn: () => {
+  respawn: async () => {
     // A proof in flight was for a chain that is about to stop existing.
     if (get().proof.status === 'computing') {
       cancelProof()
       requestId++
     }
     const { events } = get()
-    const fresh = derive(freshSpawn(events[events.length - 1]))
+    const fresh = derive(await freshSpawnAsync(currentSigner, events[events.length - 1]))
     set({
       ...fresh,
       cursor: fresh.position,
@@ -864,7 +997,41 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       at: t.position,
     })),
 
-  sign,
+  signEvent,
+
+  initSigner: async () => {
+    // Local identities are live from module load; an extension or bunker was
+    // only deferred. Force its reconnection now, so the first move never waits.
+    const pref = loadSignerPref()
+    if (!pref || pref.kind === 'local') return
+    try {
+      if (currentSigner.pubkey === pref.pubkey && currentSigner.reconnect) {
+        await currentSigner.reconnect()
+      } else {
+        await switchTo(await signerFromPref(pref))
+      }
+    } catch (err) {
+      set({ loginError: `Could not reconnect ${pref.kind}: ${err instanceof Error ? err.message : String(err)}` })
+    }
+  },
+  useNewKey: async () => { await switchTo(randomSigner()) },
+  useNsec: async (nsec) => {
+    try { await switchTo(signerFromNsec(nsec)) }
+    catch (err) { set({ loginError: err instanceof Error ? err.message : String(err) }) }
+  },
+  useNcryptsec: async (ncryptsec, password) => {
+    try { await switchTo(signerFromNcryptsec(ncryptsec, password)) }
+    catch (err) { set({ loginError: err instanceof Error ? err.message : String(err) }) }
+  },
+  useExtension: async () => {
+    try { await switchTo(await nip07Signer()) }
+    catch (err) { set({ loginError: err instanceof Error ? err.message : String(err) }) }
+  },
+  useBunker: async (uri) => {
+    try { await switchTo(await nip46Signer(uri)) }
+    catch (err) { set({ loginError: err instanceof Error ? err.message : String(err) }) }
+  },
+  clearLoginError: () => set({ loginError: null }),
 
   setPublishStatus: (id, status, reason) => {
     const { published, events, chain } = get()
@@ -951,7 +1118,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => ({
       cellDelta(alignTo(cursor[a.axis], scaleExp), origin[a.axis], scaleExp) * a.dir,
     ) as [number, number, number]
   },
-}))
+  }
+})
 
 // DEV is also true under vitest, which runs in node, and importing this module
 // for alignedOrigin must not blow up on a missing window. Same reason the

--- a/src/store/useProfiles.ts
+++ b/src/store/useProfiles.ts
@@ -1,0 +1,148 @@
+/**
+ * useProfiles.ts — who a pubkey is, cached.
+ *
+ * A pubkey is intelligible only with its kind:0: a name, a picture, maybe a
+ * nip05. Components ask for one by pubkey; this batches the misses into a
+ * single relay query, caches what comes back, and keeps it in localStorage so
+ * a reload does not refetch the world. Profiles live on the general relays
+ * (purplepag.es aggregates them), so it asks those alongside ours.
+ *
+ * The whole cache is one reactive record: a component that reads get(pubkey)
+ * re-renders when that profile arrives, without every row holding a
+ * subscription of its own.
+ */
+
+import { create } from 'zustand'
+import { queryAny } from '../lib/relay'
+import { GENERAL_RELAYS } from '../lib/contacts'
+import type { NostrEvent } from '../lib/events'
+
+export interface Profile {
+  pubkey: string
+  name: string | null
+  picture: string | null
+  about: string | null
+  nip05: string | null
+  /** created_at of the kind:0 we parsed, so a newer one wins. */
+  at: number
+}
+
+interface ProfilesState {
+  /** null = fetched, none found; undefined = not fetched. */
+  profiles: Record<string, Profile | null>
+  /** Ask for a profile; a miss is queued and fetched in the next batch. */
+  request: (pubkey: string) => void
+  get: (pubkey: string) => Profile | null | undefined
+}
+
+const STORAGE = 'onosendai:profiles'
+const HEX = /^[0-9a-f]{64}$/
+/** Refetch a cached profile after this, in case it changed. */
+const TTL_MS = 24 * 60 * 60 * 1000
+/** How many authors to ask for in one query. */
+const CHUNK = 100
+const FLUSH_MS = 250
+/** Profiles live on the general relays; the cyberspace relay is auth-gated and
+ * slow, and rarely holds kind:0, so a short wait on the general set is enough. */
+const PROFILE_WAIT_MS = 4000
+
+function loadCache(): Record<string, Profile | null> {
+  try {
+    const raw = localStorage.getItem(STORAGE)
+    const data = raw ? JSON.parse(raw) : {}
+    return data && typeof data === 'object' ? data : {}
+  } catch { return {} }
+}
+
+let saveHandle: number | null = null
+function saveCacheSoon(cache: Record<string, Profile | null>): void {
+  if (saveHandle !== null) return
+  saveHandle = window.setTimeout(() => {
+    saveHandle = null
+    try {
+      // Only real profiles are worth persisting; misses can be retried.
+      const keep: Record<string, Profile> = {}
+      for (const [pk, p] of Object.entries(cache)) if (p) keep[pk] = p
+      localStorage.setItem(STORAGE, JSON.stringify(keep))
+    } catch { /* quota or private mode */ }
+  }, 1000)
+}
+
+/** Parse a kind:0 into a Profile; null if the content is not usable JSON. */
+export function parseProfile(ev: NostrEvent): Profile | null {
+  try {
+    const meta = JSON.parse(ev.content) as Record<string, unknown>
+    const str = (v: unknown): string | null => (typeof v === 'string' && v.trim() ? v.trim() : null)
+    return {
+      pubkey: ev.pubkey,
+      name: str(meta.display_name) ?? str(meta.name),
+      picture: str(meta.picture),
+      about: str(meta.about),
+      nip05: str(meta.nip05),
+      at: ev.created_at,
+    }
+  } catch { return null }
+}
+
+const pending = new Set<string>()
+let flushHandle: number | null = null
+
+export const useProfiles = create<ProfilesState>((set, get) => {
+  const initial = loadCache()
+
+  async function flush(): Promise<void> {
+    flushHandle = null
+    const want = [...pending]
+    pending.clear()
+    if (want.length === 0) return
+
+    for (let i = 0; i < want.length; i += CHUNK) {
+      const authors = want.slice(i, i + CHUNK)
+      let events: NostrEvent[] = []
+      try {
+        events = await queryAny(GENERAL_RELAYS, { kinds: [0], authors }, PROFILE_WAIT_MS)
+      } catch { /* relays down */ }
+
+      const newest = new Map<string, Profile>()
+      for (const ev of events) {
+        const p = parseProfile(ev)
+        if (p && (!newest.has(p.pubkey) || p.at > newest.get(p.pubkey)!.at)) newest.set(p.pubkey, p)
+      }
+      const next = { ...get().profiles }
+      for (const pk of authors) next[pk] = newest.get(pk) ?? null
+      set({ profiles: next })
+      saveCacheSoon(next)
+    }
+  }
+
+  return {
+    profiles: initial,
+
+    request: (pubkey) => {
+      if (!HEX.test(pubkey)) return
+      const have = get().profiles[pubkey]
+      const stamp = withStamp.get(pubkey)
+      const fresh = have && stamp !== undefined && Date.now() - stamp < TTL_MS
+      if (fresh || pending.has(pubkey)) return
+      pending.add(pubkey)
+      if (flushHandle === null) flushHandle = window.setTimeout(() => void flush(), FLUSH_MS)
+    },
+
+    get: (pubkey) => get().profiles[pubkey],
+  }
+})
+
+if (import.meta.env.DEV && typeof window !== "undefined") { (window as unknown as { __profiles?: unknown }).__profiles = useProfiles }
+
+/** When each profile was fetched, so the TTL can refetch a stale one. */
+const withStamp = new Map<string, number>()
+useProfiles.subscribe((s, prev) => {
+  if (s.profiles === prev.profiles) return
+  const now = Date.now()
+  for (const pk of Object.keys(s.profiles)) if (s.profiles[pk] !== prev.profiles[pk]) withStamp.set(pk, now)
+})
+
+/** A short, human label for a pubkey: its name, or a shortened npub. */
+export function profileLabel(profile: Profile | null | undefined, npub: string): string {
+  return profile?.name ?? `${npub.slice(0, 12)}…${npub.slice(-4)}`
+}

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -66,6 +66,7 @@ export interface WorldItem {
   author?: string
   shard?: ShardModel
   text?: string
+  createdAt?: number
 }
 
 /** What a deploy is placing, before it lands. */
@@ -88,6 +89,8 @@ interface ShardsState {
   deleted: Record<string, true>
   inspecting: string | null
   scanning: boolean
+  /** A world item clicked open, by its inner event id. */
+  selectedSecret: string | null
 
   startDeployShard: (shardId: string) => void
   startDeployMessage: (text: string) => void
@@ -96,11 +99,14 @@ interface ShardsState {
   deploy: () => Promise<void>
   deleteInstance: (eventId: string) => Promise<void>
   inspect: (eventId: string | null) => void
+  selectSecret: (eventId: string | null) => void
   addDiscovered: (items: Hidden[]) => void
   setScanning: (scanning: boolean) => void
   testDiscovery: (eventId: string) => Promise<boolean>
   pendingShard: () => ShardModel | null
   worldItems: () => WorldItem[]
+  /** The clicked item, mine or discovered, as one shape. */
+  secretByEvent: (eventId: string) => WorldItem | null
 }
 
 const MINE_KEY = 'onosendai:deployments'
@@ -194,6 +200,7 @@ export const useShards = create<ShardsState>((set, get) => {
     deleted: loadDeleted(),
     inspecting: null,
     scanning: false,
+    selectedSecret: null,
 
     startDeployShard: (shardId) => set({ pending: { type: 'shard', shardId }, deployStatus: 'idle', deployError: null }),
     startDeployMessage: (text) => set({ pending: { type: 'message', text }, deployStatus: 'idle', deployError: null }),
@@ -297,6 +304,8 @@ export const useShards = create<ShardsState>((set, get) => {
 
     inspect: (eventId) => set({ inspecting: eventId }),
 
+    selectSecret: (eventId) => set({ selectedSecret: eventId }),
+
     addDiscovered: (items) => {
       if (items.length === 0) return
       const { deleted } = get()
@@ -330,16 +339,19 @@ export const useShards = create<ShardsState>((set, get) => {
     worldItems: () => {
       const out: WorldItem[] = []
       const seen = new Set<string>()
+      const me = useCyberspace.getState().identity.pubkey
       for (const d of get().mine) {
         seen.add(d.eventId)
-        out.push({ key: d.eventId, type: d.type, at: positionOf(d), plane: d.plane, height: d.height, mine: true, shard: d.shard, text: d.text })
+        out.push({ key: d.eventId, type: d.type, at: positionOf(d), plane: d.plane, height: d.height, mine: true, author: me, shard: d.shard, text: d.text, createdAt: d.createdAt })
       }
       for (const h of Object.values(get().discovered)) {
         if (seen.has(h.eventId)) continue
-        out.push({ key: h.eventId, type: h.type, at: h.at, plane: h.plane, height: h.height, mine: false, author: h.author, shard: h.shard, text: h.text })
+        out.push({ key: h.eventId, type: h.type, at: h.at, plane: h.plane, height: h.height, mine: false, author: h.author, shard: h.shard, text: h.text, createdAt: h.createdAt })
       }
       return out
     },
+
+    secretByEvent: (eventId) => get().worldItems().find((w) => w.key === eventId) ?? null,
   }
 })
 

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -204,7 +204,10 @@ export const useShards = create<ShardsState>((set, get) => {
 
     startDeployShard: (shardId) => set({ pending: { type: 'shard', shardId }, deployStatus: 'idle', deployError: null }),
     startDeployMessage: (text) => set({ pending: { type: 'message', text }, deployStatus: 'idle', deployError: null }),
-    setDeployHeight: (h) => set({ deployHeight: Math.max(0, Math.min(SCAN_MAX_HEIGHT, Math.round(h))) }),
+    // Buryable up to the compute ceiling (past that the region derivation
+    // throws); discovery only auto-scans to SCAN_MAX_HEIGHT, which the DeployBar
+    // warns about.
+    setDeployHeight: (h) => set({ deployHeight: Math.max(0, Math.min(MAX_COMPUTE_HEIGHT, Math.round(h))) }),
     cancelDeploy: () => set({ pending: null, deployStatus: 'idle', deployError: null }),
 
     deploy: async () => {

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -171,7 +171,7 @@ export const useShards = create<ShardsState>((set, get) => {
   /** Build and publish the region bag. */
   async function publishBag(inners: NostrEvent[], key: Uint8Array, lookupId: string, height: number, live: boolean): Promise<{ event: NostrEvent; published: boolean }> {
     const createdAt = nextBagAt(lookupId)
-    const event = cyber().sign(await bagTemplate(inners, key, lookupId, height, createdAt))
+    const event = await cyber().signEvent(await bagTemplate(inners, key, lookupId, height, createdAt))
     const result = live ? await publishMany(relaySet(), event) : { ok: true as const }
     return { event, published: live && result.ok }
   }
@@ -231,7 +231,7 @@ export const useShards = create<ShardsState>((set, get) => {
       set({ deployStatus: 'working', deployError: null })
       try {
         const rk = regionKeyAt(at, deployHeight, MAX_COMPUTE_HEIGHT)
-        const inner = cs.sign(innerTemplate)
+        const inner = await cs.signEvent(innerTemplate)
         const live = cs.live
         const existing = await gatherInners(rk.lookupId, rk.key, live)
         const allInners = mergeInners(existing, [inner])
@@ -282,7 +282,7 @@ export const useShards = create<ShardsState>((set, get) => {
       } else {
         // The last thing in the region: delete the envelope itself (NIP-09).
         if (cs.live && item.published) {
-          const del = cs.sign({
+          const del = await cs.signEvent({
             kind: 5,
             created_at: Math.floor(Date.now() / 1000),
             content: 'hidden content removed',

--- a/src/styles.css
+++ b/src/styles.css
@@ -864,6 +864,51 @@ kbd {
   white-space: nowrap;
 }
 
+/* ---------- Profile badge (face + name) ---------- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.badge__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pfp {
+  border-radius: 50%;
+  object-fit: cover;
+  flex: none;
+  display: inline-block;
+  background: rgba(0, 229, 255, 0.1);
+}
+
+.pfp--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #05070d;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.spectate__badge .badge__name {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+/* The avatars/targets/follows rows hold a badge where a bare name used to sit;
+ * the badge is the flexible column that ellipsizes. */
+.avatars__row .badge,
+.targets__row .badge,
+.targets__row--contact .badge {
+  min-width: 0;
+}
+
 /* ---------- Avatars ---------- */
 
 .avatars__find {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1183,6 +1183,168 @@ kbd {
   border-color: var(--danger);
 }
 
+/* ---------- Secret modal (a hidden thing, tapped in the world) ---------- */
+.modal__card.secret {
+  border-color: rgba(0, 229, 255, 0.5);
+  max-width: 440px;
+}
+
+.secret__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.secret__badge {
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+}
+
+.secret__badge--message { color: #ffd27d; }
+
+.secret__mine {
+  font-size: 8px;
+  letter-spacing: 0.16em;
+  color: #05070d;
+  background: var(--ok);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-weight: 700;
+}
+
+.secret__close {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 12px;
+  width: 26px;
+  height: 26px;
+  border-radius: 4px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.2);
+  cursor: pointer;
+}
+
+.secret__message {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #ffd27d;
+  background: rgba(255, 210, 125, 0.08);
+  border-left: 3px solid #ffd27d;
+  border-radius: 3px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.secret__shard {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  background: rgba(0, 229, 255, 0.06);
+  border-left: 3px solid var(--accent);
+  border-radius: 3px;
+}
+
+.secret__shard-name { font-size: 14px; color: var(--fg); }
+.secret__shard-meta { font-size: 10px; letter-spacing: 0.06em; color: var(--dim); }
+
+.secret__creator {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(0, 229, 255, 0.14);
+}
+
+.secret__label {
+  font-size: 8px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+
+.secret__person {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.secret__person-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.secret__name { font-size: 13px; color: var(--fg); }
+.secret__nip05 { font-size: 10px; color: var(--accent); }
+.secret__npub { font-size: 9px; color: var(--dim); }
+
+.secret__about {
+  margin: 8px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--dim);
+  max-height: 60px;
+  overflow-y: auto;
+}
+
+.secret__facts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.secret__facts dt {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dim);
+  margin-bottom: 2px;
+}
+
+.secret__facts dd { margin: 0; font-size: 11px; color: var(--fg); }
+
+.secret__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.secret__act {
+  flex: 1;
+  min-width: 100px;
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  height: 34px;
+  border-radius: 6px;
+  color: var(--accent);
+  background: rgba(0, 229, 255, 0.06);
+  border: 1px solid rgba(0, 229, 255, 0.4);
+  cursor: pointer;
+}
+
+.secret__act:hover { background: rgba(0, 229, 255, 0.16); }
+
+.secret__act.is-on {
+  color: #05070d;
+  background: var(--accent);
+  font-weight: 700;
+}
+
+.secret__act--danger {
+  color: var(--danger);
+  border-color: rgba(255, 59, 107, 0.5);
+  background: rgba(255, 59, 107, 0.08);
+}
+
 /* ---------- Deployment detail overlay ----------
  *
  * The wire record of a deployed shard, up while the scene is flown to it. Left

--- a/src/styles.css
+++ b/src/styles.css
@@ -3065,3 +3065,145 @@ kbd {
  * ring means nothing, since there is no extent to describe out there. */
 .target[data-mode='on'] .target__arrow { display: none; }
 .target[data-mode='off'] .target__ring { display: none; }
+
+/* ---------- Identity panel: who is signing ---------- */
+.identity__who {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.identity__who-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+
+.identity__name {
+  font-size: 13px;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.identity__signer {
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+}
+
+.identity__change {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  padding: 0 10px;
+  height: 26px;
+  border-radius: 3px;
+  color: var(--accent);
+  background: rgba(0, 229, 255, 0.06);
+  border: 1px solid rgba(0, 229, 255, 0.28);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.identity__change:hover {
+  background: rgba(0, 229, 255, 0.16);
+}
+
+/* ---------- Login modal (choosing who signs) ---------- */
+.modal__card.login {
+  border-color: rgba(0, 229, 255, 0.5);
+  max-width: 440px;
+  max-height: calc(100dvh - 32px);
+  overflow-y: auto;
+}
+
+.login__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.login__head .modal__title {
+  margin: 0;
+}
+
+.login__current {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 6px;
+  background: rgba(0, 229, 255, 0.05);
+  border: 1px solid rgba(0, 229, 255, 0.18);
+}
+
+.login__current-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.login__kind {
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+}
+
+.login__note {
+  margin: 12px 0;
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--dim);
+}
+
+.login__error {
+  margin: 0 0 12px;
+  word-break: break-word;
+}
+
+.login__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 12px;
+  margin-top: 12px;
+  border-top: 1px solid rgba(200, 245, 255, 0.08);
+}
+
+.login__section--row {
+  flex-direction: row;
+  gap: 8px;
+}
+
+.login__section--row .login__act {
+  flex: 1;
+}
+
+.login__label {
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+
+.login__input {
+  width: 100%;
+  font-size: 11px;
+  padding: 8px 9px;
+}
+
+.login__act {
+  margin-top: 2px;
+}
+
+.login__act:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1707,6 +1707,13 @@ kbd {
   color: var(--dim);
 }
 
+.deploybar__warn {
+  display: block;
+  font-size: 9px;
+  line-height: 1.5;
+  color: var(--warn);
+}
+
 .deploybar__deploy {
   margin-top: 2px;
   font-family: inherit;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3041,14 +3041,29 @@ kbd {
   opacity: 0.9;
 }
 
+/* Avatar and name, as one row just right of the marker's centre. */
+.target__body {
+  left: 14px;
+  top: 0;
+  translate: 0 -50%;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.9);
+}
+
+/* A circle that stays legible over any terrain: its own ring in the target's
+ * colour and a dark halo. */
+.target__body .pfp {
+  border: 1px solid currentColor;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.85);
+}
+
 .target__text {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  left: 12px;
-  top: -12px;
-  white-space: nowrap;
-  text-shadow: 0 0 6px rgba(0, 0, 0, 0.9);
 }
 
 .target__label {


### PR DESCRIPTION
## What

The avatar still spawns from a random key the instant the page loads, but that key is now overridable: bring an **nsec** or an encrypted **ncryptsec**, hand signing to a browser **extension (NIP-07)**, connect a remote **bunker (NIP-46)**, or roll a **new random key**. This is item 2 of the current batch (item 1 = profiles #28, item 3 = secret modal #29).

## How

- **`src/lib/signers.ts` (new)** — one `Signer` shape over local / nip07 / nip46, all `signEvent(t): Promise<NostrEvent>`. Local keys resolve instantly (wrapped in a resolved promise); extension and bunker are genuinely remote. Pref persistence (`onosendai:signer`) and a deferred-reconnect signer whose pubkey is known at once so the chain loads before the handshake finishes.
- **Signing is async everywhere.** `useCyberspace.sign()` became async `signEvent()` delegating to a mutable current signer. `applyProofMessage` awaits it and, because a remote signer can take seconds, **re-checks the request id after signing** (a cancel or respawn may have landed) and **re-reads `published`** (the publisher drains the chain while it waits). `respawn`, relay NIP-42 auth, and the shard/message deploy paths await it too.
- **Per-identity chains.** Chains now key by pubkey (`onosendai:chain:<pk>`, old single slot migrated in), so switching keys and back keeps each identity's local history. Switching signs a fresh spawn at the new key's coordinate; a returning identity drops back onto its own chain.
- **Startup reconnect.** A stored extension/bunker reconnects via `initSigner()` in `App`.
- **UI.** The Identity panel shows the current signer as a profile (avatar, name, npub) with a **CHANGE** button. `LoginModal` is portaled to `document.body` so it escapes the panel's stacking context (that was a real bug — nested, its `z-index` sat below sibling panels).

## Verified in a browser (Playwright, real UI)

- Paste an nsec → switches to its pubkey, fresh spawn, `local` kind
- A committed hop lands (proves the async signing path end to end)
- New random key → identity changes, fresh spawn
- Switch away and back → the 2-event chain is restored
- Reload → identity **and** chain persist
- Extension button disabled with no NIP-07 present
- Invalid nsec → friendly error, modal stays open

162 tests green, `tsc` and `vite build` clean.

## Stacking

Branches off `feat/secret-modal` (#29). Review/merge that first, or merge all three of this batch together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)