### PR TITLE
fix: follows list — spawned by distance, everyone else alphabetical

### DIFF
--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -10,13 +10,16 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
-import { coordToXyz, hexToCoord } from 'cyberspace-core'
-import { parsePubkey } from '../lib/chains'
+import { nip19 } from 'nostr-tools'
+import { latestByPubkey, parsePubkey, V2_ACTIONS } from '../lib/chains'
 import { fetchContacts, GENERAL_RELAYS, type Contact } from '../lib/contacts'
+import { query } from '../lib/relay'
 import { spectate } from '../lib/spectator'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
+import type { Position } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
+import { profileLabel, useProfiles } from '../store/useProfiles'
 import { ProfileBadge } from './ProfileBadge'
 
 export function TargetsPanel(): JSX.Element {
@@ -27,6 +30,9 @@ export function TargetsPanel(): JSX.Element {
   const [who, setWho] = useState(me.npub)
   const [contacts, setContacts] = useState<Contact[] | null>(null)
   const [contactsState, setContactsState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
+  // Where each follow actually is, for the ones the relay has a chain for.
+  const [positions, setPositions] = useState<Record<string, Position>>({})
+  const profiles = useProfiles((s) => s.profiles)
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {
     const t = window.setInterval(() => setNow(Date.now() / 1000), 10_000)
@@ -46,38 +52,69 @@ export function TargetsPanel(): JSX.Element {
   const whoHex = parsePubkey(who)
   const list = Object.values(targets)
 
-  // Nearest first. A follow you have never seen move still has a place: its
-  // spawn coordinate, straight from its pubkey (spec §3.1), which is exactly
-  // where it would appear. Most of a contact list has not spawned, so this is
-  // the honest position for nearly all of them. Ties (all but impossible across
-  // 85-bit coordinates) fall back to the name.
+  // Spawned first, nearest of them at the top; everyone else alphabetical below.
+  // A follow the relay has a chain for is really somewhere, so it sorts by that
+  // distance. Most of a contact list has never spawned and has no position at
+  // all, so they are equally "nowhere" and fall to the name, which is what makes
+  // a long list findable. Name is the profile name when it has arrived, else the
+  // petname, else the key.
   const sortedContacts = useMemo(() => {
     if (!contacts) return contacts
-    const withDistance = contacts.map((c) => {
-      const p = coordToXyz(hexToCoord(c.pubkey))
+    const d2 = (p: Position): bigint => {
       const dx = myPos.x - p.x
       const dy = myPos.y - p.y
       const dz = myPos.z - p.z
-      return { c, d2: dx * dx + dy * dy + dz * dz }
-    })
-    withDistance.sort((a, b) => {
-      if (a.d2 !== b.d2) return a.d2 < b.d2 ? -1 : 1
-      const an = (a.c.name ?? a.c.pubkey).toLowerCase()
-      const bn = (b.c.name ?? b.c.pubkey).toLowerCase()
+      return dx * dx + dy * dy + dz * dz
+    }
+    // The exact string ProfileBadge shows, so the order matches the names on
+    // screen: the profile name, else the petname, else the short npub.
+    const nameKey = (c: Contact): string => {
+      const p = profiles[c.pubkey]
+      return (p?.name ?? c.name ?? profileLabel(p, nip19.npubEncode(c.pubkey))).toLowerCase()
+    }
+    const byName = (a: Contact, b: Contact): number => {
+      const an = nameKey(a)
+      const bn = nameKey(b)
       return an < bn ? -1 : an > bn ? 1 : 0
+    }
+    return [...contacts].sort((a, b) => {
+      const pa = positions[a.pubkey]
+      const pb = positions[b.pubkey]
+      if (pa && pb) {
+        const da = d2(pa)
+        const db = d2(pb)
+        return da !== db ? (da < db ? -1 : 1) : byName(a, b)
+      }
+      if (pa) return -1
+      if (pb) return 1
+      return byName(a, b)
     })
-    return withDistance.map((x) => x.c)
-  }, [contacts, myPos])
+  }, [contacts, positions, myPos, profiles])
 
   const loadContacts = async (): Promise<void> => {
     if (!whoHex) return
+    const target = whoHex
     setContactsState('loading')
+    setPositions({})
+    let list: Contact[]
     try {
-      setContacts(await fetchContacts(whoHex))
-      setContactsState('ready')
+      list = await fetchContacts(target)
     } catch {
       setContactsState('error')
+      return
     }
+    setContacts(list)
+    setContactsState('ready')
+    // Best-effort: one query for every follow's chain, so the ones actually in
+    // cyberspace can sort by real distance. A failure just leaves them alongside
+    // the un-spawned, all alphabetical.
+    try {
+      const events = await query({ kinds: [3333], authors: list.map((c) => c.pubkey), '#A': V2_ACTIONS })
+      if (parsePubkey(who) !== target) return // a newer load has taken over
+      const pos: Record<string, Position> = {}
+      for (const a of latestByPubkey(events)) pos[a.pubkey] = a.position
+      setPositions(pos)
+    } catch { /* no positions: the whole list stays alphabetical */ }
   }
 
   return (


### PR DESCRIPTION
Follow-up to #31. You were right that the alphabetical secondary never showed.

## Why

The nearest-first sort gave **every** follow a spawn-coordinate distance, so no two ever tied and the alphabetical tiebreak never fired — a long list came out ordered by an arbitrary spawn-point distance, which looks random by name. But a follow who has never spawned isn't really anywhere, so a distance for them is fiction.

## Now

On load, one query fetches every follow's chain from the relay:
- Follows the relay **has a position for** sort nearest-first by where they actually are.
- Everyone else is equally "nowhere" and sorts **alphabetically** below them — which is what makes a long list findable.

The alphabetical key is the exact string `ProfileBadge` renders (profile name → petname → short npub), so the order matches the names on screen instead of the hex behind them.

## Verified in a browser

- **fiatjaf's 198 follows** (none in cyberspace): render fully alphabetical by visible name.
- **Crafted follow list**: a spawned member with the alphabetically-last petname ("zzz") renders **first**; the un-spawned rest come out A→Z (amy, bob, carol).
- 162 tests green, typecheck clean.

## Cost

One extra relay query per list load (best-effort — if it fails, the whole list just stays alphabetical). Branches off `v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)