### PR TITLE
Hyperspace: board, ride, and exit the Bitcoin block transit line (DECK-0001 v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ cd ../cyberspace-cli-js && npm install && npm run build
 | `P` | toggle dataspace and ideaspace |
 | `[` / `]` | chain explorer: one action back / forward (hold to repeat) |
 | `Home` / `End` | chain explorer: the spawn / the live head |
+| `H` | hyperspace line scrubber: browse the block line, set a destination |
 
 Movement is expressed in screen directions and resolved to world axes through
 the current view, so `W` is always "away from you" in any of the 24 reachable

--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
     <link rel="manifest" href="/site.webmanifest?v=1">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=1" color="#000000">
     <link rel="shortcut icon" href="/favicon.ico?v=1">
+    <!-- The menu logo, warmed before the menu first opens so it never pops
+         in and shifts the panel layout. -->
+    <link rel="preload" as="image" href="/logo.png">
     <meta name="msapplication-TileColor" content="#000000">
     <meta name="theme-color" content="#000000">
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fontsource/monaspace-krypton": "^5.3.0",
         "@react-three/fiber": "^8.17.10",
         "cyberspace-core": "git+https://github.com/arkin0x/cyberspace-cli-js.git#master",
+        "decimal.js": "^10.6.0",
         "nostr-tools": "^2.24.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2030,6 +2031,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-three/fiber": "^8.17.10",
         "cyberspace-core": "git+https://github.com/arkin0x/cyberspace-cli-js.git#master",
         "decimal.js": "^10.6.0",
+        "lucide-react": "^1.34.0",
         "nostr-tools": "^2.24.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2325,6 +2326,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.34.0.tgz",
+      "integrity": "sha512-vnjGJNI7Htk5+oWW8gXGuaLgwgAb0T6/iZbBrp9JCfRFwdNWZ0YTm3eyxjOLgwN6r8iyAf3UA70zNmBRBNv7yg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/maath": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@fontsource/monaspace-krypton": "^5.3.0",
     "@react-three/fiber": "^8.17.10",
     "cyberspace-core": "git+https://github.com/arkin0x/cyberspace-cli-js.git#master",
+    "decimal.js": "^10.6.0",
     "nostr-tools": "^2.24.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-three/fiber": "^8.17.10",
     "cyberspace-core": "git+https://github.com/arkin0x/cyberspace-cli-js.git#master",
     "decimal.js": "^10.6.0",
+    "lucide-react": "^1.34.0",
     "nostr-tools": "^2.24.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,10 +97,13 @@ export default function App(): JSX.Element {
       {!crowded && <Targets targets={targets} />}
       {!crowded && (
         <div className="instruments">
-          <BitReadout />
-          <ChainExplorer />
+          {/* Ordered by how often each is reached for right now: hyperspace
+              on top with its status bar, the chain under it, the XOR readout
+              last. */}
           <LineScrubber />
           <HyperspaceBar />
+          <ChainExplorer />
+          <BitReadout />
         </div>
       )}
       {showPanels && <Hud menuOpen={crowded} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,7 @@ export default function App(): JSX.Element {
       <SpectateBar />
       {!crowded && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
       {!crowded && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
-      {showPad && <TouchControls onDismiss={() => setPadOpen(false)} />}
+      {showPad && <TouchControls />}
       {!crowded && !padOpen && atHead && (
         <button
           className="chip touchhint"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,12 @@ export default function App(): JSX.Element {
     if (inspecting && isMobile) setPanelsOpen(false)
   }, [inspecting, isMobile])
 
+  // Reading a hidden thing owns the screen: the top-aligned modal sits where
+  // the instrument stack lives, so the stack stands aside and the hamburger
+  // folds instead of layering underneath it.
+  const secretOpen = useShards((s) => s.selectedSecret !== null)
+  useEffect(() => { if (secretOpen) setPanelsOpen(false) }, [secretOpen])
+
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.
   const crowded = isMobile && showPanels
@@ -95,7 +101,7 @@ export default function App(): JSX.Element {
     <div className="app">
       <Scene />
       {!crowded && <Targets targets={targets} />}
-      {!crowded && (
+      {!crowded && !secretOpen && (
         <div className="instruments">
           {/* Ordered by how often each is reached for right now: hyperspace
               on top with its status bar, the chain under it, the XOR readout

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import { BitReadout } from './hud/BitReadout'
 import { ChainExplorer } from './hud/ChainExplorer'
+import { HyperspaceBar } from './hud/HyperspaceBar'
+import { LineScrubber } from './hud/LineScrubber'
 import { SpectateBar } from './hud/SpectateBar'
 import { Workshop } from './workshop/Workshop'
 import { DeployBar } from './hud/DeployBar'
@@ -22,6 +24,7 @@ import { startPublisher } from './lib/publisher'
 import { startSelfSync } from './lib/selfSync'
 import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
+import { useHyperspace } from './store/useHyperspace'
 import { useShards } from './store/useShards'
 
 export default function App(): JSX.Element {
@@ -34,7 +37,7 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); void useCyberspace.getState().initSigner() }, [])
+  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync() }, [])
   const isMobile = useIsMobile()
   const targets = useTargets()
   // Off your own head there is nothing to drive: the movement controls stand
@@ -88,10 +91,12 @@ export default function App(): JSX.Element {
         <div className="instruments">
           <BitReadout />
           <ChainExplorer />
+          <LineScrubber />
         </div>
       )}
       {showPanels && <Hud menuOpen={crowded} />}
       <SpectateBar />
+      <HyperspaceBar />
       {!crowded && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
       {!crowded && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && <TouchControls onDismiss={() => setPadOpen(false)} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { startSelfSync } from './lib/selfSync'
 import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
 import { useHyperspace } from './store/useHyperspace'
+import { setSyncPriority } from './lib/hyperspace/anchors'
 import { useShards } from './store/useShards'
 
 export default function App(): JSX.Element {
@@ -40,10 +41,6 @@ export default function App(): JSX.Element {
   // targets' positions are kept current.
   useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync() }, [])
 
-  // Picking a destination in the scrubber is the moment the Hyperspace panel
-  // matters (BOARD and RIDE live there), so make sure the panels are open.
-  const hyperDestination = useHyperspace((s) => s.destination)
-  useEffect(() => { if (hyperDestination !== null) setPanelsOpen(true) }, [hyperDestination])
   const isMobile = useIsMobile()
   const targets = useTargets()
   // Off your own head there is nothing to drive: the movement controls stand
@@ -73,6 +70,11 @@ export default function App(): JSX.Element {
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.
   const crowded = isMobile && showPanels
+
+  // The anchor backfill runs full tilt while the panels are open (the sync
+  // numbers are being watched) and breathes between batches while they are
+  // closed, so playing in the scene gets the frames.
+  useEffect(() => { setSyncPriority(showPanels) }, [showPanels])
 
   const [padOpen, setPadOpen] = useState(true)
   const [viewMenuOpen, setViewMenuOpen] = useState(false)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useKeyboard } from './hooks/useKeyboard'
 import { useProofListener } from './hooks/useProofListener'
 import { useIsMobile } from './hooks/useIsMobile'
 import { useTargets } from './hooks/useTargets'
+import { startCalibration } from './lib/calibration'
 import { startPublisher } from './lib/publisher'
 import { startSelfSync } from './lib/selfSync'
 import { startTracker } from './lib/tracker'
@@ -37,7 +38,12 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync() }, [])
+  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync() }, [])
+
+  // Picking a destination in the scrubber is the moment the Hyperspace panel
+  // matters (BOARD and RIDE live there), so make sure the panels are open.
+  const hyperDestination = useHyperspace((s) => s.destination)
+  useEffect(() => { if (hyperDestination !== null) setPanelsOpen(true) }, [hyperDestination])
   const isMobile = useIsMobile()
   const targets = useTargets()
   // Off your own head there is nothing to drive: the movement controls stand
@@ -92,11 +98,11 @@ export default function App(): JSX.Element {
           <BitReadout />
           <ChainExplorer />
           <LineScrubber />
+          <HyperspaceBar />
         </div>
       )}
       {showPanels && <Hud menuOpen={crowded} />}
       <SpectateBar />
-      <HyperspaceBar />
       {!crowded && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
       {!crowded && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && <TouchControls onDismiss={() => setPadOpen(false)} />}

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -9,6 +9,7 @@
 
 import { useEffect } from 'react'
 import { useCyberspace } from '../store/useCyberspace'
+import { useHyperspace } from '../store/useHyperspace'
 import { useWorkshop } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { moveDirection, type MoveName } from '../lib/moves'
@@ -104,6 +105,16 @@ export function useKeyboard(): void {
       if (event.code === 'KeyP') {
         event.preventDefault()
         store.togglePlane()
+        return
+      }
+
+      // The hyperspace line scrubber: H opens it at the tip of the line, H
+      // again puts it away. The camera fly-to and its clearing live in
+      // LineScrubber's effect, so the key and the chip drive one mechanism.
+      if (event.code === 'KeyH') {
+        event.preventDefault()
+        const hs = useHyperspace.getState()
+        hs.setScrubHeight(hs.scrubHeight === null ? hs.tipHeight ?? 0 : null)
         return
       }
 

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -9,7 +9,7 @@
 
 import { useEffect } from 'react'
 import { useCyberspace } from '../store/useCyberspace'
-import { useHyperspace } from '../store/useHyperspace'
+import { exitHyperspaceView, useHyperspace } from '../store/useHyperspace'
 import { useWorkshop } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { moveDirection, type MoveName } from '../lib/moves'
@@ -75,6 +75,9 @@ export function useKeyboard(): void {
         event.preventDefault()
         // Deploying: back out of it rather than resetting the view.
         if (useShards.getState().pending) { useShards.getState().cancelDeploy(); return }
+        // Viewing a stop or EARTH: come home before anything else.
+        const hs = useHyperspace.getState()
+        if (hs.scrubHeight !== null || hs.viewOwned) { exitHyperspaceView(); return }
         store.resetView()
         return
       }
@@ -114,7 +117,8 @@ export function useKeyboard(): void {
       if (event.code === 'KeyH') {
         event.preventDefault()
         const hs = useHyperspace.getState()
-        hs.setScrubHeight(hs.scrubHeight === null ? hs.tipHeight ?? 0 : null)
+        if (hs.scrubHeight === null) hs.setScrubHeight(hs.tipHeight ?? 0)
+        else exitHyperspaceView()
         return
       }
 

--- a/src/hooks/useTargets.ts
+++ b/src/hooks/useTargets.ts
@@ -22,6 +22,7 @@ const EARTH_RADIUS = 6371n * 1000n * (1n << 33n)
 export function useTargets(): CyberTarget[] {
   const plane = useCyberspace((s) => s.anchorPlane)
   const spectating = useCyberspace((s) => s.spectate !== null)
+  const focused = useCyberspace((s) => s.focus !== null)
   const position = useCyberspace((s) => s.position)
   const tracked = useCyberspace((s) => s.targets)
   const focus = useCyberspace((s) => s.focusPubkey())
@@ -31,9 +32,11 @@ export function useTargets(): CyberTarget[] {
     // Tracked pubkeys first, except the one the scene is looking through: a
     // marker for the avatar you are standing on would sit on your own centre.
     for (const t of useCyberspace.getState().targetList()) if (t.id !== focus) out.push(t)
-    // While you are looking through someone else's eyes, the way home is a
-    // thing worth pointing at from anywhere.
-    if (spectating) out.push({ id: 'you', label: 'YOU', color: YOU, at: position })
+    // While the camera is anywhere you are not (someone else's eyes, a
+    // hyperspace stop, EARTH, a shard), the way home is a thing worth
+    // pointing at from anywhere; the projector's distance readout doubles as
+    // how far the viewed place is from where you actually stand.
+    if (spectating || focused) out.push({ id: 'you', label: 'YOU', color: YOU, at: position })
     // Ideaspace has no physical mapping, so there is no planet in it to point at.
     if (plane === 0) {
       out.push({
@@ -47,5 +50,5 @@ export function useTargets(): CyberTarget[] {
     return out
     // tracked is what targetList reads; listed so the memo follows it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [plane, spectating, position, tracked, focus])
+  }, [plane, spectating, focused, position, tracked, focus])
 }

--- a/src/hooks/useTerrainVolume.ts
+++ b/src/hooks/useTerrainVolume.ts
@@ -21,6 +21,7 @@ import {
   BLOCK_BITS, BLOCK_SIZE, cacheSize, inflightRuns, isPending,
   onTerrainData, readK, requestRun,
 } from '../lib/terrainCache'
+import { clearRunQueue } from '../lib/workers'
 import { UNKNOWN } from '../workers/terrain.worker'
 import type { Position } from '../lib/space'
 import type { ViewWindow } from './useViewWindow'
@@ -64,7 +65,7 @@ function cellAt(
   return p
 }
 
-export function useTerrainVolume(win: ViewWindow, axes: ViewAxes): TerrainVolume {
+export function useTerrainVolume(win: ViewWindow, axes: ViewAxes, suspend = false): TerrainVolume {
   // The anchor: the terrain is around whoever the scene is anchored on.
   const position = useCyberspace((s) => s.anchor)
   const scaleExp = useCyberspace((s) => s.scaleExp)
@@ -92,7 +93,17 @@ export function useTerrainVolume(win: ViewWindow, axes: ViewAxes): TerrainVolume
 
   const originKey = `${position.x},${position.y},${position.z}`
 
+  // Suspended (an Earth or hyperspace view): drop any queued terrain work so
+  // the pool goes quiet, and hand back an empty volume. The memo below keys
+  // on `suspend`, so leaving the view rebuilds and rescans automatically.
+  useEffect(() => {
+    if (suspend) clearRunQueue()
+  }, [suspend])
+
   return useMemo(() => {
+    if (suspend) {
+      return { values: new Uint8Array(VOLUME_SIZE ** 3).fill(UNKNOWN), radius: VOLUME_RADIUS }
+    }
     const t0 = performance.now()
     const R = VOLUME_RADIUS
     const N = VOLUME_SIZE
@@ -171,5 +182,5 @@ export function useTerrainVolume(win: ViewWindow, axes: ViewAxes): TerrainVolume
     return { values, radius: R }
     // originKey stands in for position, whose identity changes on every move.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [originKey, scaleExp, plane, axes, win.right, win.up, win.out, dataVersion])
+  }, [originKey, scaleExp, plane, axes, win.right, win.up, win.out, dataVersion, suspend])
 }

--- a/src/hooks/useTerrainVolume.ts
+++ b/src/hooks/useTerrainVolume.ts
@@ -23,6 +23,7 @@ import {
 } from '../lib/terrainCache'
 import { clearRunQueue } from '../lib/workers'
 import { UNKNOWN } from '../workers/terrain.worker'
+import { CURSOR_SETTLE_MS } from './useViewWindow'
 import type { Position } from '../lib/space'
 import type { ViewWindow } from './useViewWindow'
 import type { Plane } from 'cyberspace-core'
@@ -78,14 +79,32 @@ export function useTerrainVolume(win: ViewWindow, axes: ViewAxes, suspend = fals
     // Throttled rather than per-frame. A volume resolves as hundreds of small
     // runs, and rescanning every cell on each arrival is what made filling it
     // take seconds: the sampling is milliseconds, the scanning is not.
+    //
+    // The flush also waits out cursor movement. Results requested before a run
+    // of keypresses keep arriving during it, and bumping dataVersion then puts
+    // a full rescan and geometry rebuild inside the movement itself, which is
+    // exactly the stutter the settle delay exists to remove. The data loses
+    // nothing by waiting: it lands in the cache the moment it arrives, and the
+    // rescan on settle picks it all up at once.
+    let lastMove = 0
+    const unsubMove = useCyberspace.subscribe((s, prev) => {
+      if (s.cursor !== prev.cursor) lastMove = performance.now()
+    })
+    const fire = (): void => {
+      const since = performance.now() - lastMove
+      if (since < CURSOR_SETTLE_MS) {
+        flushHandle.current = window.setTimeout(fire, CURSOR_SETTLE_MS - since)
+        return
+      }
+      flushHandle.current = null
+      setDataVersion((v) => v + 1)
+    }
     const unsubscribe = onTerrainData(() => {
       if (flushHandle.current !== null) return
-      flushHandle.current = window.setTimeout(() => {
-        flushHandle.current = null
-        setDataVersion((v) => v + 1)
-      }, FLUSH_MS)
+      flushHandle.current = window.setTimeout(fire, FLUSH_MS)
     })
     return () => {
+      unsubMove()
       unsubscribe()
       if (flushHandle.current !== null) clearTimeout(flushHandle.current)
     }

--- a/src/hooks/useViewWindow.ts
+++ b/src/hooks/useViewWindow.ts
@@ -11,7 +11,7 @@
  * so sub-cell drift does not rebuild geometry every frame.
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useCyberspace } from '../store/useCyberspace'
 
 export interface ViewWindow {
@@ -21,50 +21,71 @@ export interface ViewWindow {
 }
 
 /**
- * How long the window waits behind the cursor before it moves.
+ * How long the cursor must be still before the window follows it.
  *
  * The window is what the terrain volume is centred on, and recentring it costs
- * a full rescan of every cell in the volume, measured at ~37ms. Running that
- * inside the same render that moves the cursor put it directly on the critical
- * path of a keypress, which is the one thing that has to feel instant.
+ * a full rescan of every cell in the volume plus a geometry rebuild, measured
+ * at 30 to 60ms of main thread. Paying that per keypress put it directly on
+ * the critical path of movement, which is the one thing that has to feel
+ * instant. Terrain has no such requirement: while you are travelling the stale
+ * field is fine, and it need not update at all until you stop.
  *
- * Terrain has no such requirement: it can arrive a frame or two late without
- * anyone noticing, and while a key is held it need not arrive at all until you
- * stop. So the cursor moves now and the field catches up, rather than the field
- * holding the cursor back.
+ * 250ms is chosen to outlast every repeating input in the app: OS key repeat
+ * delivers a keydown every 30 to 80ms and the touch pad repeats at 110ms, so
+ * any held or rapidly tapped run of moves coalesces into a single rescan when
+ * you come to rest, while after a lone tap the field still catches up within a
+ * quarter second.
  */
-const SETTLE_MS = 90
+export const CURSOR_SETTLE_MS = 250
+
+/** The window the cursor is in right now, read straight off the store. */
+function read(): ViewWindow {
+  const [right, up, out] = useCyberspace.getState().cursorOffset()
+  return { right: Math.round(right), up: Math.round(up), out: Math.round(out) }
+}
 
 export function useViewWindow(): ViewWindow {
-  const cursor = useCyberspace((s) => s.cursor)
-  const anchor = useCyberspace((s) => s.anchor)
-  const exploreIndex = useCyberspace((s) => s.exploreIndex)
-  const scaleExp = useCyberspace((s) => s.scaleExp)
-  const view = useCyberspace((s) => s.view)
-
-  const read = (): ViewWindow => {
-    const [right, up, out] = useCyberspace.getState().cursorOffset()
-    return { right: Math.round(right), up: Math.round(up), out: Math.round(out) }
-  }
-
   const [win, setWin] = useState<ViewWindow>(read)
-  const handle = useRef<number | null>(null)
 
   useEffect(() => {
-    if (handle.current !== null) clearTimeout(handle.current)
-    handle.current = window.setTimeout(() => {
-      handle.current = null
+    let handle: number | null = null
+
+    const fire = (): void => {
+      handle = null
       const next = read()
       setWin((prev) =>
         prev.right === next.right && prev.up === next.up && prev.out === next.out ? prev : next,
       )
-    }, SETTLE_MS)
-    return () => {
-      if (handle.current !== null) clearTimeout(handle.current)
     }
-    // cursorOffset derives from exactly these five.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cursor, anchor, exploreIndex, scaleExp, view])
+    const schedule = (): void => {
+      if (handle !== null) clearTimeout(handle)
+      handle = window.setTimeout(fire, CURSOR_SETTLE_MS)
+    }
+
+    // A transient store subscription rather than selector hooks. Subscribing
+    // this hook to `cursor` re-rendered the entire World subtree on every
+    // keypress just to restart a timer, so each move paid a React commit it
+    // did not need. The subscription restarts the timer without rendering
+    // anything, and the only render is the setWin once the cursor settles.
+    const unsubscribe = useCyberspace.subscribe((s, prev) => {
+      if (
+        s.cursor !== prev.cursor ||
+        s.anchor !== prev.anchor ||
+        s.exploreIndex !== prev.exploreIndex ||
+        s.scaleExp !== prev.scaleExp ||
+        s.view !== prev.view
+      ) schedule()
+    })
+
+    // The store may have moved between the initial state read and this effect
+    // attaching, so reconcile once on mount.
+    schedule()
+
+    return () => {
+      unsubscribe()
+      if (handle !== null) clearTimeout(handle)
+    }
+  }, [])
 
   return win
 }

--- a/src/hud/BitReadout.tsx
+++ b/src/hud/BitReadout.tsx
@@ -78,7 +78,9 @@ function toHex(binary: string): string {
 export function BitReadout(): JSX.Element {
   // Open by default: it is the readout that explains what everything else on
   // screen costs, so it has to be seen before anyone would think to dismiss it.
-  const [open, setOpen] = useState(true)
+  // Closed by default: screen space in the instrument stack is contested,
+  // and the readout is a thing you open when you want it, not a landlord.
+  const [open, setOpen] = useState(false)
   // The window can be read as binary, where the wall is a shape, or as hex,
   // where it is compact. Tapping the open grid flips between them.
   const [hex, setHex] = useState(false)

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -14,6 +14,7 @@ import { LoginModal } from './LoginModal'
 import { AvatarsPanel } from './AvatarsPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
+import { HyperspacePanel } from './HyperspacePanel'
 import { RelaysPanel } from './RelaysPanel'
 import { TargetsPanel } from './TargetsPanel'
 import { ShardsPanel } from './ShardsPanel'
@@ -200,6 +201,7 @@ function Controls(): JSX.Element {
     ['Q / E', 'scale step up / down (zoom out / in)'],
     ['R / F', 'cursor along depth axis'],
     ['P', 'toggle plane'],
+    ['H', 'hyperspace line scrubber'],
     ['[ / ]', 'chain explorer: back / forward one action'],
     ['Home / End', 'chain explorer: spawn / live head'],
   ]
@@ -238,6 +240,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
       <div className="hud__col hud__col--right">
         <ProofPanel />
         <ChainPanel />
+        <HyperspacePanel />
         <Legend />
         <ShardsPanel />
         <Controls />

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -31,7 +31,9 @@ function signed(axis: string, dir: number): string {
 function Brand(): JSX.Element {
   return (
     <header className="brand">
-      <img src="/logo.png" alt="ONOSENDAI" />
+      {/* Intrinsic dimensions reserve the box before the file arrives, so
+          even a cold cache cannot shift the layout under the pointer. */}
+      <img src="/logo.png" alt="ONOSENDAI" width={1871} height={354} decoding="async" />
       <p>Cyberspace Protocol v2 spatial explorer</p>
     </header>
   )

--- a/src/hud/HyperspaceBar.tsx
+++ b/src/hud/HyperspaceBar.tsx
@@ -12,12 +12,29 @@
 
 import { formatMs } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
+import { exitHyperspaceView, useHyperspace } from '../store/useHyperspace'
 import { abortRide, useRideRun } from './HyperspacePanel'
 
 export function HyperspaceBar(): JSX.Element | null {
   const transit = useCyberspace((s) => s.transit)
   const progress = useRideRun((s) => s.progress)
-  if (transit === null && progress === null) return null
+  const viewOwned = useHyperspace((s) => s.viewOwned)
+  const focusLabel = useCyberspace((s) => s.focus?.label ?? null)
+  if (transit === null && progress === null) {
+    // Just looking: the bar is the always-visible way home from VIEW, EARTH,
+    // or a scrubbed stop, since the panel column may be folded away.
+    if (!viewOwned) return null
+    return (
+      <div className="hyperbar" role="status">
+        <span className="hyperbar__glyph" aria-hidden="true">◆</span>
+        <span className="hyperbar__text">
+          <span className="hyperbar__label">VIEWING</span>
+          <span className="hyperbar__meta">{focusLabel ?? 'HYPERSPACE'}</span>
+        </span>
+        <button className="hyperbar__end" onClick={() => exitHyperspaceView()}>RETURN</button>
+      </div>
+    )
+  }
 
   const label = progress !== null
     ? `RIDING ${progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 100}%`

--- a/src/hud/HyperspaceBar.tsx
+++ b/src/hud/HyperspaceBar.tsx
@@ -1,0 +1,46 @@
+/**
+ * HyperspaceBar.tsx - what is true while you are on the line.
+ *
+ * Boarded is a real chain state with nothing visible in the scene: the enter
+ * event is signed and the next ride departs from it, but the avatar has not
+ * moved (§3.3). Without a bar saying so, BOARDED would be indistinguishable
+ * from standing still, and the way out would vanish whenever the panels fold.
+ * Modelled on SpectateBar; the two are mutually exclusive in practice, since
+ * boarding requires being at your own head, but this one stacks below it so a
+ * surprise overlap never hides either exit button.
+ */
+
+import { formatMs } from '../lib/space'
+import { useCyberspace } from '../store/useCyberspace'
+import { abortRide, useRideRun } from './HyperspacePanel'
+
+export function HyperspaceBar(): JSX.Element | null {
+  const transit = useCyberspace((s) => s.transit)
+  const progress = useRideRun((s) => s.progress)
+  if (transit === null && progress === null) return null
+
+  const label = progress !== null
+    ? `RIDING ${progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 100}%`
+    : 'HYPERSPACE · BOARDED'
+  const meta = progress !== null
+    ? `BLOCK ${progress.done}/${progress.total}${progress.etaMs !== null ? ` · ETA ${formatMs(progress.etaMs)}` : ''}`
+    : 'PICK A STOP AND RIDE · MOVING CANCELS'
+
+  // One gesture whatever the stage: stop any pool, forget the boarding. The
+  // wire needs nothing, the next ordinary hop cancels it there (§3.3).
+  const exit = (): void => {
+    abortRide()
+    useCyberspace.getState().cancelTransit()
+  }
+
+  return (
+    <div className="hyperbar" role="status">
+      <span className="hyperbar__glyph" aria-hidden="true">◆</span>
+      <span className="hyperbar__text">
+        <span className="hyperbar__label">{label}</span>
+        <span className="hyperbar__meta">{meta}</span>
+      </span>
+      <button className="hyperbar__end" onClick={exit}>{progress !== null ? 'CANCEL' : 'EXIT'}</button>
+    </div>
+  )
+}

--- a/src/hud/HyperspaceBar.tsx
+++ b/src/hud/HyperspaceBar.tsx
@@ -41,7 +41,7 @@ export function HyperspaceBar(): JSX.Element | null {
     : 'HYPERSPACE · BOARDED'
   const meta = progress !== null
     ? `BLOCK ${progress.done}/${progress.total}${progress.etaMs !== null ? ` · ETA ${formatMs(progress.etaMs)}` : ''}`
-    : 'PICK A STOP AND RIDE · MOVING CANCELS'
+    : 'PICK A BLOCK AND RIDE · MOVING CANCELS'
 
   // One gesture whatever the stage: stop any pool, forget the boarding. The
   // wire needs nothing, the next ordinary hop cancels it there (§3.3).

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -195,7 +195,7 @@ export function HyperspacePanel(): JSX.Element {
   }, [destination, position, plane, indexVersion])
 
   const destStop = destination !== null ? getStopByHeight(destination) : undefined
-  const tag = ready ? `READY ${stopCount()} STOPS`
+  const tag = ready ? `READY ${stopCount()} BLOCKS`
     : sync.status === 'error' ? 'ERROR'
       : sync.status === 'idle' ? 'IDLE'
         : sync.status === 'loading-cache'
@@ -210,7 +210,7 @@ export function HyperspacePanel(): JSX.Element {
       </header>
 
       <div className="hyper__group">
-        <span className="legend__label hyper__kicker hyper__kicker--nearest">Nearest stop</span>
+        <span className="legend__label hyper__kicker hyper__kicker--nearest">Nearest block</span>
         {nearest ? (
           <>
             <dl className="stats">
@@ -243,10 +243,10 @@ export function HyperspacePanel(): JSX.Element {
                 // scale, so the stop reads as a place you could stand at.
                 34,
               ) }}
-            >VIEW NEAREST STOP</button>
+            >VIEW NEAREST BLOCK</button>
           </>
         ) : (
-          <p className="legend__note">No stops in the index yet.</p>
+          <p className="legend__note">No blocks in the index yet.</p>
         )}
       </div>
 
@@ -283,8 +283,8 @@ export function HyperspacePanel(): JSX.Element {
               )}
             </dl>
             <p className="legend__note">
-              STATION is where boarding sets you down: your nearest stop as of
-              the synced tip. The ride runs from it to the destination; all of
+              STATION is where boarding sets you down: your nearest block as
+              of the synced tip. The ride runs from it to the destination; all of
               the per-block work runs locally and resumes if interrupted.
             </p>
           </>
@@ -322,6 +322,18 @@ export function HyperspacePanel(): JSX.Element {
           <button className="hyper__btn hyper__btn--abort" onClick={abortRide}>ABORT</button>
         )}
       </div>
+      {/* A dead button that never says why reads as broken. One line names
+          the gate that is actually holding BOARD shut; the answer is never
+          proof of work, because boarding itself costs none. */}
+      {transit === null && progress === null && (
+        !ready ? (
+          <p className="hyper__why">BOARD UNLOCKS WHEN THE LINE FINISHES SYNCING</p>
+        ) : destination === null ? (
+          <p className="hyper__why">BOARD NEEDS A DESTINATION BLOCK: PICK ONE ON THE LINE (H)</p>
+        ) : !atHead ? (
+          <p className="hyper__why">BOARD STARTS FROM YOUR AVATAR: RETURN TO IT FIRST</p>
+        ) : null
+      )}
       <button
         className="hyper__btn hyper__btn--earth"
         onClick={() => {
@@ -340,11 +352,12 @@ export function HyperspacePanel(): JSX.Element {
       {rideError && <p className="notice">{rideError}</p>}
 
       <p className="legend__note">
-        The nearest stop is your station: the stop boarding sets you down at.
-        VIEW NEAREST STOP flies the camera there; the viewing bar's RETURN or
-        Escape brings it home at your previous zoom. Boarding marks your chain; the ride proves fresh work for every block
-        passed and sets you down exactly at the stop. Leaving is an ordinary
-        hop, so the last mile from any stop is normal movement.
+        The nearest block is your station: the block boarding sets you down
+        at. VIEW NEAREST BLOCK flies the camera there; the viewing bar's
+        RETURN or Escape brings it home at your previous zoom. Boarding marks
+        your chain; the ride proves fresh work for every block passed and
+        sets you down exactly at the block. Leaving is an ordinary hop, so
+        the last mile from any block is normal movement.
       </p>
     </section>
   )

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -23,6 +23,16 @@ import { calibrate, computeRideProof, leafBenchmarkMs, type RideProgress } from 
 import { findStation, nearestStops } from '../lib/hyperspace/station'
 import { stopCoordExact, type Stop } from '../lib/hyperspace/stops'
 import { formatMs, formatOps, type Position } from '../lib/space'
+
+/** Ride estimates run to hours and days; raw seconds read as noise. */
+function formatDuration(ms: number): string {
+  if (ms < 90_000) return formatMs(ms)
+  const m = ms / 60_000
+  if (m < 90) return `${m.toFixed(0)} min`
+  const h = m / 60
+  if (h < 48) return `${h.toFixed(1)} h`
+  return `${(h / 24).toFixed(1)} d`
+}
 import { useCyberspace } from '../store/useCyberspace'
 import { exitHyperspaceView, ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
 
@@ -84,7 +94,15 @@ export async function startRide(): Promise<void> {
   // uses, rather than trusting anything cached from before the choice.
   const { position, plane } = useCyberspace.getState()
   const here = xyzToCoord(position.x, position.y, position.z, plane)
-  const station = findStation(getStopIndex(), here, destination)
+  // DECK-0001 v3 §4.2 (as amended): the station set is bounded by a declared
+  // as_of height, not the destination. Declare the tip we synced, so the
+  // station is the genuine nearest stop; the bound rides in the event.
+  const asOf = useHyperspace.getState().tipHeight
+  if (asOf === null || asOf < destination) {
+    useRideRun.setState({ error: 'The line is not synced past the destination yet.', progress: null })
+    return
+  }
+  const station = findStation(getStopIndex(), here, asOf)
   if (station === null) {
     useRideRun.setState({ error: 'No station: no stop at or below the destination height' })
     return
@@ -112,6 +130,7 @@ export async function startRide(): Promise<void> {
       controller.signal,
     )
     await useCyberspace.getState().completeRide({
+      asOf,
       toCoordHex: coordToHex(stopCoordExact(destStop)),
       fromHeight: station.stop.height,
       toHeight: destination,
@@ -170,7 +189,8 @@ export function HyperspacePanel(): JSX.Element {
   const estimate = useMemo(() => {
     if (destination === null) return null
     const here = xyzToCoord(position.x, position.y, position.z, plane)
-    const station = findStation(getStopIndex(), here, destination)
+    const asOf = useHyperspace.getState().tipHeight
+    const station = findStation(getStopIndex(), here, Math.max(asOf ?? destination, destination))
     if (station === null) return null
     return { station, length: rideBlocks(station.stop.height, destination).length }
   }, [destination, position, plane, indexVersion])
@@ -254,13 +274,15 @@ export function HyperspacePanel(): JSX.Element {
                   </div>
                   <div>
                     <dt>Est. time</dt>
-                    <dd>{benchMs === null ? 'CALIBRATING' : formatMs(estimate.length * benchMs)}</dd>
+                    <dd>{benchMs === null ? 'CALIBRATING' : formatDuration(estimate.length * benchMs)}</dd>
                   </div>
                 </>
               )}
             </dl>
             <p className="legend__note">
-              All of the per-block work runs locally and resumes if interrupted.
+              STATION is where boarding sets you down: your nearest stop as of
+              the synced tip. The ride runs from it to the destination; all of
+              the per-block work runs locally and resumes if interrupted.
             </p>
           </>
         )}

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -347,7 +347,9 @@ export function HyperspacePanel(): JSX.Element {
             useCyberspace.getState().focusOn(centre, 0, 'EARTH', 52)
           }
         }}
-      >EARTH</button>
+      >{/* The astronomical symbol for Earth, matching the HUD's glyph
+          voice (the touchpad's vector marks, the badge glyphs). */}
+        <span aria-hidden="true">⊕</span> EARTH</button>
       {sync.error && <p className="notice">{sync.error}</p>}
       {rideError && <p className="notice">{rideError}</p>}
 

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -24,7 +24,7 @@ import { findStation, nearestStops } from '../lib/hyperspace/station'
 import { stopCoordExact, type Stop } from '../lib/hyperspace/stops'
 import { formatMs, formatOps, type Position } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
-import { getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
+import { exitHyperspaceView, ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
 
 /**
  * Where a stop sits, for the camera. The float64-approximate coordinate is
@@ -135,6 +135,7 @@ const kindLabel = (stop: Stop): string => (stop.kind === 'port' ? 'PORT' : 'LAND
 
 export function HyperspacePanel(): JSX.Element {
   const sync = useHyperspace((s) => s.sync)
+  const viewOwned = useHyperspace((s) => s.viewOwned)
   const indexVersion = useHyperspace((s) => s.indexVersion)
   const destination = useHyperspace((s) => s.destination)
   const transit = useCyberspace((s) => s.transit)
@@ -213,13 +214,13 @@ export function HyperspacePanel(): JSX.Element {
             </dl>
             <button
               className="avatars__spectate"
-              onClick={() => useCyberspace.getState().focusOn(
+              onClick={() => { ownHyperspaceView(); useCyberspace.getState().focusOn(
                 stopPosition(nearest.stop),
                 stopPlane(nearest.stop),
                 `STATION · BLOCK ${nearest.stop.height}`,
                 34,
-              )}
-            >SPECTATE</button>
+              ) }}
+            >VIEW</button>
           </>
         ) : (
           <p className="legend__note">No stops in the index yet.</p>
@@ -298,14 +299,17 @@ export function HyperspacePanel(): JSX.Element {
       </div>
       <button
         className="hyper__btn hyper__btn--earth"
-        onClick={() => useCyberspace.getState().focusOn({ x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }, 0, 'EARTH', 52)}
+        onClick={() => { ownHyperspaceView(); useCyberspace.getState().focusOn({ x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }, 0, 'EARTH', 52) }}
       >EARTH</button>
+      {viewOwned && (
+        <button className="hyper__btn hyper__btn--earth" onClick={() => exitHyperspaceView()}>RETURN</button>
+      )}
 
       {sync.error && <p className="notice">{sync.error}</p>}
       {rideError && <p className="notice">{rideError}</p>}
 
       <p className="legend__note">
-        Boarding marks your chain; the ride proves fresh work for every block
+        The nearest stop is your station: the stop boarding sets you down at. VIEW flies the camera there; RETURN or Escape brings it home. Boarding marks your chain; the ride proves fresh work for every block
         passed and sets you down exactly at the stop. Leaving is an ordinary
         hop, so the last mile from any stop is normal movement.
       </p>

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -199,7 +199,9 @@ export function HyperspacePanel(): JSX.Element {
   const tag = ready ? `READY ${stopCount()} STOPS`
     : sync.status === 'error' ? 'ERROR'
       : sync.status === 'idle' ? 'IDLE'
-        : `SYNCING ${sync.loaded}/${sync.total}`
+        : sync.status === 'loading-cache'
+          ? `LOADING ${sync.loaded}/${sync.total}`
+          : `SYNCING ${sync.loaded}/${sync.total}`
 
   return (
     <section className="panel">

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -1,0 +1,314 @@
+/**
+ * HyperspacePanel.tsx - board the Bitcoin block transit line and ride it.
+ *
+ * DECK-0001 v3: every block is a stop, boarding assigns you the stop nearest
+ * your coordinate (the station), and a ride to any other stop costs seeded
+ * Cantor work for every block passed. This panel is the whole flow in one
+ * column: what your station would be, what a chosen destination would cost,
+ * then BOARD and RIDE. Exiting needs no button because leaving a stop is an
+ * ordinary hop.
+ *
+ * The ride computation outlives the panel: the HUD folds on a phone and on
+ * the hamburger, and a ten-minute proof must not die with a component. So the
+ * run lives at module scope in a tiny store, and both this panel and the
+ * HyperspaceBar subscribe to it.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { create } from 'zustand'
+import { coordToHex, coordToXyz, xyzToCoord, type Plane } from 'cyberspace-core'
+import { coordToLatLon } from '../lib/hyperspace/landfall'
+import { expectedRidePairs, rideBlocks } from '../lib/hyperspace/ride'
+import { calibrate, computeRideProof, leafBenchmarkMs, type RideProgress } from '../lib/hyperspace/ridePool'
+import { findStation, nearestStops } from '../lib/hyperspace/station'
+import { stopCoordExact, type Stop } from '../lib/hyperspace/stops'
+import { formatMs, formatOps, type Position } from '../lib/space'
+import { useCyberspace } from '../store/useCyberspace'
+import { getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
+
+/**
+ * Where a stop sits, for the camera. The float64-approximate coordinate is
+ * within a metre of the exact one, invisible at any spectate scale; only the
+ * signed hyperjump needs the exact coordinate.
+ */
+export function stopPosition(stop: Stop): Position {
+  const { x, y, z } = coordToXyz(stop.coordApprox)
+  return { x, y, z }
+}
+
+export function stopPlane(stop: Stop): Plane {
+  return coordToXyz(stop.coordApprox).plane
+}
+
+/** A landfall as a place on Earth: "31.6°N 98.8°W". */
+export function formatLatLon(stop: Stop): string {
+  const { lat, lon } = coordToLatLon(stop.coordApprox)
+  return `${Math.abs(lat).toFixed(1)}°${lat >= 0 ? 'N' : 'S'} ${Math.abs(lon).toFixed(1)}°${lon >= 0 ? 'E' : 'W'}`
+}
+
+interface RideRun {
+  /** Non-null while the worker pool is computing a ride proof. */
+  progress: RideProgress | null
+  /** Why the last attempt did not produce a signed hyperjump. */
+  error: string | null
+}
+
+export const useRideRun = create<RideRun>(() => ({ progress: null, error: null }))
+
+let riding = false
+let rideAbort: AbortController | null = null
+
+/** Stop the pool. The boarded state survives; EXIT clears that separately. */
+export function abortRide(): void {
+  rideAbort?.abort()
+}
+
+/**
+ * Build the job and run the proof. Module-level rather than a handler so the
+ * guard against a second concurrent ride is global: two pools racing
+ * completeRide against the same boarding would fork the chain.
+ */
+export async function startRide(): Promise<void> {
+  if (riding) return
+  const destination = useHyperspace.getState().destination
+  const transit = useCyberspace.getState().transit
+  if (destination === null || transit === null) return
+  const destStop = getStopByHeight(destination)
+  if (destStop === undefined) {
+    useRideRun.setState({ error: `Block ${destination} is not in the stop index yet` })
+    return
+  }
+  // §4.2: the station is evaluated over stops with height <= the destination
+  // height, so it only becomes a fact of the trip once the destination is
+  // fixed. Recompute it here, with the same function the panel's estimate
+  // uses, rather than trusting anything cached from before the choice.
+  const { position, plane } = useCyberspace.getState()
+  const here = xyzToCoord(position.x, position.y, position.z, plane)
+  const station = findStation(getStopIndex(), here, destination)
+  if (station === null) {
+    useRideRun.setState({ error: 'No station: no stop at or below the destination height' })
+    return
+  }
+  // Every passed block's hash seeds its leaf work (§5.3); a gap means the
+  // sync has not covered that stretch of the line yet. A zero-length ride
+  // (station is the destination) passes nothing and is valid (§5.6).
+  const blocks: Array<{ height: number; blockHash: string }> = []
+  for (const height of rideBlocks(station.stop.height, destination)) {
+    const blockHash = getStopByHeight(height)?.blockHash
+    if (!blockHash) {
+      useRideRun.setState({ error: `Block ${height} has no hash in the index yet; let the sync finish` })
+      return
+    }
+    blocks.push({ height, blockHash })
+  }
+  riding = true
+  const controller = new AbortController()
+  rideAbort = controller
+  useRideRun.setState({ error: null, progress: { done: 0, total: blocks.length, etaMs: null } })
+  try {
+    const { rootHex, mp } = await computeRideProof(
+      { previousEventIdHex: transit.enterEventId, blocks },
+      (p) => useRideRun.setState({ progress: p }),
+      controller.signal,
+    )
+    await useCyberspace.getState().completeRide({
+      toCoordHex: coordToHex(stopCoordExact(destStop)),
+      fromHeight: station.stop.height,
+      toHeight: destination,
+      rootHex,
+      mp,
+    })
+    useHyperspace.getState().setDestination(null)
+  } catch (err) {
+    // An abort is the user's own hand; only a real failure is worth a notice.
+    if (!controller.signal.aborted) {
+      useRideRun.setState({ error: err instanceof Error ? err.message : String(err) })
+    }
+  } finally {
+    riding = false
+    rideAbort = null
+    useRideRun.setState({ progress: null })
+  }
+}
+
+const kindLabel = (stop: Stop): string => (stop.kind === 'port' ? 'PORT' : 'LANDFALL')
+
+export function HyperspacePanel(): JSX.Element {
+  const sync = useHyperspace((s) => s.sync)
+  const indexVersion = useHyperspace((s) => s.indexVersion)
+  const destination = useHyperspace((s) => s.destination)
+  const transit = useCyberspace((s) => s.transit)
+  const position = useCyberspace((s) => s.position)
+  const plane = useCyberspace((s) => s.plane)
+  const atHead = useCyberspace((s) => s.atHead())
+  const progress = useRideRun((s) => s.progress)
+  const rideError = useRideRun((s) => s.error)
+  const ready = sync.status === 'ready'
+
+  // The per-leaf benchmark prices a ride in wall-clock time before you commit
+  // to it. Calibrated once; until the number exists the estimate says so
+  // rather than guessing.
+  const [benchMs, setBenchMs] = useState<number | null>(() => leafBenchmarkMs())
+  useEffect(() => {
+    let alive = true
+    calibrate().then((ms) => { if (alive) setBenchMs(ms) }).catch(() => {})
+    return () => { alive = false }
+  }, [])
+
+  // Your station candidate, live: the stop you would appear at if you boarded
+  // here. indexVersion is the store's signal that stops arrived, because the
+  // index itself is a mutable structure, not state.
+  const nearest = useMemo(() => {
+    const here = xyzToCoord(position.x, position.y, position.z, plane)
+    return nearestStops(getStopIndex(), here, 1)[0] ?? null
+  }, [position, plane, indexVersion])
+
+  // The cost estimate for the chosen destination, from the same findStation
+  // call the ride itself will make, so the number you approve is the number
+  // you get (§4.2 binds the station to the destination height).
+  const estimate = useMemo(() => {
+    if (destination === null) return null
+    const here = xyzToCoord(position.x, position.y, position.z, plane)
+    const station = findStation(getStopIndex(), here, destination)
+    if (station === null) return null
+    return { station, length: rideBlocks(station.stop.height, destination).length }
+  }, [destination, position, plane, indexVersion])
+
+  const destStop = destination !== null ? getStopByHeight(destination) : undefined
+  const tag = ready ? `READY ${stopCount()} STOPS`
+    : sync.status === 'error' ? 'ERROR'
+      : sync.status === 'idle' ? 'IDLE'
+        : `SYNCING ${sync.loaded}/${sync.total}`
+
+  return (
+    <section className="panel">
+      <header className="panel__head">
+        <h2>Hyperspace</h2>
+        <span className={`tag ${sync.status === 'error' ? 'tag--danger' : ''}`}>{tag}</span>
+      </header>
+
+      <div className="hyper__group">
+        <span className="legend__label">Nearest stop</span>
+        {nearest ? (
+          <>
+            <dl className="stats">
+              <div>
+                <dt>Block</dt>
+                <dd>{nearest.stop.height}</dd>
+              </div>
+              <div>
+                <dt>Kind</dt>
+                <dd>{kindLabel(nearest.stop)}</dd>
+              </div>
+              <div>
+                <dt>Distance</dt>
+                <dd>h{nearest.distance}</dd>
+              </div>
+              {nearest.stop.kind === 'landfall' && (
+                <div>
+                  <dt>Surface</dt>
+                  <dd>{formatLatLon(nearest.stop)}</dd>
+                </div>
+              )}
+            </dl>
+            <button
+              className="avatars__spectate"
+              onClick={() => useCyberspace.getState().focusOn(
+                stopPosition(nearest.stop),
+                stopPlane(nearest.stop),
+                `STATION · BLOCK ${nearest.stop.height}`,
+                34,
+              )}
+            >SPECTATE</button>
+          </>
+        ) : (
+          <p className="legend__note">No stops in the index yet.</p>
+        )}
+      </div>
+
+      <div className="hyper__group">
+        <span className="legend__label">Destination</span>
+        {destination === null ? (
+          <p className="legend__note">None set. Open the line scrubber (H) and pick a stop.</p>
+        ) : (
+          <>
+            <dl className="stats">
+              <div>
+                <dt>Block</dt>
+                <dd>{destination}{destStop ? ` ${kindLabel(destStop)}` : ''}</dd>
+              </div>
+              {estimate && (
+                <>
+                  <div>
+                    <dt>Station</dt>
+                    <dd>{estimate.station.stop.height}</dd>
+                  </div>
+                  <div>
+                    <dt>Ride length</dt>
+                    <dd>{estimate.length} BLOCK{estimate.length === 1 ? '' : 'S'}</dd>
+                  </div>
+                  <div>
+                    <dt>Expected work</dt>
+                    <dd>{formatOps(expectedRidePairs(estimate.length))} PAIRS</dd>
+                  </div>
+                  <div>
+                    <dt>Est. time</dt>
+                    <dd>{benchMs === null ? 'CALIBRATING' : formatMs(estimate.length * benchMs)}</dd>
+                  </div>
+                </>
+              )}
+            </dl>
+            <p className="legend__note">
+              All of the per-block work runs locally and resumes if interrupted.
+            </p>
+          </>
+        )}
+      </div>
+
+      {progress !== null && (
+        <>
+          <p className="hyper__progress">
+            RIDING {progress.done}/{progress.total}
+            {progress.etaMs !== null && ` · ETA ${formatMs(progress.etaMs)}`}
+          </p>
+          <div className="bar">
+            <div
+              className="bar__fill bar__fill--computing"
+              style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 100}%` }}
+            />
+          </div>
+        </>
+      )}
+
+      <div className="hyper__actions">
+        <button
+          className="hyper__btn"
+          disabled={!atHead || !ready || destination === null}
+          onClick={() => void useCyberspace.getState().boardHyperspace()}
+        >BOARD</button>
+        {progress === null ? (
+          <button
+            className="hyper__btn hyper__btn--ride"
+            disabled={transit === null || destination === null || !ready}
+            onClick={() => void startRide()}
+          >RIDE</button>
+        ) : (
+          <button className="hyper__btn hyper__btn--abort" onClick={abortRide}>ABORT</button>
+        )}
+      </div>
+      <button
+        className="hyper__btn hyper__btn--earth"
+        onClick={() => useCyberspace.getState().focusOn({ x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }, 0, 'EARTH', 52)}
+      >EARTH</button>
+
+      {sync.error && <p className="notice">{sync.error}</p>}
+      {rideError && <p className="notice">{rideError}</p>}
+
+      <p className="legend__note">
+        Boarding marks your chain; the ride proves fresh work for every block
+        passed and sets you down exactly at the stop. Leaving is an ordinary
+        hop, so the last mile from any stop is normal movement.
+      </p>
+    </section>
+  )
+}

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -34,7 +34,7 @@ function formatDuration(ms: number): string {
   return `${(h / 24).toFixed(1)} d`
 }
 import { useCyberspace } from '../store/useCyberspace'
-import { exitHyperspaceView, ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
+import { ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
 
 /**
  * Where a stop sits, for the camera. The float64-approximate coordinate is
@@ -154,7 +154,6 @@ const kindLabel = (stop: Stop): string => (stop.kind === 'port' ? 'PORT' : 'LAND
 
 export function HyperspacePanel(): JSX.Element {
   const sync = useHyperspace((s) => s.sync)
-  const viewOwned = useHyperspace((s) => s.viewOwned)
   const indexVersion = useHyperspace((s) => s.indexVersion)
   const destination = useHyperspace((s) => s.destination)
   const transit = useCyberspace((s) => s.transit)
@@ -211,7 +210,7 @@ export function HyperspacePanel(): JSX.Element {
       </header>
 
       <div className="hyper__group">
-        <span className="legend__label">Nearest stop</span>
+        <span className="legend__label hyper__kicker hyper__kicker--nearest">Nearest stop</span>
         {nearest ? (
           <>
             <dl className="stats">
@@ -235,14 +234,16 @@ export function HyperspacePanel(): JSX.Element {
               )}
             </dl>
             <button
-              className="avatars__spectate"
+              className="hyper__btn hyper__btn--view"
               onClick={() => { ownHyperspaceView(); useCyberspace.getState().focusOn(
                 stopPosition(nearest.stop),
                 stopPlane(nearest.stop),
                 `STATION · BLOCK ${nearest.stop.height}`,
+                // 2^34: one render cell is 2 metres, the spec's h34 human
+                // scale, so the stop reads as a place you could stand at.
                 34,
               ) }}
-            >VIEW</button>
+            >VIEW NEAREST STOP</button>
           </>
         ) : (
           <p className="legend__note">No stops in the index yet.</p>
@@ -250,7 +251,7 @@ export function HyperspacePanel(): JSX.Element {
       </div>
 
       <div className="hyper__group">
-        <span className="legend__label">Destination</span>
+        <span className="legend__label hyper__kicker hyper__kicker--destination">Destination</span>
         {destination === null ? (
           <p className="legend__note">None set. Open the line scrubber (H) and pick a stop.</p>
         ) : (
@@ -333,18 +334,40 @@ export function HyperspacePanel(): JSX.Element {
           }
         }}
       >EARTH</button>
-      {viewOwned && (
-        <button className="hyper__btn hyper__btn--earth" onClick={() => exitHyperspaceView()}>RETURN</button>
-      )}
-
       {sync.error && <p className="notice">{sync.error}</p>}
       {rideError && <p className="notice">{rideError}</p>}
 
       <p className="legend__note">
-        The nearest stop is your station: the stop boarding sets you down at. VIEW flies the camera there; RETURN or Escape brings it home. Boarding marks your chain; the ride proves fresh work for every block
+        The nearest stop is your station: the stop boarding sets you down at.
+        VIEW NEAREST STOP flies the camera there; the viewing bar's RETURN or
+        Escape brings it home at your previous zoom. Boarding marks your chain; the ride proves fresh work for every block
         passed and sets you down exactly at the stop. Leaving is an ordinary
         hop, so the last mile from any stop is normal movement.
       </p>
     </section>
+  )
+}
+
+
+/**
+ * Click-select a stop in the scene: it becomes the destination and the
+ * camera flies to it. With the scrubber open the height goes through the
+ * scrubber so its readout follows the click; closed, the focus is set
+ * directly at the current zoom so a click never yanks the scale.
+ */
+export function selectStopInScene(height: number): void {
+  const hs = useHyperspace.getState()
+  hs.setDestination(height)
+  if (hs.scrubHeight !== null) {
+    hs.setScrubHeight(height)
+    return
+  }
+  const stop = getStopByHeight(height)
+  if (!stop) return
+  ownHyperspaceView()
+  useCyberspace.getState().focusOn(
+    stopPosition(stop),
+    stopPlane(stop),
+    `BLOCK ${stop.height} · ${stop.kind === 'port' ? 'PORT' : 'LANDFALL'}`,
   )
 }

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -34,7 +34,7 @@ function formatDuration(ms: number): string {
   return `${(h / 24).toFixed(1)} d`
 }
 import { useCyberspace } from '../store/useCyberspace'
-import { ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
+import { markViewedStop, ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
 
 /**
  * Where a stop sits, for the camera. The float64-approximate coordinate is
@@ -235,7 +235,7 @@ export function HyperspacePanel(): JSX.Element {
             </dl>
             <button
               className="hyper__btn hyper__btn--view"
-              onClick={() => { ownHyperspaceView(); useCyberspace.getState().focusOn(
+              onClick={() => { ownHyperspaceView(); markViewedStop(nearest.stop.height); useCyberspace.getState().focusOn(
                 stopPosition(nearest.stop),
                 stopPlane(nearest.stop),
                 `STATION · BLOCK ${nearest.stop.height}`,
@@ -328,8 +328,10 @@ export function HyperspacePanel(): JSX.Element {
           ownHyperspaceView()
           const centre = { x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }
           if (destStop && destStop.kind === 'landfall') {
+            markViewedStop(destStop.height)
             useCyberspace.getState().focusOn(stopPosition(destStop), 0, `BLOCK ${destStop.height}`, 52)
           } else {
+            markViewedStop(null)
             useCyberspace.getState().focusOn(centre, 0, 'EARTH', 52)
           }
         }}
@@ -358,13 +360,17 @@ export function HyperspacePanel(): JSX.Element {
 export function selectStopInScene(height: number): void {
   const hs = useHyperspace.getState()
   hs.setDestination(height)
-  if (hs.scrubHeight !== null) {
+  // With the scrubber open the height goes through it (its effect flies and
+  // marks); a click on the very block it is parked on falls through to the
+  // direct path, because a no-op set would fire no effect and no fly.
+  if (hs.scrubHeight !== null && hs.scrubHeight !== height) {
     hs.setScrubHeight(height)
     return
   }
   const stop = getStopByHeight(height)
   if (!stop) return
   ownHyperspaceView()
+  markViewedStop(stop.height)
   useCyberspace.getState().focusOn(
     stopPosition(stop),
     stopPlane(stop),

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -323,7 +323,15 @@ export function HyperspacePanel(): JSX.Element {
       </div>
       <button
         className="hyper__btn hyper__btn--earth"
-        onClick={() => { ownHyperspaceView(); useCyberspace.getState().focusOn({ x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }, 0, 'EARTH', 52) }}
+        onClick={() => {
+          ownHyperspaceView()
+          const centre = { x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }
+          if (destStop && destStop.kind === 'landfall') {
+            useCyberspace.getState().focusOn(stopPosition(destStop), 0, `BLOCK ${destStop.height}`, 52)
+          } else {
+            useCyberspace.getState().focusOn(centre, 0, 'EARTH', 52)
+          }
+        }}
       >EARTH</button>
       {viewOwned && (
         <button className="hyper__btn hyper__btn--earth" onClick={() => exitHyperspaceView()}>RETURN</button>

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react'
+import { Earth } from 'lucide-react'
 import { create } from 'zustand'
 import { coordToHex, coordToXyz, xyzToCoord, type Plane } from 'cyberspace-core'
 import { coordToLatLon } from '../lib/hyperspace/landfall'
@@ -347,9 +348,7 @@ export function HyperspacePanel(): JSX.Element {
             useCyberspace.getState().focusOn(centre, 0, 'EARTH', 52)
           }
         }}
-      >{/* The astronomical symbol for Earth, matching the HUD's glyph
-          voice (the touchpad's vector marks, the badge glyphs). */}
-        <span aria-hidden="true">⊕</span> EARTH</button>
+      ><Earth size={12} strokeWidth={2.25} aria-hidden /> EARTH</button>
       {sync.error && <p className="notice">{sync.error}</p>}
       {rideError && <p className="notice">{rideError}</p>}
 

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -135,7 +135,9 @@ export function LineScrubber(): JSX.Element {
         aria-pressed={open}
       >
         {ready
-          ? `HYPERSPACE ${scrubHeight ?? tip}/${tip}`
+          ? destination !== null
+            ? `HYPERSPACE ${destination}`
+            : 'HYPERSPACE READY'
           : sync.status === 'loading-cache'
             ? `HYPERSPACE LOADING ${syncPercent}%`
             : `HYPERSPACE SYNCING ${syncPercent}%`}
@@ -159,6 +161,7 @@ export function LineScrubber(): JSX.Element {
             >VIEW</button>
           </div>
 
+          <hr className="linescrub__hr" />
           <span className="linescrub__headline linescrub__headline--to">TO BLOCK</span>
           <div className="explorer__row">
             <button className="explorer__btn" title={`Back ${JUMP} blocks (hold to repeat)`} aria-label={`Back ${JUMP} blocks`} disabled={scrubHeight === 0} {...bind(step(-JUMP))}>«</button>

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -154,7 +154,7 @@ export function LineScrubber(): JSX.Element {
             </div>
             <div className="linescrub__actions">
             <button
-              className="linescrub__set"
+              className={destination !== null ? 'linescrub__set linescrub__set--attached' : 'linescrub__set'}
               disabled={!stop}
               {...noCallout}
               onPointerDown={(e) => {

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -97,7 +97,11 @@ export function LineScrubber(): JSX.Element {
         aria-label={open ? 'Hide line scrubber' : 'Show line scrubber'}
         aria-pressed={open}
       >
-        {ready ? `HYPERSPACE ${scrubHeight ?? tip}/${tip}` : `HYPERSPACE SYNCING ${syncPercent}%`}
+        {ready
+          ? `HYPERSPACE ${scrubHeight ?? tip}/${tip}`
+          : sync.status === 'loading-cache'
+            ? `HYPERSPACE LOADING ${syncPercent}%`
+            : `HYPERSPACE SYNCING ${syncPercent}%`}
       </button>
 
       {open && ready && (

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useRef } from 'react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { useCyberspace } from '../store/useCyberspace'
-import { exitHyperspaceView, getStopByHeight, ownHyperspaceView, useHyperspace } from '../store/useHyperspace'
+import { exitHyperspaceView, getStopByHeight, markViewedStop, ownHyperspaceView, useHyperspace } from '../store/useHyperspace'
 import { formatLatLon, stopPlane, stopPosition } from './HyperspacePanel'
 
 /** The coarse step: the line is ~900k blocks, single steps are the last few. */
@@ -37,18 +37,29 @@ export function LineScrubber(): JSX.Element {
   // null would stomp a focus someone else set (a shard, the EARTH button).
   // indexVersion re-runs it so a stop that syncs in late still gets flown to.
   const prev = useRef<number | null>(null)
+  // Opening the scrubber must not steal the view: the mark parks on the
+  // chosen destination (or the tip) and the first fly happens only once the
+  // user actually moves it. Armed flips on the first height change and stays
+  // set, so the indexVersion re-run can still fly to a stop that synced in
+  // late, without un-parking a freshly opened scrubber.
+  const armed = useRef(false)
   useEffect(() => {
     const was = prev.current
     prev.current = scrubHeight
     if (scrubHeight === null) {
+      armed.current = false
       // Closed by any path that skipped exitHyperspaceView: settle through it
       // so an owned focus clears and a foreign one (a spectate) survives.
       if (was !== null) exitHyperspaceView()
       return
     }
+    if (was === null) return
+    if (was !== scrubHeight) armed.current = true
+    if (!armed.current) return
     const stop = getStopByHeight(scrubHeight)
     if (!stop) return
     ownHyperspaceView()
+    markViewedStop(stop.height)
     useCyberspace.getState().focusOn(
       stopPosition(stop),
       stopPlane(stop),
@@ -61,7 +72,7 @@ export function LineScrubber(): JSX.Element {
 
   const toggle = (): void => {
     const hs = useHyperspace.getState()
-    if (hs.scrubHeight === null) hs.setScrubHeight(hs.tipHeight ?? 0)
+    if (hs.scrubHeight === null) hs.setScrubHeight(hs.destination ?? hs.tipHeight ?? 0)
     else exitHyperspaceView()
   }
 

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -1,0 +1,155 @@
+/**
+ * LineScrubber.tsx - scrub the Bitcoin block line as a place.
+ *
+ * ChainExplorer's mechanics pointed at a different one-dimensional thing:
+ * block heights 0..tip instead of chain actions. Scrubbing flies the camera
+ * to the stop under the mark (a focus, so nothing about your chain changes)
+ * and SET DESTINATION hands the height to the Hyperspace panel.
+ *
+ * Open state IS scrubHeight in the store, so the H key and the chip drive
+ * one mechanism and cannot disagree. No per-height ticks: the line is
+ * hundreds of thousands of blocks, only the fill and the mark are drawn.
+ */
+
+import { useEffect, useRef } from 'react'
+import { noCallout, useRepeatable } from '../hooks/useRepeatable'
+import { useCyberspace } from '../store/useCyberspace'
+import { getStopByHeight, useHyperspace } from '../store/useHyperspace'
+import { formatLatLon, stopPlane, stopPosition } from './HyperspacePanel'
+
+/** The coarse step: the line is ~900k blocks, single steps are the last few. */
+const JUMP = 1000
+
+export function LineScrubber(): JSX.Element {
+  const sync = useHyperspace((s) => s.sync)
+  const tipHeight = useHyperspace((s) => s.tipHeight)
+  const scrubHeight = useHyperspace((s) => s.scrubHeight)
+  const destination = useHyperspace((s) => s.destination)
+  const indexVersion = useHyperspace((s) => s.indexVersion)
+  const bind = useRepeatable()
+
+  const ready = sync.status === 'ready' && tipHeight !== null
+  const open = scrubHeight !== null
+
+  // The focus side effect lives here rather than in the keyboard hook, so the
+  // chip, the rail, the buttons and the H key all pass through one place.
+  // Only a non-null to null transition clears the focus: clearing on every
+  // null would stomp a focus someone else set (a shard, the EARTH button).
+  // indexVersion re-runs it so a stop that syncs in late still gets flown to.
+  const prev = useRef<number | null>(null)
+  useEffect(() => {
+    const was = prev.current
+    prev.current = scrubHeight
+    if (scrubHeight === null) {
+      if (was !== null) useCyberspace.getState().clearFocus()
+      return
+    }
+    const stop = getStopByHeight(scrubHeight)
+    if (!stop) return
+    useCyberspace.getState().focusOn(
+      stopPosition(stop),
+      stopPlane(stop),
+      `BLOCK ${stop.height} · ${stop.kind === 'port' ? 'PORT' : 'LANDFALL'}`,
+      34,
+    )
+  }, [scrubHeight, indexVersion])
+
+  const toggle = (): void => {
+    const hs = useHyperspace.getState()
+    hs.setScrubHeight(hs.scrubHeight === null ? hs.tipHeight ?? 0 : null)
+  }
+
+  const step = (d: number) => (): void => {
+    const hs = useHyperspace.getState()
+    if (hs.scrubHeight === null || hs.tipHeight === null) return
+    hs.setScrubHeight(Math.max(0, Math.min(hs.tipHeight, hs.scrubHeight + d)))
+  }
+
+  // The rail: press or drag anywhere on it to land on the nearest height.
+  const rail = useRef<HTMLDivElement>(null)
+  const dragging = useRef(false)
+  const scrubTo = (clientX: number): void => {
+    const r = rail.current?.getBoundingClientRect()
+    const tip = useHyperspace.getState().tipHeight
+    if (!r || r.width === 0 || tip === null || tip <= 0) return
+    const t = Math.min(1, Math.max(0, (clientX - r.left) / r.width))
+    useHyperspace.getState().setScrubHeight(Math.round(t * tip))
+  }
+
+  const tip = tipHeight ?? 0
+  const fraction = tip <= 0 ? 0 : (scrubHeight ?? tip) / tip
+  const stop = scrubHeight !== null ? getStopByHeight(scrubHeight) : undefined
+  const syncPercent = sync.total > 0 ? Math.round((sync.loaded / sync.total) * 100) : 0
+
+  return (
+    <div className="explorer linescrub">
+      <button
+        className="chip explorer__toggle"
+        {...noCallout}
+        disabled={!ready}
+        onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); if (ready) toggle() }}
+        aria-label={open ? 'Hide line scrubber' : 'Show line scrubber'}
+        aria-pressed={open}
+      >
+        {ready ? `LINE ${scrubHeight ?? tip}/${tip}` : `LINE SYNCING ${syncPercent}%`}
+      </button>
+
+      {open && ready && (
+        <div className="explorer__body">
+          <div className="explorer__row">
+            <button className="explorer__btn" title={`Back ${JUMP} blocks (hold to repeat)`} aria-label={`Back ${JUMP} blocks`} disabled={scrubHeight === 0} {...bind(step(-JUMP))}>«</button>
+            <button className="explorer__btn" title="Back one block (hold to repeat)" aria-label="Back one block" disabled={scrubHeight === 0} {...bind(step(-1))}>◀</button>
+
+            <div
+              className="explorer__rail"
+              ref={rail}
+              role="slider"
+              aria-label="Line position"
+              aria-valuemin={0}
+              aria-valuemax={tip}
+              aria-valuenow={scrubHeight ?? tip}
+              {...noCallout}
+              onPointerDown={(e) => {
+                e.preventDefault(); e.stopPropagation()
+                dragging.current = true
+                ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+                scrubTo(e.clientX)
+              }}
+              onPointerMove={(e) => { if (dragging.current) scrubTo(e.clientX) }}
+              onPointerUp={() => { dragging.current = false }}
+              onPointerCancel={() => { dragging.current = false }}
+            >
+              <span className="explorer__line" />
+              <span className="explorer__walked" style={{ width: `${fraction * 100}%` }} />
+              <span className="explorer__mark" style={{ left: `${fraction * 100}%` }} />
+            </div>
+
+            <button className="explorer__btn" title="Forward one block (hold to repeat)" aria-label="Forward one block" disabled={scrubHeight === tip} {...bind(step(1))}>▶</button>
+            <button className="explorer__btn" title={`Forward ${JUMP} blocks (hold to repeat)`} aria-label={`Forward ${JUMP} blocks`} disabled={scrubHeight === tip} {...bind(step(JUMP))}>»</button>
+          </div>
+
+          <div className="explorer__meta">
+            <span className="explorer__type">BLOCK {scrubHeight}</span>
+            {stop ? (
+              <>
+                <span className={`linescrub__kind linescrub__kind--${stop.kind}`}>{stop.kind === 'port' ? 'PORT' : 'LANDFALL'}</span>
+                {stop.kind === 'landfall' && <span className="explorer__when">{formatLatLon(stop)}</span>}
+              </>
+            ) : (
+              <span className="explorer__when">NO STOP DATA</span>
+            )}
+            <button
+              className="linescrub__set"
+              disabled={!stop}
+              {...noCallout}
+              onPointerDown={(e) => {
+                e.preventDefault(); e.stopPropagation()
+                if (scrubHeight !== null) useHyperspace.getState().setDestination(scrubHeight)
+              }}
+            >{destination !== null && destination === scrubHeight ? 'DESTINATION SET' : 'SET DESTINATION'}</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -11,10 +11,12 @@
  * hundreds of thousands of blocks, only the fill and the mark are drawn.
  */
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
+import { xyzToCoord } from 'cyberspace-core'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { useCyberspace } from '../store/useCyberspace'
-import { exitHyperspaceView, getStopByHeight, markViewedStop, ownHyperspaceView, useHyperspace } from '../store/useHyperspace'
+import { exitHyperspaceView, getStopByHeight, getStopIndex, markViewedStop, ownHyperspaceView, useHyperspace } from '../store/useHyperspace'
+import { nearestStops } from '../lib/hyperspace/station'
 import { formatLatLon, stopPlane, stopPosition } from './HyperspacePanel'
 
 /** The coarse step: the line is ~900k blocks, single steps are the last few. */
@@ -27,6 +29,30 @@ export function LineScrubber(): JSX.Element {
   const destination = useHyperspace((s) => s.destination)
   const indexVersion = useHyperspace((s) => s.indexVersion)
   const bind = useRepeatable()
+  const position = useCyberspace((s) => s.position)
+  const plane = useCyberspace((s) => s.plane)
+
+  // Your station: the block boarding sets you down at, recomputed as blocks
+  // sync in. The overlay leads with it because every ride runs FROM here.
+  const station = useMemo(() => {
+    void indexVersion
+    const index = getStopIndex()
+    if (index.permCount === 0) return undefined
+    const here = xyzToCoord(position.x, position.y, position.z, plane)
+    return nearestStops(index, here, 1)[0]?.stop
+  }, [position, plane, indexVersion])
+
+  const viewStation = (): void => {
+    if (!station) return
+    ownHyperspaceView()
+    markViewedStop(station.height)
+    useCyberspace.getState().focusOn(
+      stopPosition(station),
+      stopPlane(station),
+      `STATION · BLOCK ${station.height}`,
+      34,
+    )
+  }
 
   const ready = sync.status === 'ready' && tipHeight !== null
   const open = scrubHeight !== null
@@ -117,6 +143,23 @@ export function LineScrubber(): JSX.Element {
 
       {open && ready && (
         <div className="explorer__body">
+          <span className="linescrub__headline">FROM NEAREST BLOCK</span>
+          <div className="linescrub__fromrow">
+            <span className="explorer__type">{station ? `BLOCK ${station.height}` : 'NO BLOCKS YET'}</span>
+            {station && (
+              <span className={`linescrub__kind linescrub__kind--${station.kind}`}>
+                {station.kind === 'port' ? 'PORT' : 'LANDFALL'}
+              </span>
+            )}
+            <button
+              className="linescrub__view"
+              disabled={!station}
+              {...noCallout}
+              onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); viewStation() }}
+            >VIEW</button>
+          </div>
+
+          <span className="linescrub__headline linescrub__headline--to">TO BLOCK</span>
           <div className="explorer__row">
             <button className="explorer__btn" title={`Back ${JUMP} blocks (hold to repeat)`} aria-label={`Back ${JUMP} blocks`} disabled={scrubHeight === 0} {...bind(step(-JUMP))}>«</button>
             <button className="explorer__btn" title="Back one block (hold to repeat)" aria-label="Back one block" disabled={scrubHeight === 0} {...bind(step(-1))}>◀</button>
@@ -160,7 +203,7 @@ export function LineScrubber(): JSX.Element {
                   {stop.kind === 'landfall' && <span className="explorer__when">{formatLatLon(stop)}</span>}
                 </>
               ) : (
-                <span className="explorer__when">NO STOP DATA</span>
+                <span className="explorer__when">NO BLOCK DATA</span>
               )}
             </div>
             <div className="linescrub__actions">

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -53,7 +53,9 @@ export function LineScrubber(): JSX.Element {
       stopPosition(stop),
       stopPlane(stop),
       `BLOCK ${stop.height} · ${stop.kind === 'port' ? 'PORT' : 'LANDFALL'}`,
-      34,
+      // A landfall is a place on Earth: frame the globe with the landfall's
+      // side toward the camera instead of standing on the surface grid.
+      stop.kind === 'landfall' ? 52 : 34,
     )
   }, [scrubHeight, indexVersion])
 
@@ -95,7 +97,7 @@ export function LineScrubber(): JSX.Element {
         aria-label={open ? 'Hide line scrubber' : 'Show line scrubber'}
         aria-pressed={open}
       >
-        {ready ? `LINE ${scrubHeight ?? tip}/${tip}` : `LINE SYNCING ${syncPercent}%`}
+        {ready ? `HYPERSPACE ${scrubHeight ?? tip}/${tip}` : `HYPERSPACE SYNCING ${syncPercent}%`}
       </button>
 
       {open && ready && (
@@ -151,6 +153,18 @@ export function LineScrubber(): JSX.Element {
                 if (scrubHeight !== null) useHyperspace.getState().setDestination(scrubHeight)
               }}
             >{destination !== null && destination === scrubHeight ? 'DESTINATION SET' : 'SET DESTINATION'}</button>
+            {destination !== null && (
+              <button
+                className="linescrub__clear"
+                title="Clear destination"
+                aria-label="Clear destination"
+                {...noCallout}
+                onPointerDown={(e) => {
+                  e.preventDefault(); e.stopPropagation()
+                  useHyperspace.getState().setDestination(null)
+                }}
+              >✕</button>
+            )}
           </div>
         </div>
       )}

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useRef } from 'react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { useCyberspace } from '../store/useCyberspace'
-import { getStopByHeight, useHyperspace } from '../store/useHyperspace'
+import { exitHyperspaceView, getStopByHeight, ownHyperspaceView, useHyperspace } from '../store/useHyperspace'
 import { formatLatLon, stopPlane, stopPosition } from './HyperspacePanel'
 
 /** The coarse step: the line is ~900k blocks, single steps are the last few. */
@@ -41,11 +41,14 @@ export function LineScrubber(): JSX.Element {
     const was = prev.current
     prev.current = scrubHeight
     if (scrubHeight === null) {
-      if (was !== null) useCyberspace.getState().clearFocus()
+      // Closed by any path that skipped exitHyperspaceView: settle through it
+      // so an owned focus clears and a foreign one (a spectate) survives.
+      if (was !== null) exitHyperspaceView()
       return
     }
     const stop = getStopByHeight(scrubHeight)
     if (!stop) return
+    ownHyperspaceView()
     useCyberspace.getState().focusOn(
       stopPosition(stop),
       stopPlane(stop),
@@ -56,7 +59,8 @@ export function LineScrubber(): JSX.Element {
 
   const toggle = (): void => {
     const hs = useHyperspace.getState()
-    hs.setScrubHeight(hs.scrubHeight === null ? hs.tipHeight ?? 0 : null)
+    if (hs.scrubHeight === null) hs.setScrubHeight(hs.tipHeight ?? 0)
+    else exitHyperspaceView()
   }
 
   const step = (d: number) => (): void => {

--- a/src/hud/LineScrubber.tsx
+++ b/src/hud/LineScrubber.tsx
@@ -138,16 +138,21 @@ export function LineScrubber(): JSX.Element {
             <button className="explorer__btn" title={`Forward ${JUMP} blocks (hold to repeat)`} aria-label={`Forward ${JUMP} blocks`} disabled={scrubHeight === tip} {...bind(step(JUMP))}>»</button>
           </div>
 
-          <div className="explorer__meta">
-            <span className="explorer__type">BLOCK {scrubHeight}</span>
-            {stop ? (
-              <>
-                <span className={`linescrub__kind linescrub__kind--${stop.kind}`}>{stop.kind === 'port' ? 'PORT' : 'LANDFALL'}</span>
-                {stop.kind === 'landfall' && <span className="explorer__when">{formatLatLon(stop)}</span>}
-              </>
-            ) : (
-              <span className="explorer__when">NO STOP DATA</span>
-            )}
+          <div className="explorer__meta linescrub__meta">
+            <div className="linescrub__info">
+              <span className="explorer__type">BLOCK {scrubHeight}</span>
+              {stop ? (
+                <>
+                  <span className={`linescrub__kind linescrub__kind--${stop.kind}`}>
+                    {stop.kind === 'port' ? 'PORT · IDEASPACE' : "LANDFALL · DATASPACE · EARTH'S SURFACE"}
+                  </span>
+                  {stop.kind === 'landfall' && <span className="explorer__when">{formatLatLon(stop)}</span>}
+                </>
+              ) : (
+                <span className="explorer__when">NO STOP DATA</span>
+              )}
+            </div>
+            <div className="linescrub__actions">
             <button
               className="linescrub__set"
               disabled={!stop}
@@ -169,6 +174,7 @@ export function LineScrubber(): JSX.Element {
                 }}
               >✕</button>
             )}
+            </div>
           </div>
         </div>
       )}

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -10,6 +10,7 @@
 
 import { useMemo } from 'react'
 import { estimateHopCost, estimateSidestepCost } from 'cyberspace-core'
+import { useCalibration } from '../lib/calibration'
 import { formatMs, formatOps } from '../lib/space'
 import { samePosition, sidestepTarget, useCyberspace } from '../store/useCyberspace'
 
@@ -34,6 +35,10 @@ export function ProofPanel(): JSX.Element {
   const position = useCyberspace((s) => s.position)
   const cursor = useCyberspace((s) => s.cursor)
   const plane = useCyberspace((s) => s.plane)
+  // What calibration measured this machine finishing in budget: conservative
+  // defaults until the quiet benchmark lands, then the line updates in place.
+  const hopCeil = useCalibration((s) => s.hopHeight)
+  const sidestepCeil = useCalibration((s) => s.sidestepHeight)
 
   // Live preview of the action the cursor is lining up. Both estimates are
   // closed-form, so cheap enough to run on every noodle.
@@ -157,6 +162,8 @@ export function ProofPanel(): JSX.Element {
           {proof.message && <p className="notice">{proof.message}</p>}
         </>
       )}
+
+      <p className="legend__note">{`THIS MACHINE: HOP <= h${hopCeil} · SIDESTEP <= h${sidestepCeil}`}</p>
     </section>
   )
 }

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -48,7 +48,7 @@ export function SecretModal(): JSX.Element | null {
   const target = (): void => useCyberspace.getState().toggleTarget(author, profile?.name ?? null)
 
   return (
-    <div className="modal" role="dialog" aria-modal="true" aria-label="Hidden content" onPointerDown={close}>
+    <div className="modal modal--top" role="dialog" aria-modal="true" aria-label="Hidden content" onPointerDown={close}>
       <div className="modal__card secret" onPointerDown={(e) => e.stopPropagation()}>
         <div className="secret__head">
           <span className={`secret__badge secret__badge--${item.type}`}>{item.type === 'message' ? '✎ MESSAGE' : '◇ SHARD'}</span>

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -22,7 +22,7 @@ import { useShards } from '../store/useShards'
 import { useUiHints } from '../store/useUiHints'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 
-export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Element {
+export function TouchControls(): JSX.Element {
   const proof = useCyberspace((s) => s.proof)
   const position = useCyberspace((s) => s.position)
   const cursor = useCyberspace((s) => s.cursor)
@@ -92,12 +92,19 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
             {b.sub && <span className="touchpad__sub">{b.sub}</span>}
           </button>
         ))}
+        {/* The hub doubles as the scale readout and its reset: a tap returns
+            to 2^0, the finest scale. Hiding the pad lives on the canvas tap,
+            where it always also lived, so nothing is lost to the reset. */}
         <button
           className="touchpad__hub"
-          aria-label={`Scale 2^${scaleExp}. Tap to hide controls.`}
-          title="Hide controls"
+          aria-label={`Scale 2^${scaleExp}. Tap to reset scale to 2^0.`}
+          title="Reset scale to 2^0"
           {...noCallout}
-          onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); onDismiss() }}
+          onPointerDown={(e) => {
+            e.preventDefault(); e.stopPropagation()
+            const s = useCyberspace.getState()
+            s.adjustScale(-s.scaleExp)
+          }}
         >2^{scaleExp}</button>
       </div>
 

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -19,6 +19,7 @@ import { useCyberspace } from '../store/useCyberspace'
 import { moveDirection, type MoveName } from '../lib/moves'
 import { MAX_SCALE_EXP } from '../lib/space'
 import { useShards } from '../store/useShards'
+import { useUiHints } from '../store/useUiHints'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 
 export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Element {
@@ -29,6 +30,9 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
   const live = useCyberspace((s) => s.live)
   const deploying = useShards((s) => s.pending !== null)
   const bind = useRepeatable()
+  // The scene's covering box reports when the region it draws is a clipped
+  // stand-in; the zoom-out key is the remedy, so it echoes that (useUiHints).
+  const coveringClipped = useUiHints((s) => s.coveringClipped)
 
   const computing = proof.status === 'computing'
   const armed = !(position.x === cursor.x && position.y === cursor.y && position.z === cursor.z)
@@ -43,7 +47,7 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
   // exactly how many cells a 3x3 pad has.
   const pad: Array<{
     cell: string; glyph: string; sub?: string; title: string
-    act: () => void; disabled?: boolean
+    act: () => void; disabled?: boolean; hint?: boolean
   }> = [
     // The physics convention for a vector through the page: a tail seen from
     // behind going in, an arrow tip seen head-on coming out. It is the right
@@ -62,7 +66,12 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
     //
     // adjustScale already clamps, but a key that silently does nothing reads as
     // broken rather than as the end of the range.
-    { cell: 'zoomout', glyph: '+', title: 'Coarser scale (Q)', act: scale(1), disabled: scaleExp >= MAX_SCALE_EXP },
+    //
+    // Glows while the covering box is clipped, because coarser scale is the
+    // fix the scene is asking for. Not while disabled: a glowing dead key
+    // would promise a remedy it cannot deliver.
+    { cell: 'zoomout', glyph: '+', title: 'Coarser scale (Q)', act: scale(1), disabled: scaleExp >= MAX_SCALE_EXP,
+      hint: coveringClipped && scaleExp < MAX_SCALE_EXP },
     { cell: 'down', glyph: '▼', title: 'Down (S)', act: move('down') },
     { cell: 'zoomin', glyph: '−', title: 'Finer scale (E)', act: scale(-1), disabled: scaleExp <= 0 },
   ]
@@ -73,7 +82,7 @@ export function TouchControls({ onDismiss }: { onDismiss: () => void }): JSX.Ele
         {pad.map((b) => (
           <button
             key={b.cell}
-            className={`touchpad__key touchpad__key--${b.cell}`}
+            className={`touchpad__key touchpad__key--${b.cell}${b.hint ? ' is-zoomhint' : ''}`}
             title={b.title}
             aria-label={b.title}
             disabled={b.disabled}

--- a/src/lib/calibration.test.ts
+++ b/src/lib/calibration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * calibration.test.ts - the quiet benchmark's math, pinned down.
+ *
+ * Everything here fails silently in production: a fitted growth ratio below
+ * the floor projects h19/h20 as affordable on a machine that dies at h18 (the
+ * tab just stalls, no error anywhere), a stale or foreign cache serves
+ * another machine's ceilings, an unmeasured gap projected upward from a cheap
+ * low reading underquotes a height the data already showed to be expensive,
+ * and a sidestep ceiling outside [20, 40] either promises hour-long hashes or
+ * refuses walls the machine crosses in seconds. None of these throw; they
+ * only recommend the wrong number.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  CACHE_TTL_MS,
+  DEFAULT_HOP_HEIGHT,
+  DEFAULT_SIDESTEP_HEIGHT,
+  cacheValid,
+  calibrationState,
+  hopCeiling,
+  projectCantorMs,
+  recommendedHopHeight,
+  recommendedSidestepHeight,
+  sidestepCeiling,
+  startCalibration,
+  type CalibrationCacheEntry,
+} from './calibration'
+
+describe('projectCantorMs', () => {
+  it('returns measured heights untouched', () => {
+    expect(projectCantorMs({ 12: 10, 14: 40 }, 14)).toBe(40)
+    expect(projectCantorMs({ 12: 10, 14: 40 }, 12)).toBe(10)
+  })
+
+  it('extrapolates upward at the fitted ratio when it is steeper than the floor', () => {
+    // 100 -> 900 over two heights is 3x per height; 3 > 2.5 so the fit wins.
+    expect(projectCantorMs({ 14: 100, 16: 900 }, 17)).toBeCloseTo(2700, 6)
+    expect(projectCantorMs({ 14: 100, 16: 900 }, 18)).toBeCloseTo(8100, 6)
+  })
+
+  it('floors a too-flat fitted ratio at 2.5x per height', () => {
+    // 100 -> 121 fits 1.1x per height, which no real machine exhibits; the
+    // floor keeps the projection honest.
+    expect(projectCantorMs({ 14: 100, 16: 121 }, 17)).toBeCloseTo(121 * 2.5, 6)
+    expect(projectCantorMs({ 14: 100, 16: 121 }, 18)).toBeCloseTo(121 * 2.5 * 2.5, 6)
+  })
+
+  it('projects an unmeasured gap down from the measurement above it', () => {
+    expect(projectCantorMs({ 14: 100, 16: 900 }, 15)).toBeCloseTo(300, 6)
+  })
+
+  it('uses the floor with a single measurement, and NaN with none', () => {
+    expect(projectCantorMs({ 16: 100 }, 18)).toBeCloseTo(625, 6)
+    expect(projectCantorMs({}, 16)).toBeNaN()
+  })
+})
+
+describe('hopCeiling', () => {
+  it('lets a fast machine keep h20', () => {
+    // Fitted 2x floors to 2.5x: h20 projects to 4687.5 ms, inside 5000.
+    expect(hopCeiling({ 12: 8, 14: 30, 16: 120 })).toBe(20)
+  })
+
+  it('caps a decent machine at h19', () => {
+    // Same shape, 2.5x slower: h19 fits at 4687.5 ms, h20 busts at 11718.75.
+    expect(hopCeiling({ 12: 19, 14: 75, 16: 300 })).toBe(19)
+  })
+
+  it('caps a slow machine at its last affordable measurement', () => {
+    // h16 measured just inside budget; every projection above it busts.
+    expect(hopCeiling({ 12: 75, 14: 600, 16: 4800 })).toBe(16)
+  })
+
+  it('drops below the measurements when even they bust the budget', () => {
+    // h16 measured 9600 > 5000; h15 projects to 9600 / sqrt(8) ~ 3394.
+    expect(hopCeiling({ 12: 150, 14: 1200, 16: 9600 })).toBe(15)
+  })
+
+  it('clamps to the floor when nothing fits, without underquoting the gaps', () => {
+    // h13 projected upward from the cheap h12 would look affordable; it must
+    // project down from the measured h14 instead and bust like everything else.
+    expect(hopCeiling({ 12: 6000, 14: 20000, 16: 70000 })).toBe(12)
+  })
+
+  it('falls back to the default with nothing measured', () => {
+    expect(hopCeiling({})).toBe(DEFAULT_HOP_HEIGHT)
+  })
+})
+
+describe('sidestepCeiling', () => {
+  it('derives the largest wall 2^(h+1) hashes fit in the budget', () => {
+    // 1.5M hashes/s for 60 s affords 9e7 hashes: 2^26 fits, 2^27 does not.
+    expect(sidestepCeiling(1_500_000)).toBe(25)
+  })
+
+  it('clamps both ends of the range', () => {
+    expect(sidestepCeiling(1000)).toBe(20)
+    expect(sidestepCeiling(1e12)).toBe(40)
+  })
+
+  it('falls back to the default on a junk rate', () => {
+    expect(sidestepCeiling(0)).toBe(DEFAULT_SIDESTEP_HEIGHT)
+    expect(sidestepCeiling(-5)).toBe(DEFAULT_SIDESTEP_HEIGHT)
+    expect(sidestepCeiling(Number.NaN)).toBe(DEFAULT_SIDESTEP_HEIGHT)
+  })
+})
+
+describe('cacheValid', () => {
+  const entry: CalibrationCacheEntry = {
+    version: 1,
+    at: 1_000_000,
+    fingerprint: '8:Mozilla/. (X; Linux x_)',
+    cantorMsByHeight: { 12: 8, 14: 30, 16: 120 },
+    sha256PerSec: 500_000,
+  }
+
+  it('accepts a fresh entry from the same machine', () => {
+    expect(cacheValid(entry, entry.at + 1, entry.fingerprint)).toBe(true)
+    expect(cacheValid(entry, entry.at + CACHE_TTL_MS - 1, entry.fingerprint)).toBe(true)
+  })
+
+  it('expires at the TTL', () => {
+    expect(cacheValid(entry, entry.at + CACHE_TTL_MS, entry.fingerprint)).toBe(false)
+  })
+
+  it('rejects a timestamp from the future (the clock moved)', () => {
+    expect(cacheValid(entry, entry.at - 1, entry.fingerprint)).toBe(false)
+  })
+
+  it('rejects another machine\'s fingerprint', () => {
+    expect(cacheValid(entry, entry.at + 1, '4:Mozilla/. (M; Intel Mac OS X __)')).toBe(false)
+  })
+
+  it('rejects malformed or foreign shapes', () => {
+    expect(cacheValid(null, 1, entry.fingerprint)).toBe(false)
+    expect(cacheValid('junk', 1, entry.fingerprint)).toBe(false)
+    expect(cacheValid({ ...entry, version: 2 }, entry.at + 1, entry.fingerprint)).toBe(false)
+    expect(cacheValid({ ...entry, cantorMsByHeight: {} }, entry.at + 1, entry.fingerprint)).toBe(false)
+    expect(cacheValid({ ...entry, sha256PerSec: 0 }, entry.at + 1, entry.fingerprint)).toBe(false)
+    expect(cacheValid({ ...entry, cantorMsByHeight: { 12: 'fast' } }, entry.at + 1, entry.fingerprint)).toBe(false)
+  })
+})
+
+describe('singleton under node', () => {
+  it('serves the conservative defaults and stays pending without a Worker', () => {
+    expect(calibrationState()).toBe('pending')
+    expect(recommendedHopHeight()).toBe(DEFAULT_HOP_HEIGHT)
+    expect(recommendedSidestepHeight()).toBe(DEFAULT_SIDESTEP_HEIGHT)
+    // No Worker in node: startCalibration must no-op, not throw or spin.
+    startCalibration()
+    expect(calibrationState()).toBe('pending')
+    expect(recommendedHopHeight()).toBe(DEFAULT_HOP_HEIGHT)
+  })
+})

--- a/src/lib/calibration.ts
+++ b/src/lib/calibration.ts
@@ -1,0 +1,265 @@
+/**
+ * calibration.ts - what THIS machine can really compute, learned quietly.
+ *
+ * The protocol allows Cantor hops up to h20 and the UI used to advertise
+ * exactly that, but an h20 hop has never been observed to finish on real
+ * hardware: a commit computes up to three axis trees plus terrain, and the
+ * BigInt levels of one big tree allocate hundreds of megabytes, so the tab
+ * stalls or dies well below the nominal cap. Advertising a move the machine
+ * cannot complete is worse than an honest smaller ceiling.
+ *
+ * So a one-shot benchmark (workers/calibrate.worker.ts) times real single-axis
+ * Cantor trees and the raw SHA-256 rate, and the ceilings recommended here are
+ * derived from those timings against a wall-clock budget. MAX_COMPUTE_HEIGHT
+ * in the store stays the HARD cap (memory safety); this module only lowers
+ * what the app voluntarily attempts. Bigger moves are a future cloud offload's
+ * job, not this module's.
+ *
+ * The math is exported pure so tests can pin it down - a wrong ceiling fails
+ * silently as a stalled tab, never as an error. The singleton below owns the
+ * worker, the localStorage cache and the snapshot the HUD subscribes to.
+ */
+
+import { create } from 'zustand'
+import type { CalibrateResponse } from '../workers/calibrate.worker'
+
+/** Budget for ONE axis tree of a hop. A worst-case commit computes up to
+ * three axis trees plus the temporal tree, so 5 s per axis keeps a whole
+ * commit under roughly 20 s. */
+export const HOP_AXIS_BUDGET_MS = 5000
+/** Budget for a whole sidestep. Pure SHA-256 in O(h) memory, so it can run
+ * far longer than a hop without endangering the tab; a minute is the most a
+ * progress bar can honestly ask of anyone. */
+export const SIDESTEP_BUDGET_MS = 60_000
+
+/** Until measured: h17 finishes in seconds on modest hardware, where the old
+ * advertised h20 has never been seen to finish anywhere. */
+export const DEFAULT_HOP_HEIGHT = 17
+export const DEFAULT_SIDESTEP_HEIGHT = 24
+
+/** Cantor cost per height never grows slower than this in practice (2x the
+ * leaves times widening BigInts). Flooring the fitted ratio keeps one lucky
+ * pair of fast timings from projecting an h19/h20 the machine cannot do. */
+const GROWTH_RATIO_FLOOR = 2.5
+
+/** The range a hop recommendation can land in. The top mirrors the protocol's
+ * DEFAULT_MAX_COMPUTE_HEIGHT (the store's hard cap; importing it from there
+ * would be an import cycle), the bottom is the floor of the benchmark. */
+const HOP_CEILING_MIN = 12
+const HOP_CEILING_MAX = 20
+
+/** Sidestep recommendations are clamped here: below h20 a sidestep loses to a
+ * plain hop, above h40 even a fast machine is into hours of hashing. */
+const SIDESTEP_CEILING_MIN = 20
+const SIDESTEP_CEILING_MAX = 40
+
+/**
+ * Projected wall-clock ms for ONE axis Cantor tree at height h. Measured
+ * heights are returned as measured; gaps and heights above the data are
+ * log-linear extrapolations from the nearest measured height at the growth
+ * ratio fitted to the top two measurements, floored at GROWTH_RATIO_FLOOR so
+ * the projection is conservative. NaN when there are no measurements at all.
+ */
+export function projectCantorMs(cantorMsByHeight: Record<number, number>, h: number): number {
+  const measured = cantorMsByHeight[h]
+  if (measured !== undefined) return measured
+  const heights = Object.keys(cantorMsByHeight).map(Number).sort((a, b) => a - b)
+  if (heights.length === 0) return NaN
+  const top = heights[heights.length - 1]
+  let ratio = GROWTH_RATIO_FLOOR
+  if (heights.length >= 2) {
+    // Coarse timers can report ~0 ms; clamping keeps the fit finite.
+    const topMs = Math.max(cantorMsByHeight[top], 0.5)
+    const below = heights[heights.length - 2]
+    const belowMs = Math.max(cantorMsByHeight[below], 0.5)
+    const fitted = Math.pow(topMs / belowMs, 1 / (top - below))
+    if (Number.isFinite(fitted)) ratio = Math.max(fitted, GROWTH_RATIO_FLOOR)
+  }
+  // Project from the nearest measured height ABOVE h when one exists (an
+  // unmeasured gap), else upward from the top measurement. Projecting a gap
+  // downward from the top, not upward from below, keeps a cheap low reading
+  // from underquoting a height the data already showed to be expensive.
+  const baseH = heights.find((x) => x > h) ?? top
+  const baseMs = Math.max(cantorMsByHeight[baseH], 0.5)
+  return baseMs * Math.pow(ratio, h - baseH)
+}
+
+/**
+ * The largest hop height in [12, 20] whose projected single-axis time fits
+ * the budget; 12 when nothing does, and the conservative default when there
+ * is nothing measured to project from.
+ */
+export function hopCeiling(cantorMsByHeight: Record<number, number>, budgetMs: number = HOP_AXIS_BUDGET_MS): number {
+  if (Object.keys(cantorMsByHeight).length === 0) return DEFAULT_HOP_HEIGHT
+  for (let h = HOP_CEILING_MAX; h > HOP_CEILING_MIN; h--) {
+    if (projectCantorMs(cantorMsByHeight, h) <= budgetMs) return h
+  }
+  return HOP_CEILING_MIN
+}
+
+/**
+ * The largest sidestep height whose ~2^(h+1) hashes fit the budget at the
+ * measured rate, clamped to [20, 40]. The default when the rate is junk.
+ */
+export function sidestepCeiling(sha256PerSec: number, budgetMs: number = SIDESTEP_BUDGET_MS): number {
+  if (!Number.isFinite(sha256PerSec) || sha256PerSec <= 0) return DEFAULT_SIDESTEP_HEIGHT
+  const affordable = sha256PerSec * (budgetMs / 1000)
+  // Largest h with 2^(h+1) <= affordable.
+  const h = Math.floor(Math.log2(affordable)) - 1
+  return Math.min(SIDESTEP_CEILING_MAX, Math.max(SIDESTEP_CEILING_MIN, h))
+}
+
+/** What the cache stores: the raw measurements, not derived ceilings, so a
+ * future budget change re-derives without re-benchmarking. */
+export interface CalibrationCacheEntry {
+  version: 1
+  /** Date.now() at measurement. */
+  at: number
+  /** cacheFingerprint() at measurement; a different machine must remeasure. */
+  fingerprint: string
+  cantorMsByHeight: Record<number, number>
+  sha256PerSec: number
+}
+
+/** Hardware does not change often, but browsers update and machines get
+ * swapped; a week keeps the numbers honest without re-running every load. */
+export const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Whether a stored entry may be trusted right now. Pure so the tests can walk
+ * the clock and the fingerprint; a stale or foreign entry that slipped
+ * through would quietly serve another machine's ceilings.
+ */
+export function cacheValid(entry: unknown, now: number, fingerprint: string): entry is CalibrationCacheEntry {
+  if (typeof entry !== 'object' || entry === null) return false
+  const e = entry as Partial<CalibrationCacheEntry>
+  if (e.version !== 1) return false
+  if (e.fingerprint !== fingerprint) return false
+  // A timestamp in the future means the clock moved; its age is meaningless.
+  if (typeof e.at !== 'number' || now < e.at || now - e.at >= CACHE_TTL_MS) return false
+  if (typeof e.sha256PerSec !== 'number' || !Number.isFinite(e.sha256PerSec) || e.sha256PerSec <= 0) return false
+  if (typeof e.cantorMsByHeight !== 'object' || e.cantorMsByHeight === null) return false
+  const values = Object.values(e.cantorMsByHeight)
+  if (values.length === 0) return false
+  return values.every((v) => typeof v === 'number' && Number.isFinite(v) && v >= 0)
+}
+
+/** What the cache is keyed by: logical cores plus a COARSE user agent
+ * (digits stripped, so a browser point release keeps the measurements while a
+ * different browser or machine throws them away). */
+export function cacheFingerprint(): string {
+  if (typeof navigator === 'undefined') return 'no-navigator'
+  return `${navigator.hardwareConcurrency ?? 0}:${navigator.userAgent.replace(/[0-9]/g, '')}`
+}
+
+export type CalibrationStatus = 'pending' | 'measured' | 'cached'
+
+interface CalibrationSnapshot {
+  status: CalibrationStatus
+  /** Recommended hop ceiling: measured, else the conservative default. */
+  hopHeight: number
+  /** Recommended sidestep ceiling: measured, else the default. */
+  sidestepHeight: number
+}
+
+/**
+ * The live snapshot, as a store so the HUD re-renders the moment a benchmark
+ * or a cache read lands, the same mechanism every other panel uses.
+ */
+export const useCalibration = create<CalibrationSnapshot>(() => ({
+  status: 'pending',
+  hopHeight: DEFAULT_HOP_HEIGHT,
+  sidestepHeight: DEFAULT_SIDESTEP_HEIGHT,
+}))
+
+/** The hop ceiling commit() should route by. Conservative until measured. */
+export function recommendedHopHeight(): number {
+  return useCalibration.getState().hopHeight
+}
+
+/** The sidestep ceiling the UI should quote. Conservative until measured. */
+export function recommendedSidestepHeight(): number {
+  return useCalibration.getState().sidestepHeight
+}
+
+export function calibrationState(): CalibrationStatus {
+  return useCalibration.getState().status
+}
+
+const CACHE_KEY = 'onosendai:calibration'
+/** Startup is the busiest this app ever is (terrain pool, relays, profile
+ * fetches); the benchmark waits out that burst so it never competes with it. */
+const START_DELAY_MS = 8000
+
+function loadCache(): CalibrationCacheEntry | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const entry: unknown = JSON.parse(raw)
+    return cacheValid(entry, Date.now(), cacheFingerprint()) ? entry : null
+  } catch {
+    /* corrupt, private mode, or no localStorage (tests) */
+    return null
+  }
+}
+
+function saveCache(entry: CalibrationCacheEntry): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(entry))
+  } catch { /* private mode or quota; remeasuring next load is fine */ }
+}
+
+let started = false
+
+/**
+ * Idempotent. A valid cached measurement applies immediately with no worker;
+ * otherwise the benchmark is deferred past startup and runs once. Under
+ * vitest (node, no Worker) this is a no-op and the defaults stand.
+ */
+export function startCalibration(): void {
+  if (started) return
+  started = true
+  if (typeof Worker === 'undefined') return
+  const cached = loadCache()
+  if (cached) {
+    useCalibration.setState({
+      status: 'cached',
+      hopHeight: hopCeiling(cached.cantorMsByHeight),
+      sidestepHeight: sidestepCeiling(cached.sha256PerSec),
+    })
+    return
+  }
+  setTimeout(runBenchmark, START_DELAY_MS)
+}
+
+/** The worker is owned here, not in lib/workers.ts: it runs exactly once and
+ * dies, so it has no place in the long-lived pool registry. */
+function runBenchmark(): void {
+  let worker: Worker
+  try {
+    worker = new Worker(new URL('../workers/calibrate.worker.ts', import.meta.url), { type: 'module' })
+  } catch {
+    return
+  }
+  worker.onmessage = (event: MessageEvent<CalibrateResponse>) => {
+    const msg = event.data
+    worker.terminate()
+    // A failed benchmark leaves the conservative defaults standing, which is
+    // the right failure mode: never promise more than was proven.
+    if (msg.type !== 'result') return
+    saveCache({
+      version: 1,
+      at: Date.now(),
+      fingerprint: cacheFingerprint(),
+      cantorMsByHeight: msg.cantorMsByHeight,
+      sha256PerSec: msg.sha256PerSec,
+    })
+    useCalibration.setState({
+      status: 'measured',
+      hopHeight: hopCeiling(msg.cantorMsByHeight),
+      sidestepHeight: sidestepCeiling(msg.sha256PerSec),
+    })
+  }
+  worker.onerror = () => worker.terminate()
+  worker.postMessage({ id: 1 })
+}

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -16,7 +16,7 @@ import { nip19 } from 'nostr-tools'
 import { query, subscribe } from './relay'
 
 /** The actions this client understands, and therefore the only ones it asks for. */
-export const V2_ACTIONS = ['spawn', 'hop', 'sidestep']
+export const V2_ACTIONS = ['spawn', 'hop', 'sidestep', 'enter-hyperspace', 'hyperjump']
 
 const KIND = 3333
 

--- a/src/lib/covering.test.ts
+++ b/src/lib/covering.test.ts
@@ -136,3 +136,61 @@ describe('covering box containment', () => {
     }
   })
 })
+
+/**
+ * clippedAxes names WHICH walls of a clipped box understate the extent, so the
+ * renderer can animate exactly those and leave the honest ones still.
+ */
+describe('clipped axes', () => {
+  /** Straddles a height-17 boundary on whichever axes it is stepped across. */
+  const STRADDLE = (1n << 16n) - 1n
+
+  it('is empty when nothing is clipped', () => {
+    const to: Position = { x: AVATAR.x + 3n, y: AVATAR.y - 2n, z: AVATAR.z + 1n }
+    for (const axes of VIEWS) {
+      const box = coveringBox(AVATAR, to, alignedOrigin(AVATAR, 0), 0, axes, MAX_CELLS)
+      expect(box.clipped).toBe(false)
+      expect(box.clippedAxes).toEqual([])
+    }
+  })
+
+  it('names exactly the one axis whose region outgrew the window', () => {
+    // A two-cell step across the boundary covers 131072 cells on x; y and z do
+    // not move, so their coverings stay one cell each.
+    const from: Position = { x: STRADDLE, y: 5n, z: 9n }
+    const to: Position = { x: from.x + 2n, y: from.y, z: from.z }
+    for (const axes of VIEWS) {
+      const box = coveringBox(from, to, alignedOrigin(from, 0), 0, axes, MAX_CELLS)
+      expect(box.clipped).toBe(true)
+      expect(box.clippedAxes).toEqual(['x'])
+    }
+  })
+
+  it('names every clipped axis when several outgrow the window', () => {
+    // x and y straddle the height-17 boundary; z steps within a 4-cell subtree.
+    const from: Position = { x: STRADDLE, y: STRADDLE, z: 9n }
+    const to: Position = { x: from.x + 2n, y: from.y + 2n, z: from.z + 1n }
+    for (const axes of VIEWS) {
+      const box = coveringBox(from, to, alignedOrigin(from, 0), 0, axes, MAX_CELLS)
+      // Sorted before comparing: the list is built in screen order, which the
+      // view reshuffles, while WHICH axes are clipped is view-independent.
+      expect([...box.clippedAxes].sort()).toEqual(['x', 'y'])
+    }
+  })
+
+  it('reports the same unclamped heights and ops clipped or not', () => {
+    const from: Position = { x: STRADDLE, y: STRADDLE, z: STRADDLE }
+    const to: Position = { x: from.x + 100n, y: from.y + 100n, z: from.z + 100n }
+    const origin = alignedOrigin(from, 0)
+    // Wide enough for the 131072-cell region, so nothing needs a stand-in.
+    const wide = coveringBox(from, to, origin, 0, VIEWS[0], 1_000_000)
+    const tight = coveringBox(from, to, origin, 0, VIEWS[0], MAX_CELLS)
+    expect(wide.clipped).toBe(false)
+    expect(wide.clippedAxes).toEqual([])
+    expect(tight.clipped).toBe(true)
+    expect([...tight.clippedAxes].sort()).toEqual(['x', 'y', 'z'])
+    expect(tight.heights).toEqual(wide.heights)
+    expect(tight.peak).toBe(wide.peak)
+    expect(tight.ops).toBe(wide.ops)
+  })
+})

--- a/src/lib/covering.ts
+++ b/src/lib/covering.ts
@@ -14,7 +14,7 @@
 
 import { BufferGeometry, Float32BufferAttribute } from 'three'
 import { findLcaHeight, subtreeCantorOps } from 'cyberspace-core'
-import { alignTo, cellDelta, stepFor, type Position, type ViewAxes } from './space'
+import { alignTo, cellDelta, stepFor, type AxisName, type Position, type ViewAxes } from './space'
 
 export interface Covering {
   /** Render-space centre, in cells. */
@@ -31,6 +31,13 @@ export interface Covering {
   degenerate: boolean
   /** True when the real region is too large to draw and this is a stand-in. */
   clipped: boolean
+  /**
+   * Which world axes were too large to draw. `clipped` says the box understates
+   * its extent somewhere; this says where, so the renderer can put the "bigger
+   * than your view" motion on exactly the walls that understate it and leave
+   * the honest ones still.
+   */
+  clippedAxes: AxisName[]
 }
 
 /**
@@ -57,6 +64,7 @@ export function coveringBox(
   let peak = 0
   let ops = 0
   let clipped = false
+  const clippedAxes: AxisName[] = []
 
   for (let s = 0; s < 3; s++) {
     const axis = screen[s].axis
@@ -83,13 +91,14 @@ export function coveringBox(
     // Too big to draw. Bracket the endpoints instead, which always contains both
     // however far apart they are, and never lands somewhere neither of them is.
     clipped = true
+    clippedAxes.push(axis)
     const a = cellDelta(alignTo(from[axis], scaleExp), origin[axis], scaleExp)
     const b = cellDelta(alignTo(to[axis], scaleExp), origin[axis], scaleExp)
     size[s] = Math.max(1, Math.abs(b - a) + 1)
     centre[s] = ((a + b) / 2) * screen[s].dir
   }
 
-  return { centre, size, heights, peak, ops, degenerate: peak === 0, clipped }
+  return { centre, size, heights, peak, ops, degenerate: peak === 0, clipped, clippedAxes }
 }
 
 /** Edges of an axis-aligned box given its centre and per-axis size, in cells. */

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -66,6 +66,8 @@ export interface ActionEvent {
   /** Hyperjump only (DECK-0001 v3 §5.2): the boarding and destination heights. */
   fromHeight?: number
   toHeight?: number
+  /** Hyperjump only: the declared station set bound (as_of tag). */
+  asOf?: number
   /** Hyperjump only: the sampled openings, as written in the `mp` tag. */
   mp?: string
 }
@@ -200,6 +202,10 @@ export interface HyperjumpInput {
   toCoordHex: string
   fromHeight: number
   toHeight: number
+  /** The station set bound: the highest stop height considered when the
+   * station was computed (DECK-0001 v3 §4.2 as amended). Travelers declare
+   * the tip they synced to. */
+  asOf?: number
   /** The ride's Merkle root (64 hex; the zero root for a zero-length ride). */
   rootHex: string
   /** The sampled openings; empty string for a zero-length ride. */
@@ -221,6 +227,7 @@ export function hyperjumpTemplate(i: HyperjumpInput): EventTemplate {
       ['C', i.toCoordHex],
       ['from_height', String(i.fromHeight)],
       ['B', String(i.toHeight)],
+      ...(i.asOf !== undefined ? [['as_of', String(i.asOf)]] : []),
       ['proof', i.rootHex],
       ['mp', i.mp],
       ...sectorTags({ x: at.x, y: at.y, z: at.z }),
@@ -313,6 +320,8 @@ export function parseAction(ev: NostrEvent): ActionEvent | null {
     if (fromStr === undefined || !/^\d+$/.test(fromStr)) return null
     if (toStr === undefined || !/^\d+$/.test(toStr)) return null
     if (tag(ev, 'mp') === undefined) return null
+    const asOfStr = tag(ev, 'as_of')
+    if (asOfStr !== undefined && !/^\d+$/.test(asOfStr)) return null
     return {
       ...base,
       type,
@@ -322,6 +331,7 @@ export function parseAction(ev: NostrEvent): ActionEvent | null {
       proofHash,
       fromHeight: Number.parseInt(fromStr, 10),
       toHeight: Number.parseInt(toStr, 10),
+      asOf: asOfStr !== undefined ? Number.parseInt(asOfStr, 10) : undefined,
       mp: tag(ev, 'mp'),
     }
   }

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -28,7 +28,7 @@ import type { Position } from './space'
 /** §8.1: every movement action, spawn included, is this one kind. */
 export const ACTION_KIND = 3333
 
-export type ActionType = 'spawn' | 'hop' | 'sidestep'
+export type ActionType = 'spawn' | 'hop' | 'sidestep' | 'enter-hyperspace' | 'hyperjump'
 
 /** The shape nostr-tools signs and relays return; named here so nothing in
  * the app has to import it from the library to talk about an event. */
@@ -63,6 +63,11 @@ export interface ActionEvent {
   proofHash: string | null
   /** The `S` tag, as written. */
   sector: string
+  /** Hyperjump only (DECK-0001 v3 §5.2): the boarding and destination heights. */
+  fromHeight?: number
+  toHeight?: number
+  /** Hyperjump only: the sampled openings, as written in the `mp` tag. */
+  mp?: string
 }
 
 const HEX_64 = /^[0-9a-f]{64}$/
@@ -155,6 +160,74 @@ export function sidestepTemplate(i: SidestepInput): EventTemplate {
   }
 }
 
+export interface EnterHyperspaceInput {
+  createdAt: number
+  genesisId: string
+  previousId: string
+  /** Where the identity is standing; an enter does not move it (§3.3). */
+  at: Position
+  plane: Plane
+  /** The §3.2 entry proof hash. */
+  proofHash: string
+}
+
+/** DECK-0001 v3 §3.1: board the line from wherever you stand. c equals C. */
+export function enterHyperspaceTemplate(i: EnterHyperspaceInput): EventTemplate {
+  const here = positionHex(i.at, i.plane)
+  return {
+    kind: ACTION_KIND,
+    created_at: i.createdAt,
+    content: '',
+    tags: [
+      ['A', 'enter-hyperspace'],
+      ['e', i.genesisId, '', 'genesis'],
+      ['e', i.previousId, '', 'previous'],
+      ['c', here],
+      ['C', here],
+      ['proof', i.proofHash],
+      ...sectorTags(i.at),
+    ],
+  }
+}
+
+export interface HyperjumpInput {
+  createdAt: number
+  genesisId: string
+  previousId: string
+  /** The identity's current coordinate (the enter coordinate, or the previous stop). */
+  prevCoordHex: string
+  /** The destination stop's coordinate, already a 64-hex coord256. */
+  toCoordHex: string
+  fromHeight: number
+  toHeight: number
+  /** The ride's Merkle root (64 hex; the zero root for a zero-length ride). */
+  rootHex: string
+  /** The sampled openings; empty string for a zero-length ride. */
+  mp: string
+}
+
+/** DECK-0001 v3 §5.2: ride the line from the station (or current stop) to a stop. */
+export function hyperjumpTemplate(i: HyperjumpInput): EventTemplate {
+  const at = coordToXyz(hexToCoord(i.toCoordHex))
+  return {
+    kind: ACTION_KIND,
+    created_at: i.createdAt,
+    content: '',
+    tags: [
+      ['A', 'hyperjump'],
+      ['e', i.genesisId, '', 'genesis'],
+      ['e', i.previousId, '', 'previous'],
+      ['c', i.prevCoordHex],
+      ['C', i.toCoordHex],
+      ['from_height', String(i.fromHeight)],
+      ['B', String(i.toHeight)],
+      ['proof', i.rootHex],
+      ['mp', i.mp],
+      ...sectorTags({ x: at.x, y: at.y, z: at.z }),
+    ],
+  }
+}
+
 export function bytesToHex(bytes: Uint8Array): string {
   let out = ''
   for (const b of bytes) out += b.toString(16).padStart(2, '0')
@@ -187,7 +260,15 @@ function marked(ev: NostrEvent, marker: string): string | undefined {
 export function parseAction(ev: NostrEvent): ActionEvent | null {
   if (ev.kind !== ACTION_KIND) return null
   const type = tag(ev, 'A')
-  if (type !== 'spawn' && type !== 'hop' && type !== 'sidestep') return null
+  if (
+    type !== 'spawn' &&
+    type !== 'hop' &&
+    type !== 'sidestep' &&
+    type !== 'enter-hyperspace' &&
+    type !== 'hyperjump'
+  ) {
+    return null
+  }
   const coordHex = tag(ev, 'C')
   if (!coordHex || !HEX_64.test(coordHex)) return null
   const sector = tag(ev, 'S')
@@ -220,6 +301,29 @@ export function parseAction(ev: NostrEvent): ActionEvent | null {
   if (!proofHash || !HEX_64.test(proofHash)) return null
   if (type === 'sidestep') {
     for (const t of ['mr', 'mp', 'hx', 'hy', 'hz']) if (tag(ev, t) === undefined) return null
+  }
+  if (type === 'enter-hyperspace') {
+    // §3.1: an enter does not move; c must equal C.
+    if (prevCoordHex !== coordHex) return null
+  }
+  if (type === 'hyperjump') {
+    // §5.2: boarding and destination heights, and the openings tag (possibly empty).
+    const fromStr = tag(ev, 'from_height')
+    const toStr = tag(ev, 'B')
+    if (fromStr === undefined || !/^\d+$/.test(fromStr)) return null
+    if (toStr === undefined || !/^\d+$/.test(toStr)) return null
+    if (tag(ev, 'mp') === undefined) return null
+    return {
+      ...base,
+      type,
+      prevCoordHex,
+      genesisId,
+      previousId,
+      proofHash,
+      fromHeight: Number.parseInt(fromStr, 10),
+      toHeight: Number.parseInt(toStr, 10),
+      mp: tag(ev, 'mp'),
+    }
   }
   return { ...base, type, prevCoordHex, genesisId, previousId, proofHash }
 }

--- a/src/lib/hyperspace/anchors.test.ts
+++ b/src/lib/hyperspace/anchors.test.ts
@@ -17,6 +17,7 @@ import {
   recordFromStop,
   runsOf,
   stopFromRecord,
+  subtractCovered,
   type StopRecord,
 } from './anchors'
 import type { Stop } from './stops'
@@ -52,6 +53,37 @@ describe('mergeCovered', () => {
     const covered: Array<[number, number]> = [[0, 5]]
     mergeCovered(covered, [4, 9])
     expect(covered).toEqual([[0, 5]])
+  })
+})
+
+describe('subtractCovered', () => {
+  it('removes a whole range', () => {
+    expect(subtractCovered([[0, 9]], [0, 9])).toEqual([])
+    expect(subtractCovered([[3, 5]], [0, 9])).toEqual([])
+  })
+
+  it('trims overlaps on either side', () => {
+    expect(subtractCovered([[0, 9]], [0, 4])).toEqual([[5, 9]])
+    expect(subtractCovered([[0, 9]], [5, 9])).toEqual([[0, 4]])
+  })
+
+  it('splits a containing range', () => {
+    expect(subtractCovered([[0, 9]], [3, 5])).toEqual([[0, 2], [6, 9]])
+  })
+
+  it('leaves disjoint ranges alone and never mutates', () => {
+    const covered: Array<[number, number]> = [[0, 2], [10, 12]]
+    expect(subtractCovered(covered, [4, 8])).toEqual([[0, 2], [10, 12]])
+    expect(covered).toEqual([[0, 2], [10, 12]])
+  })
+
+  it('subtracts across several ranges', () => {
+    expect(subtractCovered([[0, 2], [4, 6], [8, 10]], [1, 9])).toEqual([[0, 0], [10, 10]])
+  })
+
+  it('round-trips with mergeCovered', () => {
+    const merged = mergeCovered([[0, 4]], [10, 14])
+    expect(subtractCovered(mergeCovered(merged, [5, 9]), [5, 9])).toEqual(merged)
   })
 })
 

--- a/src/lib/hyperspace/anchors.test.ts
+++ b/src/lib/hyperspace/anchors.test.ts
@@ -1,0 +1,185 @@
+/**
+ * What would fail silently without these tests: a covered-range merge that
+ * drops a range or misses an adjacency would make every reload re-fetch
+ * thousands of heights, or worse, believe a hole is covered and never fetch
+ * it; a wrong complement or batching would skip heights outright; a dedupe
+ * keeping the legacy anchor over the v3 one would pin a landfall to a
+ * derived coordinate when the publisher supplied the exact one; and a cache
+ * round trip that loses bigint precision would quietly misplace every stop.
+ * The UI would look plausible in all of these.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  batchesOf,
+  mergeCovered,
+  missingRanges,
+  pickBetter,
+  recordFromStop,
+  runsOf,
+  stopFromRecord,
+  type StopRecord,
+} from './anchors'
+import type { Stop } from './stops'
+
+describe('mergeCovered', () => {
+  it('inserts into an empty list', () => {
+    expect(mergeCovered([], [3, 7])).toEqual([[3, 7]])
+  })
+
+  it('merges an overlap', () => {
+    expect(mergeCovered([[0, 5]], [4, 9])).toEqual([[0, 9]])
+  })
+
+  it('merges adjacency: end + 1 touching start is one stretch', () => {
+    expect(mergeCovered([[0, 4]], [5, 9])).toEqual([[0, 9]])
+    expect(mergeCovered([[5, 9]], [0, 4])).toEqual([[0, 9]])
+  })
+
+  it('absorbs a contained range without changing the container', () => {
+    expect(mergeCovered([[0, 10]], [3, 5])).toEqual([[0, 10]])
+  })
+
+  it('bridges across several existing ranges', () => {
+    expect(mergeCovered([[0, 2], [5, 6], [10, 12]], [3, 9])).toEqual([[0, 12]])
+  })
+
+  it('keeps disjoint ranges sorted', () => {
+    expect(mergeCovered([[10, 12]], [0, 3])).toEqual([[0, 3], [10, 12]])
+    expect(mergeCovered([[0, 3]], [10, 12])).toEqual([[0, 3], [10, 12]])
+  })
+
+  it('never mutates its inputs', () => {
+    const covered: Array<[number, number]> = [[0, 5]]
+    mergeCovered(covered, [4, 9])
+    expect(covered).toEqual([[0, 5]])
+  })
+})
+
+describe('missingRanges', () => {
+  it('is everything when nothing is covered', () => {
+    expect(missingRanges([], 7)).toEqual([[0, 7]])
+    expect(missingRanges([], 0)).toEqual([[0, 0]])
+  })
+
+  it('is empty when fully covered', () => {
+    expect(missingRanges([[0, 3]], 3)).toEqual([])
+    expect(missingRanges([[0, 10]], 3)).toEqual([])
+  })
+
+  it('finds the holes between and around covered ranges', () => {
+    expect(missingRanges([[2, 4], [8, 9]], 12)).toEqual([[0, 1], [5, 7], [10, 12]])
+  })
+
+  it('clamps to the tip when coverage starts beyond it', () => {
+    expect(missingRanges([[10, 20]], 5)).toEqual([[0, 5]])
+  })
+})
+
+describe('batchesOf', () => {
+  it('chunks one range into batches of at most size', () => {
+    expect(batchesOf([[0, 4]], 2)).toEqual([[0, 1], [2, 3], [4]])
+  })
+
+  it('fills a batch across disjoint ranges, ascending', () => {
+    expect(batchesOf([[0, 1], [5, 6]], 3)).toEqual([[0, 1, 5], [6]])
+  })
+
+  it('handles exact multiples and empty input', () => {
+    expect(batchesOf([[0, 3]], 2)).toEqual([[0, 1], [2, 3]])
+    expect(batchesOf([], 500)).toEqual([])
+  })
+})
+
+describe('runsOf', () => {
+  it('splits an ascending list into contiguous runs', () => {
+    expect(runsOf([1, 2, 3, 7, 8, 10])).toEqual([[1, 3], [7, 8], [10, 10]])
+    expect(runsOf([])).toEqual([])
+    expect(runsOf([4])).toEqual([[4, 4]])
+  })
+})
+
+describe('pickBetter', () => {
+  const legacy = { hasM: false, name: 'legacy' }
+  const v3 = { hasM: true, name: 'v3' }
+
+  it('prefers the anchor with an M tag regardless of order', () => {
+    expect(pickBetter(legacy, v3)).toBe(v3)
+    expect(pickBetter(v3, legacy)).toBe(v3)
+  })
+
+  it('keeps the first seen on a tie', () => {
+    expect(pickBetter(legacy, { hasM: false, name: 'second' })).toBe(legacy)
+    expect(pickBetter(v3, { hasM: true, name: 'second' })).toBe(v3)
+  })
+})
+
+describe('stop record round trip', () => {
+  const hex64 = (last: string): string => '0'.repeat(63) + last
+
+  it('round-trips a landfall through hex without losing bigint precision', () => {
+    // High bit and low bit set: any float64 detour would destroy one of them.
+    const coord = (1n << 255n) | 1n
+    const stop: Stop = {
+      height: 900123,
+      kind: 'landfall',
+      merkleRoot: hex64('2'),
+      blockHash: hex64('a'),
+      coordExact: null,
+      coordApprox: coord,
+    }
+    const row = recordFromStop(stop)
+    expect(row.coordApproxHex).toHaveLength(64)
+    const back = stopFromRecord(row)
+    expect(back).not.toBeNull()
+    expect(back?.coordApprox).toBe(coord)
+    // A landfall's exact coordinate is re-derived from the hash, not cached.
+    expect(back?.coordExact).toBeNull()
+    expect(back?.blockHash).toBe(stop.blockHash)
+  })
+
+  it('pads small coordinates to 64 hex chars and restores them', () => {
+    const stop: Stop = {
+      height: 0,
+      kind: 'landfall',
+      merkleRoot: hex64('4'),
+      blockHash: hex64('b'),
+      coordExact: null,
+      coordApprox: 5n,
+    }
+    const row = recordFromStop(stop)
+    expect(row.coordApproxHex).toBe(hex64('5'))
+    expect(stopFromRecord(row)?.coordApprox).toBe(5n)
+  })
+
+  it('restores a port with coordExact equal to coordApprox', () => {
+    const coord = (0xabcdefn << 200n) | 0x1234567890n
+    const stop: Stop = {
+      height: 42,
+      kind: 'port',
+      merkleRoot: coord.toString(16).padStart(64, '0'),
+      blockHash: null,
+      coordExact: coord,
+      coordApprox: coord,
+    }
+    const back = stopFromRecord(recordFromStop(stop))
+    expect(back?.coordExact).toBe(coord)
+    expect(back?.coordApprox).toBe(coord)
+  })
+
+  it('rejects corrupt rows instead of trusting the cache', () => {
+    const good: StopRecord = {
+      height: 7,
+      kind: 'landfall',
+      merkleRoot: hex64('2'),
+      blockHash: hex64('c'),
+      coordApproxHex: hex64('9'),
+    }
+    expect(stopFromRecord(good)).not.toBeNull()
+    expect(stopFromRecord({ ...good, height: -1 })).toBeNull()
+    expect(stopFromRecord({ ...good, height: 1.5 })).toBeNull()
+    expect(stopFromRecord({ ...good, kind: 'weird' as StopRecord['kind'] })).toBeNull()
+    expect(stopFromRecord({ ...good, merkleRoot: 'zz' })).toBeNull()
+    expect(stopFromRecord({ ...good, coordApproxHex: '0x12' })).toBeNull()
+    expect(stopFromRecord({ ...good, blockHash: 'short' })).toBeNull()
+  })
+})

--- a/src/lib/hyperspace/anchors.test.ts
+++ b/src/lib/hyperspace/anchors.test.ts
@@ -6,7 +6,10 @@
  * keeping the legacy anchor over the v3 one would pin a landfall to a
  * derived coordinate when the publisher supplied the exact one; and a cache
  * round trip that loses bigint precision would quietly misplace every stop.
- * The UI would look plausible in all of these.
+ * A replay-stretch complement that wrongly believes a range is covered is
+ * the worst of them: 'covered' promises those heights are done, so nothing
+ * would ever re-fetch the rows the boot skipped and the index would stay
+ * silently short. The UI would look plausible in all of these.
  */
 import { describe, expect, it } from 'vitest'
 import {
@@ -15,6 +18,7 @@ import {
   missingRanges,
   pickBetter,
   recordFromStop,
+  replayStretches,
   runsOf,
   stopFromRecord,
   subtractCovered,
@@ -127,6 +131,34 @@ describe('runsOf', () => {
     expect(runsOf([1, 2, 3, 7, 8, 10])).toEqual([[1, 3], [7, 8], [10, 10]])
     expect(runsOf([])).toEqual([])
     expect(runsOf([4])).toEqual([[4, 4]])
+  })
+})
+
+describe('replayStretches', () => {
+  it('is one unbounded stretch with no snapshot and no blobs (the old full replay)', () => {
+    expect(replayStretches([], [])).toEqual([[0, null]])
+  })
+
+  it('matches the blob-only complement when there is no snapshot', () => {
+    expect(replayStretches([], [[2, 4], [8, 9]])).toEqual([[0, 1], [5, 7], [10, null]])
+  })
+
+  it('leaves only the open tail when the snapshot covered everything so far', () => {
+    expect(replayStretches([[0, 100]], [])).toEqual([[101, null]])
+  })
+
+  it('replays the head when coverage does not start at zero', () => {
+    expect(replayStretches([[5, 9]], [])).toEqual([[0, 4], [10, null]])
+  })
+
+  it('finds the gaps between covered stretches', () => {
+    expect(replayStretches([[2, 4], [10, 14]], [[6, 7]])).toEqual([[0, 1], [5, 5], [8, 9], [15, null]])
+  })
+
+  it('unions snapshot and blob coverage, fusing overlap and adjacency', () => {
+    expect(replayStretches([[0, 4]], [[5, 9]])).toEqual([[10, null]])
+    expect(replayStretches([[0, 10]], [[5, 20]])).toEqual([[21, null]])
+    expect(replayStretches([[10, 12]], [[0, 3]])).toEqual([[4, 9], [13, null]])
   })
 })
 

--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -274,6 +274,9 @@ export interface SyncCallbacks {
 
 const BATCH_SIZE = 500
 const CONCURRENCY = 3
+/** Gap between relay batches while the panels are closed: the user is in the
+ * scene, so frames outrank the backfill's finish line. */
+const BACKGROUND_BATCH_GAP_MS = 600
 const RETRY_MS = 30_000
 /** indexVersion bump floor once the line is ready (the live tail). */
 const BUMP_MS = 500
@@ -523,6 +526,16 @@ async function discoverTip(): Promise<number | null> {
   return tip
 }
 
+// The pace lever, driven by the hamburger menu: open panels mean the user is
+// watching the sync numbers, so it runs full tilt; closed panels mean they
+// are playing, so the backfill breathes between batches. Off until the app
+// says otherwise, which errs toward smooth frames on first paint.
+let syncHighPriority = false
+
+export function setSyncPriority(high: boolean): void {
+  syncHighPriority = high
+}
+
 async function processBatch(heights: number[], cb: SyncCallbacks): Promise<void> {
   const events = await query({ kinds: [321], '#B': heights.map(String), limit: 2000 })
   const best = new Map<number, { stop: Stop; hasM: boolean }>()
@@ -563,6 +576,7 @@ async function syncMissing(tip: number, cb: SyncCallbacks): Promise<void> {
       const batch = batches[next]
       next += 1
       await processBatch(batch, cb)
+      if (!syncHighPriority) await delay(BACKGROUND_BATCH_GAP_MS)
     }
   }
   await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()))

--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -285,6 +285,7 @@ const MERGE_SLICE_MS = 12
 const CACHE_CHUNK = 50_000
 const COVERED_KEY = 'covered'
 const SNAPSHOT_KEY = 'indexSnapshot'
+const TIP_KEY = 'tip'
 /** Tail re-snapshot gates: both must pass, so the ~130 MB put stays rare. */
 const SNAPSHOT_INTERVAL_MS = 10 * 60_000
 const SNAPSHOT_MIN_GROWTH = 5000
@@ -393,6 +394,16 @@ function persistCovered(): void {
   const database = db
   metaChain = metaChain
     .then(() => putMeta(database, COVERED_KEY, covered))
+    .catch(() => { /* cache write is best effort */ })
+}
+
+/** Remember the tip across reloads, riding the same write chain as covered,
+ * so the next boot can report the cache replay as a real percentage. */
+function persistTip(tip: number): void {
+  if (!db) return
+  const database = db
+  metaChain = metaChain
+    .then(() => putMeta(database, TIP_KEY, tip))
     .catch(() => { /* cache write is best effort */ })
 }
 
@@ -577,6 +588,7 @@ function startTail(cb: SyncCallbacks): void {
     if (knownTip === null || stop.height > knownTip) {
       knownTip = stop.height
       cb.onTip(stop.height)
+      persistTip(stop.height)
     }
     cb.onLoaded(anchorIndex.size)
     scheduleBump(cb)
@@ -622,6 +634,20 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
     db = null
   }
 
+  // The previous session's tip, so the loading phase can show a real
+  // percentage: without it the total is unknown until the manifest or the
+  // relay answers, and the whole cache replay reads LOADING 0%. Stale is
+  // fine, the tip only grows, and every later onTip overwrites it.
+  if (db) {
+    try {
+      const t = await getMeta(db, TIP_KEY)
+      if (typeof t === 'number' && Number.isSafeInteger(t) && t >= 0) {
+        knownTip = t
+        cb.onTip(t)
+      }
+    } catch { /* cache read is best effort */ }
+  }
+
   // Header-blob phase. fetchManifest never throws; null means the relay owns
   // everything this session.
   const mf = await fetchManifest()
@@ -630,6 +656,7 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
     setStatus(cb, 'syncing')
     knownTip = mf.manifest.generatedAtHeight
     cb.onTip(knownTip)
+    persistTip(knownTip)
     const result = await runHeaderSync(mf.manifest, mf.url, {
       onProgress: (_startHeight, verified) => cb.onLoaded(anchorIndex.size + verified),
       onColumns: (cols) => {
@@ -671,6 +698,7 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
       const tip = Math.max(relayTip ?? 0, knownMax ?? 0)
       knownTip = tip
       cb.onTip(tip)
+      persistTip(tip)
       setStatus(cb, 'syncing')
       await syncMissing(tip, cb)
       // Do not declare ready with rows still outside the sorted view; the

--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -1,0 +1,425 @@
+/**
+ * anchors.ts: the kind 321 anchor sync engine behind useHyperspace.
+ *
+ * The line is ~950k stops and grows by one every ten minutes, so the problem
+ * is shaped like a one-time bulk download plus a trickle. Everything fetched
+ * is cached in IndexedDB alongside a 'covered' list of height ranges, so a
+ * reload replays the cache and only fetches the complement. A height the
+ * relay has no anchor for still counts as covered; without that, a single
+ * genuinely missing block would be re-queried on every load forever.
+ *
+ * The stop index and the by-height map are module-level mutable singletons,
+ * the cameraPose convention: bulk data React must never re-render on.
+ * Components watch useHyperspace.indexVersion instead, and the engine bumps
+ * it at most once per 500 ms while the bulk load churns.
+ *
+ * Bulk insertion is a sorted-array merge (bulkInsert) rather than per-stop
+ * insertStop, because a splice into a ~950k-element array per stop is
+ * quadratic across a full load. The live tail is one block per ten minutes,
+ * which is what insertStop is for.
+ *
+ * Coordinates are persisted as 64-char hex, never through Number: a coord256
+ * has 256 bits and a float64 mantissa has 53, so a numeric round trip would
+ * silently move every cached stop.
+ *
+ * The pure range and dedupe helpers are exported for anchors.test.ts; the
+ * driver below them is the impure part.
+ */
+
+import { query, subscribe } from '../relay'
+import { stopFromAnchor, type Stop, type StopKind } from './stops'
+import { insertStop, type StopIndex } from './station'
+import { getAllPaged, getMeta, openDb, putMany, putMeta, STOPS_STORE } from './idb'
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a range into a sorted, merged list of inclusive [start, end] ranges,
+ * fusing overlaps and adjacency ([0,4] + [5,9] is one covered stretch).
+ * Returns a new array; the inputs are never mutated, because the caller may
+ * hand the previous value to an in-flight IndexedDB write.
+ */
+export function mergeCovered(
+  covered: Array<[number, number]>,
+  range: [number, number],
+): Array<[number, number]> {
+  const all = [...covered, range].sort((a, b) => a[0] - b[0] || a[1] - b[1])
+  const out: Array<[number, number]> = []
+  for (const [start, end] of all) {
+    const last = out[out.length - 1]
+    if (last && start <= last[1] + 1) {
+      if (end > last[1]) last[1] = end
+    } else {
+      out.push([start, end])
+    }
+  }
+  return out
+}
+
+/**
+ * The complement of the covered ranges within [0, tip]. Assumes covered is
+ * sorted and merged, which mergeCovered maintains.
+ */
+export function missingRanges(
+  covered: Array<[number, number]>,
+  tip: number,
+): Array<[number, number]> {
+  const out: Array<[number, number]> = []
+  let cursor = 0
+  for (const [start, end] of covered) {
+    if (cursor > tip) break
+    if (start > cursor) out.push([cursor, Math.min(start - 1, tip)])
+    if (end + 1 > cursor) cursor = end + 1
+  }
+  if (cursor <= tip) out.push([cursor, tip])
+  return out
+}
+
+/**
+ * Flatten ranges into ascending height batches of at most `size`. A batch may
+ * span disjoint ranges: the relay filter takes an explicit height list, so
+ * there is no reason to waste a round trip on a short tail range.
+ */
+export function batchesOf(ranges: Array<[number, number]>, size: number): number[][] {
+  const out: number[][] = []
+  let current: number[] = []
+  for (const [start, end] of ranges) {
+    for (let h = start; h <= end; h++) {
+      current.push(h)
+      if (current.length === size) {
+        out.push(current)
+        current = []
+      }
+    }
+  }
+  if (current.length > 0) out.push(current)
+  return out
+}
+
+/** Contiguous runs within an ascending height list, as inclusive ranges. */
+export function runsOf(heights: number[]): Array<[number, number]> {
+  const out: Array<[number, number]> = []
+  for (const h of heights) {
+    const last = out[out.length - 1]
+    if (last && h === last[1] + 1) last[1] = h
+    else out.push([h, h])
+  }
+  return out
+}
+
+/**
+ * Dedupe preference between two anchors for the same height. hasM is whether
+ * the anchor event carried an M tag: a v3 anchor supplies the stop coordinate
+ * exactly, a legacy one forces the landfall to be re-derived, so v3 wins.
+ * On a tie the first seen wins, so ingestion order is stable.
+ */
+export interface StopRecordLike {
+  hasM: boolean
+}
+
+export function pickBetter<T extends StopRecordLike>(first: T, incoming: T): T {
+  return incoming.hasM && !first.hasM ? incoming : first
+}
+
+// ---------------------------------------------------------------------------
+// Cache rows
+// ---------------------------------------------------------------------------
+
+/** A stop as it sits in the IndexedDB 'stops' store: plain JSON, hex coords. */
+export interface StopRecord {
+  height: number
+  kind: StopKind
+  merkleRoot: string
+  blockHash: string | null
+  coordApproxHex: string
+}
+
+const HEX64 = /^[0-9a-f]{64}$/
+
+export function recordFromStop(stop: Stop): StopRecord {
+  return {
+    height: stop.height,
+    kind: stop.kind,
+    merkleRoot: stop.merkleRoot,
+    blockHash: stop.blockHash,
+    coordApproxHex: stop.coordApprox.toString(16).padStart(64, '0'),
+  }
+}
+
+/**
+ * Rebuild a Stop from a cached row, or null for anything corrupt: the cache
+ * is a convenience, so a bad row is dropped and re-fetched, never trusted.
+ * coordExact is not cached. A port's equals its coordApprox; a landfall's is
+ * re-derived from the block hash on demand by stopCoordExact.
+ */
+export function stopFromRecord(row: StopRecord): Stop | null {
+  if (!Number.isSafeInteger(row.height) || row.height < 0) return null
+  if (row.kind !== 'port' && row.kind !== 'landfall') return null
+  if (!HEX64.test(row.merkleRoot) || !HEX64.test(row.coordApproxHex)) return null
+  if (row.blockHash !== null && !HEX64.test(row.blockHash)) return null
+  const coordApprox = BigInt('0x' + row.coordApproxHex)
+  return {
+    height: row.height,
+    kind: row.kind,
+    merkleRoot: row.merkleRoot,
+    blockHash: row.blockHash,
+    coordExact: row.kind === 'port' ? coordApprox : null,
+    coordApprox,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singletons
+// ---------------------------------------------------------------------------
+
+/** The live, mutable stop index. Same object identity for the page's life;
+ * bulkInsert swaps its internal arrays in place. */
+export const anchorIndex: StopIndex = { keys: [], stops: [] }
+
+/** Every known stop by height; its size is sync.loaded. */
+export const anchorsByHeight = new Map<number, Stop>()
+
+// ---------------------------------------------------------------------------
+// Sync driver
+// ---------------------------------------------------------------------------
+
+export interface SyncCallbacks {
+  onStatus: (status: 'loading-cache' | 'syncing' | 'ready' | 'error', error?: string) => void
+  onLoaded: (loaded: number) => void
+  onTip: (tip: number) => void
+  onIndexChanged: () => void
+}
+
+const BATCH_SIZE = 500
+const CONCURRENCY = 3
+const RETRY_MS = 30_000
+const BUMP_MS = 500
+const CACHE_CHUNK = 5000
+const COVERED_KEY = 'covered'
+
+let running = false
+let db: IDBDatabase | null = null
+let covered: Array<[number, number]> = []
+let knownTip: number | null = null
+let metaChain: Promise<void> = Promise.resolve()
+let lastBump = 0
+let bumpTimer: ReturnType<typeof setTimeout> | null = null
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Bump indexVersion now, or trail into one bump at most every BUMP_MS. */
+function scheduleBump(cb: SyncCallbacks): void {
+  const since = Date.now() - lastBump
+  if (since >= BUMP_MS) {
+    lastBump = Date.now()
+    cb.onIndexChanged()
+    return
+  }
+  if (bumpTimer !== null) return
+  bumpTimer = setTimeout(() => {
+    bumpTimer = null
+    lastBump = Date.now()
+    cb.onIndexChanged()
+  }, BUMP_MS - since)
+}
+
+/** Merge a batch of stops into the index in one O(n + m) pass. */
+function bulkInsert(stops: Stop[]): void {
+  if (stops.length === 0) return
+  const add = stops.map((s) => ({ key: s.coordApprox >> 1n, stop: s }))
+  add.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+  const oldKeys = anchorIndex.keys
+  const oldStops = anchorIndex.stops
+  const keys: bigint[] = []
+  const merged: Stop[] = []
+  let i = 0
+  let j = 0
+  while (i < oldKeys.length || j < add.length) {
+    if (j >= add.length || (i < oldKeys.length && oldKeys[i] <= add[j].key)) {
+      keys.push(oldKeys[i])
+      merged.push(oldStops[i])
+      i++
+    } else {
+      keys.push(add[j].key)
+      merged.push(add[j].stop)
+      j++
+    }
+  }
+  anchorIndex.keys = keys
+  anchorIndex.stops = merged
+}
+
+function validCovered(v: unknown): v is Array<[number, number]> {
+  return Array.isArray(v) && v.every((r) =>
+    Array.isArray(r) && r.length === 2 &&
+    Number.isSafeInteger(r[0]) && Number.isSafeInteger(r[1]) &&
+    r[0] >= 0 && r[1] >= r[0])
+}
+
+/**
+ * Persist the covered ranges through a promise chain so concurrent batches
+ * cannot commit an older snapshot after a newer one: each link reads the
+ * current `covered` when it runs, not when it was queued.
+ */
+function persistCovered(): void {
+  if (!db) return
+  const database = db
+  metaChain = metaChain
+    .then(() => putMeta(database, COVERED_KEY, covered))
+    .catch(() => { /* cache write is best effort */ })
+}
+
+async function loadCache(cb: SyncCallbacks): Promise<void> {
+  if (!db) return
+  const stored = await getMeta(db, COVERED_KEY)
+  if (validCovered(stored)) covered = stored
+  await getAllPaged<StopRecord>(db, STOPS_STORE, CACHE_CHUNK, (row) => row.height, async (rows) => {
+    const fresh: Stop[] = []
+    for (const row of rows) {
+      const stop = stopFromRecord(row)
+      if (stop && !anchorsByHeight.has(stop.height)) {
+        anchorsByHeight.set(stop.height, stop)
+        fresh.push(stop)
+      }
+    }
+    bulkInsert(fresh)
+    cb.onLoaded(anchorsByHeight.size)
+    scheduleBump(cb)
+    // A cold ~950k-row load must not starve rendering: hand back the loop.
+    await delay(0)
+  })
+}
+
+/** The max B among the newest anchors; the NTH publisher tails the tip. */
+async function discoverTip(): Promise<number | null> {
+  const events = await query({ kinds: [321], limit: 20 })
+  let tip: number | null = null
+  for (const ev of events) {
+    const stop = stopFromAnchor(ev)
+    if (stop && (tip === null || stop.height > tip)) tip = stop.height
+  }
+  return tip
+}
+
+function maxKnownHeight(): number | null {
+  let max: number | null = null
+  for (const h of anchorsByHeight.keys()) if (max === null || h > max) max = h
+  return max
+}
+
+async function processBatch(heights: number[], cb: SyncCallbacks): Promise<void> {
+  const events = await query({ kinds: [321], '#B': heights.map(String), limit: 2000 })
+  const best = new Map<number, { stop: Stop; hasM: boolean }>()
+  for (const ev of events) {
+    const stop = stopFromAnchor(ev)
+    if (!stop || anchorsByHeight.has(stop.height)) continue
+    const candidate = { stop, hasM: ev.tags.some((t) => t.length >= 2 && t[0] === 'M') }
+    const seen = best.get(stop.height)
+    best.set(stop.height, seen ? pickBetter(seen, candidate) : candidate)
+  }
+  const fresh = [...best.values()].map((b) => b.stop)
+  for (const stop of fresh) anchorsByHeight.set(stop.height, stop)
+  bulkInsert(fresh)
+  // The whole batch is covered even where no event came back: the relay may
+  // genuinely lack a few heights, and re-querying them forever would pin the
+  // sync just short of done.
+  for (const run of runsOf(heights)) covered = mergeCovered(covered, run)
+  cb.onLoaded(anchorsByHeight.size)
+  scheduleBump(cb)
+  if (db && fresh.length > 0) {
+    try {
+      await putMany(db, STOPS_STORE, fresh.map(recordFromStop))
+    } catch { /* cache write is best effort */ }
+  }
+  persistCovered()
+}
+
+async function syncMissing(tip: number, cb: SyncCallbacks): Promise<void> {
+  const batches = batchesOf(missingRanges(covered, tip), BATCH_SIZE)
+  let next = 0
+  const worker = async (): Promise<void> => {
+    while (next < batches.length) {
+      const batch = batches[next]
+      next += 1
+      await processBatch(batch, cb)
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()))
+}
+
+/** Hold a subscription so new blocks land as the publisher anchors them. */
+function startTail(cb: SyncCallbacks): void {
+  const since = Math.floor(Date.now() / 1000) - 3600
+  subscribe({ kinds: [321], since }, (ev) => {
+    const stop = stopFromAnchor(ev)
+    // The publisher re-announces the tip continuously; a height already in
+    // the map is the common case here, not an error.
+    if (!stop || anchorsByHeight.has(stop.height)) return
+    anchorsByHeight.set(stop.height, stop)
+    insertStop(anchorIndex, stop)
+    covered = mergeCovered(covered, [stop.height, stop.height])
+    if (db) {
+      putMany(db, STOPS_STORE, [recordFromStop(stop)]).catch(() => { /* best effort */ })
+      persistCovered()
+    }
+    if (knownTip === null || stop.height > knownTip) {
+      knownTip = stop.height
+      cb.onTip(stop.height)
+    }
+    cb.onLoaded(anchorsByHeight.size)
+    scheduleBump(cb)
+  })
+}
+
+/**
+ * The whole pipeline: cache replay, tip discovery, batched backfill with a
+ * 30 s retry, then the live tail. Runs once per page; the store's startSync
+ * is the idempotence gate, this flag is just belt and braces.
+ */
+export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
+  if (running) return
+  running = true
+
+  cb.onStatus('loading-cache')
+  try {
+    db = await openDb()
+  } catch {
+    // Private mode or a broken IndexedDB: sync still works, it just cannot
+    // resume across reloads.
+    db = null
+  }
+  try {
+    await loadCache(cb)
+  } catch {
+    // A corrupt cache is not fatal: whatever validated is in the index, and
+    // the network stage re-fetches anything the cache failed to deliver.
+  }
+
+  for (;;) {
+    try {
+      const relayTip = await discoverTip()
+      const cachedTip = maxKnownHeight()
+      if (relayTip === null && cachedTip === null) {
+        cb.onStatus('error', 'no anchors from the relay and no cache to fall back on')
+        await delay(RETRY_MS)
+        continue
+      }
+      // The cache can be ahead of a relay that lost data; trust the max so
+      // loaded never exceeds total.
+      const tip = Math.max(relayTip ?? 0, cachedTip ?? 0)
+      knownTip = tip
+      cb.onTip(tip)
+      cb.onStatus('syncing')
+      await syncMissing(tip, cb)
+      cb.onStatus('ready')
+      break
+    } catch (e) {
+      cb.onStatus('error', e instanceof Error ? e.message : String(e))
+      await delay(RETRY_MS)
+    }
+  }
+
+  startTail(cb)
+}

--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -1,26 +1,34 @@
 /**
- * anchors.ts: the kind 321 anchor sync engine behind useHyperspace.
+ * anchors.ts: the stop sync engine behind useHyperspace.
  *
- * The line is ~950k stops and grows by one every ten minutes, so the problem
- * is shaped like a one-time bulk download plus a trickle. Everything fetched
- * is cached in IndexedDB alongside a 'covered' list of height ranges, so a
- * reload replays the cache and only fetches the complement. A height the
- * relay has no anchor for still counts as covered; without that, a single
- * genuinely missing block would be re-queried on every load forever.
+ * The line is ~1M stops and grows by one every ten minutes. The primary
+ * source is now the statically served header blobs (headerSync.ts): a worker
+ * downloads, verifies and derives them off the main thread and hands back
+ * flat columns, which covers everything up to the manifest's generation
+ * height for ~50 MB instead of ~570 MB of relay events. The kind-321 relay
+ * path remains for everything else: the tail beyond the blobs, any blob that
+ * failed verification, and the whole line when the manifest is unreachable,
+ * in which case this degrades to exactly the old behaviour.
  *
- * The stop index and the by-height map are module-level mutable singletons,
- * the cameraPose convention: bulk data React must never re-render on.
- * Components watch useHyperspace.indexVersion instead, and the engine bumps
- * it at most once per 500 ms while the bulk load churns.
+ * Relay-fetched stops are cached in IndexedDB alongside a 'covered' list of
+ * height ranges, so a reload replays the cache and only fetches the
+ * complement. A height the relay has no anchor for still counts as covered;
+ * without that, a single genuinely missing block would be re-queried on every
+ * load forever. Blob-verified heights are deliberately NOT persisted in
+ * 'covered': the Cache API holds the raw blobs and re-verification is cheap,
+ * and if the manifest ever vanishes those heights must become the relay's
+ * job again. Rows the blobs supersede are pruned from IndexedDB after sync
+ * (and subtracted from 'covered') so the stops store holds relay-sourced
+ * heights only.
  *
- * Bulk insertion is a sorted-array merge (bulkInsert) rather than per-stop
- * insertStop, because a splice into a ~950k-element array per stop is
- * quadratic across a full load. The live tail is one block per ten minutes,
- * which is what insertStop is for.
- *
- * Coordinates are persisted as 64-char hex, never through Number: a coord256
- * has 256 bits and a float64 mantissa has 53, so a numeric round trip would
- * silently move every cached stop.
+ * The stop index is a module-level mutable singleton, the cameraPose
+ * convention: bulk data React must never re-render on. Components watch
+ * useHyperspace.indexVersion instead; while the bulk load churns the engine
+ * bumps it at most once per 2.5 s, and once ready at most twice a second.
+ * All bulk arrivals (blob columns, cache replay, relay batches) go through
+ * the columnar index's pending queue and are folded into the sorted view by
+ * an idle-scheduled incremental merge, never by a long main-thread stall;
+ * only the one-block-per-ten-minutes tail takes the in-place insert path.
  *
  * The pure range and dedupe helpers are exported for anchors.test.ts; the
  * driver below them is the impure part.
@@ -28,8 +36,26 @@
 
 import { query, subscribe } from '../relay'
 import { stopFromAnchor, type Stop, type StopKind } from './stops'
-import { insertStop, type StopIndex } from './station'
-import { getAllPaged, getMeta, openDb, putMany, putMeta, STOPS_STORE } from './idb'
+import {
+  appendColumns,
+  appendStops,
+  createStopIndex,
+  hasPending,
+  insertRow,
+  mergeStep,
+  rowByHeight,
+  type StopIndex,
+} from './compactIndex'
+import { fetchManifest, runHeaderSync } from './headerSync'
+import {
+  deleteRange,
+  getMeta,
+  getRangePaged,
+  openDb,
+  putMany,
+  putMeta,
+  STOPS_STORE,
+} from './idb'
 
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for tests)
@@ -54,6 +80,24 @@ export function mergeCovered(
     } else {
       out.push([start, end])
     }
+  }
+  return out
+}
+
+/** Remove a range from a sorted, merged covered list; the pruning inverse of
+ * mergeCovered, with the same never-mutate contract. */
+export function subtractCovered(
+  covered: Array<[number, number]>,
+  range: [number, number],
+): Array<[number, number]> {
+  const out: Array<[number, number]> = []
+  for (const [start, end] of covered) {
+    if (end < range[0] || start > range[1]) {
+      out.push([start, end])
+      continue
+    }
+    if (start < range[0]) out.push([start, range[0] - 1])
+    if (end > range[1]) out.push([range[1] + 1, end])
   }
   return out
 }
@@ -175,18 +219,18 @@ export function stopFromRecord(row: StopRecord): Stop | null {
 // ---------------------------------------------------------------------------
 
 /** The live, mutable stop index. Same object identity for the page's life;
- * bulkInsert swaps its internal arrays in place. */
-export const anchorIndex: StopIndex = { keys: [], stops: [] }
-
-/** Every known stop by height; its size is sync.loaded. */
-export const anchorsByHeight = new Map<number, Stop>()
+ * rows append and the sorted view is swapped in place. */
+export const anchorIndex: StopIndex = createStopIndex()
 
 // ---------------------------------------------------------------------------
 // Sync driver
 // ---------------------------------------------------------------------------
 
+export type SyncSource = 'blobs' | 'relay' | 'mixed'
+
 export interface SyncCallbacks {
   onStatus: (status: 'loading-cache' | 'syncing' | 'ready' | 'error', error?: string) => void
+  onSource: (source: SyncSource) => void
   onLoaded: (loaded: number) => void
   onTip: (tip: number) => void
   onIndexChanged: () => void
@@ -195,24 +239,48 @@ export interface SyncCallbacks {
 const BATCH_SIZE = 500
 const CONCURRENCY = 3
 const RETRY_MS = 30_000
+/** indexVersion bump floor once the line is ready (the live tail). */
 const BUMP_MS = 500
+/** Bump floor while syncing: geometry rebuilds off ~1M points are the single
+ * most expensive reaction to a bump, so during the bulk load they are rationed. */
+const SYNC_BUMP_MS = 2500
+/** Main-thread budget per merge slice; comfortably inside one frame. */
+const MERGE_SLICE_MS = 12
 const CACHE_CHUNK = 5000
 const COVERED_KEY = 'covered'
 
 let running = false
 let db: IDBDatabase | null = null
 let covered: Array<[number, number]> = []
+/** Verified header-blob ranges, this session only (see the header comment). */
+let blobCovered: Array<[number, number]> = []
+/** Rows delivered by verified blobs, for the source label. */
+let blobRows = 0
 let knownTip: number | null = null
 let metaChain: Promise<void> = Promise.resolve()
+let currentStatus: 'loading-cache' | 'syncing' | 'ready' | 'error' = 'loading-cache'
 let lastBump = 0
 let bumpTimer: ReturnType<typeof setTimeout> | null = null
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
-/** Bump indexVersion now, or trail into one bump at most every BUMP_MS. */
+/** Idle-time scheduling where the platform offers it, macrotask elsewhere. */
+function later(fn: () => void): void {
+  if (typeof requestIdleCallback === 'function') requestIdleCallback(() => fn(), { timeout: 200 })
+  else setTimeout(fn, 0)
+}
+
+function setStatus(cb: SyncCallbacks, status: typeof currentStatus, error?: string): void {
+  currentStatus = status
+  cb.onStatus(status, error)
+}
+
+/** Bump indexVersion now, or trail into one bump per interval; the interval
+ * widens while syncing (see SYNC_BUMP_MS). */
 function scheduleBump(cb: SyncCallbacks): void {
+  const interval = currentStatus === 'ready' ? BUMP_MS : SYNC_BUMP_MS
   const since = Date.now() - lastBump
-  if (since >= BUMP_MS) {
+  if (since >= interval) {
     lastBump = Date.now()
     cb.onIndexChanged()
     return
@@ -222,34 +290,46 @@ function scheduleBump(cb: SyncCallbacks): void {
     bumpTimer = null
     lastBump = Date.now()
     cb.onIndexChanged()
-  }, BUMP_MS - since)
+  }, interval - since)
 }
 
-/** Merge a batch of stops into the index in one O(n + m) pass. */
-function bulkInsert(stops: Stop[]): void {
-  if (stops.length === 0) return
-  const add = stops.map((s) => ({ key: s.coordApprox >> 1n, stop: s }))
-  add.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
-  const oldKeys = anchorIndex.keys
-  const oldStops = anchorIndex.stops
-  const keys: bigint[] = []
-  const merged: Stop[] = []
-  let i = 0
-  let j = 0
-  while (i < oldKeys.length || j < add.length) {
-    if (j >= add.length || (i < oldKeys.length && oldKeys[i] <= add[j].key)) {
-      keys.push(oldKeys[i])
-      merged.push(oldStops[i])
-      i++
-    } else {
-      keys.push(add[j].key)
-      merged.push(add[j].stop)
-      j++
+// ---------------------------------------------------------------------------
+// Incremental merge pump
+// ---------------------------------------------------------------------------
+
+let mergePumping = false
+let mergeWaiters: Array<() => void> = []
+
+/** Fold pending rows into the sorted view in idle-time slices. Reentrant:
+ * appends that land mid-merge just extend the run. */
+function pumpMerge(cb: SyncCallbacks): void {
+  if (mergePumping) return
+  if (!hasPending(anchorIndex)) return
+  mergePumping = true
+  const run = (): void => {
+    const done = mergeStep(anchorIndex, MERGE_SLICE_MS)
+    if (!done) {
+      later(run)
+      return
     }
+    mergePumping = false
+    scheduleBump(cb)
+    const waiters = mergeWaiters
+    mergeWaiters = []
+    for (const w of waiters) w()
   }
-  anchorIndex.keys = keys
-  anchorIndex.stops = merged
+  later(run)
 }
+
+/** Resolves once nothing is pending and no merge is in flight. */
+function whenMerged(): Promise<void> {
+  if (!mergePumping && !hasPending(anchorIndex)) return Promise.resolve()
+  return new Promise((resolve) => mergeWaiters.push(resolve))
+}
+
+// ---------------------------------------------------------------------------
+// Covered bookkeeping
+// ---------------------------------------------------------------------------
 
 function validCovered(v: unknown): v is Array<[number, number]> {
   return Array.isArray(v) && v.every((r) =>
@@ -271,25 +351,61 @@ function persistCovered(): void {
     .catch(() => { /* cache write is best effort */ })
 }
 
+/** covered plus the session's verified blob ranges: what the relay backfill
+ * does NOT need to fetch. */
+function effectiveCovered(): Array<[number, number]> {
+  let out = covered
+  for (const range of blobCovered) out = mergeCovered(out, range)
+  return out
+}
+
+/** The gaps between blob-covered ranges, [start, endOrNull] with null for the
+ * open-ended tail: where cached relay rows could still be useful. */
+function uncoveredStretches(ranges: Array<[number, number]>): Array<[number, number | null]> {
+  const out: Array<[number, number | null]> = []
+  let cursor = 0
+  for (const [start, end] of ranges) {
+    if (start > cursor) out.push([cursor, start - 1])
+    if (end + 1 > cursor) cursor = end + 1
+  }
+  out.push([cursor, null])
+  return out
+}
+
+/** Where stops have come from so far, for the HUD. */
+function announceSource(cb: SyncCallbacks): void {
+  const source: SyncSource = blobRows === 0
+    ? 'relay'
+    : anchorIndex.size > blobRows ? 'mixed' : 'blobs'
+  cb.onSource(source)
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline stages
+// ---------------------------------------------------------------------------
+
 async function loadCache(cb: SyncCallbacks): Promise<void> {
   if (!db) return
   const stored = await getMeta(db, COVERED_KEY)
   if (validCovered(stored)) covered = stored
-  await getAllPaged<StopRecord>(db, STOPS_STORE, CACHE_CHUNK, (row) => row.height, async (rows) => {
-    const fresh: Stop[] = []
-    for (const row of rows) {
-      const stop = stopFromRecord(row)
-      if (stop && !anchorsByHeight.has(stop.height)) {
-        anchorsByHeight.set(stop.height, stop)
-        fresh.push(stop)
+  // Only replay heights the blobs did not deliver. When there are no blobs
+  // this is one unbounded stretch, i.e. exactly the old full replay.
+  for (const [start, end] of uncoveredStretches(blobCovered)) {
+    await getRangePaged<StopRecord>(db, STOPS_STORE, start, end, CACHE_CHUNK, (row) => row.height, async (rows) => {
+      const fresh: Stop[] = []
+      for (const row of rows) {
+        const stop = stopFromRecord(row)
+        if (stop && rowByHeight(anchorIndex, stop.height) === -1) fresh.push(stop)
       }
-    }
-    bulkInsert(fresh)
-    cb.onLoaded(anchorsByHeight.size)
-    scheduleBump(cb)
-    // A cold ~950k-row load must not starve rendering: hand back the loop.
-    await delay(0)
-  })
+      appendStops(anchorIndex, fresh)
+      cb.onLoaded(anchorIndex.size)
+      scheduleBump(cb)
+      pumpMerge(cb)
+      // A cold bulk load must not starve rendering: hand back the loop.
+      await delay(0)
+    })
+  }
+  announceSource(cb)
 }
 
 /** The max B among the newest anchors; the NTH publisher tails the tip. */
@@ -303,31 +419,26 @@ async function discoverTip(): Promise<number | null> {
   return tip
 }
 
-function maxKnownHeight(): number | null {
-  let max: number | null = null
-  for (const h of anchorsByHeight.keys()) if (max === null || h > max) max = h
-  return max
-}
-
 async function processBatch(heights: number[], cb: SyncCallbacks): Promise<void> {
   const events = await query({ kinds: [321], '#B': heights.map(String), limit: 2000 })
   const best = new Map<number, { stop: Stop; hasM: boolean }>()
   for (const ev of events) {
     const stop = stopFromAnchor(ev)
-    if (!stop || anchorsByHeight.has(stop.height)) continue
+    if (!stop || rowByHeight(anchorIndex, stop.height) !== -1) continue
     const candidate = { stop, hasM: ev.tags.some((t) => t.length >= 2 && t[0] === 'M') }
     const seen = best.get(stop.height)
     best.set(stop.height, seen ? pickBetter(seen, candidate) : candidate)
   }
   const fresh = [...best.values()].map((b) => b.stop)
-  for (const stop of fresh) anchorsByHeight.set(stop.height, stop)
-  bulkInsert(fresh)
+  appendStops(anchorIndex, fresh)
   // The whole batch is covered even where no event came back: the relay may
   // genuinely lack a few heights, and re-querying them forever would pin the
   // sync just short of done.
   for (const run of runsOf(heights)) covered = mergeCovered(covered, run)
-  cb.onLoaded(anchorsByHeight.size)
+  cb.onLoaded(anchorIndex.size)
   scheduleBump(cb)
+  pumpMerge(cb)
+  announceSource(cb)
   if (db && fresh.length > 0) {
     try {
       await putMany(db, STOPS_STORE, fresh.map(recordFromStop))
@@ -337,7 +448,7 @@ async function processBatch(heights: number[], cb: SyncCallbacks): Promise<void>
 }
 
 async function syncMissing(tip: number, cb: SyncCallbacks): Promise<void> {
-  const batches = batchesOf(missingRanges(covered, tip), BATCH_SIZE)
+  const batches = batchesOf(missingRanges(effectiveCovered(), tip), BATCH_SIZE)
   let next = 0
   const worker = async (): Promise<void> => {
     while (next < batches.length) {
@@ -355,10 +466,11 @@ function startTail(cb: SyncCallbacks): void {
   subscribe({ kinds: [321], since }, (ev) => {
     const stop = stopFromAnchor(ev)
     // The publisher re-announces the tip continuously; a height already in
-    // the map is the common case here, not an error.
-    if (!stop || anchorsByHeight.has(stop.height)) return
-    anchorsByHeight.set(stop.height, stop)
-    insertStop(anchorIndex, stop)
+    // the index is the common case here, not an error.
+    if (!stop || rowByHeight(anchorIndex, stop.height) !== -1) return
+    insertRow(anchorIndex, stop)
+    // insertRow defers to the pending queue when a bulk merge is running.
+    if (hasPending(anchorIndex)) pumpMerge(cb)
     covered = mergeCovered(covered, [stop.height, stop.height])
     if (db) {
       putMany(db, STOPS_STORE, [recordFromStop(stop)]).catch(() => { /* best effort */ })
@@ -368,21 +480,42 @@ function startTail(cb: SyncCallbacks): void {
       knownTip = stop.height
       cb.onTip(stop.height)
     }
-    cb.onLoaded(anchorsByHeight.size)
+    cb.onLoaded(anchorIndex.size)
     scheduleBump(cb)
+    announceSource(cb)
   })
 }
 
 /**
- * The whole pipeline: cache replay, tip discovery, batched backfill with a
- * 30 s retry, then the live tail. Runs once per page; the store's startSync
- * is the idempotence gate, this flag is just belt and braces.
+ * After a successful blob sync the IndexedDB rows inside blob ranges are
+ * redundant weight (the Cache API already holds those heights in 48 bytes a
+ * block); drop them and shrink 'covered' to match, so the stops store holds
+ * relay-sourced heights only. Idempotent, best effort, after ready.
+ */
+async function pruneBlobCovered(): Promise<void> {
+  if (!db || blobCovered.length === 0) return
+  const database = db
+  try {
+    for (const range of blobCovered) {
+      await deleteRange(database, STOPS_STORE, range[0], range[1])
+      covered = subtractCovered(covered, range)
+    }
+    persistCovered()
+  } catch { /* cache cleanup is best effort */ }
+}
+
+/**
+ * The whole pipeline: verified header blobs first (when the manifest is
+ * reachable), then the IndexedDB replay of relay-cached rows, then the
+ * batched relay backfill of whatever is left with a 30 s retry, then the
+ * live tail. Runs once per page; the store's startSync is the idempotence
+ * gate, this flag is just belt and braces.
  */
 export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
   if (running) return
   running = true
 
-  cb.onStatus('loading-cache')
+  setStatus(cb, 'loading-cache')
   try {
     db = await openDb()
   } catch {
@@ -390,6 +523,35 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
     // resume across reloads.
     db = null
   }
+
+  // Header-blob phase. fetchManifest never throws; null means the relay owns
+  // everything this session.
+  const mf = await fetchManifest()
+  if (mf) {
+    cb.onSource('blobs')
+    setStatus(cb, 'syncing')
+    knownTip = mf.manifest.generatedAtHeight
+    cb.onTip(knownTip)
+    const result = await runHeaderSync(mf.manifest, mf.url, {
+      onProgress: (_startHeight, verified) => cb.onLoaded(anchorIndex.size + verified),
+      onColumns: (cols) => {
+        blobRows += appendColumns(anchorIndex, cols)
+        cb.onLoaded(anchorIndex.size)
+        scheduleBump(cb)
+        pumpMerge(cb)
+      },
+      onBlobFailed: (startHeight, count, reason) => {
+        console.warn(
+          `[hyperspace] header blob ${startHeight}..${startHeight + count - 1} discarded: ${reason}; falling back to relay sync for that range`,
+        )
+      },
+    })
+    blobCovered = result.covered
+    announceSource(cb)
+  } else {
+    cb.onSource('relay')
+  }
+
   try {
     await loadCache(cb)
   } catch {
@@ -400,26 +562,32 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
   for (;;) {
     try {
       const relayTip = await discoverTip()
-      const cachedTip = maxKnownHeight()
-      if (relayTip === null && cachedTip === null) {
-        cb.onStatus('error', 'no anchors from the relay and no cache to fall back on')
+      const knownMax = anchorIndex.maxHeight >= 0 ? anchorIndex.maxHeight : null
+      if (relayTip === null && knownMax === null) {
+        setStatus(cb, 'error', 'no anchors from the relay and no cache to fall back on')
         await delay(RETRY_MS)
         continue
       }
-      // The cache can be ahead of a relay that lost data; trust the max so
-      // loaded never exceeds total.
-      const tip = Math.max(relayTip ?? 0, cachedTip ?? 0)
+      // Blobs or the cache can be ahead of a relay that lost data; trust the
+      // max so loaded never exceeds total.
+      const tip = Math.max(relayTip ?? 0, knownMax ?? 0)
       knownTip = tip
       cb.onTip(tip)
-      cb.onStatus('syncing')
+      setStatus(cb, 'syncing')
       await syncMissing(tip, cb)
-      cb.onStatus('ready')
+      // Do not declare ready with rows still outside the sorted view; the
+      // panel's nearest-stop answers should be over the full line.
+      pumpMerge(cb)
+      await whenMerged()
+      setStatus(cb, 'ready')
+      cb.onIndexChanged()
       break
     } catch (e) {
-      cb.onStatus('error', e instanceof Error ? e.message : String(e))
+      setStatus(cb, 'error', e instanceof Error ? e.message : String(e))
       await delay(RETRY_MS)
     }
   }
 
   startTail(cb)
+  void pruneBlobCovered()
 }

--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -12,7 +12,11 @@
  *
  * Relay-fetched stops are cached in IndexedDB alongside a 'covered' list of
  * height ranges, so a reload replays the cache and only fetches the
- * complement. A height the relay has no anchor for still counts as covered;
+ * complement. The BUILT index is additionally persisted wholesale (meta key
+ * 'indexSnapshot') once the pipeline is ready and occasionally from the tail:
+ * replaying ~1M rows re-sorts the line for tens of seconds on every load,
+ * while adopting the snapshot is one bulk read plus a byHeight rebuild, and
+ * the row replay then only covers what arrived after the snapshot. A height the relay has no anchor for still counts as covered;
  * without that, a single genuinely missing block would be re-queried on every
  * load forever. Blob-verified heights are deliberately NOT persisted in
  * 'covered': the Cache API holds the raw blobs and re-verification is cheap,
@@ -37,13 +41,16 @@
 import { query, subscribe } from '../relay'
 import { stopFromAnchor, type Stop, type StopKind } from './stops'
 import {
+  adoptSnapshot,
   appendColumns,
   appendStops,
   createStopIndex,
   hasPending,
   insertRow,
+  mergeAll,
   mergeStep,
   rowByHeight,
+  serializeIndex,
   type StopIndex,
 } from './compactIndex'
 import { fetchManifest, runHeaderSync } from './headerSync'
@@ -139,6 +146,35 @@ export function batchesOf(ranges: Array<[number, number]>, size: number): number
     }
   }
   if (current.length > 0) out.push(current)
+  return out
+}
+
+/**
+ * Where the IndexedDB row replay still has work to do: the complement of the
+ * union of the snapshot's covered ranges and this session's verified blob
+ * ranges, as [start, endOrNull] stretches with null for the open-ended tail.
+ * Every IDB row inside coveredAtSnapshot is by construction already in the
+ * adopted snapshot (rows are appended to the index when they arrive, and the
+ * snapshot serialized the whole index), and blob heights were just appended
+ * by the header phase, so replaying either would only burn IDB reads on rows
+ * the height dedupe then drops. With no snapshot this reduces to the
+ * blob-only complement, i.e. byte-for-byte the pre-snapshot behaviour; with
+ * neither it is one unbounded stretch, the old full replay.
+ */
+export function replayStretches(
+  coveredAtSnapshot: Array<[number, number]>,
+  blobCovered: Array<[number, number]>,
+): Array<[number, number | null]> {
+  let union: Array<[number, number]> = []
+  for (const range of coveredAtSnapshot) union = mergeCovered(union, range)
+  for (const range of blobCovered) union = mergeCovered(union, range)
+  const out: Array<[number, number | null]> = []
+  let cursor = 0
+  for (const [start, end] of union) {
+    if (start > cursor) out.push([cursor, start - 1])
+    if (end + 1 > cursor) cursor = end + 1
+  }
+  out.push([cursor, null])
   return out
 }
 
@@ -248,6 +284,10 @@ const SYNC_BUMP_MS = 2500
 const MERGE_SLICE_MS = 12
 const CACHE_CHUNK = 50_000
 const COVERED_KEY = 'covered'
+const SNAPSHOT_KEY = 'indexSnapshot'
+/** Tail re-snapshot gates: both must pass, so the ~130 MB put stays rare. */
+const SNAPSHOT_INTERVAL_MS = 10 * 60_000
+const SNAPSHOT_MIN_GROWTH = 5000
 
 let running = false
 let db: IDBDatabase | null = null
@@ -256,6 +296,11 @@ let covered: Array<[number, number]> = []
 let blobCovered: Array<[number, number]> = []
 /** Rows delivered by verified blobs, for the source label. */
 let blobRows = 0
+/** Index size and wall clock at the last snapshot write (or adoption), the
+ * baselines for the tail's re-snapshot gates and the redundant-write skip. */
+let snapshotSize = 0
+let snapshotAt = 0
+let snapshotWriting = false
 let knownTip: number | null = null
 let metaChain: Promise<void> = Promise.resolve()
 let currentStatus: 'loading-cache' | 'syncing' | 'ready' | 'error' = 'loading-cache'
@@ -359,17 +404,39 @@ function effectiveCovered(): Array<[number, number]> {
   return out
 }
 
-/** The gaps between blob-covered ranges, [start, endOrNull] with null for the
- * open-ended tail: where cached relay rows could still be useful. */
-function uncoveredStretches(ranges: Array<[number, number]>): Array<[number, number | null]> {
-  const out: Array<[number, number | null]> = []
-  let cursor = 0
-  for (const [start, end] of ranges) {
-    if (start > cursor) out.push([cursor, start - 1])
-    if (end + 1 > cursor) cursor = end + 1
+/** The stored 'indexSnapshot' meta shape. The snapshot itself stays unknown
+ * here on purpose: adoptSnapshot owns its deep validation. */
+function validSnapshotMeta(v: unknown): v is { snapshot: unknown; coveredAtSnapshot: Array<[number, number]> } {
+  if (typeof v !== 'object' || v === null) return false
+  const m = v as Record<string, unknown>
+  return typeof m.snapshot === 'object' && m.snapshot !== null && validCovered(m.coveredAtSnapshot)
+}
+
+/**
+ * Persist the built index wholesale so the next boot adopts it instead of
+ * re-sorting a million replayed rows. coveredAtSnapshot rides along so that
+ * boot's replay can skip every IDB row the snapshot already contains. One
+ * structured-clone put of ~130 MB of ArrayBuffers, which IndexedDB handles;
+ * best effort like every other cache write. mergeAll first: serializeIndex
+ * refuses a half-merged index, and by the time this runs (ready, or the
+ * quiescent tail) there is at most a sliver pending.
+ */
+async function persistSnapshot(): Promise<void> {
+  if (!db || snapshotWriting) return
+  const database = db
+  snapshotWriting = true
+  try {
+    mergeAll(anchorIndex)
+    const snapshot = serializeIndex(anchorIndex)
+    if (snapshot) {
+      await putMeta(database, SNAPSHOT_KEY, { snapshot, coveredAtSnapshot: effectiveCovered() })
+      snapshotSize = snapshot.count
+      snapshotAt = Date.now()
+    }
+  } catch { /* cache write is best effort */
+  } finally {
+    snapshotWriting = false
   }
-  out.push([cursor, null])
-  return out
 }
 
 /** Where stops have come from so far, for the HUD. */
@@ -390,9 +457,26 @@ async function loadCache(cb: SyncCallbacks): Promise<void> {
   const before = anchorIndex.size
   const stored = await getMeta(db, COVERED_KEY)
   if (validCovered(stored)) covered = stored
-  // Only replay heights the blobs did not deliver. When there are no blobs
-  // this is one unbounded stretch, i.e. exactly the old full replay.
-  for (const [start, end] of uncoveredStretches(blobCovered)) {
+  // Adopt the persisted built index wholesale when possible: the same rows
+  // the replay below would re-sort, in one bulk read. adoptSnapshot refuses
+  // a non-empty index, so a session the header blobs already fed falls back
+  // to the plain replay unchanged; so does any invalid or missing snapshot.
+  let coveredAtSnapshot: Array<[number, number]> = []
+  let adopted = 0
+  try {
+    const snapMeta = await getMeta(db, SNAPSHOT_KEY)
+    if (validSnapshotMeta(snapMeta) && adoptSnapshot(anchorIndex, snapMeta.snapshot)) {
+      adopted = anchorIndex.size - before
+      coveredAtSnapshot = snapMeta.coveredAtSnapshot
+      snapshotSize = anchorIndex.size
+      snapshotAt = Date.now()
+      cb.onLoaded(anchorIndex.size)
+      scheduleBump(cb)
+    }
+  } catch { /* snapshot read is best effort; the row replay below covers it */ }
+  // Only replay heights neither the snapshot nor the blobs delivered. With
+  // neither this is one unbounded stretch, i.e. exactly the old full replay.
+  for (const [start, end] of replayStretches(coveredAtSnapshot, blobCovered)) {
     await getRangePaged<StopRecord>(db, STOPS_STORE, start, end, CACHE_CHUNK, (row) => row.height, async (rows) => {
       const fresh: Stop[] = []
       for (const row of rows) {
@@ -410,7 +494,10 @@ async function loadCache(cb: SyncCallbacks): Promise<void> {
   announceSource(cb)
   const restored = anchorIndex.size - before
   if (restored > 0) {
-    console.info(`[hyperspace] resumed ${restored} stops from cache in ${Math.round(performance.now() - t0)} ms`)
+    const ms = Math.round(performance.now() - t0)
+    console.info(adopted > 0
+      ? `[hyperspace] resumed ${adopted} stops (snapshot) + ${restored - adopted} rows in ${ms} ms`
+      : `[hyperspace] resumed ${restored} stops from cache in ${ms} ms`)
   }
 }
 
@@ -481,6 +568,11 @@ function startTail(cb: SyncCallbacks): void {
     if (db) {
       putMany(db, STOPS_STORE, [recordFromStop(stop)]).catch(() => { /* best effort */ })
       persistCovered()
+      // Re-snapshot occasionally so a long-lived tab's accumulation is not
+      // replayed row by row on the next boot; both gates must pass.
+      if (Date.now() - snapshotAt >= SNAPSHOT_INTERVAL_MS && anchorIndex.size - snapshotSize >= SNAPSHOT_MIN_GROWTH) {
+        void persistSnapshot()
+      }
     }
     if (knownTip === null || stop.height > knownTip) {
       knownTip = stop.height
@@ -587,6 +679,11 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
       await whenMerged()
       setStatus(cb, 'ready')
       cb.onIndexChanged()
+      // Persist the built index for the next boot. Awaited on purpose: the
+      // bulk sync just finished, so nothing is hot. Skipped when no row has
+      // landed since the last write (a reload that adopted the snapshot and
+      // backfilled nothing) because rewriting identical buffers buys nothing.
+      if (anchorIndex.size !== snapshotSize) await persistSnapshot()
       break
     } catch (e) {
       setStatus(cb, 'error', e instanceof Error ? e.message : String(e))

--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -246,7 +246,7 @@ const BUMP_MS = 500
 const SYNC_BUMP_MS = 2500
 /** Main-thread budget per merge slice; comfortably inside one frame. */
 const MERGE_SLICE_MS = 12
-const CACHE_CHUNK = 5000
+const CACHE_CHUNK = 50_000
 const COVERED_KEY = 'covered'
 
 let running = false
@@ -386,6 +386,8 @@ function announceSource(cb: SyncCallbacks): void {
 
 async function loadCache(cb: SyncCallbacks): Promise<void> {
   if (!db) return
+  const t0 = performance.now()
+  const before = anchorIndex.size
   const stored = await getMeta(db, COVERED_KEY)
   if (validCovered(stored)) covered = stored
   // Only replay heights the blobs did not deliver. When there are no blobs
@@ -406,6 +408,10 @@ async function loadCache(cb: SyncCallbacks): Promise<void> {
     })
   }
   announceSource(cb)
+  const restored = anchorIndex.size - before
+  if (restored > 0) {
+    console.info(`[hyperspace] resumed ${restored} stops from cache in ${Math.round(performance.now() - t0)} ms`)
+  }
 }
 
 /** The max B among the newest anchors; the NTH publisher tails the tip. */

--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -526,7 +526,11 @@ async function discoverTip(): Promise<number | null> {
 async function processBatch(heights: number[], cb: SyncCallbacks): Promise<void> {
   const events = await query({ kinds: [321], '#B': heights.map(String), limit: 2000 })
   const best = new Map<number, { stop: Stop; hasM: boolean }>()
-  for (const ev of events) {
+  // Parsed in slices with the loop handed back between them: a batch is up
+  // to 2000 events, and rendering must not wait for all of them.
+  for (let i = 0; i < events.length; i++) {
+    if (i > 0 && i % 250 === 0) await delay(0)
+    const ev = events[i]
     const stop = stopFromAnchor(ev)
     if (!stop || rowByHeight(anchorIndex, stop.height) !== -1) continue
     const candidate = { stop, hasM: ev.tags.some((t) => t.length >= 2 && t[0] === 'M') }

--- a/src/lib/hyperspace/checkpoints.ts
+++ b/src/lib/hyperspace/checkpoints.ts
@@ -1,0 +1,31 @@
+/**
+ * checkpoints.ts: block hashes this build KNOWS, independent of any server.
+ *
+ * The header blobs prove their own work, but proof of work alone only shows
+ * that someone spent energy: a fabricated low-difficulty chain could satisfy
+ * every structural rule. Pinning known mainnet block hashes into the source
+ * makes that impossible past the pinned heights: a blob whose reconstruction
+ * disagrees with an embedded checkpoint is discarded no matter what the
+ * manifest says, so a compromised manifest host cannot substitute a chain.
+ *
+ * The manifest carries its own checkpoint list (the last block of each blob);
+ * those are always enforced. Entries below are the second, stronger opinion,
+ * verified wherever their height lands inside a blob.
+ */
+
+export interface Checkpoint {
+  height: number
+  /** Display-order (byte-reversed sha256d) block hash, 64 lowercase hex. */
+  blockHash: string
+}
+
+/** The mainnet genesis block. */
+export const GENESIS_HASH = '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f'
+
+export const EMBEDDED_CHECKPOINTS: Checkpoint[] = [
+  { height: 0, blockHash: GENESIS_HASH },
+  // TODO(headers-v1 packager): append the final-block hash of each published
+  // blob here once the packager publishes the release, e.g.
+  // { height: 49999, blockHash: '...' },
+  // { height: 99999, blockHash: '...' },
+]

--- a/src/lib/hyperspace/checkpoints.ts
+++ b/src/lib/hyperspace/checkpoints.ts
@@ -24,8 +24,26 @@ export const GENESIS_HASH = '000000000019d6689c085ae165831e934ff763ae46a2a6c172b
 
 export const EMBEDDED_CHECKPOINTS: Checkpoint[] = [
   { height: 0, blockHash: GENESIS_HASH },
-  // TODO(headers-v1 packager): append the final-block hash of each published
-  // blob here once the packager publishes the release, e.g.
-  // { height: 49999, blockHash: '...' },
-  // { height: 99999, blockHash: '...' },
+  // The final block of each published headers-v1 blob, pinned 2026-08-24;
+  // every value independently confirmed against blockstream.info before
+  // pinning, so the manifest host and this list are separate authorities.
+  { height: 49999, blockHash: '000000000845517b31c6820d83f25cff46429bf136a7515fe504116427e60f8e' },
+  { height: 99999, blockHash: '000000000002d01c1fccc21636b607dfd930d31d01c3a62104612a1719011250' },
+  { height: 149999, blockHash: '00000000000008df4269884f1d3bfc2aed3ea747292abb89be3dc3faa8c5d26f' },
+  { height: 199999, blockHash: '00000000000003a20def7a05a77361b9657ff954b2f2080e135ea6f5970da215' },
+  { height: 249999, blockHash: '0000000000000009c2e82d884ec07b4aafb64ca3ef83baca2b6b0b5eb72c8f02' },
+  { height: 299999, blockHash: '000000000000000067ecc744b5ae34eebbde14d21ca4db51652e4d67e155f07e' },
+  { height: 349999, blockHash: '000000000000000002045664f89a1077d0c6c0aaa6dd89b485208cf92d6bbd30' },
+  { height: 399999, blockHash: '0000000000000000030034b661aed920a9bdf6bbfa6d2e7a021f78481882fa39' },
+  { height: 449999, blockHash: '0000000000000000024c4a35f0485bab79ce341cdd5cc6b15186d9b5b57bf3da' },
+  { height: 499999, blockHash: '0000000000000000007962066dcd6675830883516bcf40047d42740a85eb2919' },
+  { height: 549999, blockHash: '00000000000000000013dad60a42a3401a8f37ca02f1c00ac5923e674566a3ae' },
+  { height: 599999, blockHash: '00000000000000000003ecd827f336c6971f6f77a0b9fba362398dd867975645' },
+  { height: 649999, blockHash: '000000000000000000076c1eea129cec5a5291d0ee516c3305df33b0ba76ac51' },
+  { height: 699999, blockHash: '0000000000000000000aa3ce000eb559f4143be419108134e0ce71042fc636eb' },
+  { height: 749999, blockHash: '00000000000000000001e3aee44a04a5c3461181d25c8803ff6d617173e34533' },
+  { height: 799999, blockHash: '000000000000000000012117ad9f72c1c0e42227c2d042dca23e6b96bd9fbb55' },
+  { height: 849999, blockHash: '000000000000000000026b072f9347d86942f6786dd1fc362acfd9522715b313' },
+  { height: 899999, blockHash: '0000000000000000000196400396be46d0816dc462df4c3450972f589f4d7d24' },
+  { height: 949999, blockHash: '00000000000000000000df842728edc58cf64288ca21433257700f3d5b45f286' },
 ]

--- a/src/lib/hyperspace/compactIndex.test.ts
+++ b/src/lib/hyperspace/compactIndex.test.ts
@@ -1,0 +1,236 @@
+/**
+ * What would fail silently without these tests: a columnar index that drops
+ * or duplicates a row during a merge would return a plausible-but-wrong
+ * station forever after; a blob column appended with the wrong height base
+ * would hand the ride builder the wrong block hashes; and a permutation
+ * corrupted by an interrupted incremental merge would poison every prefix
+ * search. The cross-checks here build the same stop set through every entry
+ * path (builder, blob columns, relay batches, single inserts) and demand
+ * identical answers.
+ */
+import { describe, expect, it } from 'vitest'
+import { xyzToCoord } from 'cyberspace-core'
+import { bytesToHex, hexToBytes } from '../events'
+import { bigToBytes32, type BlobColumns } from './headers'
+import {
+  appendColumns,
+  appendStops,
+  createStopIndex,
+  hasPending,
+  keyHexAtSorted,
+  mergeAll,
+  mergeStep,
+  rowByHeight,
+  stopAt,
+  stopByHeight,
+} from './compactIndex'
+import { buildIndex, findStation, insertStop, maxAxisLca } from './station'
+import type { Stop } from './stops'
+
+function mulberry32(seed: number): () => number {
+  let a = seed
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function rand85(rng: () => number): bigint {
+  let v = 0n
+  for (let i = 0; i < 6; i++) v = (v << 16n) | BigInt(Math.floor(rng() * 65536))
+  return v & ((1n << 85n) - 1n)
+}
+
+function hex64(rng: () => number): string {
+  let out = ''
+  for (let i = 0; i < 8; i++) out += Math.floor(rng() * 0x100000000).toString(16).padStart(8, '0')
+  return out
+}
+
+/** Synthetic ports only: findStation re-derives landfall finalists through
+ * the exact decimal path, which is far too slow for hundreds of queries. */
+function syntheticStop(height: number, coord: bigint, blockHash: string | null): Stop {
+  return {
+    height,
+    kind: 'port',
+    merkleRoot: coord.toString(16).padStart(64, '0'),
+    blockHash,
+    coordExact: coord,
+    coordApprox: coord,
+  }
+}
+
+function bruteStation(stops: Stop[], coord: bigint, maxHeight: number): { height: number; distance: number } | null {
+  let best: { height: number; distance: number } | null = null
+  for (const s of stops) {
+    if (s.height > maxHeight) continue
+    const d = maxAxisLca(coord, s.coordExact as bigint)
+    if (best === null || d < best.distance || (d === best.distance && s.height < best.height)) {
+      best = { height: s.height, distance: d }
+    }
+  }
+  return best
+}
+
+/** Build worker-shaped columns from stops with consecutive heights, the way
+ * verifyAndDerive would (keys = coord >> 1, order sorted by key). */
+function columnsFrom(stops: Stop[], startHeight: number): BlobColumns {
+  const count = stops.length
+  const keys = new Uint8Array(count * 32)
+  const kinds = new Uint8Array(count)
+  const merkles = new Uint8Array(count * 32)
+  const hashes = new Uint8Array(count * 32)
+  const coords = new Uint8Array(count * 32)
+  stops.forEach((stop, i) => {
+    expect(stop.height).toBe(startHeight + i)
+    keys.set(bigToBytes32(stop.coordApprox >> 1n), i * 32)
+    kinds[i] = stop.kind === 'port' ? 1 : 0
+    merkles.set(hexToBytes(stop.merkleRoot), i * 32)
+    hashes.set(hexToBytes(stop.blockHash as string), i * 32)
+    coords.set(bigToBytes32(stop.coordApprox), i * 32)
+  })
+  const order = new Uint32Array(count)
+  for (let i = 0; i < count; i++) order[i] = i
+  order.sort((a, b) => {
+    const ha = bytesToHex(keys.subarray(a * 32, a * 32 + 32))
+    const hb = bytesToHex(keys.subarray(b * 32, b * 32 + 32))
+    return ha < hb ? -1 : ha > hb ? 1 : 0
+  })
+  return { startHeight, count, keys, kinds, merkles, hashes, coords, order }
+}
+
+function assertSorted(index: ReturnType<typeof createStopIndex>): void {
+  for (let i = 1; i < index.permCount; i++) {
+    expect(keyHexAtSorted(index, i) >= keyHexAtSorted(index, i - 1)).toBe(true)
+  }
+}
+
+describe('blob columns and relay rows interleaved', () => {
+  it('answers findStation exactly like the plain builder and brute force', () => {
+    const rng = mulberry32(77)
+    const stops: Stop[] = []
+    for (let h = 0; h < 240; h++) {
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), hex64(rng)))
+    }
+    const reference = buildIndex(stops)
+
+    // The mixed-path index: two "blobs" (heights 0..69, 70..139) with relay
+    // batches interleaved between and after them, out of height order.
+    const mixed = createStopIndex()
+    appendColumns(mixed, columnsFrom(stops.slice(0, 70), 0))
+    const relay = stops.slice(140)
+    appendStops(mixed, relay.slice(60).reverse())
+    appendColumns(mixed, columnsFrom(stops.slice(70, 140), 70))
+    appendStops(mixed, relay.slice(0, 60))
+    mergeAll(mixed)
+
+    expect(mixed.size).toBe(240)
+    assertSorted(mixed)
+    for (let trial = 0; trial < 50; trial++) {
+      const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
+      const maxHeight = trial % 3 === 0 ? 100 : 10_000
+      const got = findStation(mixed, q, maxHeight)
+      const ref = findStation(reference, q, maxHeight)
+      const brute = bruteStation(stops, q, maxHeight)
+      expect(got?.stop.height).toBe(brute?.height)
+      expect(got?.distance).toBe(brute?.distance)
+      expect(got?.stop.height).toBe(ref?.stop.height)
+    }
+  })
+
+  it('skips heights the index already has, first source wins', () => {
+    const rng = mulberry32(5)
+    const stops: Stop[] = []
+    for (let h = 0; h < 60; h++) {
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), hex64(rng)))
+    }
+    const index = createStopIndex()
+    appendColumns(index, columnsFrom(stops.slice(0, 50), 0))
+    // Relay rows for 40..59 with DIFFERENT hashes: the overlap (40..49) must
+    // keep the blob's version, the tail (50..59) must land.
+    const relayVersion = stops.map((s) => ({ ...s, blockHash: hex64(rng) }))
+    expect(appendStops(index, relayVersion.slice(40))).toBe(10)
+    mergeAll(index)
+    expect(index.size).toBe(60)
+    expect(stopByHeight(index, 45)?.blockHash).toBe(stops[45].blockHash)
+    expect(stopByHeight(index, 55)?.blockHash).toBe(relayVersion[55].blockHash)
+  })
+})
+
+describe('getStopByHeight / blockHash round trip', () => {
+  it('materializes stops from columns, memoized with stable identity', () => {
+    const rng = mulberry32(13)
+    const stops: Stop[] = []
+    for (let h = 100; h < 130; h++) {
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), hex64(rng)))
+    }
+    const index = createStopIndex()
+    appendColumns(index, columnsFrom(stops, 100))
+    mergeAll(index)
+    for (const want of stops) {
+      const got = stopByHeight(index, want.height)
+      expect(got).toBeDefined()
+      expect(got?.height).toBe(want.height)
+      expect(got?.merkleRoot).toBe(want.merkleRoot)
+      expect(got?.blockHash).toBe(want.blockHash)
+      expect(got?.coordApprox).toBe(want.coordApprox)
+      // Ports carry their exact coordinate straight from the column.
+      expect(got?.coordExact).toBe(want.coordApprox)
+      // Identity is stable: the ride builder and the scrubber must see the
+      // same object (stopCoordExact caches onto it).
+      expect(stopByHeight(index, want.height)).toBe(got)
+    }
+    expect(rowByHeight(index, 99)).toBe(-1)
+    expect(stopByHeight(index, 500)).toBeUndefined()
+  })
+})
+
+describe('incremental merging', () => {
+  it('a zero-budget merge completes over many slices with a correct result', () => {
+    const rng = mulberry32(99)
+    const stops: Stop[] = []
+    for (let h = 0; h < 20_000; h++) {
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), null))
+    }
+    const index = createStopIndex()
+    appendStops(index, stops.slice(0, 15_000))
+    mergeAll(index)
+    appendStops(index, stops.slice(15_000))
+    let slices = 0
+    while (!mergeStep(index, 0)) slices++
+    // A 15k + 5k merge at zero budget must have yielded repeatedly; that is
+    // the whole point of the sliced merge.
+    expect(slices).toBeGreaterThan(2)
+    expect(index.permCount).toBe(20_000)
+    assertSorted(index)
+    const reference = buildIndex(stops)
+    for (let trial = 0; trial < 20; trial++) {
+      const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
+      expect(findStation(index, q, 30_000)?.stop.height)
+        .toBe(findStation(reference, q, 30_000)?.stop.height)
+    }
+  })
+
+  it('insertStop defers while rows are pending and still lands after the merge', () => {
+    const rng = mulberry32(21)
+    const index = createStopIndex()
+    const batch: Stop[] = []
+    for (let h = 0; h < 100; h++) {
+      batch.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), null))
+    }
+    appendStops(index, batch)
+    expect(hasPending(index)).toBe(true)
+    const late = syntheticStop(500, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), null)
+    insertStop(index, late)
+    // Deferred, not lost: visible by height at once, spatially after merging.
+    expect(rowByHeight(index, 500)).not.toBe(-1)
+    mergeAll(index)
+    expect(index.permCount).toBe(101)
+    assertSorted(index)
+    expect(findStation(index, late.coordApprox, 10_000)?.stop.height).toBe(500)
+    expect(stopAt(index, rowByHeight(index, 500)).height).toBe(500)
+  })
+})

--- a/src/lib/hyperspace/compactIndex.test.ts
+++ b/src/lib/hyperspace/compactIndex.test.ts
@@ -6,13 +6,19 @@
  * corrupted by an interrupted incremental merge would poison every prefix
  * search. The cross-checks here build the same stop set through every entry
  * path (builder, blob columns, relay batches, single inserts) and demand
- * identical answers.
+ * identical answers. The snapshot round trip has its own silent failure
+ * mode: a snapshot adopted with a truncated column, a permutation that skips
+ * a row, or a byHeight rebuilt off wrong heights would resume ~1M stops
+ * instantly and answer plausibly-but-wrong forever, so the adopted index is
+ * cross-checked against the original and malformed snapshots must be
+ * refused with the target left untouched.
  */
 import { describe, expect, it } from 'vitest'
 import { xyzToCoord } from 'cyberspace-core'
 import { bytesToHex, hexToBytes } from '../events'
 import { bigToBytes32, type BlobColumns } from './headers'
 import {
+  adoptSnapshot,
   appendColumns,
   appendStops,
   createStopIndex,
@@ -21,10 +27,11 @@ import {
   mergeAll,
   mergeStep,
   rowByHeight,
+  serializeIndex,
   stopAt,
   stopByHeight,
 } from './compactIndex'
-import { buildIndex, findStation, insertStop, maxAxisLca } from './station'
+import { buildIndex, findStation, insertStop, maxAxisLca, nearestStops } from './station'
 import type { Stop } from './stops'
 
 function mulberry32(seed: number): () => number {
@@ -232,5 +239,125 @@ describe('incremental merging', () => {
     assertSorted(index)
     expect(findStation(index, late.coordApprox, 10_000)?.stop.height).toBe(500)
     expect(stopAt(index, rowByHeight(index, 500)).height).toBe(500)
+  })
+})
+
+describe('snapshot serialize / adopt', () => {
+  /** A merged mixed-source index (blob columns + relay rows, some without a
+   * block hash) and the stops behind it, for round-trip cross-checks. */
+  function buildSample(): { index: ReturnType<typeof createStopIndex>; stops: Stop[] } {
+    const rng = mulberry32(31)
+    const stops: Stop[] = []
+    for (let h = 0; h < 300; h++) {
+      const hash = h < 150 ? hex64(rng) : h % 3 === 0 ? null : hex64(rng)
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), hash))
+    }
+    const index = createStopIndex()
+    appendColumns(index, columnsFrom(stops.slice(0, 150), 0))
+    appendStops(index, stops.slice(150))
+    mergeAll(index)
+    return { index, stops }
+  }
+
+  it('round-trips: the adopted index answers exactly like the original', () => {
+    const { index, stops } = buildSample()
+    const snap = serializeIndex(index)
+    if (snap === null) throw new Error('expected a snapshot from a merged index')
+    const fresh = createStopIndex()
+    expect(adoptSnapshot(fresh, snap)).toBe(true)
+    expect(fresh.size).toBe(index.size)
+    expect(fresh.permCount).toBe(index.permCount)
+    expect(fresh.maxHeight).toBe(index.maxHeight)
+    assertSorted(fresh)
+    // byHeight was rebuilt, not copied: every height must resolve with all
+    // its columns intact, blockHash (and its absence) included.
+    for (const want of stops) {
+      const got = stopByHeight(fresh, want.height)
+      expect(got?.merkleRoot).toBe(want.merkleRoot)
+      expect(got?.blockHash).toBe(want.blockHash)
+      expect(got?.coordApprox).toBe(want.coordApprox)
+    }
+    expect(rowByHeight(fresh, 300)).toBe(-1)
+    const rng = mulberry32(87)
+    for (let trial = 0; trial < 40; trial++) {
+      const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
+      const maxHeight = trial % 3 === 0 ? 120 : 10_000
+      const a = findStation(index, q, maxHeight)
+      const b = findStation(fresh, q, maxHeight)
+      expect(b?.stop.height).toBe(a?.stop.height)
+      expect(b?.distance).toBe(a?.distance)
+      const na = nearestStops(index, q, 8).map((r) => [r.stop.height, r.distance])
+      const nb = nearestStops(fresh, q, 8).map((r) => [r.stop.height, r.distance])
+      expect(nb).toEqual(na)
+    }
+  })
+
+  it('an adopted index keeps growing: appends land and stay queryable', () => {
+    const { index } = buildSample()
+    const fresh = createStopIndex()
+    expect(adoptSnapshot(fresh, serializeIndex(index))).toBe(true)
+    const rng = mulberry32(53)
+    const late = syntheticStop(1000, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), hex64(rng))
+    insertStop(fresh, late)
+    expect(stopByHeight(fresh, 1000)?.blockHash).toBe(late.blockHash)
+    expect(findStation(fresh, late.coordApprox, 10_000)?.stop.height).toBe(1000)
+    assertSorted(fresh)
+  })
+
+  it('returns null with rows pending or a merge parked mid-flight, works after mergeAll', () => {
+    const rng = mulberry32(61)
+    const stops: Stop[] = []
+    for (let h = 0; h < 6000; h++) {
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), null))
+    }
+    const index = createStopIndex()
+    appendStops(index, stops.slice(0, 3000))
+    expect(serializeIndex(index)).toBeNull()
+    mergeAll(index)
+    appendStops(index, stops.slice(3000))
+    expect(mergeStep(index, 0)).toBe(false)
+    expect(serializeIndex(index)).toBeNull()
+    mergeAll(index)
+    expect(serializeIndex(index)).not.toBeNull()
+  })
+
+  it('rejects malformed snapshots outright, leaving the target untouched', () => {
+    const { index } = buildSample()
+    const snap = serializeIndex(index)
+    if (snap === null) throw new Error('expected a snapshot from a merged index')
+
+    // A non-empty target must refuse: adopting over existing rows would
+    // duplicate heights behind byHeight's back.
+    const occupied = createStopIndex()
+    const rng = mulberry32(19)
+    appendStops(occupied, [syntheticStop(0, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 1), null)])
+    expect(adoptSnapshot(occupied, snap)).toBe(false)
+
+    // A permutation with a duplicated entry (so another row is skipped).
+    const dupPerm = snap.perm.slice(0)
+    const dupView = new Uint32Array(dupPerm)
+    dupView[1] = dupView[0]
+
+    const cases: unknown[] = [
+      null,
+      42,
+      { ...snap, version: 2 },
+      { ...snap, count: snap.count + 1 },
+      { ...snap, count: snap.count - 1 },
+      { ...snap, keys: snap.keys.slice(0, snap.keys.byteLength - 1) },
+      { ...snap, heights: snap.heights.slice(0, snap.heights.byteLength - 4) },
+      { ...snap, perm: snap.coords },
+      { ...snap, perm: dupPerm },
+      { ...snap, maxHeight: snap.maxHeight + 1 },
+    ]
+    for (const bad of cases) {
+      const fresh = createStopIndex()
+      expect(adoptSnapshot(fresh, bad)).toBe(false)
+      // The failed adopt mutated nothing: the same target still accepts the
+      // good snapshot afterwards.
+      expect(fresh.size).toBe(0)
+      expect(adoptSnapshot(fresh, snap)).toBe(true)
+      expect(fresh.size).toBe(index.size)
+    }
   })
 })

--- a/src/lib/hyperspace/compactIndex.ts
+++ b/src/lib/hyperspace/compactIndex.ts
@@ -1,0 +1,448 @@
+/**
+ * compactIndex.ts: the columnar stop index behind hyperspace.
+ *
+ * The line is ~1M stops. The previous index held them as a million Stop
+ * objects plus a parallel bigint key array; between object headers, bigints
+ * and hex strings that was hundreds of megabytes and made every bulk merge a
+ * GC event. Here the hot data lives in five flat typed-array columns (32-byte
+ * keys, coords, merkles, hashes, plus a kind byte and a u32 height per row),
+ * and Stop objects are materialized on demand only for the handful of rows
+ * the UI actually touches (memoized so identity is stable and lazy exact
+ * coordinates cache on the object as before).
+ *
+ * Rows are append-only and never move, so a row id is a stable handle for
+ * the page's life. Sorted order lives in a separate permutation (`perm`),
+ * because bulk arrivals must not stall the main thread: appended rows sit in
+ * key-sorted pending runs until an incremental merge (mergeStep, bounded by
+ * a time budget per slice) folds them into a new permutation. Height lookups
+ * (byHeight) see appended rows immediately; spatial queries see them when
+ * the merge lands, which is the same freshness contract the bulk relay sync
+ * always had.
+ *
+ * Keys are big-endian byte strings rather than bigints on purpose: bytewise
+ * compare is allocation-free, and 32 fixed bytes in a flat buffer is what
+ * makes the worker handoff a transferable copy instead of a million boxed
+ * bigint constructions.
+ */
+
+import { coordToXyz, type Xyz } from 'cyberspace-core'
+import { bytesToHex, hexToBytes } from '../events'
+import { bigToBytes32, bytesToBigAt, type BlobColumns } from './headers'
+import type { Stop } from './stops'
+
+/** kinds column bits. */
+const KIND_PORT = 1
+const HAS_HASH = 2
+
+interface MergeState {
+  /** Row ids being merged in, ascending by key. */
+  incoming: Uint32Array
+  /** The permutation being built; swapped in whole when complete, so queries
+   * keep a consistent view mid-merge. */
+  out: Uint32Array
+  i: number
+  j: number
+  k: number
+}
+
+export interface StopIndex {
+  /** Rows appended so far. Rows never move and are never removed. */
+  size: number
+  /** Allocated row capacity of the columns. */
+  capacity: number
+  keys: Uint8Array
+  coords: Uint8Array
+  merkles: Uint8Array
+  hashes: Uint8Array
+  kinds: Uint8Array
+  heights: Uint32Array
+  /** Sorted view: perm[0..permCount) are row ids ascending by key bytes. */
+  perm: Uint32Array
+  permCount: number
+  /** height -> row + 1 (0 = absent); dense because heights are. */
+  byHeight: Uint32Array
+  /** Highest height present, or -1 when empty. */
+  maxHeight: number
+  /** Key-sorted row-id runs appended but not yet merged into perm. */
+  pending: Uint32Array[]
+  merge: MergeState | null
+  /** Materialized stops by row. Only rows the UI touched, so it stays small
+   * relative to the columns; identity stability is what StopField's decode
+   * cache and stopCoordExact's lazy caching rely on. */
+  stopCache: Map<number, Stop>
+  /** Decoded axes by row, for the renderer (coordToXyz costs seconds over a
+   * million rows, so each row is de-interleaved once, ever). */
+  xyz: Array<Xyz | undefined>
+}
+
+export function createStopIndex(): StopIndex {
+  return {
+    size: 0,
+    capacity: 0,
+    keys: new Uint8Array(0),
+    coords: new Uint8Array(0),
+    merkles: new Uint8Array(0),
+    hashes: new Uint8Array(0),
+    kinds: new Uint8Array(0),
+    heights: new Uint32Array(0),
+    perm: new Uint32Array(0),
+    permCount: 0,
+    byHeight: new Uint32Array(0),
+    maxHeight: -1,
+    pending: [],
+    merge: null,
+    stopCache: new Map(),
+    xyz: [],
+  }
+}
+
+function grow<T extends Uint8Array | Uint32Array>(old: T, length: number, make: (n: number) => T): T {
+  const next = make(length)
+  next.set(old as never)
+  return next
+}
+
+function ensureCapacity(index: StopIndex, extra: number): void {
+  const needed = index.size + extra
+  if (needed <= index.capacity) return
+  const cap = Math.max(needed, index.capacity * 2, 65536)
+  index.keys = grow(index.keys, cap * 32, (n) => new Uint8Array(n))
+  index.coords = grow(index.coords, cap * 32, (n) => new Uint8Array(n))
+  index.merkles = grow(index.merkles, cap * 32, (n) => new Uint8Array(n))
+  index.hashes = grow(index.hashes, cap * 32, (n) => new Uint8Array(n))
+  index.kinds = grow(index.kinds, cap, (n) => new Uint8Array(n))
+  index.heights = grow(index.heights, cap, (n) => new Uint32Array(n))
+  index.capacity = cap
+}
+
+function ensureByHeight(index: StopIndex, height: number): void {
+  if (height < index.byHeight.length) return
+  const cap = Math.max(height + 1, index.byHeight.length * 2, 65536)
+  index.byHeight = grow(index.byHeight, cap, (n) => new Uint32Array(n))
+}
+
+// ---------------------------------------------------------------------------
+// Row accessors
+// ---------------------------------------------------------------------------
+
+export function rowByHeight(index: StopIndex, height: number): number {
+  if (height < 0 || height >= index.byHeight.length) return -1
+  return index.byHeight[height] - 1
+}
+
+export function heightAt(index: StopIndex, row: number): number {
+  return index.heights[row]
+}
+
+export function kindIsPort(index: StopIndex, row: number): boolean {
+  return (index.kinds[row] & KIND_PORT) !== 0
+}
+
+export function coordApproxAt(index: StopIndex, row: number): bigint {
+  return bytesToBigAt(index.coords, row * 32)
+}
+
+/** Decoded axes for a row, de-interleaved once and cached. */
+export function xyzAt(index: StopIndex, row: number): Xyz {
+  let d = index.xyz[row]
+  if (!d) {
+    d = coordToXyz(coordApproxAt(index, row))
+    index.xyz[row] = d
+  }
+  return d
+}
+
+/** Materialize the Stop for a row; memoized so identity is stable. */
+export function stopAt(index: StopIndex, row: number): Stop {
+  const cached = index.stopCache.get(row)
+  if (cached) return cached
+  const col = row * 32
+  const port = (index.kinds[row] & KIND_PORT) !== 0
+  const coordApprox = coordApproxAt(index, row)
+  const stop: Stop = {
+    height: index.heights[row],
+    kind: port ? 'port' : 'landfall',
+    merkleRoot: bytesToHex(index.merkles.subarray(col, col + 32)),
+    blockHash: (index.kinds[row] & HAS_HASH) !== 0
+      ? bytesToHex(index.hashes.subarray(col, col + 32))
+      : null,
+    coordExact: port ? coordApprox : null,
+    coordApprox,
+  }
+  index.stopCache.set(row, stop)
+  return stop
+}
+
+export function stopByHeight(index: StopIndex, height: number): Stop | undefined {
+  const row = rowByHeight(index, height)
+  return row === -1 ? undefined : stopAt(index, row)
+}
+
+// ---------------------------------------------------------------------------
+// Key comparison
+// ---------------------------------------------------------------------------
+
+export function compareRowKeys(index: StopIndex, a: number, b: number): number {
+  const keys = index.keys
+  const oa = a * 32
+  const ob = b * 32
+  for (let i = 0; i < 32; i++) {
+    const d = keys[oa + i] - keys[ob + i]
+    if (d !== 0) return d
+  }
+  return 0
+}
+
+export function compareRowKeyToBytes(index: StopIndex, row: number, bytes: Uint8Array): number {
+  const keys = index.keys
+  const off = row * 32
+  for (let i = 0; i < 32; i++) {
+    const d = keys[off + i] - bytes[i]
+    if (d !== 0) return d
+  }
+  return 0
+}
+
+/** The key at sorted position `pos`, as hex; fixed width makes hex order
+ * equal numeric order, which is what the sortedness tests lean on. */
+export function keyHexAtSorted(index: StopIndex, pos: number): string {
+  const off = index.perm[pos] * 32
+  return bytesToHex(index.keys.subarray(off, off + 32))
+}
+
+// ---------------------------------------------------------------------------
+// Appending
+// ---------------------------------------------------------------------------
+
+/** Write one stop's columns at the next row; caller ensured capacity. */
+function writeRow(index: StopIndex, stop: Stop): number {
+  const row = index.size
+  const col = row * 32
+  index.keys.set(bigToBytes32(stop.coordApprox >> 1n), col)
+  index.coords.set(bigToBytes32(stop.coordApprox), col)
+  index.merkles.set(hexToBytes(stop.merkleRoot), col)
+  if (stop.blockHash !== null) index.hashes.set(hexToBytes(stop.blockHash), col)
+  index.kinds[row] = (stop.kind === 'port' ? KIND_PORT : 0) | (stop.blockHash !== null ? HAS_HASH : 0)
+  index.heights[row] = stop.height
+  ensureByHeight(index, stop.height)
+  index.byHeight[stop.height] = row + 1
+  if (stop.height > index.maxHeight) index.maxHeight = stop.height
+  index.size = row + 1
+  return row
+}
+
+/**
+ * Append relay-sourced stops as one key-sorted pending run. Heights already
+ * in the index (and duplicates within the batch, first wins) are skipped:
+ * every source of a given height describes the same block. Returns how many
+ * rows were actually appended; call mergeStep (or a scheduler around it) to
+ * make them visible to spatial queries.
+ */
+export function appendStops(index: StopIndex, stops: Stop[]): number {
+  if (stops.length === 0) return 0
+  ensureCapacity(index, stops.length)
+  const rows: number[] = []
+  for (const stop of stops) {
+    if (rowByHeight(index, stop.height) !== -1) continue
+    rows.push(writeRow(index, stop))
+  }
+  if (rows.length === 0) return 0
+  const run = Uint32Array.from(rows)
+  run.sort((a, b) => compareRowKeys(index, a, b))
+  index.pending.push(run)
+  return run.length
+}
+
+/**
+ * Append a verified header blob's columns. Heights are consecutive from
+ * cols.startHeight, so row r of the blob is height startHeight + r. The
+ * common case (no height already present) is a bulk buffer copy; overlap
+ * with cached relay rows falls back to per-row filtering.
+ */
+export function appendColumns(index: StopIndex, cols: BlobColumns): number {
+  const { startHeight, count } = cols
+  if (count === 0) return 0
+  ensureCapacity(index, count)
+  ensureByHeight(index, startHeight + count - 1)
+
+  let dup = false
+  for (let r = 0; r < count; r++) {
+    if (rowByHeight(index, startHeight + r) !== -1) {
+      dup = true
+      break
+    }
+  }
+
+  const base = index.size
+  if (!dup) {
+    index.keys.set(cols.keys, base * 32)
+    index.coords.set(cols.coords, base * 32)
+    index.merkles.set(cols.merkles, base * 32)
+    index.hashes.set(cols.hashes, base * 32)
+    for (let r = 0; r < count; r++) {
+      index.kinds[base + r] = (cols.kinds[r] === 1 ? KIND_PORT : 0) | HAS_HASH
+      index.heights[base + r] = startHeight + r
+      index.byHeight[startHeight + r] = base + r + 1
+    }
+    index.size = base + count
+    const run = new Uint32Array(count)
+    for (let k = 0; k < count; k++) run[k] = base + cols.order[k]
+    index.pending.push(run)
+    if (startHeight + count - 1 > index.maxHeight) index.maxHeight = startHeight + count - 1
+    return count
+  }
+
+  // Overlap path: copy only the missing heights, preserving the blob's key
+  // order for the pending run via a source-row -> dest-row map.
+  const dest = new Int32Array(count).fill(-1)
+  for (let r = 0; r < count; r++) {
+    const height = startHeight + r
+    if (rowByHeight(index, height) !== -1) continue
+    const row = index.size
+    const col = row * 32
+    const src = r * 32
+    index.keys.set(cols.keys.subarray(src, src + 32), col)
+    index.coords.set(cols.coords.subarray(src, src + 32), col)
+    index.merkles.set(cols.merkles.subarray(src, src + 32), col)
+    index.hashes.set(cols.hashes.subarray(src, src + 32), col)
+    index.kinds[row] = (cols.kinds[r] === 1 ? KIND_PORT : 0) | HAS_HASH
+    index.heights[row] = height
+    index.byHeight[height] = row + 1
+    if (height > index.maxHeight) index.maxHeight = height
+    index.size = row + 1
+    dest[r] = row
+  }
+  const kept: number[] = []
+  for (let k = 0; k < count; k++) {
+    const row = dest[cols.order[k]]
+    if (row !== -1) kept.push(row)
+  }
+  if (kept.length === 0) return 0
+  index.pending.push(Uint32Array.from(kept))
+  return kept.length
+}
+
+/**
+ * Insert one stop (the live tail: one block per ten minutes). When the index
+ * is quiescent this splices the permutation in place (one native memmove);
+ * during a bulk merge it joins the pending queue instead so the merge's
+ * snapshot arithmetic stays valid.
+ */
+export function insertRow(index: StopIndex, stop: Stop): void {
+  if (rowByHeight(index, stop.height) !== -1) return
+  if (index.merge !== null || index.pending.length > 0) {
+    appendStops(index, [stop])
+    return
+  }
+  ensureCapacity(index, 1)
+  const row = writeRow(index, stop)
+  const keyOff = row * 32
+  const key = index.keys.subarray(keyOff, keyOff + 32)
+  let lo = 0
+  let hi = index.permCount
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (compareRowKeyToBytes(index, index.perm[mid], key) < 0) lo = mid + 1
+    else hi = mid
+  }
+  if (index.permCount === index.perm.length) {
+    index.perm = grow(index.perm, Math.max(index.permCount + 1, index.perm.length * 2, 1024), (n) => new Uint32Array(n))
+  }
+  index.perm.copyWithin(lo + 1, lo, index.permCount)
+  index.perm[lo] = row
+  index.permCount += 1
+}
+
+// ---------------------------------------------------------------------------
+// Incremental merging
+// ---------------------------------------------------------------------------
+
+export function hasPending(index: StopIndex): boolean {
+  return index.pending.length > 0 || index.merge !== null
+}
+
+function mergeRuns(index: StopIndex, a: Uint32Array, b: Uint32Array): Uint32Array {
+  const out = new Uint32Array(a.length + b.length)
+  let i = 0
+  let j = 0
+  let k = 0
+  while (i < a.length && j < b.length) {
+    out[k++] = compareRowKeys(index, a[i], b[j]) <= 0 ? a[i++] : b[j++]
+  }
+  if (i < a.length) out.set(a.subarray(i), k)
+  if (j < b.length) out.set(b.subarray(j), k)
+  return out
+}
+
+/** Fold every pending run into one sorted incoming list. Runs are already
+ * sorted, so this is linear pairwise merging, cheap even for many small
+ * relay batches coalesced behind one bulk merge. */
+function drainPending(index: StopIndex): Uint32Array {
+  let runs = index.pending
+  index.pending = []
+  while (runs.length > 1) {
+    const next: Uint32Array[] = []
+    for (let i = 0; i < runs.length; i += 2) {
+      next.push(i + 1 < runs.length ? mergeRuns(index, runs[i], runs[i + 1]) : runs[i])
+    }
+    runs = next
+  }
+  return runs[0]
+}
+
+/** Check the clock every this many merge steps; a step is a compare + a u32
+ * write, so 1024 of them are far below a millisecond. */
+const BUDGET_CHECK_EVERY = 1024
+
+/**
+ * Advance the merge by at most `budgetMs` of work. Returns true when the
+ * permutation is fully up to date (nothing pending, no merge in flight).
+ * The permutation swaps atomically at the end, so a caller can keep querying
+ * between slices and always sees a consistent (if slightly stale) view.
+ */
+export function mergeStep(index: StopIndex, budgetMs: number): boolean {
+  let st = index.merge
+  if (st === null) {
+    if (index.pending.length === 0) return true
+    const incoming = drainPending(index)
+    st = { incoming, out: new Uint32Array(index.permCount + incoming.length), i: 0, j: 0, k: 0 }
+    index.merge = st
+  }
+  const deadline = performance.now() + budgetMs
+  const perm = index.perm
+  const inc = st.incoming
+  const out = st.out
+  const n = index.permCount
+  const m = inc.length
+  let { i, j, k } = st
+  let steps = 0
+  while (i < n && j < m) {
+    out[k++] = compareRowKeys(index, perm[i], inc[j]) <= 0 ? perm[i++] : inc[j++]
+    if (++steps === BUDGET_CHECK_EVERY) {
+      steps = 0
+      if (performance.now() >= deadline) {
+        st.i = i
+        st.j = j
+        st.k = k
+        return false
+      }
+    }
+  }
+  if (i < n) {
+    out.set(perm.subarray(i, n), k)
+    k += n - i
+  }
+  if (j < m) {
+    out.set(inc.subarray(j, m), k)
+    k += m - j
+  }
+  index.perm = out
+  index.permCount = k
+  index.merge = null
+  return index.pending.length === 0
+}
+
+/** Drain everything synchronously: builders, tests, and node. */
+export function mergeAll(index: StopIndex): void {
+  while (!mergeStep(index, Number.POSITIVE_INFINITY)) { /* keep folding */ }
+}

--- a/src/lib/hyperspace/compactIndex.ts
+++ b/src/lib/hyperspace/compactIndex.ts
@@ -446,3 +446,118 @@ export function mergeStep(index: StopIndex, budgetMs: number): boolean {
 export function mergeAll(index: StopIndex): void {
   while (!mergeStep(index, Number.POSITIVE_INFINITY)) { /* keep folding */ }
 }
+
+// ---------------------------------------------------------------------------
+// Snapshot persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * The built index as a handful of ArrayBuffers, the shape IndexedDB can store
+ * and hand back wholesale. Replaying ~1M cached rows re-sorts the whole line
+ * on every page load; adopting a snapshot is one bulk read plus a byHeight
+ * rebuild. The buffers are copies sliced to `count`, never views into the
+ * live typed arrays, so an in-flight IndexedDB write is not racing rows
+ * appended after serialization.
+ */
+export interface IndexSnapshot {
+  version: 1
+  count: number
+  maxHeight: number
+  keys: ArrayBuffer
+  coords: ArrayBuffer
+  merkles: ArrayBuffer
+  hashes: ArrayBuffer
+  kinds: ArrayBuffer
+  heights: ArrayBuffer
+  perm: ArrayBuffer
+}
+
+/**
+ * Serialize a fully merged index, or null while rows are still pending: a
+ * mid-merge permutation does not order every row, and persisting it would
+ * silently hide the unmerged tail from spatial queries after adoption.
+ * Callers run mergeAll first.
+ */
+export function serializeIndex(index: StopIndex): IndexSnapshot | null {
+  if (hasPending(index) || index.permCount !== index.size) return null
+  const count = index.size
+  return {
+    version: 1,
+    count,
+    maxHeight: index.maxHeight,
+    keys: index.keys.slice(0, count * 32).buffer,
+    coords: index.coords.slice(0, count * 32).buffer,
+    merkles: index.merkles.slice(0, count * 32).buffer,
+    hashes: index.hashes.slice(0, count * 32).buffer,
+    kinds: index.kinds.slice(0, count).buffer,
+    heights: index.heights.slice(0, count).buffer,
+    perm: index.perm.slice(0, count).buffer,
+  }
+}
+
+/** The value when it is an ArrayBuffer of exactly byteLength, else null. */
+function bufferOf(v: unknown, byteLength: number): ArrayBuffer | null {
+  return v instanceof ArrayBuffer && v.byteLength === byteLength ? v : null
+}
+
+/**
+ * Adopt a stored snapshot into an EMPTY index. Everything is validated before
+ * the first mutation (shape, version, exact buffer lengths, perm being a real
+ * permutation, heights unique and consistent with maxHeight), because a
+ * half-adopted index would answer queries plausibly and wrongly forever; on
+ * any mismatch the index is untouched (false) and the caller falls back to
+ * the row replay. The buffers become the live columns without copying: the
+ * snapshot comes out of IndexedDB as a structured clone the index then owns,
+ * and no code path writes inside the first `count` rows afterwards (rows
+ * never mutate, and adoption leaves capacity === count so the next append
+ * grows into fresh buffers before writing).
+ */
+export function adoptSnapshot(index: StopIndex, snap: unknown): boolean {
+  if (index.size !== 0 || index.permCount !== 0 || hasPending(index)) return false
+  if (typeof snap !== 'object' || snap === null) return false
+  const s = snap as Record<string, unknown>
+  if (s.version !== 1) return false
+  const count = s.count
+  if (typeof count !== 'number' || !Number.isSafeInteger(count) || count < 0) return false
+  const maxHeight = s.maxHeight
+  if (typeof maxHeight !== 'number' || !Number.isSafeInteger(maxHeight)) return false
+  if (count === 0 ? maxHeight !== -1 : maxHeight < 0) return false
+  const keys = bufferOf(s.keys, count * 32)
+  const coords = bufferOf(s.coords, count * 32)
+  const merkles = bufferOf(s.merkles, count * 32)
+  const hashes = bufferOf(s.hashes, count * 32)
+  const kinds = bufferOf(s.kinds, count)
+  const heights = bufferOf(s.heights, count * 4)
+  const perm = bufferOf(s.perm, count * 4)
+  if (!keys || !coords || !merkles || !hashes || !kinds || !heights || !perm) return false
+
+  const heightCol = new Uint32Array(heights)
+  const permCol = new Uint32Array(perm)
+  const byHeight = new Uint32Array(count === 0 ? 0 : maxHeight + 1)
+  const seen = new Uint8Array(count)
+  let highest = -1
+  for (let row = 0; row < count; row++) {
+    const h = heightCol[row]
+    if (h > maxHeight || byHeight[h] !== 0) return false
+    byHeight[h] = row + 1
+    if (h > highest) highest = h
+    const p = permCol[row]
+    if (p >= count || seen[p] !== 0) return false
+    seen[p] = 1
+  }
+  if (highest !== maxHeight) return false
+
+  index.keys = new Uint8Array(keys)
+  index.coords = new Uint8Array(coords)
+  index.merkles = new Uint8Array(merkles)
+  index.hashes = new Uint8Array(hashes)
+  index.kinds = new Uint8Array(kinds)
+  index.heights = heightCol
+  index.perm = permCol
+  index.permCount = count
+  index.byHeight = byHeight
+  index.maxHeight = maxHeight
+  index.size = count
+  index.capacity = count
+  return true
+}

--- a/src/lib/hyperspace/enter.ts
+++ b/src/lib/hyperspace/enter.ts
@@ -1,0 +1,40 @@
+/**
+ * enter.ts: DECK-0001 v3 §3.2, the entry proof.
+ *
+ * The base protocol's temporal axis at the identity's current coordinate,
+ * with no spatial component: K from terrain at C, the seeded Cantor root from
+ * the previous event id, enter_n = pi(0, cantor_t), double SHA-256. Worst case
+ * K = 16 is about a tenth of a second; this is a freshness binding, not a
+ * fare (the toll is reserved, §7).
+ */
+import {
+  alignedBase,
+  cantorPair,
+  computeSubtreeCantor,
+  coordToXyz,
+  hexToBytes,
+  bytesToHex,
+  intToBytesBE,
+  sha256,
+  terrainK,
+  TEMPORAL_MAX_COMPUTE_HEIGHT,
+} from 'cyberspace-core'
+
+const AXIS_MASK = (1n << 85n) - 1n
+
+export function computeEnterProof(coord: bigint, previousEventIdHex: string): string {
+  if (previousEventIdHex.length !== 64) throw new Error('previousEventIdHex must be 64 hex chars')
+  const { x, y, z, plane } = coordToXyz(coord)
+  const k = terrainK(x, y, z, plane)
+  let t = 0n
+  for (const b of hexToBytes(previousEventIdHex)) t = (t << 8n) | BigInt(b)
+  t &= AXIS_MASK
+  const cantorT = computeSubtreeCantor(alignedBase(t, k), k, TEMPORAL_MAX_COMPUTE_HEIGHT)
+  const enterN = cantorPair(0n, cantorT)
+  return bytesToHex(sha256(sha256(intToBytesBE(enterN))))
+}
+
+/** A verifier's check is the same computation. */
+export function verifyEnterProof(coord: bigint, previousEventIdHex: string, proofHash: string): boolean {
+  return computeEnterProof(coord, previousEventIdHex) === proofHash.toLowerCase()
+}

--- a/src/lib/hyperspace/headerSync.test.ts
+++ b/src/lib/hyperspace/headerSync.test.ts
@@ -1,0 +1,85 @@
+/**
+ * What would fail silently without these tests: a lax manifest parser would
+ * let a malformed or hostile manifest describe overlapping or misaligned
+ * blobs, and the worker's per-blob height arithmetic (row r = startHeight +
+ * r) would then file every stop under the wrong block. The parser is the
+ * gate that makes those invariants safe to assume everywhere downstream.
+ */
+import { describe, expect, it } from 'vitest'
+import { HEADERS_MANIFEST_URL, blobUrl, manifestUrl, parseManifest } from './headerSync'
+
+const good = () => ({
+  formatVersion: 1,
+  network: 'mainnet',
+  blobSize: 50000,
+  generatedAtHeight: 964321,
+  blobs: [
+    { ordinal: 0, startHeight: 0, count: 50000, sha256: 'a'.repeat(64), file: 'headers-000.bin' },
+    { ordinal: 1, startHeight: 50000, count: 14322, sha256: 'b'.repeat(64), file: 'headers-001.bin' },
+  ],
+  checkpoints: [
+    { height: 49999, blockHash: 'c'.repeat(64) },
+    { height: 64321, blockHash: 'd'.repeat(64) },
+  ],
+})
+
+describe('parseManifest', () => {
+  it('accepts a well-formed manifest', () => {
+    const m = parseManifest(good())
+    expect(m).not.toBeNull()
+    expect(m?.blobs.length).toBe(2)
+    expect(m?.blobs[1].startHeight).toBe(50000)
+    expect(m?.checkpoints[0].blockHash).toBe('c'.repeat(64))
+  })
+
+  it('rejects the wrong format version or network', () => {
+    expect(parseManifest({ ...good(), formatVersion: 2 })).toBeNull()
+    expect(parseManifest({ ...good(), network: 'testnet' })).toBeNull()
+    expect(parseManifest(null)).toBeNull()
+    expect(parseManifest('manifest')).toBeNull()
+  })
+
+  it('rejects misaligned or non-contiguous blobs', () => {
+    const gap = good()
+    gap.blobs[1].ordinal = 2
+    expect(parseManifest(gap)).toBeNull()
+    const misaligned = good()
+    misaligned.blobs[1].startHeight = 50001
+    expect(parseManifest(misaligned)).toBeNull()
+  })
+
+  it('rejects impossible counts, and partial blobs before the last', () => {
+    const zero = good()
+    zero.blobs[0].count = 0
+    expect(parseManifest(zero)).toBeNull()
+    const oversized = good()
+    oversized.blobs[0].count = 50001
+    expect(parseManifest(oversized)).toBeNull()
+    const partialFirst = good()
+    partialFirst.blobs[0].count = 49999
+    expect(parseManifest(partialFirst)).toBeNull()
+  })
+
+  it('rejects malformed digests and checkpoints', () => {
+    const badSha = good()
+    badSha.blobs[0].sha256 = 'xyz'
+    expect(parseManifest(badSha)).toBeNull()
+    const badCp = good()
+    badCp.checkpoints[0].blockHash = 'C'.repeat(64) // uppercase is out of spec
+    expect(parseManifest(badCp)).toBeNull()
+  })
+})
+
+describe('URL plumbing', () => {
+  it('defaults to the release manifest URL when no override exists', () => {
+    // Under node there is no localStorage, which is exactly the guarded path.
+    expect(manifestUrl()).toBe(HEADERS_MANIFEST_URL)
+  })
+
+  it('resolves blob files relative to the manifest', () => {
+    expect(blobUrl('https://example.com/x/manifest.json', 'headers-000.bin'))
+      .toBe('https://example.com/x/headers-000.bin')
+    expect(blobUrl('https://example.com/x/manifest.json', 'https://cdn.example.com/h.bin'))
+      .toBe('https://cdn.example.com/h.bin')
+  })
+})

--- a/src/lib/hyperspace/headerSync.ts
+++ b/src/lib/hyperspace/headerSync.ts
@@ -17,8 +17,12 @@
 import type { BlobColumns } from './headers'
 import type { HeadersRequest, HeadersResponse } from '../../workers/headers.worker'
 
+// raw.githubusercontent, not a release asset: release downloads send no
+// access-control-allow-origin header and are unfetchable from a browser,
+// raw sends *. The headers-v1 branch holds only the blobs, the manifest,
+// and a README.
 export const HEADERS_MANIFEST_URL =
-  'https://github.com/arkin0x/nth/releases/download/headers-v1/manifest.json'
+  'https://raw.githubusercontent.com/arkin0x/nth/headers-v1/manifest.json'
 
 const MANIFEST_OVERRIDE_KEY = 'onosendai:headersManifest'
 

--- a/src/lib/hyperspace/headerSync.ts
+++ b/src/lib/hyperspace/headerSync.ts
@@ -1,0 +1,193 @@
+/**
+ * headerSync.ts: fetch the header-blob manifest and drive the verify worker.
+ *
+ * The manifest is a small JSON published next to the blobs; it is the only
+ * thing fetched on the main thread. Everything heavy (blob download, digest,
+ * chain verification, stop derivation) happens in headers.worker.ts, and the
+ * results come back as transferable columns. A missing or malformed manifest
+ * is NOT an error: the caller logs once and the relay path covers everything,
+ * exactly as before blobs existed.
+ *
+ * The manifest URL lives here so there is one config spot. For development
+ * against locally packaged blobs, set
+ * localStorage['onosendai:headersManifest'] to any URL; blob files resolve
+ * relative to wherever the manifest came from.
+ */
+
+import type { BlobColumns } from './headers'
+import type { HeadersRequest, HeadersResponse } from '../../workers/headers.worker'
+
+export const HEADERS_MANIFEST_URL =
+  'https://github.com/arkin0x/nth/releases/download/headers-v1/manifest.json'
+
+const MANIFEST_OVERRIDE_KEY = 'onosendai:headersManifest'
+
+export interface ManifestBlob {
+  ordinal: number
+  startHeight: number
+  count: number
+  /** sha256 of the blob file's bytes, 64 lowercase hex. */
+  sha256: string
+  file: string
+}
+
+export interface ManifestCheckpoint {
+  height: number
+  /** Display-order block hash of the LAST block of a blob. */
+  blockHash: string
+}
+
+export interface HeadersManifest {
+  formatVersion: 1
+  network: 'mainnet'
+  blobSize: number
+  generatedAtHeight: number
+  blobs: ManifestBlob[]
+  checkpoints: ManifestCheckpoint[]
+}
+
+export function manifestUrl(): string {
+  // localStorage can throw in odd embeddings; the default must survive that.
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const override = localStorage.getItem(MANIFEST_OVERRIDE_KEY)
+      if (override) return override
+    }
+  } catch { /* fall through to the default */ }
+  return HEADERS_MANIFEST_URL
+}
+
+/** Blob file URLs resolve relative to the manifest they were named in. */
+export function blobUrl(manifest: string, file: string): string {
+  return new URL(file, manifest).toString()
+}
+
+const HEX64 = /^[0-9a-f]{64}$/
+
+/**
+ * Validate an untrusted manifest into a HeadersManifest, or null. Strict on
+ * the invariants verification leans on: ordinals contiguous from zero, each
+ * blob starting exactly at ordinal * blobSize, only the last blob partial.
+ */
+export function parseManifest(raw: unknown): HeadersManifest | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const m = raw as Record<string, unknown>
+  if (m.formatVersion !== 1 || m.network !== 'mainnet') return null
+  const blobSize = m.blobSize
+  const generatedAtHeight = m.generatedAtHeight
+  if (!Number.isSafeInteger(blobSize) || (blobSize as number) <= 0) return null
+  if (!Number.isSafeInteger(generatedAtHeight) || (generatedAtHeight as number) < 0) return null
+  if (!Array.isArray(m.blobs) || !Array.isArray(m.checkpoints)) return null
+  const blobs: ManifestBlob[] = []
+  for (const entry of m.blobs as unknown[]) {
+    if (typeof entry !== 'object' || entry === null) return null
+    const b = entry as Record<string, unknown>
+    const { ordinal, startHeight, count, sha256, file } = b
+    if (!Number.isSafeInteger(ordinal) || (ordinal as number) !== blobs.length) return null
+    if (startHeight !== (ordinal as number) * (blobSize as number)) return null
+    if (!Number.isSafeInteger(count) || (count as number) <= 0 || (count as number) > (blobSize as number)) return null
+    if ((count as number) < (blobSize as number) && (ordinal as number) !== (m.blobs as unknown[]).length - 1) return null
+    if (typeof sha256 !== 'string' || !HEX64.test(sha256)) return null
+    if (typeof file !== 'string' || file.length === 0) return null
+    blobs.push({
+      ordinal: ordinal as number,
+      startHeight: startHeight as number,
+      count: count as number,
+      sha256,
+      file,
+    })
+  }
+  const checkpoints: ManifestCheckpoint[] = []
+  for (const entry of m.checkpoints as unknown[]) {
+    if (typeof entry !== 'object' || entry === null) return null
+    const c = entry as Record<string, unknown>
+    if (!Number.isSafeInteger(c.height) || (c.height as number) < 0) return null
+    if (typeof c.blockHash !== 'string' || !HEX64.test(c.blockHash)) return null
+    checkpoints.push({ height: c.height as number, blockHash: c.blockHash })
+  }
+  return {
+    formatVersion: 1,
+    network: 'mainnet',
+    blobSize: blobSize as number,
+    generatedAtHeight: generatedAtHeight as number,
+    blobs,
+    checkpoints,
+  }
+}
+
+/**
+ * Fetch and validate the manifest, or null on any failure. Null is the
+ * degrade-to-relay signal, so this logs its one warning here and never
+ * throws.
+ */
+export async function fetchManifest(): Promise<{ manifest: HeadersManifest; url: string } | null> {
+  if (typeof fetch === 'undefined') return null
+  const url = manifestUrl()
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const manifest = parseManifest(await res.json())
+    if (!manifest) throw new Error('malformed manifest')
+    return { manifest, url }
+  } catch (e) {
+    console.warn('[hyperspace] header manifest unavailable, syncing everything from the relay:', e)
+    return null
+  }
+}
+
+export interface HeaderSyncHandlers {
+  /** Records verified so far within the blob currently being walked. */
+  onProgress: (startHeight: number, verified: number) => void
+  /** A verified blob's derived columns, in ascending blob order. */
+  onColumns: (cols: BlobColumns) => void
+  /** A discarded blob; its range must fall back to relay sync. */
+  onBlobFailed: (startHeight: number, count: number, reason: string) => void
+}
+
+export interface HeaderSyncResult {
+  /** Verified inclusive height ranges, ascending, one per delivered blob. */
+  covered: Array<[number, number]>
+}
+
+/**
+ * Run the worker over every blob in the manifest. Resolves (never rejects)
+ * when the worker reports done or dies; whatever verified before a crash is
+ * kept and the rest is the relay's job.
+ */
+export function runHeaderSync(
+  manifest: HeadersManifest,
+  url: string,
+  handlers: HeaderSyncHandlers,
+): Promise<HeaderSyncResult> {
+  return new Promise((resolve) => {
+    const worker = new Worker(new URL('../../workers/headers.worker.ts', import.meta.url), {
+      type: 'module',
+    })
+    const covered: Array<[number, number]> = []
+    const finish = (): void => {
+      worker.terminate()
+      resolve({ covered })
+    }
+    worker.onmessage = (event: MessageEvent<HeadersResponse>) => {
+      const msg = event.data
+      if (msg.type === 'progress') {
+        handlers.onProgress(msg.startHeight, msg.verified)
+      } else if (msg.type === 'blob') {
+        covered.push([msg.columns.startHeight, msg.columns.startHeight + msg.columns.count - 1])
+        handlers.onColumns(msg.columns)
+      } else if (msg.type === 'blob-failed') {
+        handlers.onBlobFailed(msg.startHeight, msg.count, msg.reason)
+      } else {
+        finish()
+      }
+    }
+    // A worker that throws never posts done; without this the sync pipeline
+    // would hang forever instead of falling back to the relay.
+    worker.onerror = (event) => {
+      console.warn('[hyperspace] headers worker failed:', event.message)
+      finish()
+    }
+    const request: HeadersRequest = { type: 'sync', manifest, manifestUrl: url }
+    worker.postMessage(request)
+  })
+}

--- a/src/lib/hyperspace/headers.test.ts
+++ b/src/lib/hyperspace/headers.test.ts
@@ -1,0 +1,249 @@
+/**
+ * What would fail silently without these tests: a byte-order slip anywhere in
+ * the record layout would make every block hash wrong yet still produce a
+ * plausible-looking cloud of stops; a PoW or checkpoint check that never
+ * actually fired would turn the "self-verifying" blobs into blind trust of a
+ * static file host. So the format is pinned against REAL mainnet headers
+ * (blocks 0-5, hardcoded from the wire), and every failure path is exercised
+ * with a deliberate corruption.
+ */
+import { describe, expect, it } from 'vitest'
+import { bytesToHex, hexToBytes } from '../events'
+import { planeOfMerkleRoot } from './stops'
+import { landfallCoordApprox } from './landfall'
+import {
+  HEADER_RECORD_SIZE,
+  bigToBytes32,
+  bytesToBigAt,
+  decodeCompactTarget,
+  genesisState,
+  hashMeetsTarget,
+  readRecord,
+  reverse32,
+  sha256d,
+  verifyAndDerive,
+  wireHeader,
+  writeRecord,
+  type HeaderRecord,
+} from './headers'
+
+// The first six mainnet block headers, exactly as they appear on the wire
+// (fetched from mempool.space and frozen here; the genesis hex is the one
+// every Bitcoin implementation embeds).
+const HEADERS = [
+  '0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c',
+  '010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299',
+  '010000004860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a8300000000d5fdcc541e25de1c7a5addedf24858b8bb665c9f36ef744ee42c316022c90f9bb0bc6649ffff001d08d2bd61',
+  '01000000bddd99ccfda39da1b108ce1a5d70038d0a967bacb68b6b63065f626a0000000044f672226090d85db9a9f2fbfe5f0f9609b387af7be5b7fbb7a1767c831c9e995dbe6649ffff001d05e0ed6d',
+  '010000004944469562ae1c2c74d9a535e00b6f3e40ffbad4f2fda3895501b582000000007a06ea98cd40ba2e3288262b28638cec5337c1456aaf5eedc8e9e5a20f062bdf8cc16649ffff001d2bfee0a9',
+  '0100000085144a84488ea88d221c8bd6c059da090e88f8a2c99690ee55dbba4e00000000e11c48fecdd9e72510ca84f023370c9a38bf91ac5cae88019bee94d24528526344c36649ffff001d1d03e477',
+]
+
+// The corresponding display (byte-reversed sha256d) block ids.
+const IDS = [
+  '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
+  '00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048',
+  '000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd',
+  '0000000082b5015589a3fdf2d4baff403e6f0be035a5d9742c1cae6295464449',
+  '000000004ebadb55ee9096c9a2f8880e09da59c0d68b1c228da88e48844a1485',
+  '000000009b7262315dbf071787ad3656097b892abffd1f95a1a022f896f533fc',
+]
+
+function recordFromWireHex(hex: string): HeaderRecord {
+  const bytes = hexToBytes(hex)
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  return {
+    version: dv.getInt32(0, true),
+    merkleInternal: bytes.subarray(36, 68),
+    time: dv.getUint32(68, true),
+    bits: dv.getUint32(72, true),
+    nonce: dv.getUint32(76, true),
+  }
+}
+
+function packBlob(records: HeaderRecord[]): Uint8Array {
+  const out = new Uint8Array(records.length * HEADER_RECORD_SIZE)
+  records.forEach((rec, i) => writeRecord(out, i, rec))
+  return out
+}
+
+const realBlob = (): Uint8Array => packBlob(HEADERS.map(recordFromWireHex))
+const noChecks = { finalHashHex: null, embedded: new Map<number, string>() }
+
+describe('record layout', () => {
+  it('pack/unpack round-trips every real header', () => {
+    for (const hex of HEADERS) {
+      const rec = recordFromWireHex(hex)
+      const buf = new Uint8Array(HEADER_RECORD_SIZE)
+      writeRecord(buf, 0, rec)
+      const back = readRecord(buf, 0)
+      expect(back.version).toBe(rec.version)
+      expect(bytesToHex(back.merkleInternal)).toBe(bytesToHex(rec.merkleInternal))
+      expect(back.time).toBe(rec.time)
+      expect(back.bits).toBe(rec.bits)
+      expect(back.nonce).toBe(rec.nonce)
+    }
+  })
+
+  it('reconstructs the exact genesis wire header from a record plus zeros', () => {
+    const rec = recordFromWireHex(HEADERS[0])
+    expect(bytesToHex(wireHeader(rec, new Uint8Array(32)))).toBe(HEADERS[0])
+  })
+})
+
+describe('compact bits', () => {
+  it('decodes the genesis target', () => {
+    const target = decodeCompactTarget(0x1d00ffff)
+    expect(target).not.toBeNull()
+    expect(bytesToHex(target as Uint8Array)).toBe('00000000ffff' + '0'.repeat(52))
+  })
+
+  it('rejects negative and zero encodings', () => {
+    expect(decodeCompactTarget(0x1d80ffff)).toBeNull()
+    expect(decodeCompactTarget(0x1d000000)).toBeNull()
+  })
+
+  it('compares the display hash against the target bytewise', () => {
+    const target = decodeCompactTarget(0x1d00ffff) as Uint8Array
+    expect(hashMeetsTarget(hexToBytes(IDS[0]), target)).toBe(true)
+    const above = target.slice()
+    above[31] += 1 // exactly target + 1
+    expect(hashMeetsTarget(above, target)).toBe(false)
+    expect(hashMeetsTarget(target, target)).toBe(true)
+  })
+})
+
+describe('verifyAndDerive over real mainnet headers', () => {
+  it('reconstructs the known block ids with linkage, PoW and checkpoints', () => {
+    const verdict = verifyAndDerive(realBlob(), 0, 6, genesisState(), {
+      finalHashHex: IDS[5],
+      embedded: new Map([[0, IDS[0]]]),
+    })
+    expect(verdict.ok).toBe(true)
+    if (!verdict.ok) return
+    const { columns, state } = verdict
+    for (let i = 0; i < 6; i++) {
+      expect(bytesToHex(columns.hashes.subarray(i * 32, i * 32 + 32))).toBe(IDS[i])
+    }
+    // The carried state seeds the next blob: it must be block 5's own hash.
+    expect(bytesToHex(reverse32(state.prevHashInternal))).toBe(IDS[5])
+    expect(state.prevBits).toBe(0x1d00ffff)
+  })
+
+  it('extracts the plane bit as the display merkle LSB', () => {
+    const verdict = verifyAndDerive(realBlob(), 0, 6, genesisState(), noChecks)
+    expect(verdict.ok).toBe(true)
+    if (!verdict.ok) return
+    for (let i = 0; i < 6; i++) {
+      const merkleHex = bytesToHex(verdict.columns.merkles.subarray(i * 32, i * 32 + 32))
+      expect(verdict.columns.kinds[i]).toBe(planeOfMerkleRoot(merkleHex))
+      expect(verdict.columns.kinds[i]).toBe(parseInt(merkleHex[63], 16) & 1)
+    }
+  })
+
+  it('derives coords per kind, and keys as coord >> 1 in sorted order', () => {
+    const verdict = verifyAndDerive(realBlob(), 0, 6, genesisState(), noChecks)
+    expect(verdict.ok).toBe(true)
+    if (!verdict.ok) return
+    const { columns } = verdict
+    for (let i = 0; i < 6; i++) {
+      const coord = bytesToBigAt(columns.coords, i * 32)
+      expect(bytesToBigAt(columns.keys, i * 32)).toBe(coord >> 1n)
+      if (columns.kinds[i] === 1) {
+        // A port sits at its merkle root's coordinate.
+        expect(bytesToHex(columns.coords.subarray(i * 32, i * 32 + 32)))
+          .toBe(bytesToHex(columns.merkles.subarray(i * 32, i * 32 + 32)))
+      } else {
+        const hashHex = bytesToHex(columns.hashes.subarray(i * 32, i * 32 + 32))
+        expect(coord).toBe(landfallCoordApprox(hashHex))
+      }
+    }
+    // The order permutation really is ascending by key bytes.
+    for (let k = 1; k < 6; k++) {
+      const a = bytesToBigAt(columns.keys, columns.order[k - 1] * 32)
+      const b = bytesToBigAt(columns.keys, columns.order[k] * 32)
+      expect(a <= b).toBe(true)
+    }
+  })
+
+  it('fails on a tampered byte, anywhere it lands', () => {
+    // Merkle byte: block 3's own hash changes, so its PoW check collapses.
+    const tamperedMerkle = realBlob()
+    tamperedMerkle[3 * HEADER_RECORD_SIZE + 10] ^= 0xff
+    expect(verifyAndDerive(tamperedMerkle, 0, 6, genesisState(), noChecks).ok).toBe(false)
+    // Nonce byte: same record, different field.
+    const tamperedNonce = realBlob()
+    tamperedNonce[2 * HEADER_RECORD_SIZE + 45] ^= 0x01
+    expect(verifyAndDerive(tamperedNonce, 0, 6, genesisState(), noChecks).ok).toBe(false)
+  })
+
+  it('fails on checkpoint disagreement, manifest or embedded', () => {
+    const wrongFinal = verifyAndDerive(realBlob(), 0, 6, genesisState(), {
+      finalHashHex: IDS[4],
+      embedded: new Map(),
+    })
+    expect(wrongFinal.ok).toBe(false)
+    if (!wrongFinal.ok) expect(wrongFinal.reason).toMatch(/checkpoint/)
+    const wrongEmbedded = verifyAndDerive(realBlob(), 0, 6, genesisState(), {
+      finalHashHex: IDS[5],
+      embedded: new Map([[0, IDS[1]]]),
+    })
+    expect(wrongEmbedded.ok).toBe(false)
+    if (!wrongEmbedded.ok) expect(wrongEmbedded.reason).toMatch(/embedded/)
+  })
+
+  it('fails on a size mismatch instead of reading garbage', () => {
+    expect(verifyAndDerive(realBlob().subarray(0, 47), 0, 1, genesisState(), noChecks).ok).toBe(false)
+  })
+})
+
+describe('the 2016-block bits window', () => {
+  // A permissive target (top byte 0x7f) so records can be "mined" in a couple
+  // of tries; the window RULE is what is under test, not difficulty.
+  const EASY = 0x207fff00
+  const EASY2 = 0x207ffe00
+
+  function mine(prev: Uint8Array, bits: number, seed: number): HeaderRecord {
+    const merkle = new Uint8Array(32)
+    merkle[0] = seed & 0xff
+    merkle[31] = (seed >>> 8) & 0xff
+    const target = decodeCompactTarget(bits) as Uint8Array
+    for (let nonce = 0; ; nonce++) {
+      const rec: HeaderRecord = { version: 0x20000000, merkleInternal: merkle, time: 1700000000 + seed, bits, nonce }
+      if (hashMeetsTarget(reverse32(sha256d(wireHeader(rec, prev))), target)) return rec
+    }
+  }
+
+  function minedChain(startHeight: number, count: number, bitsAt: (h: number) => number): Uint8Array {
+    let prev: Uint8Array = new Uint8Array(32)
+    const records: HeaderRecord[] = []
+    for (let i = 0; i < count; i++) {
+      const rec = mine(prev, bitsAt(startHeight + i), i)
+      records.push(rec)
+      prev = sha256d(wireHeader(rec, prev))
+    }
+    return packBlob(records)
+  }
+
+  it('allows a bits change exactly at a retarget boundary', () => {
+    const blob = minedChain(2014, 4, (h) => (h >= 2016 ? EASY2 : EASY))
+    const state = { prevHashInternal: new Uint8Array(32), prevBits: null }
+    expect(verifyAndDerive(blob, 2014, 4, state, noChecks).ok).toBe(true)
+  })
+
+  it('rejects a bits change mid-window', () => {
+    const blob = minedChain(2014, 4, (h) => (h >= 2015 ? EASY2 : EASY))
+    const state = { prevHashInternal: new Uint8Array(32), prevBits: null }
+    const verdict = verifyAndDerive(blob, 2014, 4, state, noChecks)
+    expect(verdict.ok).toBe(false)
+    if (!verdict.ok) expect(verdict.reason).toMatch(/mid-window/)
+  })
+})
+
+describe('byte helpers', () => {
+  it('bigToBytes32 and bytesToBigAt round-trip extreme values', () => {
+    for (const v of [0n, 1n, (1n << 255n) | 1n, (1n << 256n) - 1n]) {
+      expect(bytesToBigAt(bigToBytes32(v), 0)).toBe(v)
+    }
+  })
+})

--- a/src/lib/hyperspace/headers.ts
+++ b/src/lib/hyperspace/headers.ts
@@ -1,0 +1,352 @@
+/**
+ * headers.ts: the headers-v1 static blob format and its verifier.
+ *
+ * The hyperspace line needs one fact per Bitcoin block (the merkle root, and
+ * the block hash for landfalls), and the relay path pays ~570 MB of kind-321
+ * events on the main thread to get it. A block header is 80 bytes and is
+ * self-verifying, so instead we ship 48-byte records (the header minus its
+ * prev_hash, which is redundant: it is the sha256d of the header before it)
+ * in statically served blobs of 50k blocks, and verify the whole chain
+ * locally: linkage, proof of work against the compact target, the mainnet
+ * 2016-block retarget window, and pinned checkpoints. Everything in this file
+ * is pure and synchronous so the same code runs in the worker and under node
+ * in tests; the worker owns fetch and the Cache API.
+ *
+ * Byte-order glossary, because Bitcoin has two: INTERNAL order is what gets
+ * hashed (the wire encoding); DISPLAY order is the byte-reversed form every
+ * explorer prints and every kind-321 anchor carries. The blob stores merkle
+ * roots internally; every column we emit is display order, matching stops.ts.
+ */
+
+import { sha256 } from 'cyberspace-core'
+import { bytesToHex, hexToBytes } from '../events'
+import { landfallCoordApprox } from './landfall'
+
+export const HEADER_RECORD_SIZE = 48
+/** Full wire header: version, prev_hash, merkle_root, time, bits, nonce. */
+export const WIRE_HEADER_SIZE = 80
+/** Mainnet difficulty retarget interval: bits may only change at multiples. */
+export const RETARGET_INTERVAL = 2016
+
+export interface HeaderRecord {
+  version: number
+  /** Merkle root in INTERNAL byte order (reverse of the display hex). */
+  merkleInternal: Uint8Array
+  time: number
+  bits: number
+  nonce: number
+}
+
+/** Read record `index` of a packed blob. The merkle is a view, not a copy. */
+export function readRecord(bytes: Uint8Array, index: number): HeaderRecord {
+  const off = index * HEADER_RECORD_SIZE
+  const dv = new DataView(bytes.buffer, bytes.byteOffset + off, HEADER_RECORD_SIZE)
+  return {
+    version: dv.getInt32(0, true),
+    merkleInternal: bytes.subarray(off + 4, off + 36),
+    time: dv.getUint32(36, true),
+    bits: dv.getUint32(40, true),
+    nonce: dv.getUint32(44, true),
+  }
+}
+
+/** Write record `index` of a packed blob; the format the packager emits. */
+export function writeRecord(out: Uint8Array, index: number, rec: HeaderRecord): void {
+  const off = index * HEADER_RECORD_SIZE
+  const dv = new DataView(out.buffer, out.byteOffset + off, HEADER_RECORD_SIZE)
+  dv.setInt32(0, rec.version, true)
+  out.set(rec.merkleInternal, off + 4)
+  dv.setUint32(36, rec.time, true)
+  dv.setUint32(40, rec.bits, true)
+  dv.setUint32(44, rec.nonce, true)
+}
+
+/** Reassemble the 80-byte wire header a record stands for. */
+export function wireHeader(rec: HeaderRecord, prevHashInternal: Uint8Array): Uint8Array {
+  const out = new Uint8Array(WIRE_HEADER_SIZE)
+  const dv = new DataView(out.buffer)
+  dv.setInt32(0, rec.version, true)
+  out.set(prevHashInternal, 4)
+  out.set(rec.merkleInternal, 36)
+  dv.setUint32(68, rec.time, true)
+  dv.setUint32(72, rec.bits, true)
+  dv.setUint32(76, rec.nonce, true)
+  return out
+}
+
+export function sha256d(bytes: Uint8Array): Uint8Array {
+  return sha256(sha256(bytes))
+}
+
+/** Copy of 32 bytes reversed: internal order <-> display order. */
+export function reverse32(bytes: Uint8Array): Uint8Array {
+  const out = new Uint8Array(32)
+  for (let i = 0; i < 32; i++) out[i] = bytes[31 - i]
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Small byte/bigint helpers shared with the columnar index
+// ---------------------------------------------------------------------------
+
+export function bigToBytes32(v: bigint): Uint8Array {
+  const out = new Uint8Array(32)
+  let n = v
+  for (let i = 31; i >= 0; i--) {
+    out[i] = Number(n & 0xffn)
+    n >>= 8n
+  }
+  return out
+}
+
+export function bytesToBigAt(bytes: Uint8Array, offset: number): bigint {
+  let n = 0n
+  for (let i = 0; i < 32; i++) n = (n << 8n) | BigInt(bytes[offset + i])
+  return n
+}
+
+/** dst = src >> 1 over 32 big-endian bytes, without a bigint round trip. */
+export function shiftRight1Into(src: Uint8Array, srcOff: number, dst: Uint8Array, dstOff: number): void {
+  let carry = 0
+  for (let i = 0; i < 32; i++) {
+    const b = src[srcOff + i]
+    dst[dstOff + i] = (b >>> 1) | (carry << 7)
+    carry = b & 1
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Proof of work
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode Bitcoin compact bits into a 32-byte big-endian target, or null when
+ * the encoding is unusable for PoW (negative flag, zero mantissa, or a value
+ * that overflows 256 bits). value = mantissa * 256^(exponent - 3).
+ */
+export function decodeCompactTarget(bits: number): Uint8Array | null {
+  const exponent = bits >>> 24
+  const mantissa = bits & 0x007fffff
+  if ((bits & 0x00800000) !== 0) return null
+  if (mantissa === 0) return null
+  const out = new Uint8Array(32)
+  const mBytes = [(mantissa >>> 16) & 0xff, (mantissa >>> 8) & 0xff, mantissa & 0xff]
+  for (let k = 0; k < 3; k++) {
+    // Mantissa byte k has weight 256^(exponent - 1 - k): big-endian index
+    // 32 - exponent + k. Off the top is overflow; off the bottom truncates,
+    // exactly like arith_uint256::SetCompact.
+    const pos = 32 - exponent + k
+    if (pos < 0) {
+      if (mBytes[k] !== 0) return null
+      continue
+    }
+    if (pos > 31) continue
+    out[pos] = mBytes[k]
+  }
+  return out
+}
+
+/** The PoW rule: the DISPLAY hash, read as a big-endian 256-bit integer,
+ * must not exceed the target. Bytewise compare, never through Number. */
+export function hashMeetsTarget(displayHash: Uint8Array, target: Uint8Array): boolean {
+  for (let i = 0; i < 32; i++) {
+    if (displayHash[i] < target[i]) return true
+    if (displayHash[i] > target[i]) return false
+  }
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Chain state and verification
+// ---------------------------------------------------------------------------
+
+export interface ChainState {
+  /** sha256d of the previous reconstructed header, INTERNAL order; all zeros
+   * before height 0, per the genesis header's prev_hash field. */
+  prevHashInternal: Uint8Array
+  /** Compact bits of the previous header, for the retarget-window rule.
+   * null when unknown (the first blob, or one seeded from a checkpoint after
+   * a discarded blob), which accepts the first bits seen. */
+  prevBits: number | null
+}
+
+export function genesisState(): ChainState {
+  return { prevHashInternal: new Uint8Array(32), prevBits: null }
+}
+
+/** Seed linkage from a known display hash (a checkpoint), losing the bits
+ * memory: the window rule then re-arms on the first record. */
+export function checkpointState(displayHashHex: string): ChainState {
+  return { prevHashInternal: reverse32(hexToBytes(displayHashHex)), prevBits: null }
+}
+
+/**
+ * The per-blob columns the worker hands to the main thread. All byte columns
+ * are row-major, 32 bytes per row; every buffer is transferable.
+ */
+export interface BlobColumns {
+  startHeight: number
+  count: number
+  /** Plane-stripped interleaved coordinate (coordApprox >> 1), big-endian. */
+  keys: Uint8Array
+  /** 1 = port (merkle plane bit 1), 0 = landfall. */
+  kinds: Uint8Array
+  /** Merkle roots, display order. */
+  merkles: Uint8Array
+  /** Block hashes, display order. */
+  hashes: Uint8Array
+  /** Approximate stop coordinate (coord256), big-endian. */
+  coords: Uint8Array
+  /** Permutation of [0, count) sorting rows ascending by key bytes, so the
+   * main thread can merge without sorting. */
+  order: Uint32Array
+}
+
+export interface BlobChecks {
+  /** Display hash the blob's final record must reconstruct to (the manifest
+   * checkpoint). null skips the check; only tests and benchmarks do that. */
+  finalHashHex: string | null
+  /** Embedded checkpoints by height, verified wherever a height lands here. */
+  embedded: ReadonlyMap<number, string>
+}
+
+export type BlobVerdict =
+  | { ok: true; columns: BlobColumns; state: ChainState }
+  | { ok: false; reason: string }
+
+/** How often the walk reports progress, in records. */
+const PROGRESS_EVERY = 4096
+
+/**
+ * Verify `count` records starting at `startHeight` and derive the stop
+ * columns in the same pass. Returns the columns and the chain state to carry
+ * into the next blob, or a reason to discard this one. All-or-nothing on
+ * purpose: a blob that fails anywhere is untrusted everywhere, and the relay
+ * path can cover its range instead.
+ *
+ * Note the trust chain: bits are self-declared, so PoW alone would accept a
+ * fabricated easy chain. What makes the verdict strong is the combination:
+ * the final hash must equal the manifest checkpoint, embedded checkpoints
+ * (compiled into the app) must match where present, and every record in
+ * between is linked by sha256d. Forging any record means re-mining real
+ * mainnet difficulty from there to the checkpoint.
+ */
+export function verifyAndDerive(
+  bytes: Uint8Array,
+  startHeight: number,
+  count: number,
+  state: ChainState,
+  checks: BlobChecks,
+  onProgress?: (verified: number) => void,
+): BlobVerdict {
+  if (count <= 0) return { ok: false, reason: 'empty blob' }
+  if (bytes.length !== count * HEADER_RECORD_SIZE) {
+    return { ok: false, reason: `blob is ${bytes.length} bytes, expected ${count * HEADER_RECORD_SIZE}` }
+  }
+
+  const keys = new Uint8Array(count * 32)
+  const kinds = new Uint8Array(count)
+  const merkles = new Uint8Array(count * 32)
+  const hashes = new Uint8Array(count * 32)
+  const coords = new Uint8Array(count * 32)
+
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  // One reused header buffer: the loop runs up to 50k times per blob.
+  const header = new Uint8Array(WIRE_HEADER_SIZE)
+  const headerDv = new DataView(header.buffer)
+
+  let prevHash = state.prevHashInternal
+  let prevBits = state.prevBits
+  let target: Uint8Array | null = prevBits === null ? null : decodeCompactTarget(prevBits)
+
+  let lastDisplayHex = ''
+  for (let i = 0; i < count; i++) {
+    const height = startHeight + i
+    const off = i * HEADER_RECORD_SIZE
+    const bits = dv.getUint32(off + 40, true)
+
+    // Mainnet difficulty rule: within a 2016-block window the target is
+    // constant; it may only move at a retarget boundary. We cannot recompute
+    // the retarget itself (that needs full timestamp history), but holding
+    // the window shape plus the endpoint checkpoints pins the chain.
+    if (prevBits !== null && bits !== prevBits && height % RETARGET_INTERVAL !== 0) {
+      return { ok: false, reason: `bits changed mid-window at height ${height}` }
+    }
+    if (target === null || bits !== prevBits) {
+      target = decodeCompactTarget(bits)
+      if (target === null) return { ok: false, reason: `invalid compact bits at height ${height}` }
+    }
+    prevBits = bits
+
+    // Reconstruct the wire header: version || prev_hash || merkle || time || bits || nonce.
+    headerDv.setInt32(0, dv.getInt32(off, true), true)
+    header.set(prevHash, 4)
+    header.set(bytes.subarray(off + 4, off + 36), 36)
+    headerDv.setUint32(68, dv.getUint32(off + 36, true), true)
+    headerDv.setUint32(72, bits, true)
+    headerDv.setUint32(76, dv.getUint32(off + 44, true), true)
+
+    const hashInternal = sha256d(header)
+    const displayHash = reverse32(hashInternal)
+    if (!hashMeetsTarget(displayHash, target)) {
+      return { ok: false, reason: `proof of work failed at height ${height}` }
+    }
+
+    const embedded = checks.embedded.get(height)
+    if (embedded !== undefined) {
+      lastDisplayHex = bytesToHex(displayHash)
+      if (lastDisplayHex !== embedded) {
+        return { ok: false, reason: `embedded checkpoint mismatch at height ${height}` }
+      }
+    }
+
+    // Derive the stop (DECK-0001 v3 §1): the merkle's plane bit picks port
+    // or landfall. Display LSB of the merkle equals internal byte 0's LSB.
+    const plane = bytes[off + 4] & 1
+    kinds[i] = plane
+    const col = i * 32
+    hashes.set(displayHash, col)
+    for (let b = 0; b < 32; b++) merkles[col + b] = bytes[off + 35 - b]
+    if (plane === 1) {
+      // A port sits at the merkle root's own coordinate.
+      coords.set(merkles.subarray(col, col + 32), col)
+    } else {
+      // Landfall: float64 approximation only; the exact decimal path is
+      // derived lazily on the main thread when a verifier-visible value is
+      // needed (stopCoordExact), never here.
+      const approx = landfallCoordApprox(bytesToHex(displayHash))
+      coords.set(bigToBytes32(approx), col)
+    }
+    shiftRight1Into(coords, col, keys, col)
+
+    prevHash = hashInternal
+    if (onProgress && (i + 1) % PROGRESS_EVERY === 0) onProgress(i + 1)
+  }
+
+  if (checks.finalHashHex !== null) {
+    const finalHex = bytesToHex(hashes.subarray((count - 1) * 32, count * 32))
+    if (finalHex !== checks.finalHashHex) {
+      return { ok: false, reason: `checkpoint mismatch at height ${startHeight + count - 1}` }
+    }
+  }
+
+  // Pre-sort the rows by key so the main thread merges instead of sorting.
+  const order = new Uint32Array(count)
+  for (let i = 0; i < count; i++) order[i] = i
+  order.sort((a, b) => {
+    const oa = a * 32
+    const ob = b * 32
+    for (let i = 0; i < 32; i++) {
+      const d = keys[oa + i] - keys[ob + i]
+      if (d !== 0) return d
+    }
+    return 0
+  })
+
+  onProgress?.(count)
+  return {
+    ok: true,
+    columns: { startHeight, count, keys, kinds, merkles, hashes, coords, order },
+    state: { prevHashInternal: prevHash, prevBits },
+  }
+}

--- a/src/lib/hyperspace/idb.ts
+++ b/src/lib/hyperspace/idb.ts
@@ -1,0 +1,88 @@
+/**
+ * idb.ts: a promise wrapper over the one IndexedDB database hyperspace uses.
+ *
+ * Why IndexedDB and not localStorage: the stop cache approaches a million
+ * rows, and localStorage is synchronous, string-only and capped in megabytes.
+ * The helpers stay tiny on purpose: open with a fixed schema, paged reads,
+ * bulk writes, one meta record per key. Nothing in here knows what a stop is;
+ * anchors.ts owns the row shapes.
+ *
+ * getAllPaged pages with a lower-bound key range restarted after each chunk
+ * rather than one giant getAll, because materialising ~950k rows in a single
+ * request blocks the main thread and doubles peak memory. The caller's chunk
+ * handler is awaited between pages, which is where it yields to the event
+ * loop so the UI stays alive during a cold cache load.
+ */
+
+export const DB_NAME = 'onosendai:hyperspace'
+const DB_VERSION = 1
+export const STOPS_STORE = 'stops'
+export const META_STORE = 'meta'
+
+function request<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB request failed'))
+  })
+}
+
+export function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STOPS_STORE)) db.createObjectStore(STOPS_STORE, { keyPath: 'height' })
+      if (!db.objectStoreNames.contains(META_STORE)) db.createObjectStore(META_STORE, { keyPath: 'key' })
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB open failed'))
+  })
+}
+
+/**
+ * Read every row of a store in key order, chunkSize rows at a time. keyOf
+ * extracts the primary key from a row so the next page can start just past
+ * the previous one; rows come back in key order, so the last row's key is
+ * the high-water mark.
+ */
+export async function getAllPaged<T>(
+  db: IDBDatabase,
+  store: string,
+  chunkSize: number,
+  keyOf: (row: T) => IDBValidKey,
+  onChunk: (rows: T[]) => void | Promise<void>,
+): Promise<void> {
+  let after: IDBValidKey | null = null
+  for (;;) {
+    const range = after === null ? null : IDBKeyRange.lowerBound(after, true)
+    const os = db.transaction(store, 'readonly').objectStore(store)
+    const rows = await request(os.getAll(range, chunkSize)) as T[]
+    if (rows.length === 0) return
+    await onChunk(rows)
+    if (rows.length < chunkSize) return
+    after = keyOf(rows[rows.length - 1])
+  }
+}
+
+/** Put every row in one transaction; resolves when the transaction commits. */
+export function putMany(db: IDBDatabase, store: string, rows: unknown[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, 'readwrite')
+    const os = tx.objectStore(store)
+    for (const row of rows) os.put(row)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error ?? new Error('IndexedDB write failed'))
+    tx.onabort = () => reject(tx.error ?? new Error('IndexedDB write aborted'))
+  })
+}
+
+/** The stored value under a meta key, or undefined when it was never written. */
+export async function getMeta(db: IDBDatabase, key: string): Promise<unknown> {
+  const os = db.transaction(META_STORE, 'readonly').objectStore(META_STORE)
+  const row = await request(os.get(key)) as { value?: unknown } | undefined
+  return row?.value
+}
+
+export function putMeta(db: IDBDatabase, key: string, value: unknown): Promise<void> {
+  return putMany(db, META_STORE, [{ key, value }])
+}

--- a/src/lib/hyperspace/idb.ts
+++ b/src/lib/hyperspace/idb.ts
@@ -64,6 +64,53 @@ export async function getAllPaged<T>(
   }
 }
 
+/**
+ * Read rows with keys in [lower, upper] in key order, chunked like
+ * getAllPaged. upper === null means unbounded above; the header-blob path
+ * uses that to replay whatever tail the blobs did not cover without knowing
+ * the tip yet.
+ */
+export async function getRangePaged<T>(
+  db: IDBDatabase,
+  store: string,
+  lower: IDBValidKey,
+  upper: IDBValidKey | null,
+  chunkSize: number,
+  keyOf: (row: T) => IDBValidKey,
+  onChunk: (rows: T[]) => void | Promise<void>,
+): Promise<void> {
+  let from = lower
+  let open = false
+  for (;;) {
+    const range = upper === null
+      ? IDBKeyRange.lowerBound(from, open)
+      : IDBKeyRange.bound(from, upper, open, false)
+    const os = db.transaction(store, 'readonly').objectStore(store)
+    const rows = await request(os.getAll(range, chunkSize)) as T[]
+    if (rows.length === 0) return
+    await onChunk(rows)
+    if (rows.length < chunkSize) return
+    from = keyOf(rows[rows.length - 1])
+    open = true
+  }
+}
+
+/** Delete every row with a key in [lower, upper]; one transaction. */
+export function deleteRange(
+  db: IDBDatabase,
+  store: string,
+  lower: IDBValidKey,
+  upper: IDBValidKey,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, 'readwrite')
+    tx.objectStore(store).delete(IDBKeyRange.bound(lower, upper))
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error ?? new Error('IndexedDB delete failed'))
+    tx.onabort = () => reject(tx.error ?? new Error('IndexedDB delete aborted'))
+  })
+}
+
 /** Put every row in one transaction; resolves when the transaction commits. */
 export function putMany(db: IDBDatabase, store: string, rows: unknown[]): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/src/lib/hyperspace/landfall.test.ts
+++ b/src/lib/hyperspace/landfall.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { coordToHex } from 'cyberspace-core'
+import { landfallCoord, landfallCoordApprox, coordToLatLon } from './landfall'
+
+// DECK-0001 v3 §1.2 golden vectors (mainnet block hashes).
+const VECTORS: Array<[number, string, string, number, number]> = [
+  [398, '000000002f7d702a27ccd65158740198f79d4ba1ddea8ab14b56b63a6289fe89', '56db6db6db6db6db6db6db3e27c436f9d3b79fb5fc6457798936b3e749e38f56', 31.63, -98.85],
+  [100399, '000000000003cb256436f213199e7047e187ab99e6d3176262bfb9be49d2a31a', '3b6db6db6db6db6db6db6d1eb09e85e5f572906af5a025a39ae284dd83278b72', -54.83, 129.06],
+  [300399, '0000000000000000212f189879294318528669d239d5fbd30e6ffcc6015ced21', 'c492492492492492492492c7807ba8ecefd0a48a7b41dfbb50da5947b489ed8c', 57.04, -60.77],
+  [363199, '000000000000000001e65a8804c7d97ee1fd52394632bdebdaf402935dcddeec', 'a9249249249249249249258087f30451bd8dd013357959fe2b07fa052488980c', -39.03, 5.7],
+  [500399, '000000000000000000521f92387f9f43258f62465e9f88b19ecad2c30e44d7ff', '3b6db6db6db6db6db6db6d312f699ee9f35318557d9ee813b46f229215524a30', -65.92, 134.98],
+  [700398, '00000000000000000005608e4c1ff53901186e766df5eaa87c636857ed814fa9', '56db6db6db6db6db6db6dbfdb284c1592e0d02ffd65f9d6c12d48a2b483d7da0', 86.47, -109.22],
+  [900399, '00000000000000000001e412795ed39b18e56338e9b3c20d91edf59d20e020c9', 'c4924924924924924924920c53c81e9d260623340e5c3a75b6de6e4715cd1724', 6.07, -75.88],
+  [950399, '00000000000000000001f081b994866dc3beb2c3ecd5976e9bda474e54e027c1', 'e000000000000000000000618f9c2d172da11fc0701996d4a89df1f60aecf732', 3.86, 63.9],
+]
+
+describe('landfall derivation (DECK-0001 v3 §1.2)', () => {
+  it('reproduces the golden vectors exactly', () => {
+    for (const [, hash, expected] of VECTORS) {
+      expect(coordToHex(landfallCoord(hash))).toBe(expected)
+    }
+  })
+
+  it('lands on the ellipsoid at the expected lat/lon', () => {
+    for (const [, hash, , lat, lon] of VECTORS) {
+      const ll = coordToLatLon(landfallCoord(hash))
+      expect(Math.abs(ll.lat - lat)).toBeLessThan(0.02)
+      expect(Math.abs(ll.lon - lon)).toBeLessThan(0.02)
+      expect(Math.abs(ll.altM)).toBeLessThan(1)
+    }
+  })
+
+  it('float64 approximation agrees with the exact derivation to within a few metres', () => {
+    for (const [, hash] of VECTORS) {
+      const exact = landfallCoord(hash)
+      const approx = landfallCoordApprox(hash)
+      const a = coordToLatLon(exact)
+      const b = coordToLatLon(approx)
+      expect(Math.abs(a.lat - b.lat)).toBeLessThan(1e-4)
+      expect(Math.abs(a.lon - b.lon)).toBeLessThan(1e-4)
+      expect(Math.abs(a.altM - b.altM)).toBeLessThan(5)
+    }
+  })
+})

--- a/src/lib/hyperspace/landfall.ts
+++ b/src/lib/hyperspace/landfall.ts
@@ -1,0 +1,208 @@
+/**
+ * landfall.ts: DECK-0001 v3 §1.2, the landfall derivation.
+ *
+ * A block whose merkle root has plane bit 0 "falls to Earth": its stop
+ * coordinate is the point on the WGS84 ellipsoid where a direction chosen by
+ * sha256(LANDFALL_DOMAIN || block_hash) meets the surface. This is consensus
+ * critical, so it runs in the same decimal profile as the base spec's GPS
+ * mapping (precision 96, ROUND_HALF_EVEN, the exact PI_STR, Taylor sin/cos),
+ * with every operation performed in the order the DECK lists.
+ *
+ * `landfallCoordApprox` is a float64 shortcut good to about a metre, for
+ * indexing and rendering hundreds of thousands of stops quickly. Anything a
+ * verifier compares against MUST use the exact `landfallCoord`.
+ */
+import Decimal from 'decimal.js'
+import { sha256, hexToBytes, xyzToCoord, coordToXyz, PLANE_DATASPACE } from 'cyberspace-core'
+
+export const LANDFALL_DOMAIN = new TextEncoder().encode('CYBERSPACE_LANDFALL_V1')
+
+// Independent constructor so we never mutate decimal.js's global config.
+const D = Decimal.clone({ precision: 96, rounding: Decimal.ROUND_HALF_EVEN })
+
+const PI_STR =
+  '3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679'
+const PI = new D(PI_STR)
+const TWO_PI = PI.times(2)
+const HALF_PI = PI.div(2)
+const TRIG_EPS = new D('1e-88')
+const TRIG_MAX_ITER = 256
+
+const WGS84_A_M = new D('6378137')
+const WGS84_F = new D(1).div('298.257223563')
+const WGS84_B_M = WGS84_A_M.times(new D(1).minus(WGS84_F))
+
+const AXIS_BITS = 85
+const AXIS_MAX = (1n << BigInt(AXIS_BITS)) - 1n
+const AXIS_CENTER = 1n << BigInt(AXIS_BITS - 1)
+const UNITS_PER_KM = new D(1000).times(new D(2).pow(33))
+const TWO_128 = new D(2).pow(128)
+
+function truncMod(x: Decimal, m: Decimal): Decimal {
+  // Python Decimal %: truncated toward zero, sign of the dividend.
+  return x.minus(m.times(x.dividedToIntegerBy(m)))
+}
+
+/** Deterministic (sin, cos) per CYBERSPACE_V2 §9.5. */
+export function sinCos(xIn: Decimal): { sin: Decimal; cos: Decimal } {
+  let x = truncMod(xIn, TWO_PI)
+  if (x.gt(PI)) x = x.minus(TWO_PI)
+  let cosSign = new D(1)
+  if (x.gt(HALF_PI)) {
+    x = PI.minus(x)
+    cosSign = new D(-1)
+  } else if (x.lt(HALF_PI.neg())) {
+    x = PI.neg().minus(x)
+    cosSign = new D(-1)
+  }
+  const x2 = x.times(x)
+  let sinSum = x
+  let sinTerm = x
+  let converged = false
+  for (let k = 1; k <= TRIG_MAX_ITER; k++) {
+    const denom = new D(2 * k).times(2 * k + 1)
+    sinTerm = sinTerm.neg().times(x2).div(denom)
+    sinSum = sinSum.plus(sinTerm)
+    if (sinTerm.abs().lt(TRIG_EPS)) {
+      converged = true
+      break
+    }
+  }
+  if (!converged) throw new Error('sin() Taylor series did not converge')
+  let cosSum = new D(1)
+  let cosTerm = new D(1)
+  converged = false
+  for (let k = 1; k <= TRIG_MAX_ITER; k++) {
+    const denom = new D(2 * k - 1).times(2 * k)
+    cosTerm = cosTerm.neg().times(x2).div(denom)
+    cosSum = cosSum.plus(cosTerm)
+    if (cosTerm.abs().lt(TRIG_EPS)) {
+      converged = true
+      break
+    }
+  }
+  if (!converged) throw new Error('cos() Taylor series did not converge')
+  return { sin: sinSum, cos: cosSum.times(cosSign) }
+}
+
+/** km from the centre to a u85 axis value, ROUND_HALF_EVEN, clamped (§9.7 step 9). */
+export function kmToAxisU(kmFromCenter: Decimal): bigint {
+  const u = kmFromCenter.times(UNITS_PER_KM).plus(new D(AXIS_CENTER.toString()))
+  let uInt = BigInt(u.toDecimalPlaces(0, Decimal.ROUND_HALF_EVEN).toFixed(0))
+  if (uInt < 0n) uInt = 0n
+  if (uInt > AXIS_MAX) uInt = AXIS_MAX
+  return uInt
+}
+
+function bytesToBigInt(b: Uint8Array): bigint {
+  let n = 0n
+  for (const x of b) n = (n << 8n) | BigInt(x)
+  return n
+}
+
+function normalizeHash(blockHashHex: string): Uint8Array {
+  const clean = blockHashHex.startsWith('0x') ? blockHashHex.slice(2) : blockHashHex
+  if (!/^[0-9a-fA-F]{64}$/.test(clean)) throw new Error('block hash must be 64 hex chars')
+  return hexToBytes(clean.toLowerCase())
+}
+
+/** The unit ECEF direction (float64) chosen by the block hash. Shared by exact and approx paths. */
+export function landfallSeed(blockHashHex: string): Uint8Array {
+  const h = normalizeHash(blockHashHex)
+  const pre = new Uint8Array(LANDFALL_DOMAIN.length + 32)
+  pre.set(LANDFALL_DOMAIN, 0)
+  pre.set(h, LANDFALL_DOMAIN.length)
+  return sha256(pre)
+}
+
+/** Exact landfall axis values (DECK-0001 v3 §1.2 steps 1 to 10). */
+export function landfallXyz(blockHashHex: string): { x: bigint; y: bigint; z: bigint } {
+  const seed = landfallSeed(blockHashHex)
+  const u1 = new D(bytesToBigInt(seed.subarray(0, 16)).toString()).div(TWO_128)
+  const u2 = new D(bytesToBigInt(seed.subarray(16, 32)).toString()).div(TWO_128)
+  const lon = new D(2).times(u1).minus(1).times(PI)
+  const z = new D(2).times(u2).minus(1)
+  const rxy = new D(1).minus(z.times(z)).sqrt()
+  const { sin: sinLon, cos: cosLon } = sinCos(lon)
+  const dx = rxy.times(cosLon)
+  const dy = rxy.times(sinLon)
+  const dz = z
+  const inv = dx
+    .times(dx)
+    .plus(dy.times(dy))
+    .div(WGS84_A_M.times(WGS84_A_M))
+    .plus(dz.times(dz).div(WGS84_B_M.times(WGS84_B_M)))
+    .sqrt()
+  const r = new D(1).div(inv)
+  const km = new D(1000)
+  const xKm = r.times(dx).div(km)
+  const yKm = r.times(dy).div(km)
+  const zKm = r.times(dz).div(km)
+  // Axis permutation per §9.4: X_cs = X_ecef, Y_cs = Z_ecef, Z_cs = Y_ecef.
+  return { x: kmToAxisU(xKm), y: kmToAxisU(zKm), z: kmToAxisU(yKm) }
+}
+
+/** Exact landfall coord256 (plane 0). */
+export function landfallCoord(blockHashHex: string): bigint {
+  const { x, y, z } = landfallXyz(blockHashHex)
+  return xyzToCoord(x, y, z, PLANE_DATASPACE)
+}
+
+const G_PER_M = 2 ** 33
+const A_F = 6378137
+const F_F = 1 / 298.257223563
+const B_F = A_F * (1 - F_F)
+const CENTER_F = 2 ** 84
+
+/**
+ * Float64 landfall approximation, about a metre of error (2^33 G), for the
+ * index and the renderer. Never use for anything a verifier will check.
+ */
+export function landfallXyzApprox(blockHashHex: string): { x: bigint; y: bigint; z: bigint } {
+  const seed = landfallSeed(blockHashHex)
+  const u1 = Number(bytesToBigInt(seed.subarray(0, 8))) / 2 ** 64
+  const u2 = Number(bytesToBigInt(seed.subarray(16, 24))) / 2 ** 64
+  const lon = (2 * u1 - 1) * Math.PI
+  const z = 2 * u2 - 1
+  const rxy = Math.sqrt(1 - z * z)
+  const dx = rxy * Math.cos(lon)
+  const dy = rxy * Math.sin(lon)
+  const dz = z
+  const r = 1 / Math.sqrt((dx * dx + dy * dy) / (A_F * A_F) + (dz * dz) / (B_F * B_F))
+  const toU = (m: number) => BigInt(Math.round(m * G_PER_M)) + BigInt(CENTER_F)
+  return { x: toU(r * dx), y: toU(r * dz), z: toU(r * dy) }
+}
+
+export function landfallCoordApprox(blockHashHex: string): bigint {
+  const { x, y, z } = landfallXyzApprox(blockHashHex)
+  return xyzToCoord(x, y, z, PLANE_DATASPACE)
+}
+
+/** Float64 inverse for labels: dataspace axis values to WGS84 lat/lon/alt (metres). */
+export function axesToLatLon(x: bigint, y: bigint, z: bigint): { lat: number; lon: number; altM: number } {
+  const xm = Number(x - AXIS_CENTER) / G_PER_M
+  const ym = Number(y - AXIS_CENTER) / G_PER_M
+  const zm = Number(z - AXIS_CENTER) / G_PER_M
+  // Undo the permutation: X_ecef = X_cs, Z_ecef = Y_cs, Y_ecef = Z_cs.
+  const X = xm
+  const Y = zm
+  const Z = ym
+  const e2 = F_F * (2 - F_F)
+  const p = Math.hypot(X, Y)
+  const lon = Math.atan2(Y, X)
+  let lat = Math.atan2(Z, p * (1 - e2))
+  let N = A_F
+  let alt = 0
+  for (let i = 0; i < 6; i++) {
+    const s = Math.sin(lat)
+    N = A_F / Math.sqrt(1 - e2 * s * s)
+    alt = p / Math.cos(lat) - N
+    lat = Math.atan2(Z, p * (1 - (e2 * N) / (N + alt)))
+  }
+  return { lat: (lat * 180) / Math.PI, lon: (lon * 180) / Math.PI, altM: alt }
+}
+
+export function coordToLatLon(coord: bigint): { lat: number; lon: number; altM: number } {
+  const { x, y, z } = coordToXyz(coord)
+  return axesToLatLon(x, y, z)
+}

--- a/src/lib/hyperspace/ride.test.ts
+++ b/src/lib/hyperspace/ride.test.ts
@@ -1,0 +1,193 @@
+/**
+ * What would fail silently: a wrong domain constant, byte order, or padding
+ * rule would produce internally consistent proofs that no other implementation
+ * accepts. The round-trip test proves prover and verifier agree; the tamper
+ * tests prove the verifier is actually looking.
+ */
+import { describe, expect, it } from 'vitest'
+import { bytesToHex, sha256 } from 'cyberspace-core'
+import {
+  K_LINE,
+  SAMPLES,
+  buildRideProof,
+  computeRideLeaf,
+  decodeOpenings,
+  encodeOpenings,
+  exactRidePairs,
+  inclusionPath,
+  lineTerrainK,
+  merkleDepth,
+  merkleLayers,
+  rideBlocks,
+  rideSeed,
+  sampleIndices,
+  verifyInclusion,
+  verifyRideLevel1,
+} from './ride'
+
+const PREV = 'ab'.repeat(32)
+
+/** Deterministic fake block hashes for synthetic chains. */
+function fakeHash(height: number): string {
+  const bytes = new TextEncoder().encode(`fake-block-${height}`)
+  return Array.from(sha256(bytes), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+describe('line terrain and seeds', () => {
+  it('K is in [0, 16] and deterministic', () => {
+    for (let b = 0; b < 50; b++) {
+      const k = lineTerrainK(fakeHash(b))
+      expect(k).toBeGreaterThanOrEqual(0)
+      expect(k).toBeLessThanOrEqual(16)
+      expect(lineTerrainK(fakeHash(b))).toBe(k)
+    }
+  })
+
+  it('seeds differ per block and per chain position, and fit in 85 bits', () => {
+    const a = rideSeed(PREV, 100)
+    const b = rideSeed(PREV, 101)
+    const c = rideSeed('cd'.repeat(32), 100)
+    expect(a).not.toBe(b)
+    expect(a).not.toBe(c)
+    expect(a < 1n << 85n).toBe(true)
+  })
+
+  it('leaves are deterministic and bound to the chain position', () => {
+    const l1 = computeRideLeaf(PREV, 100, fakeHash(100))
+    const l2 = computeRideLeaf(PREV, 100, fakeHash(100))
+    const l3 = computeRideLeaf('cd'.repeat(32), 100, fakeHash(100))
+    expect(bytesToHex(l1)).toBe(bytesToHex(l2))
+    expect(bytesToHex(l1)).not.toBe(bytesToHex(l3))
+  })
+})
+
+describe('ride geometry', () => {
+  it('rideBlocks spans (lo, hi] in either direction', () => {
+    expect(rideBlocks(10, 13)).toEqual([11, 12, 13])
+    expect(rideBlocks(13, 10)).toEqual([11, 12, 13])
+    expect(rideBlocks(7, 7)).toEqual([])
+  })
+
+  it('merkleDepth matches padding', () => {
+    expect(merkleDepth(1)).toBe(0)
+    expect(merkleDepth(2)).toBe(1)
+    expect(merkleDepth(3)).toBe(2)
+    expect(merkleDepth(5)).toBe(3)
+  })
+})
+
+describe('merkle and openings', () => {
+  it('inclusion paths verify for every leaf, including padded trees', () => {
+    const leaves = [0, 1, 2, 3, 4].map((i) => sha256(new Uint8Array([i])))
+    const layers = merkleLayers(leaves)
+    const root = layers[layers.length - 1][0]
+    for (let i = 0; i < leaves.length; i++) {
+      const path = inclusionPath(layers, i)
+      expect(verifyInclusion(leaves[i], i, path, root)).toBe(true)
+      expect(verifyInclusion(leaves[i], i ^ 1, path, root)).toBe(false)
+    }
+  })
+
+  it('openings encode/decode round-trips', () => {
+    const leaves = [0, 1, 2, 3].map((i) => sha256(new Uint8Array([i])))
+    const layers = merkleLayers(leaves)
+    const paths = [0, 2].map((i) => inclusionPath(layers, i))
+    const mp = encodeOpenings(paths)
+    const back = decodeOpenings(mp, 2)
+    expect(back).not.toBeNull()
+    expect(encodeOpenings(back as Uint8Array[][])).toBe(mp)
+    expect(decodeOpenings(mp, 3)).toBeNull()
+  })
+
+  it('sample indices are deterministic and in range', () => {
+    const root = sha256(new Uint8Array([9]))
+    const idx = sampleIndices(root, 7)
+    expect(idx.length).toBe(SAMPLES)
+    for (const i of idx) {
+      expect(i).toBeGreaterThanOrEqual(0)
+      expect(i).toBeLessThan(7)
+    }
+    expect(sampleIndices(root, 7)).toEqual(idx)
+  })
+})
+
+describe('full ride round trip (prover and verifier agree)', () => {
+  it('a synthetic 5-block ride proves and verifies at Level 1', async () => {
+    const blocks = rideBlocks(100, 105)
+    const leaves = blocks.map((b) => computeRideLeaf(PREV, b, fakeHash(b)))
+    const proof = buildRideProof(leaves)
+    const result = await verifyRideLevel1({
+      previousEventIdHex: PREV,
+      fromHeight: 100,
+      toHeight: 105,
+      rootHex: proof.rootHex,
+      mp: proof.mp,
+      blockHashFor: (h) => fakeHash(h),
+    })
+    expect(result.reason).toBeNull()
+    expect(result.ok).toBe(true)
+    expect(result.checked).toBe(SAMPLES)
+  })
+
+  it('rejects a proof built under a different chain position', async () => {
+    const blocks = rideBlocks(100, 105)
+    const leaves = blocks.map((b) => computeRideLeaf('cd'.repeat(32), b, fakeHash(b)))
+    const proof = buildRideProof(leaves)
+    const result = await verifyRideLevel1({
+      previousEventIdHex: PREV,
+      fromHeight: 100,
+      toHeight: 105,
+      rootHex: proof.rootHex,
+      mp: proof.mp,
+      blockHashFor: (h) => fakeHash(h),
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a tampered opening', async () => {
+    const blocks = rideBlocks(200, 203)
+    const leaves = blocks.map((b) => computeRideLeaf(PREV, b, fakeHash(b)))
+    const proof = buildRideProof(leaves)
+    const tampered = proof.mp.replace(/^../, proof.mp.startsWith('00') ? '11' : '00')
+    const result = await verifyRideLevel1({
+      previousEventIdHex: PREV,
+      fromHeight: 200,
+      toHeight: 203,
+      rootHex: proof.rootHex,
+      mp: tampered,
+      blockHashFor: (h) => fakeHash(h),
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('accepts only the zero root for a zero-length ride', async () => {
+    const proof = buildRideProof([])
+    expect(proof.rootHex).toBe('0'.repeat(64))
+    const ok = await verifyRideLevel1({
+      previousEventIdHex: PREV,
+      fromHeight: 7,
+      toHeight: 7,
+      rootHex: proof.rootHex,
+      mp: '',
+      blockHashFor: (h) => fakeHash(h),
+    })
+    expect(ok.ok).toBe(true)
+    const bad = await verifyRideLevel1({
+      previousEventIdHex: PREV,
+      fromHeight: 7,
+      toHeight: 7,
+      rootHex: 'ab'.repeat(32),
+      mp: '',
+      blockHashFor: (h) => fakeHash(h),
+    })
+    expect(bad.ok).toBe(false)
+  })
+})
+
+describe('cost estimates', () => {
+  it('exactRidePairs sums 2^(K + K_LINE)', () => {
+    const hashes = [fakeHash(1), fakeHash(2)]
+    const expected = hashes.reduce((acc, h) => acc + 2 ** (lineTerrainK(h) + K_LINE), 0)
+    expect(exactRidePairs(hashes)).toBe(expected)
+  })
+})

--- a/src/lib/hyperspace/ride.ts
+++ b/src/lib/hyperspace/ride.ts
@@ -1,0 +1,269 @@
+/**
+ * ride.ts: DECK-0001 v3 §5. A ride passes the blocks strictly between the two
+ * endpoints plus the destination; each carries seeded Cantor work at height
+ * K_b + K_LINE, hashed into a leaf, Merkle-aggregated into the proof root,
+ * with SAMPLES Fiat-Shamir openings for Level 1 verification.
+ *
+ * Everything here is consensus-critical and pure; the worker pool wraps it.
+ */
+import {
+  sha256,
+  hexToBytes,
+  bytesToHex,
+  intToBytesBE,
+  alignedBase,
+  computeSubtreeCantor,
+} from 'cyberspace-core'
+
+export const K_LINE = 6
+export const RIDE_MAX_HEIGHT = 16 + K_LINE
+export const SAMPLES = 32
+export const PAD_LEAF = new Uint8Array(32)
+
+const enc = new TextEncoder()
+export const HYPERSPACE_TERRAIN_DOMAIN = enc.encode('CYBERSPACE_HYPERSPACE_TERRAIN_V1')
+export const HYPERSPACE_SEED_DOMAIN = enc.encode('CYBERSPACE_HYPERSPACE_SEED_V1')
+export const HYPERSPACE_LEAF_DOMAIN = enc.encode('CYBERSPACE_HYPERSPACE_LEAF_V1')
+export const HYPERSPACE_SAMPLE_DOMAIN = enc.encode('CYBERSPACE_HYPERSPACE_SAMPLE_V1')
+
+const AXIS_MASK = (1n << 85n) - 1n
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  let len = 0
+  for (const p of parts) len += p.length
+  const out = new Uint8Array(len)
+  let o = 0
+  for (const p of parts) {
+    out.set(p, o)
+    o += p.length
+  }
+  return out
+}
+
+export function be64(n: number): Uint8Array {
+  const out = new Uint8Array(8)
+  let v = BigInt(n)
+  for (let i = 7; i >= 0; i--) {
+    out[i] = Number(v & 0xffn)
+    v >>= 8n
+  }
+  return out
+}
+
+export function be32(n: number): Uint8Array {
+  const out = new Uint8Array(4)
+  out[0] = (n >>> 24) & 0xff
+  out[1] = (n >>> 16) & 0xff
+  out[2] = (n >>> 8) & 0xff
+  out[3] = n & 0xff
+  return out
+}
+
+function bytesToBigInt(b: Uint8Array): bigint {
+  let n = 0n
+  for (const x of b) n = (n << 8n) | BigInt(x)
+  return n
+}
+
+/** §5.3 step 1: line terrain K for a block, from its hash. K in [0, 16]. */
+export function lineTerrainK(blockHashHex: string): number {
+  const digest = sha256(concat(HYPERSPACE_TERRAIN_DOMAIN, hexToBytes(blockHashHex)))
+  let word = (digest[0] << 8) | digest[1]
+  let count = 0
+  while (word) {
+    count += word & 1
+    word >>>= 1
+  }
+  return count
+}
+
+/** §5.3 step 3: the temporal seed for block b under this chain position. */
+export function rideSeed(previousEventIdHex: string, height: number): bigint {
+  if (previousEventIdHex.length !== 64) throw new Error('previousEventIdHex must be 64 hex chars')
+  const digest = sha256(concat(HYPERSPACE_SEED_DOMAIN, hexToBytes(previousEventIdHex), be64(height)))
+  return bytesToBigInt(digest) & AXIS_MASK
+}
+
+/** §5.3 steps 1 to 5: one block's leaf, repeating its full Cantor work. */
+export function computeRideLeaf(previousEventIdHex: string, height: number, blockHashHex: string): Uint8Array {
+  const k = lineTerrainK(blockHashHex)
+  const h = k + K_LINE
+  const t = rideSeed(previousEventIdHex, height)
+  const cantorT = computeSubtreeCantor(alignedBase(t, h), h, RIDE_MAX_HEIGHT)
+  return sha256(concat(HYPERSPACE_LEAF_DOMAIN, be64(height), intToBytesBE(cantorT)))
+}
+
+/** The heights a ride from `from` to `to` passes: (lo, hi], ascending. */
+export function rideBlocks(fromHeight: number, toHeight: number): number[] {
+  const lo = Math.min(fromHeight, toHeight)
+  const hi = Math.max(fromHeight, toHeight)
+  const out: number[] = []
+  for (let b = lo + 1; b <= hi; b++) out.push(b)
+  return out
+}
+
+export function paddedCount(n: number): number {
+  if (n <= 1) return Math.max(n, 0)
+  let p = 1
+  while (p < n) p <<= 1
+  return p
+}
+
+export function merkleDepth(n: number): number {
+  const p = paddedCount(n)
+  let d = 0
+  for (let v = p; v > 1; v >>= 1) d++
+  return d
+}
+
+/** §5.4: pad with PAD_LEAF to a power of two, parent = sha256(left || right). */
+export function merkleLayers(leaves: Uint8Array[]): Uint8Array[][] {
+  if (leaves.length === 0) return [[]]
+  const p = paddedCount(leaves.length)
+  let level: Uint8Array[] = leaves.slice()
+  while (level.length < p) level.push(PAD_LEAF)
+  const layers: Uint8Array[][] = [level]
+  while (level.length > 1) {
+    const next: Uint8Array[] = new Array(level.length / 2)
+    for (let i = 0; i < level.length; i += 2) {
+      next[i / 2] = sha256(concat(level[i], level[i + 1]))
+    }
+    layers.push(next)
+    level = next
+  }
+  return layers
+}
+
+export function merkleRoot(leaves: Uint8Array[]): Uint8Array {
+  const layers = merkleLayers(leaves)
+  const top = layers[layers.length - 1]
+  return top.length === 1 ? top[0] : PAD_LEAF
+}
+
+/** §5.5: Fiat-Shamir sample indices among the n real leaves. */
+export function sampleIndices(root: Uint8Array, n: number, samples: number = SAMPLES): number[] {
+  if (n <= 0) return []
+  const out: number[] = []
+  for (let i = 0; i < samples; i++) {
+    const digest = sha256(concat(HYPERSPACE_SAMPLE_DOMAIN, root, be32(i)))
+    out.push(Number(bytesToBigInt(digest) % BigInt(n)))
+  }
+  return out
+}
+
+/** The sibling path (leaf level first) for one index. */
+export function inclusionPath(layers: Uint8Array[][], index: number): Uint8Array[] {
+  const path: Uint8Array[] = []
+  let i = index
+  for (let level = 0; level < layers.length - 1; level++) {
+    path.push(layers[level][i ^ 1])
+    i >>= 1
+  }
+  return path
+}
+
+export function verifyInclusion(leaf: Uint8Array, index: number, path: Uint8Array[], root: Uint8Array): boolean {
+  let acc = leaf
+  let i = index
+  for (const sibling of path) {
+    acc = (i & 1) === 0 ? sha256(concat(acc, sibling)) : sha256(concat(sibling, acc))
+    i >>= 1
+  }
+  if (acc.length !== root.length) return false
+  for (let k = 0; k < acc.length; k++) if (acc[k] !== root[k]) return false
+  return true
+}
+
+/** The mp tag: SAMPLES inclusion paths, ':'-joined, each path hex-concatenated. */
+export function encodeOpenings(paths: Uint8Array[][]): string {
+  return paths.map((p) => p.map((s) => bytesToHex(s)).join('')).join(':')
+}
+
+export function decodeOpenings(mp: string, depth: number): Uint8Array[][] | null {
+  if (mp === '') return depth === 0 ? [] : null
+  const parts = mp.split(':')
+  const out: Uint8Array[][] = []
+  for (const part of parts) {
+    if (part.length !== depth * 64 || !/^[0-9a-f]*$/.test(part)) return null
+    const path: Uint8Array[] = []
+    for (let i = 0; i < depth; i++) path.push(hexToBytes(part.slice(i * 64, i * 64 + 64)))
+    out.push(path)
+  }
+  return out
+}
+
+export interface RideProof {
+  rootHex: string
+  mp: string
+}
+
+/**
+ * Compute the full ride proof from precomputed leaves (§5.4 and §5.5).
+ * Leaves must be in ascending height order for rideBlocks(from, to).
+ */
+export function buildRideProof(leaves: Uint8Array[]): RideProof {
+  if (leaves.length === 0) {
+    return { rootHex: '0'.repeat(64), mp: '' } // §5.6 zero-length ride
+  }
+  const layers = merkleLayers(leaves)
+  const root = layers[layers.length - 1][0]
+  const indices = sampleIndices(root, leaves.length)
+  const paths = indices.map((i) => inclusionPath(layers, i))
+  return { rootHex: bytesToHex(root), mp: encodeOpenings(paths) }
+}
+
+export interface RideVerifyInput {
+  previousEventIdHex: string
+  fromHeight: number
+  toHeight: number
+  rootHex: string
+  mp: string
+  /** Block hash for a height, 64 lowercase hex. */
+  blockHashFor: (height: number) => string | Promise<string>
+}
+
+export interface RideVerifyResult {
+  ok: boolean
+  checked: number
+  reason: string | null
+}
+
+/** Level 1 verification (§5.5): recompute the sampled leaves from scratch. */
+export async function verifyRideLevel1(input: RideVerifyInput): Promise<RideVerifyResult> {
+  const blocks = rideBlocks(input.fromHeight, input.toHeight)
+  const n = blocks.length
+  if (n === 0) {
+    const ok = input.rootHex === '0'.repeat(64) && input.mp === ''
+    return { ok, checked: 0, reason: ok ? null : 'zero-length ride must carry the zero root' }
+  }
+  if (!/^[0-9a-f]{64}$/.test(input.rootHex)) return { ok: false, checked: 0, reason: 'malformed root' }
+  const root = hexToBytes(input.rootHex)
+  const depth = merkleDepth(n)
+  const indices = sampleIndices(root, n)
+  const paths = decodeOpenings(input.mp, depth)
+  if (paths === null || paths.length !== indices.length) {
+    return { ok: false, checked: 0, reason: 'malformed openings' }
+  }
+  for (let s = 0; s < indices.length; s++) {
+    const idx = indices[s]
+    const height = blocks[idx]
+    const hash = await input.blockHashFor(height)
+    const leaf = computeRideLeaf(input.previousEventIdHex, height, hash)
+    if (!verifyInclusion(leaf, idx, paths[s], root)) {
+      return { ok: false, checked: s, reason: `opening ${s} (block ${height}) does not verify` }
+    }
+  }
+  return { ok: true, checked: indices.length, reason: null }
+}
+
+/** Expected Cantor pairings for a ride of n blocks (mean 2^K_LINE * (3/2)^16). */
+export function expectedRidePairs(n: number): number {
+  return n * Math.round(2 ** K_LINE * (3 / 2) ** 16)
+}
+
+/** Exact pairings for known block hashes: sum of 2^(K_b + K_LINE). */
+export function exactRidePairs(blockHashes: string[]): number {
+  let total = 0
+  for (const h of blockHashes) total += 2 ** (lineTerrainK(h) + K_LINE)
+  return total
+}

--- a/src/lib/hyperspace/ridePool.test.ts
+++ b/src/lib/hyperspace/ridePool.test.ts
@@ -1,0 +1,163 @@
+/**
+ * What would fail silently: a chunk planner that drops or reorders a block, a
+ * resume that trusts leaves from another chain position, or an assembly that
+ * follows completion order instead of height order would each produce a proof
+ * that is internally consistent and Level-1-verifies against nothing. The
+ * assembly test closes the loop through verifyRideLevel1 so prover-side
+ * bookkeeping is checked by the real verifier, not by itself.
+ *
+ * Workers do not exist under vitest/node, so the pure planning, resume and
+ * assembly parts are tested directly, and computeRideProof itself is tested
+ * end to end through its sequential fallback path.
+ *
+ * Block heights: a ride from 6 to 12 passes heights 7..12 whose fakeHash
+ * terrain K is at most 9 (verified offline), so no test rolls a 2^22 block.
+ */
+import { describe, expect, it } from 'vitest'
+import { bytesToHex, sha256 } from 'cyberspace-core'
+import { buildRideProof, computeRideLeaf, rideBlocks, verifyRideLevel1 } from './ride'
+import {
+  RIDE_CHUNK_SIZE,
+  assembleLeaves,
+  computeRideProof,
+  leafKey,
+  pendingBlocks,
+  planChunks,
+} from './ridePool'
+import type { RideJob, RideProgress } from './ridePool'
+
+const PREV = 'ab'.repeat(32)
+const OTHER_PREV = 'cd'.repeat(32)
+
+/** Deterministic fake block hashes, same construction as ride.test.ts. */
+function fakeHash(height: number): string {
+  const bytes = new TextEncoder().encode(`fake-block-${height}`)
+  return Array.from(sha256(bytes), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function syntheticBlocks(fromHeight: number, toHeight: number): RideJob['blocks'] {
+  return rideBlocks(fromHeight, toHeight).map((height) => ({ height, blockHash: fakeHash(height) }))
+}
+
+/** Cheap placeholder blocks for planner tests that never compute a leaf. */
+function junkBlocks(count: number): RideJob['blocks'] {
+  return Array.from({ length: count }, (_, i) => ({ height: 1000 + i, blockHash: '00'.repeat(32) }))
+}
+
+describe('chunk planner', () => {
+  it('splits into chunks of RIDE_CHUNK_SIZE, ascending, pull-order stable', () => {
+    const blocks = junkBlocks(150)
+    const chunks = planChunks(blocks)
+    expect(chunks.map((c) => c.length)).toEqual([64, 64, 22])
+    // Workers pull chunks in index order, so the flattened plan must be the
+    // input verbatim: any drop or reorder here is a wrong proof later.
+    expect(chunks.flat()).toEqual(blocks)
+    expect(RIDE_CHUNK_SIZE).toBe(64)
+  })
+
+  it('handles empty and sub-chunk inputs', () => {
+    expect(planChunks([])).toEqual([])
+    const five = junkBlocks(5)
+    expect(planChunks(five)).toEqual([five])
+  })
+})
+
+describe('resume skip logic', () => {
+  it('skips exactly the cached heights keyed to this ride', () => {
+    const job: RideJob = { previousEventIdHex: PREV, blocks: junkBlocks(6) }
+    const heights = job.blocks.map((b) => b.height)
+    const cached = new Set([
+      leafKey(PREV, heights[1]),
+      leafKey(PREV, heights[4]),
+      // A leaf from another chain position must NOT be trusted: its seed
+      // differs, so counting it as done would poison the proof.
+      leafKey(OTHER_PREV, heights[2]),
+    ])
+    const pending = pendingBlocks(job, cached)
+    expect(pending.map((b) => b.height)).toEqual([heights[0], heights[2], heights[3], heights[5]])
+  })
+
+  it('skips nothing when the cache is empty and everything when it is full', () => {
+    const job: RideJob = { previousEventIdHex: PREV, blocks: junkBlocks(4) }
+    expect(pendingBlocks(job, new Set())).toEqual(job.blocks)
+    const all = new Set(job.blocks.map((b) => leafKey(PREV, b.height)))
+    expect(pendingBlocks(job, all)).toEqual([])
+  })
+})
+
+describe('assembly order', () => {
+  it('completion-ordered leaves assemble ascending and Level-1-verify', async () => {
+    const blocks = syntheticBlocks(6, 12)
+    // Simulate arrival in completion order: reversed, with the middle first.
+    const arrival = [blocks[3], ...blocks.slice().reverse().filter((b) => b !== blocks[3])]
+    const byHeight = new Map<number, string>()
+    for (const b of arrival) {
+      byHeight.set(b.height, bytesToHex(computeRideLeaf(PREV, b.height, b.blockHash)))
+    }
+    const proof = buildRideProof(assembleLeaves(blocks, byHeight))
+    const direct = buildRideProof(blocks.map((b) => computeRideLeaf(PREV, b.height, b.blockHash)))
+    expect(proof.rootHex).toBe(direct.rootHex)
+    expect(proof.mp).toBe(direct.mp)
+    const result = await verifyRideLevel1({
+      previousEventIdHex: PREV,
+      fromHeight: 6,
+      toHeight: 12,
+      rootHex: proof.rootHex,
+      mp: proof.mp,
+      blockHashFor: (h) => fakeHash(h),
+    })
+    expect(result.reason).toBeNull()
+    expect(result.ok).toBe(true)
+  })
+
+  it('throws on a missing leaf instead of assembling a short proof', () => {
+    const blocks = junkBlocks(3)
+    const byHeight = new Map<number, string>([[blocks[0].height, '11'.repeat(32)]])
+    expect(() => assembleLeaves(blocks, byHeight)).toThrow('missing ride leaf')
+  })
+})
+
+describe('computeRideProof (sequential fallback under node)', () => {
+  it('empty job resolves immediately to the zero-length proof', async () => {
+    const seen: RideProgress[] = []
+    const proof = await computeRideProof({ previousEventIdHex: PREV, blocks: [] }, (p) => seen.push(p))
+    expect(proof.rootHex).toBe('0'.repeat(64))
+    expect(proof.mp).toBe('')
+    expect(seen[seen.length - 1]).toEqual({ done: 0, total: 0, etaMs: null })
+  })
+
+  it('a 4-block job runs end to end and Level-1-verifies', async () => {
+    const blocks = syntheticBlocks(6, 10)
+    const seen: RideProgress[] = []
+    const proof = await computeRideProof({ previousEventIdHex: PREV, blocks }, (p) => seen.push(p))
+    const result = await verifyRideLevel1({
+      previousEventIdHex: PREV,
+      fromHeight: 6,
+      toHeight: 10,
+      rootHex: proof.rootHex,
+      mp: proof.mp,
+      blockHashFor: (h) => fakeHash(h),
+    })
+    expect(result.reason).toBeNull()
+    expect(result.ok).toBe(true)
+    // Final forced progress call reports completion; under 20 fresh leaves
+    // the ETA stays null rather than extrapolating from noise.
+    expect(seen[seen.length - 1]).toEqual({ done: 4, total: 4, etaMs: null })
+  })
+
+  it('rejects a second concurrent call', async () => {
+    const first = computeRideProof({ previousEventIdHex: PREV, blocks: syntheticBlocks(6, 10) }, () => {})
+    await expect(
+      computeRideProof({ previousEventIdHex: PREV, blocks: [] }, () => {}),
+    ).rejects.toThrow('ride already computing')
+    await first
+  })
+
+  it('rejects with aborted when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      computeRideProof({ previousEventIdHex: PREV, blocks: syntheticBlocks(6, 10) }, () => {}, controller.signal),
+    ).rejects.toThrow('aborted')
+  })
+})

--- a/src/lib/hyperspace/ridePool.ts
+++ b/src/lib/hyperspace/ridePool.ts
@@ -1,0 +1,483 @@
+/**
+ * ridePool.ts: the ride computation layer over ride.ts (DECK-0001 §5.7).
+ *
+ * A ride is 300k+ independent leaves at ~100 ms average each, hours of work
+ * that the spec says SHOULD run "in a background worker with progress and
+ * resumption". Three decisions follow from that:
+ *
+ * 1. Pull queue, not pre-partitioning. Blocks go to workers in chunks of
+ *    RIDE_CHUNK_SIZE, and a worker asks for the next chunk only when it
+ *    finishes one. Leaf cost spans 2^10 to 2^22 pairings, so a pre-partitioned
+ *    pool would leave every worker idle behind the one that drew the heavy
+ *    stretch (same lesson as the terrain pool in lib/workers.ts).
+ *
+ * 2. Every finished leaf is persisted to IndexedDB, batched. A reload or an
+ *    abort mid-ride loses at most the unflushed tail, and the next attempt
+ *    for the same previousEventIdHex resumes where this one stopped. Leaves
+ *    are seeded by previousEventIdHex (§5.3 step 3), so rows are keyed by it
+ *    and never shared across chain positions.
+ *
+ * 3. The Merkle aggregation stays on the main thread. It is ~1M sha256 of 64
+ *    bytes for a full ride, a few seconds once, and keeping it here means the
+ *    workers speak one message shape and hold no state worth recovering.
+ *
+ * The pool is created per computeRideProof call and terminated when the call
+ * settles, so an idle app holds no worker threads hostage.
+ */
+
+import { bytesToHex, hexToBytes, sha256 } from 'cyberspace-core'
+import {
+  buildRideProof,
+  computeRideLeaf,
+  exactRidePairs,
+  expectedRidePairs,
+  lineTerrainK,
+} from './ride'
+import type { RideChunkRequest, RideChunkResponse } from '../../workers/ride.worker'
+
+export interface RideJob {
+  /** 64 hex; the enter event id. Every leaf is seeded by it (§5.3). */
+  previousEventIdHex: string
+  /** Ascending height. Possibly 300k+ entries, possibly empty. */
+  blocks: Array<{ height: number; blockHash: string }>
+}
+
+export interface RideProgress {
+  done: number
+  total: number
+  etaMs: number | null
+}
+
+/**
+ * Blocks per worker message. Small enough that a pulled chunk represents a
+ * few seconds of average work (so the pull queue can rebalance around a heavy
+ * block), large enough that message overhead is noise.
+ */
+export const RIDE_CHUNK_SIZE = 64
+
+/** Split pending blocks into chunks; workers pull them in index order. */
+export function planChunks(
+  blocks: RideJob['blocks'],
+  size: number = RIDE_CHUNK_SIZE,
+): Array<RideJob['blocks']> {
+  const chunks: Array<RideJob['blocks']> = []
+  for (let i = 0; i < blocks.length; i += size) chunks.push(blocks.slice(i, i + size))
+  return chunks
+}
+
+/** The persistence key for one leaf. Prefix-scannable by ride. */
+export function leafKey(previousEventIdHex: string, height: number): string {
+  return `${previousEventIdHex}:${height}`
+}
+
+/**
+ * The blocks still to compute, given the keys already persisted. Keys carry
+ * the previousEventIdHex, so a cache from another chain position skips
+ * nothing: its leaves are worthless here (§5.3 seeds differ).
+ */
+export function pendingBlocks(job: RideJob, cachedKeys: Set<string>): RideJob['blocks'] {
+  return job.blocks.filter((b) => !cachedKeys.has(leafKey(job.previousEventIdHex, b.height)))
+}
+
+/**
+ * Order completed leaves for buildRideProof. Leaves arrive in completion
+ * order (a pool property, not a protocol one); §5.4 requires ascending
+ * height, so assembly follows job.blocks, not arrival.
+ */
+export function assembleLeaves(
+  blocks: RideJob['blocks'],
+  leafHexByHeight: Map<number, string>,
+): Uint8Array[] {
+  return blocks.map((b) => {
+    const hex = leafHexByHeight.get(b.height)
+    if (hex === undefined) throw new Error(`missing ride leaf for block ${b.height}`)
+    return hexToBytes(hex)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB persistence (inline promise wrapper; absent IDB degrades to
+// running without resumption, which is how tests run under node)
+// ---------------------------------------------------------------------------
+
+const DB_NAME = 'onosendai:hyperspace-rides'
+const STORE = 'leaves'
+
+interface LeafRow {
+  key: string
+  leafHex: string
+}
+
+function openRideDb(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === 'undefined') return Promise.resolve(null)
+  return new Promise((resolve) => {
+    const req = indexedDB.open(DB_NAME, 1)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'key' })
+    }
+    req.onsuccess = () => resolve(req.result)
+    // Persistence is an optimization; a broken IDB must not block the ride.
+    req.onerror = () => resolve(null)
+  })
+}
+
+/** All keys of one ride share the `${prev}:` prefix, and ':' < ';'. */
+function rideRange(previousEventIdHex: string): IDBKeyRange {
+  return IDBKeyRange.bound(`${previousEventIdHex}:`, `${previousEventIdHex};`)
+}
+
+function readCachedLeaves(
+  db: IDBDatabase | null,
+  previousEventIdHex: string,
+): Promise<Map<number, string>> {
+  const out = new Map<number, string>()
+  if (!db) return Promise.resolve(out)
+  return new Promise((resolve) => {
+    const req = db.transaction(STORE, 'readonly').objectStore(STORE).getAll(rideRange(previousEventIdHex))
+    req.onsuccess = () => {
+      for (const row of req.result as LeafRow[]) {
+        out.set(Number(row.key.slice(previousEventIdHex.length + 1)), row.leafHex)
+      }
+      resolve(out)
+    }
+    req.onerror = () => resolve(out)
+  })
+}
+
+function writeLeafRows(db: IDBDatabase | null, rows: LeafRow[]): Promise<void> {
+  if (!db || rows.length === 0) return Promise.resolve()
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE, 'readwrite')
+    const store = tx.objectStore(STORE)
+    for (const row of rows) store.put(row)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => resolve()
+    tx.onabort = () => resolve()
+  })
+}
+
+function deleteRideRows(db: IDBDatabase | null, previousEventIdHex: string): Promise<void> {
+  if (!db) return Promise.resolve()
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE, 'readwrite')
+    tx.objectStore(STORE).delete(rideRange(previousEventIdHex))
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => resolve()
+    tx.onabort = () => resolve()
+  })
+}
+
+const FLUSH_INTERVAL_MS = 250
+const FLUSH_BATCH = 500
+
+/**
+ * Batches leaf rows into periodic IDB transactions. One put per leaf would be
+ * 300k+ transactions; batching by time and count keeps it to a handful per
+ * second while capping what an interruption can lose.
+ */
+function makePersister(db: IDBDatabase | null) {
+  let buffer: LeafRow[] = []
+  let inFlight: Promise<void> = Promise.resolve()
+  const flush = (): Promise<void> => {
+    if (buffer.length > 0) {
+      const rows = buffer
+      buffer = []
+      inFlight = inFlight.then(() => writeLeafRows(db, rows))
+    }
+    return inFlight
+  }
+  const timer: ReturnType<typeof setInterval> | null =
+    db ? setInterval(() => void flush(), FLUSH_INTERVAL_MS) : null
+  return {
+    add(key: string, leafHex: string): void {
+      if (!db) return
+      buffer.push({ key, leafHex })
+      if (buffer.length >= FLUSH_BATCH) void flush()
+    },
+    /** Flush the tail and stop the timer. Runs on every settle path. */
+    async stop(): Promise<void> {
+      if (timer !== null) clearInterval(timer)
+      await flush()
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+const PROGRESS_INTERVAL_MS = 100
+/** Below this many fresh leaves the rate estimate is noise; report no ETA. */
+const ETA_MIN_FRESH = 20
+
+function makeProgressReporter(
+  onProgress: (p: RideProgress) => void,
+  total: number,
+  resumed: number,
+) {
+  const started = performance.now()
+  let done = resumed
+  let fresh = 0
+  let lastPost = -Infinity
+  const post = (force: boolean) => {
+    const now = performance.now()
+    if (!force && now - lastPost < PROGRESS_INTERVAL_MS) return
+    lastPost = now
+    // Mean wall-clock per fresh leaf since start. Resumed leaves cost nothing
+    // and would fake a rate; parallelism is absorbed because the mean is over
+    // wall-clock, not worker time.
+    const etaMs = fresh >= ETA_MIN_FRESH ? ((total - done) * (now - started)) / fresh : null
+    onProgress({ done, total, etaMs })
+  }
+  return {
+    start(): void {
+      post(true)
+    },
+    leafDone(): void {
+      done++
+      fresh++
+      post(false)
+    },
+    final(): void {
+      post(true)
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The pool
+// ---------------------------------------------------------------------------
+
+let rideRunning = false
+
+function abortError(): Error {
+  const err = new Error('aborted')
+  err.name = 'AbortError'
+  return err
+}
+
+/**
+ * Compute the full ride proof for a job. Resolves with the §5.4/§5.5 proof;
+ * rejects with 'aborted' if the signal fires (partial leaves stay persisted
+ * for resume) or with the first worker error. Only one ride runs at a time:
+ * the pool sizes itself to the machine, so a second concurrent ride would
+ * only slow both, and the leaf store is per-ride anyway.
+ */
+export async function computeRideProof(
+  job: RideJob,
+  onProgress: (p: RideProgress) => void,
+  signal?: AbortSignal,
+): Promise<{ rootHex: string; mp: string }> {
+  if (rideRunning) throw new Error('ride already computing')
+  rideRunning = true
+  try {
+    return await runRide(job, onProgress, signal)
+  } finally {
+    rideRunning = false
+  }
+}
+
+async function runRide(
+  job: RideJob,
+  onProgress: (p: RideProgress) => void,
+  signal?: AbortSignal,
+): Promise<{ rootHex: string; mp: string }> {
+  if (signal?.aborted) throw abortError()
+  const { previousEventIdHex, blocks } = job
+  if (blocks.length === 0) {
+    // §5.6 zero-length ride: nothing to compute, nothing to persist.
+    onProgress({ done: 0, total: 0, etaMs: null })
+    return buildRideProof([])
+  }
+
+  const db = await openRideDb()
+  const cached = await readCachedLeaves(db, previousEventIdHex)
+  const cachedKeys = new Set<string>()
+  for (const height of cached.keys()) cachedKeys.add(leafKey(previousEventIdHex, height))
+  const pending = pendingBlocks(job, cachedKeys)
+  const leafHexByHeight = new Map(cached)
+
+  const progress = makeProgressReporter(onProgress, blocks.length, blocks.length - pending.length)
+  progress.start()
+
+  const persister = makePersister(db)
+  try {
+    if (pending.length > 0) {
+      if (typeof Worker === 'undefined') {
+        await computeSequentially(previousEventIdHex, pending, leafHexByHeight, persister, progress, signal)
+      } else {
+        await computeInPool(previousEventIdHex, pending, leafHexByHeight, persister, progress, signal)
+      }
+    }
+  } finally {
+    // Flush on every settle path, abort included, so a retry resumes from
+    // here instead of repaying the work.
+    await persister.stop()
+  }
+
+  progress.final()
+  const proof = buildRideProof(assembleLeaves(blocks, leafHexByHeight))
+  // Best effort: leaves for a proven ride will never be asked for again.
+  await deleteRideRows(db, previousEventIdHex)
+  return proof
+}
+
+/**
+ * No-Worker fallback (tests under node, and any headless embedder). Same
+ * semantics, sequential, with a microtask yield per leaf so an abort flagged
+ * between leaves is honored promptly.
+ */
+async function computeSequentially(
+  previousEventIdHex: string,
+  pending: RideJob['blocks'],
+  out: Map<number, string>,
+  persister: ReturnType<typeof makePersister>,
+  progress: ReturnType<typeof makeProgressReporter>,
+  signal?: AbortSignal,
+): Promise<void> {
+  for (const { height, blockHash } of pending) {
+    if (signal?.aborted) throw abortError()
+    const leafHex = bytesToHex(computeRideLeaf(previousEventIdHex, height, blockHash))
+    out.set(height, leafHex)
+    persister.add(leafKey(previousEventIdHex, height), leafHex)
+    progress.leafDone()
+    await Promise.resolve()
+  }
+}
+
+function computeInPool(
+  previousEventIdHex: string,
+  pending: RideJob['blocks'],
+  out: Map<number, string>,
+  persister: ReturnType<typeof makePersister>,
+  progress: ReturnType<typeof makeProgressReporter>,
+  signal?: AbortSignal,
+): Promise<void> {
+  const chunks = planChunks(pending)
+  const poolSize = Math.min(chunks.length, Math.max(1, (navigator.hardwareConcurrency || 4) - 1))
+
+  return new Promise<void>((resolve, reject) => {
+    const workers: Worker[] = []
+    let settled = false
+    let nextChunk = 0
+    let leavesLeft = pending.length
+    let msgId = 0
+    /** Leaves still expected per in-flight chunk id. */
+    const remaining = new Map<number, number>()
+
+    const finish = (err: Error | null) => {
+      if (settled) return
+      settled = true
+      signal?.removeEventListener('abort', onAbort)
+      for (const w of workers) w.terminate()
+      if (err) reject(err)
+      else resolve()
+    }
+    const onAbort = () => finish(abortError())
+
+    const assign = (worker: Worker) => {
+      if (settled || nextChunk >= chunks.length) return
+      const chunk = chunks[nextChunk++]
+      const id = ++msgId
+      remaining.set(id, chunk.length)
+      const request: RideChunkRequest = { id, previousEventIdHex, chunk }
+      worker.postMessage(request)
+    }
+
+    signal?.addEventListener('abort', onAbort)
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+
+    for (let i = 0; i < poolSize; i++) {
+      const worker = new Worker(new URL('../../workers/ride.worker.ts', import.meta.url), {
+        type: 'module',
+      })
+      workers.push(worker)
+      worker.addEventListener('message', (event: MessageEvent<RideChunkResponse>) => {
+        if (settled) return
+        const msg = event.data
+        if (msg.type === 'error') {
+          finish(new Error(msg.message))
+          return
+        }
+        out.set(msg.height, msg.leafHex)
+        persister.add(leafKey(previousEventIdHex, msg.height), msg.leafHex)
+        progress.leafDone()
+        leavesLeft--
+        const left = (remaining.get(msg.id) ?? 1) - 1
+        if (left > 0) {
+          remaining.set(msg.id, left)
+        } else {
+          // The chunk is done; this worker pulls the next one. Pull, not
+          // pre-partition: a 2^22 block stalls only its own worker.
+          remaining.delete(msg.id)
+          assign(worker)
+        }
+        if (leavesLeft === 0) finish(null)
+      })
+      // A crashed worker never posts again; without this the ride would hang
+      // silently one chunk short of done.
+      worker.addEventListener('error', (event) => {
+        finish(new Error(event.message || 'ride worker failed'))
+      })
+      assign(worker)
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+let benchmarkMs: number | null = null
+let calibrating: Promise<number> | null = null
+
+/**
+ * The K values the calibration sample spans. Low through average, never the
+ * heavy tail: a K=16 block alone is 2^22 pairings and would make calibration
+ * itself seconds long. The measurement is normalized per pairing and scaled
+ * to the binomial mean block, so excluding the tail does not bias the result,
+ * it only bounds the cost.
+ */
+const CALIBRATION_KS = [4, 5, 6, 7, 8, 9, 10, 11]
+
+function calibrationHashes(): string[] {
+  const enc = new TextEncoder()
+  const found = new Map<number, string>()
+  for (let counter = 0; found.size < CALIBRATION_KS.length && counter < 100_000; counter++) {
+    const hex = bytesToHex(sha256(enc.encode(`ride-calibration-${counter}`)))
+    const k = lineTerrainK(hex)
+    if (CALIBRATION_KS.includes(k) && !found.has(k)) found.set(k, hex)
+  }
+  return CALIBRATION_KS.filter((k) => found.has(k)).map((k) => found.get(k) as string)
+}
+
+/**
+ * Measure ms per average block on this machine, once. Times 8 synthetic
+ * leaves on the main thread, derives ms per Cantor pairing, and scales to the
+ * §5.7 expected pairings of the mean block. Idempotent; concurrent and later
+ * calls share the first measurement.
+ */
+export function calibrate(): Promise<number> {
+  if (calibrating) return calibrating
+  calibrating = (async () => {
+    const previousEventIdHex = 'ca'.repeat(32)
+    const hashes = calibrationHashes()
+    const started = performance.now()
+    for (let i = 0; i < hashes.length; i++) {
+      computeRideLeaf(previousEventIdHex, 1_000 + i, hashes[i])
+    }
+    const elapsed = performance.now() - started
+    benchmarkMs = (elapsed / exactRidePairs(hashes)) * expectedRidePairs(1)
+    return benchmarkMs
+  })()
+  return calibrating
+}
+
+/** The cached calibration, null until calibrate() first resolves. */
+export function leafBenchmarkMs(): number | null {
+  return benchmarkMs
+}

--- a/src/lib/hyperspace/station.test.ts
+++ b/src/lib/hyperspace/station.test.ts
@@ -1,0 +1,133 @@
+/**
+ * What would fail silently without these tests: a wrong shift in the prefix
+ * search would return a plausible-but-wrong station, the traveler's hyperjump
+ * would verify locally and be rejected by everyone else, and nothing in the UI
+ * would look broken. The brute-force cross-check is the guard.
+ */
+import { describe, expect, it } from 'vitest'
+import { xyzToCoord } from 'cyberspace-core'
+import { buildIndex, findStation, insertStop, maxAxisLca, maxAxisLcaViaAxes, nearestStops } from './station'
+import type { Stop } from './stops'
+
+function rand85(rng: () => number): bigint {
+  let v = 0n
+  for (let i = 0; i < 6; i++) v = (v << 16n) | BigInt(Math.floor(rng() * 65536))
+  return v & ((1n << 85n) - 1n)
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function syntheticStop(height: number, coord: bigint): Stop {
+  return {
+    height,
+    kind: 'port',
+    merkleRoot: coord.toString(16).padStart(64, '0'),
+    blockHash: null,
+    coordExact: coord,
+    coordApprox: coord,
+  }
+}
+
+function bruteStation(stops: Stop[], coord: bigint, maxHeight: number): { height: number; distance: number } | null {
+  let best: { height: number; distance: number } | null = null
+  for (const s of stops) {
+    if (s.height > maxHeight) continue
+    const d = maxAxisLca(coord, s.coordExact as bigint)
+    if (best === null || d < best.distance || (d === best.distance && s.height < best.height)) {
+      best = { height: s.height, distance: d }
+    }
+  }
+  return best
+}
+
+describe('maxAxisLca', () => {
+  it('agrees with the per-axis definition on random pairs', () => {
+    const rng = mulberry32(7)
+    for (let i = 0; i < 200; i++) {
+      const a = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), Math.random() < 0.5 ? 0 : 1)
+      const b = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), Math.random() < 0.5 ? 0 : 1)
+      expect(maxAxisLca(a, b)).toBe(maxAxisLcaViaAxes(a, b))
+    }
+  })
+
+  it('ignores the plane bit', () => {
+    const a = xyzToCoord(5n, 6n, 7n, 0)
+    const b = xyzToCoord(5n, 6n, 7n, 1)
+    expect(maxAxisLca(a, b)).toBe(0)
+  })
+})
+
+describe('findStation', () => {
+  it('matches brute force over random stop sets, including height bounds and ties', () => {
+    const rng = mulberry32(42)
+    const stops: Stop[] = []
+    for (let h = 0; h < 300; h++) {
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), h % 2 === 0 ? 0 : 1)))
+    }
+    // A deliberate tie: two stops at the same coordinate, different heights.
+    stops.push(syntheticStop(500, stops[10].coordExact as bigint))
+    const index = buildIndex(stops)
+    for (let trial = 0; trial < 60; trial++) {
+      const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
+      const maxHeight = trial % 3 === 0 ? 50 : 10_000
+      const got = findStation(index, q, maxHeight)
+      const want = bruteStation(stops, q, maxHeight)
+      expect(got?.stop.height).toBe(want?.height)
+      expect(got?.distance).toBe(want?.distance)
+    }
+    // Query at the tied coordinate: the lower height must win.
+    const tied = findStation(index, stops[10].coordExact as bigint, 10_000)
+    expect(tied?.stop.height).toBe(10)
+    expect(tied?.distance).toBe(0)
+  })
+
+  it('honours the destination-height bound even when nearer newer stops exist', () => {
+    const rng = mulberry32(9)
+    const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
+    const near = syntheticStop(900, q ^ 2n) // one interleaved bit away
+    const far = syntheticStop(3, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0))
+    const index = buildIndex([near, far])
+    expect(findStation(index, q, 10_000)?.stop.height).toBe(900)
+    expect(findStation(index, q, 100)?.stop.height).toBe(3)
+    expect(findStation(index, q, 1)).toBeNull()
+  })
+
+  it('insertStop keeps the index sorted and searchable', () => {
+    const rng = mulberry32(11)
+    const index = buildIndex([])
+    const stops: Stop[] = []
+    for (let h = 0; h < 50; h++) {
+      const s = syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0))
+      stops.push(s)
+      insertStop(index, s)
+    }
+    for (let i = 1; i < index.keys.length; i++) {
+      expect(index.keys[i] >= index.keys[i - 1]).toBe(true)
+    }
+    const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
+    expect(findStation(index, q, 10_000)?.stop.height).toBe(bruteStation(stops, q, 10_000)?.height)
+  })
+
+  it('nearestStops returns k results sorted by prefix distance', () => {
+    const rng = mulberry32(23)
+    const stops: Stop[] = []
+    for (let h = 0; h < 100; h++) {
+      stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)))
+    }
+    const index = buildIndex(stops)
+    const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
+    const got = nearestStops(index, q, 5)
+    expect(got.length).toBe(5)
+    const all = stops.map((s) => maxAxisLca(q, s.coordExact as bigint)).sort((a, b) => a - b)
+    expect(got[0].distance).toBe(all[0])
+  })
+})

--- a/src/lib/hyperspace/station.test.ts
+++ b/src/lib/hyperspace/station.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest'
 import { xyzToCoord } from 'cyberspace-core'
 import { buildIndex, findStation, insertStop, maxAxisLca, maxAxisLcaViaAxes, nearestStops } from './station'
+import { keyHexAtSorted } from './compactIndex'
 import type { Stop } from './stops'
 
 function rand85(rng: () => number): bigint {
@@ -110,8 +111,10 @@ describe('findStation', () => {
       stops.push(s)
       insertStop(index, s)
     }
-    for (let i = 1; i < index.keys.length; i++) {
-      expect(index.keys[i] >= index.keys[i - 1]).toBe(true)
+    // Fixed-width hex sorts like the underlying 255-bit keys, so string
+    // comparison is a faithful sortedness probe over the permutation.
+    for (let i = 1; i < index.permCount; i++) {
+      expect(keyHexAtSorted(index, i) >= keyHexAtSorted(index, i - 1)).toBe(true)
     }
     const q = xyzToCoord(rand85(rng), rand85(rng), rand85(rng), 0)
     expect(findStation(index, q, 10_000)?.stop.height).toBe(bruteStation(stops, q, 10_000)?.height)

--- a/src/lib/hyperspace/station.test.ts
+++ b/src/lib/hyperspace/station.test.ts
@@ -5,9 +5,10 @@
  * would look broken. The brute-force cross-check is the guard.
  */
 import { describe, expect, it } from 'vitest'
-import { xyzToCoord } from 'cyberspace-core'
-import { buildIndex, findStation, insertStop, maxAxisLca, maxAxisLcaViaAxes, nearestStops } from './station'
-import { keyHexAtSorted } from './compactIndex'
+import { coordToXyz, xyzToCoord } from 'cyberspace-core'
+import { buildIndex, coverageRuns, findStation, insertStop, maxAxisLca, maxAxisLcaViaAxes, nearestStops } from './station'
+import { keyHexAtSorted, rowByHeight } from './compactIndex'
+import { stepFor } from '../space'
 import type { Stop } from './stops'
 
 function rand85(rng: () => number): bigint {
@@ -132,5 +133,49 @@ describe('findStation', () => {
     expect(got.length).toBe(5)
     const all = stops.map((s) => maxAxisLca(q, s.coordExact as bigint)).sort((a, b) => a - b)
     expect(got[0].distance).toBe(all[0])
+  })
+})
+
+describe('coverageRuns', () => {
+  it('covers every stop within reach of the box, across scales', () => {
+    const rng = mulberry32(77)
+    const axisMax = (1n << 85n) - 1n
+    const clampAxis = (v: bigint): bigint => (v < 0n ? 0n : v > axisMax ? axisMax : v)
+    for (const scaleExp of [0, 30, 52, 70, 85]) {
+      const q = { x: rand85(rng), y: rand85(rng), z: rand85(rng) }
+      const step = stepFor(scaleExp)
+      const stops: Stop[] = []
+      for (let h = 0; h < 200; h++) {
+        stops.push(syntheticStop(h, xyzToCoord(rand85(rng), rand85(rng), rand85(rng), h % 2 === 0 ? 0 : 1)))
+      }
+      // Stops planted inside the reach box, so the assertion has teeth at
+      // every scale (a random 85-bit point is never within reach at fine
+      // scales).
+      for (let h = 200; h < 240; h++) {
+        const off = (): bigint => BigInt(Math.floor(rng() * 380) - 190) * step
+        stops.push(syntheticStop(h, xyzToCoord(
+          clampAxis(q.x + off()), clampAxis(q.y + off()), clampAxis(q.z + off()), h % 2 === 0 ? 0 : 1,
+        )))
+      }
+      const index = buildIndex(stops)
+      const runs = coverageRuns(index, q.x, q.y, q.z, scaleExp, 194)
+      for (let i = 0; i < runs.length; i++) {
+        expect(runs[i][0]).toBeLessThan(runs[i][1])
+        if (i > 0) expect(runs[i][0]).toBeGreaterThanOrEqual(runs[i - 1][1])
+      }
+      const covered = new Set<number>()
+      for (const [start, end] of runs) for (let p = start; p < end; p++) covered.add(index.perm[p])
+      const reach = 194n * step
+      const within = (a: bigint, b: bigint): boolean => (a > b ? a - b : b - a) <= reach
+      let inReach = 0
+      for (const stop of stops) {
+        const pos = coordToXyz(stop.coordExact as bigint)
+        if (within(pos.x, q.x) && within(pos.y, q.y) && within(pos.z, q.z)) {
+          inReach++
+          expect(covered.has(rowByHeight(index, stop.height))).toBe(true)
+        }
+      }
+      expect(inReach).toBeGreaterThan(0)
+    }
   })
 })

--- a/src/lib/hyperspace/station.ts
+++ b/src/lib/hyperspace/station.ts
@@ -1,0 +1,168 @@
+/**
+ * station.ts: DECK-0001 v3 §4. The station is the stop nearest an identity's
+ * coordinate in the protocol's cube metric, ties to the lowest height,
+ * over stops with height at or below the destination height.
+ *
+ * The metric: d(p, q) = max over axes of findLcaHeight, which equals
+ * 85 - floor(L / 3) where L is the shared prefix of the interleaved
+ * coordinates with the plane bit stripped. So nearest-by-cube is
+ * longest-common-prefix, and a sorted array turns the lookup into a binary
+ * search plus a scan of the run sharing the winning prefix. Never an O(N)
+ * comparison against every stop.
+ *
+ * Landfalls enter the index with float64-approximate coordinates (about a
+ * metre of error). That cannot change a distance decided at h47 and above,
+ * but to be safe against ties the finalists are re-derived exactly before
+ * the winner is chosen.
+ */
+import { findLcaHeight, coordToXyz } from 'cyberspace-core'
+import { type Stop, stopCoordExact } from './stops'
+
+/** Max-axis LCA height between two coord256 values, plane bits ignored. */
+export function maxAxisLca(a: bigint, b: bigint): number {
+  const xor = (a >> 1n) ^ (b >> 1n)
+  if (xor === 0n) return 0
+  const j = xor.toString(2).length - 1 // index of the highest differing interleaved bit
+  return Math.floor(j / 3) + 1
+}
+
+export interface StopIndex {
+  /** Plane-stripped interleaved keys, ascending. */
+  keys: bigint[]
+  /** stops[i] corresponds to keys[i]. */
+  stops: Stop[]
+}
+
+export function buildIndex(stops: Stop[]): StopIndex {
+  const entries = stops.map((s) => ({ key: s.coordApprox >> 1n, stop: s }))
+  entries.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+  return { keys: entries.map((e) => e.key), stops: entries.map((e) => e.stop) }
+}
+
+/** Insert one stop, keeping the index sorted. O(log n) search, O(n) splice. */
+export function insertStop(index: StopIndex, stop: Stop): void {
+  const key = stop.coordApprox >> 1n
+  let lo = 0
+  let hi = index.keys.length
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (index.keys[mid] < key) lo = mid + 1
+    else hi = mid
+  }
+  index.keys.splice(lo, 0, key)
+  index.stops.splice(lo, 0, stop)
+}
+
+function lowerBound(keys: bigint[], value: bigint): number {
+  let lo = 0
+  let hi = keys.length
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1
+    if (keys[mid] < value) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
+/** [start, end) of the run of keys sharing coordKey's prefix down to axis bit d. */
+function prefixRange(index: StopIndex, coordKey: bigint, d: number): [number, number] {
+  if (d >= 85) return [0, index.keys.length]
+  const shift = BigInt(3 * d)
+  const base = (coordKey >> shift) << shift
+  const end = base + (1n << shift)
+  return [lowerBound(index.keys, base), lowerBound(index.keys, end)]
+}
+
+export interface StationResult {
+  stop: Stop
+  /** Max-axis LCA height from the query coordinate to the stop, exact. */
+  distance: number
+}
+
+/**
+ * The station per §4.2: nearest stop by max-axis LCA with height <= maxHeight,
+ * ties to the lowest height. Exact: finalists are re-derived before deciding.
+ */
+export function findStation(index: StopIndex, coord: bigint, maxHeight: number): StationResult | null {
+  if (index.keys.length === 0) return null
+  const key = coord >> 1n
+
+  // Approximate best distance from the sort neighbours.
+  const p = lowerBound(index.keys, key)
+  let dGuess = 86
+  for (const i of [p - 1, p]) {
+    if (i >= 0 && i < index.keys.length) {
+      const d = maxAxisLcaKeys(key, index.keys[i])
+      if (d < dGuess) dGuess = d
+    }
+  }
+  if (dGuess > 85) dGuess = 85
+
+  // Widen the cube until it holds a qualifying stop, then decide exactly.
+  for (let d = dGuess; d <= 85; d++) {
+    const [start, end] = prefixRange(index, key, d)
+    let best: StationResult | null = null
+    for (let i = start; i < end; i++) {
+      const stop = index.stops[i]
+      if (stop.height > maxHeight) continue
+      const exact = maxAxisLca(coord, stopCoordExact(stop))
+      if (
+        best === null ||
+        exact < best.distance ||
+        (exact === best.distance && stop.height < best.stop.height)
+      ) {
+        best = { stop, distance: exact }
+      }
+    }
+    if (best !== null) return best
+  }
+  return null
+}
+
+function maxAxisLcaKeys(aKey: bigint, bKey: bigint): number {
+  const xor = aKey ^ bKey
+  if (xor === 0n) return 0
+  const j = xor.toString(2).length - 1
+  return Math.floor(j / 3) + 1
+}
+
+/** The k nearest stops to a coordinate (no height bound), for the UI. */
+export function nearestStops(index: StopIndex, coord: bigint, k: number): StationResult[] {
+  if (index.keys.length === 0) return []
+  const key = coord >> 1n
+  const p = lowerBound(index.keys, key)
+  const out: StationResult[] = []
+  const seen = new Set<number>()
+  let lo = p - 1
+  let hi = p
+  // The k nearest by prefix all sit adjacent in sort order; merge outward.
+  while (out.length < k && (lo >= 0 || hi < index.keys.length)) {
+    const dLo = lo >= 0 ? maxAxisLcaKeys(key, index.keys[lo]) : 86
+    const dHi = hi < index.keys.length ? maxAxisLcaKeys(key, index.keys[hi]) : 86
+    if (dLo <= dHi) {
+      if (!seen.has(lo)) {
+        out.push({ stop: index.stops[lo], distance: dLo })
+        seen.add(lo)
+      }
+      lo--
+    } else {
+      if (!seen.has(hi)) {
+        out.push({ stop: index.stops[hi], distance: dHi })
+        seen.add(hi)
+      }
+      hi++
+    }
+  }
+  return out
+}
+
+/** Cross-check helper: the same distance computed the slow, per-axis way. */
+export function maxAxisLcaViaAxes(a: bigint, b: bigint): number {
+  const pa = coordToXyz(a)
+  const pb = coordToXyz(b)
+  return Math.max(
+    findLcaHeight(pa.x, pb.x),
+    findLcaHeight(pa.y, pb.y),
+    findLcaHeight(pa.z, pb.z),
+  )
+}

--- a/src/lib/hyperspace/station.ts
+++ b/src/lib/hyperspace/station.ts
@@ -6,9 +6,15 @@
  * The metric: d(p, q) = max over axes of findLcaHeight, which equals
  * 85 - floor(L / 3) where L is the shared prefix of the interleaved
  * coordinates with the plane bit stripped. So nearest-by-cube is
- * longest-common-prefix, and a sorted array turns the lookup into a binary
+ * longest-common-prefix, and a sorted view turns the lookup into a binary
  * search plus a scan of the run sharing the winning prefix. Never an O(N)
  * comparison against every stop.
+ *
+ * The index is the columnar StopIndex (compactIndex.ts): keys are 32-byte
+ * big-endian plane-stripped coordinates and sorted order is a permutation of
+ * row ids, so every comparison here is bytewise over flat buffers rather
+ * than bigint maths over boxed keys. The prefix arithmetic (mask, +2^shift)
+ * is done on byte arrays for the same reason.
  *
  * Landfalls enter the index with float64-approximate coordinates (about a
  * metre of error). That cannot change a distance decided at h47 and above,
@@ -17,6 +23,18 @@
  */
 import { findLcaHeight, coordToXyz } from 'cyberspace-core'
 import { type Stop, stopCoordExact } from './stops'
+import { bigToBytes32 } from './headers'
+import {
+  appendStops,
+  createStopIndex,
+  heightAt,
+  insertRow,
+  mergeAll,
+  stopAt,
+  type StopIndex,
+} from './compactIndex'
+
+export type { StopIndex } from './compactIndex'
 
 /** Max-axis LCA height between two coord256 values, plane bits ignored. */
 export function maxAxisLca(a: bigint, b: bigint): number {
@@ -26,51 +44,86 @@ export function maxAxisLca(a: bigint, b: bigint): number {
   return Math.floor(j / 3) + 1
 }
 
-export interface StopIndex {
-  /** Plane-stripped interleaved keys, ascending. */
-  keys: bigint[]
-  /** stops[i] corresponds to keys[i]. */
-  stops: Stop[]
-}
-
+/** Build a fully merged index from stops; the test and boot-time builder. */
 export function buildIndex(stops: Stop[]): StopIndex {
-  const entries = stops.map((s) => ({ key: s.coordApprox >> 1n, stop: s }))
-  entries.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
-  return { keys: entries.map((e) => e.key), stops: entries.map((e) => e.stop) }
+  const index = createStopIndex()
+  appendStops(index, stops)
+  mergeAll(index)
+  return index
 }
 
-/** Insert one stop, keeping the index sorted. O(log n) search, O(n) splice. */
+/** Insert one stop, keeping the sorted view coherent (compactIndex decides
+ * between an in-place splice and the pending-merge queue). */
 export function insertStop(index: StopIndex, stop: Stop): void {
-  const key = stop.coordApprox >> 1n
-  let lo = 0
-  let hi = index.keys.length
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1
-    if (index.keys[mid] < key) lo = mid + 1
-    else hi = mid
-  }
-  index.keys.splice(lo, 0, key)
-  index.stops.splice(lo, 0, stop)
+  insertRow(index, stop)
 }
 
-function lowerBound(keys: bigint[], value: bigint): number {
+/** First sorted position whose key is >= bytes. */
+function lowerBound(index: StopIndex, bytes: Uint8Array): number {
+  const keys = index.keys
+  const perm = index.perm
   let lo = 0
-  let hi = keys.length
+  let hi = index.permCount
   while (lo < hi) {
     const mid = (lo + hi) >> 1
-    if (keys[mid] < value) lo = mid + 1
+    const off = perm[mid] * 32
+    let cmp = 0
+    for (let i = 0; i < 32; i++) {
+      const d = keys[off + i] - bytes[i]
+      if (d !== 0) {
+        cmp = d
+        break
+      }
+    }
+    if (cmp < 0) lo = mid + 1
     else hi = mid
   }
   return lo
 }
 
-/** [start, end) of the run of keys sharing coordKey's prefix down to axis bit d. */
-function prefixRange(index: StopIndex, coordKey: bigint, d: number): [number, number] {
-  if (d >= 85) return [0, index.keys.length]
-  const shift = BigInt(3 * d)
-  const base = (coordKey >> shift) << shift
-  const end = base + (1n << shift)
-  return [lowerBound(index.keys, base), lowerBound(index.keys, end)]
+/**
+ * [start, end) of the sorted run sharing keyBytes' prefix down to axis bit d,
+ * i.e. keys in [key & ~(2^(3d) - 1), same + 2^(3d)). Byte arithmetic: zero
+ * the low 3d bits for the base, then add one at bit 3d for the end; a carry
+ * off the top means the run extends to the end of the array.
+ */
+function prefixRange(index: StopIndex, keyBytes: Uint8Array, d: number): [number, number] {
+  if (d >= 85) return [0, index.permCount]
+  const shift = 3 * d
+  const base = keyBytes.slice()
+  const fullBytes = shift >> 3
+  for (let i = 0; i < fullBytes; i++) base[31 - i] = 0
+  const rem = shift & 7
+  if (rem > 0) base[31 - fullBytes] &= (0xff << rem) & 0xff
+  const start = lowerBound(index, base)
+  const end = base.slice()
+  let byteIdx = 31 - fullBytes
+  let add = 1 << rem
+  while (byteIdx >= 0) {
+    const sum = end[byteIdx] + add
+    end[byteIdx] = sum & 0xff
+    if (sum < 256) break
+    add = 1
+    byteIdx--
+  }
+  if (byteIdx < 0) return [start, index.permCount]
+  return [start, lowerBound(index, end)]
+}
+
+/** Max-axis LCA between a query key and the key at sorted position pos,
+ * from the first differing byte; equal keys are distance 0. */
+function lcaAtSorted(index: StopIndex, qBytes: Uint8Array, pos: number): number {
+  const keys = index.keys
+  const off = index.perm[pos] * 32
+  for (let b = 0; b < 32; b++) {
+    const x = keys[off + b] ^ qBytes[b]
+    if (x !== 0) {
+      const msb = 31 - Math.clz32(x)
+      const j = (31 - b) * 8 + msb // bit index from the LSB of the 255-bit key
+      return Math.floor(j / 3) + 1
+    }
+  }
+  return 0
 }
 
 export interface StationResult {
@@ -84,15 +137,15 @@ export interface StationResult {
  * ties to the lowest height. Exact: finalists are re-derived before deciding.
  */
 export function findStation(index: StopIndex, coord: bigint, maxHeight: number): StationResult | null {
-  if (index.keys.length === 0) return null
-  const key = coord >> 1n
+  if (index.permCount === 0) return null
+  const key = bigToBytes32(coord >> 1n)
 
   // Approximate best distance from the sort neighbours.
-  const p = lowerBound(index.keys, key)
+  const p = lowerBound(index, key)
   let dGuess = 86
   for (const i of [p - 1, p]) {
-    if (i >= 0 && i < index.keys.length) {
-      const d = maxAxisLcaKeys(key, index.keys[i])
+    if (i >= 0 && i < index.permCount) {
+      const d = lcaAtSorted(index, key, i)
       if (d < dGuess) dGuess = d
     }
   }
@@ -103,8 +156,9 @@ export function findStation(index: StopIndex, coord: bigint, maxHeight: number):
     const [start, end] = prefixRange(index, key, d)
     let best: StationResult | null = null
     for (let i = start; i < end; i++) {
-      const stop = index.stops[i]
-      if (stop.height > maxHeight) continue
+      const row = index.perm[i]
+      if (heightAt(index, row) > maxHeight) continue
+      const stop = stopAt(index, row)
       const exact = maxAxisLca(coord, stopCoordExact(stop))
       if (
         best === null ||
@@ -119,35 +173,28 @@ export function findStation(index: StopIndex, coord: bigint, maxHeight: number):
   return null
 }
 
-function maxAxisLcaKeys(aKey: bigint, bKey: bigint): number {
-  const xor = aKey ^ bKey
-  if (xor === 0n) return 0
-  const j = xor.toString(2).length - 1
-  return Math.floor(j / 3) + 1
-}
-
 /** The k nearest stops to a coordinate (no height bound), for the UI. */
 export function nearestStops(index: StopIndex, coord: bigint, k: number): StationResult[] {
-  if (index.keys.length === 0) return []
-  const key = coord >> 1n
-  const p = lowerBound(index.keys, key)
+  if (index.permCount === 0) return []
+  const key = bigToBytes32(coord >> 1n)
+  const p = lowerBound(index, key)
   const out: StationResult[] = []
   const seen = new Set<number>()
   let lo = p - 1
   let hi = p
   // The k nearest by prefix all sit adjacent in sort order; merge outward.
-  while (out.length < k && (lo >= 0 || hi < index.keys.length)) {
-    const dLo = lo >= 0 ? maxAxisLcaKeys(key, index.keys[lo]) : 86
-    const dHi = hi < index.keys.length ? maxAxisLcaKeys(key, index.keys[hi]) : 86
+  while (out.length < k && (lo >= 0 || hi < index.permCount)) {
+    const dLo = lo >= 0 ? lcaAtSorted(index, key, lo) : 86
+    const dHi = hi < index.permCount ? lcaAtSorted(index, key, hi) : 86
     if (dLo <= dHi) {
       if (!seen.has(lo)) {
-        out.push({ stop: index.stops[lo], distance: dLo })
+        out.push({ stop: stopAt(index, index.perm[lo]), distance: dLo })
         seen.add(lo)
       }
       lo--
     } else {
       if (!seen.has(hi)) {
-        out.push({ stop: index.stops[hi], distance: dHi })
+        out.push({ stop: stopAt(index, index.perm[hi]), distance: dHi })
         seen.add(hi)
       }
       hi++

--- a/src/lib/hyperspace/station.ts
+++ b/src/lib/hyperspace/station.ts
@@ -21,7 +21,8 @@
  * but to be safe against ties the finalists are re-derived exactly before
  * the winner is chosen.
  */
-import { findLcaHeight, coordToXyz } from 'cyberspace-core'
+import { findLcaHeight, coordToXyz, xyzToCoord } from 'cyberspace-core'
+import { stepFor } from '../space'
 import { type Stop, stopCoordExact } from './stops'
 import { bigToBytes32 } from './headers'
 import {
@@ -212,4 +213,54 @@ export function maxAxisLcaViaAxes(a: bigint, b: bigint): number {
     findLcaHeight(pa.y, pb.y),
     findLcaHeight(pa.z, pb.z),
   )
+}
+
+const AXIS_MAX = (1n << 85n) - 1n
+
+/**
+ * Sorted-view runs covering every stop within `reachCells` of a position at
+ * this scale. An axis-aligned box no wider than an aligned cube spans at
+ * most two aligned cells per axis, so the cubes of the box's eight corners,
+ * at the first level whose cube side exceeds the box, are the whole cover;
+ * each cube is one prefixRange run and the runs are merged. A superset by
+ * construction: callers still range-test each row, they just never touch
+ * the hundreds of thousands of rows that cannot qualify, which is what
+ * keeps a spawn-scale scan at microseconds instead of seconds of decode.
+ */
+export function coverageRuns(
+  index: StopIndex,
+  x: bigint,
+  y: bigint,
+  z: bigint,
+  scaleExp: number,
+  reachCells: number,
+): Array<[number, number]> {
+  if (index.permCount === 0) return []
+  let r = BigInt(Math.max(1, Math.ceil(reachCells))) * stepFor(scaleExp)
+  if (r < 1n) r = 1n
+  // 2^d must exceed the box's 2r+1 gibsons; the bit length of 2r does that
+  // whether or not 2r is a power of two.
+  const d = Math.min(85, (2n * r).toString(2).length)
+  const clamp = (v: bigint): bigint => (v < 0n ? 0n : v > AXIS_MAX ? AXIS_MAX : v)
+  const runs: Array<[number, number]> = []
+  for (const cx of [clamp(x - r), clamp(x + r)]) {
+    for (const cy of [clamp(y - r), clamp(y + r)]) {
+      for (const cz of [clamp(z - r), clamp(z + r)]) {
+        const key = bigToBytes32(xyzToCoord(cx, cy, cz, 0) >> 1n)
+        const run = prefixRange(index, key, d)
+        if (run[1] > run[0]) runs.push(run)
+      }
+    }
+  }
+  runs.sort((a, b) => a[0] - b[0] || a[1] - b[1])
+  const merged: Array<[number, number]> = []
+  for (const [start, end] of runs) {
+    const last = merged[merged.length - 1]
+    if (last && start <= last[1]) {
+      if (end > last[1]) last[1] = end
+    } else {
+      merged.push([start, end])
+    }
+  }
+  return merged
 }

--- a/src/lib/hyperspace/stops.ts
+++ b/src/lib/hyperspace/stops.ts
@@ -1,0 +1,104 @@
+/**
+ * stops.ts: DECK-0001 v3 §1 and §2. A stop is one Bitcoin block as a location.
+ *
+ * The merkle root's plane bit decides the kind: 1 = a port in ideaspace at the
+ * root coordinate, 0 = a landfall on the WGS84 surface at a point the block
+ * hash picks (landfall.ts). Anchors (kind 321) are the discovery convenience;
+ * the parser below is strict but silent, in the style of parseAction: anything
+ * malformed returns null rather than throwing.
+ *
+ * Legacy anchors (published before v3) carry C = merkle root for every block
+ * and no M tag. For a plane-0 legacy anchor the landfall coordinate must be
+ * derived from H; we derive the float64 approximation eagerly (about a metre
+ * of error, fine for the index and the renderer) and the exact decimal
+ * coordinate lazily, only when a verifier-visible value is needed.
+ */
+import { hexToCoord, coordToHex } from 'cyberspace-core'
+import { landfallCoord, landfallCoordApprox } from './landfall'
+
+export type StopKind = 'port' | 'landfall'
+
+export interface Stop {
+  height: number
+  kind: StopKind
+  /** Merkle root, 64 lowercase hex. For a port this is also the coordinate. */
+  merkleRoot: string
+  /** Block hash, 64 lowercase hex, when known (needed to derive a landfall). */
+  blockHash: string | null
+  /** Exact stop coordinate, when known. Ports always have it. */
+  coordExact: bigint | null
+  /** Approximate coordinate for indexing and rendering; equals coordExact for ports. */
+  coordApprox: bigint
+}
+
+const HEX64 = /^[0-9a-f]{64}$/
+
+export function planeOfMerkleRoot(merkleRootHex: string): 0 | 1 {
+  const last = merkleRootHex[merkleRootHex.length - 1]
+  return (parseInt(last, 16) & 1) as 0 | 1
+}
+
+function tag(tags: string[][], name: string): string | undefined {
+  for (const t of tags) if (t.length >= 2 && t[0] === name) return t[1]
+  return undefined
+}
+
+export interface AnchorEvent {
+  kind: number
+  tags: string[][]
+}
+
+/**
+ * Parse a kind 321 anchor into a Stop, handling both v3 and legacy formats.
+ * Returns null for anything malformed or unusable.
+ */
+export function stopFromAnchor(ev: AnchorEvent): Stop | null {
+  if (ev.kind !== 321) return null
+  const bStr = tag(ev.tags, 'B')
+  if (bStr === undefined || !/^\d+$/.test(bStr)) return null
+  const height = Number.parseInt(bStr, 10)
+  if (!Number.isSafeInteger(height) || height < 0) return null
+  const c = tag(ev.tags, 'C')?.toLowerCase()
+  if (!c || !HEX64.test(c)) return null
+  const m = tag(ev.tags, 'M')?.toLowerCase()
+  const h = tag(ev.tags, 'H')?.toLowerCase()
+  if (h !== undefined && !HEX64.test(h)) return null
+
+  if (m !== undefined) {
+    // v3 anchor: M is the merkle root, C is the stop coordinate.
+    if (!HEX64.test(m)) return null
+    const kind: StopKind = planeOfMerkleRoot(m) === 1 ? 'port' : 'landfall'
+    if (kind === 'port' && c !== m) return null
+    if (kind === 'landfall' && !h) return null
+    const coord = hexToCoord(c)
+    return { height, kind, merkleRoot: m, blockHash: h ?? null, coordExact: coord, coordApprox: coord }
+  }
+
+  // Legacy anchor: C is the merkle root.
+  const kind: StopKind = planeOfMerkleRoot(c) === 1 ? 'port' : 'landfall'
+  if (kind === 'port') {
+    const coord = hexToCoord(c)
+    return { height, kind, merkleRoot: c, blockHash: h ?? null, coordExact: coord, coordApprox: coord }
+  }
+  if (!h) return null // a legacy landfall without a block hash cannot be placed
+  return {
+    height,
+    kind,
+    merkleRoot: c,
+    blockHash: h,
+    coordExact: null,
+    coordApprox: landfallCoordApprox(h),
+  }
+}
+
+/** Exact stop coordinate, deriving and caching the landfall when needed. */
+export function stopCoordExact(stop: Stop): bigint {
+  if (stop.coordExact !== null) return stop.coordExact
+  if (!stop.blockHash) throw new Error(`stop ${stop.height} has no block hash to derive a landfall from`)
+  stop.coordExact = landfallCoord(stop.blockHash)
+  return stop.coordExact
+}
+
+export function stopCoordHex(stop: Stop): string {
+  return coordToHex(stopCoordExact(stop))
+}

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -11,7 +11,8 @@
  * is down is a normal condition, not an exception.
  */
 
-import { SimplePool } from 'nostr-tools/pool'
+import { AbstractSimplePool } from 'nostr-tools/abstract-pool'
+import { verifyEvent } from 'nostr-tools/pure'
 import type { Filter } from 'nostr-tools/filter'
 import type { EventTemplate, VerifiedEvent } from 'nostr-tools/core'
 import type { NostrEvent } from './events'
@@ -24,7 +25,7 @@ export const CYBERSPACE_RELAY = DEFAULT_RELAY
 /** How long a publish or a one-shot query waits before giving up. */
 const MAX_WAIT_MS = 8000
 
-let pool: SimplePool | null = null
+let pool: AbstractSimplePool | null = null
 
 /**
  * Sign a relay's NIP-42 challenge with this identity's key, so a relay that
@@ -36,9 +37,23 @@ function authSign(template: EventTemplate): Promise<VerifiedEvent> {
   return useCyberspace.getState().signEvent(template) as unknown as Promise<VerifiedEvent>
 }
 
-export function getPool(): SimplePool {
+export function getPool(): AbstractSimplePool {
   if (!pool) {
-    pool = new SimplePool()
+    // Signature checks run synchronously per arriving event, on the main
+    // thread, inside the pool. For the kind-321 anchor backfill that is a
+    // million schnorr verifications sprayed through the session as ~1 ms
+    // tasks: precisely the grain that makes an idle page judder (input
+    // gestures defer timer work, which is why dragging looked smooth).
+    // 321 has no publisher allowlist yet, so the signature proves nothing an
+    // attacker could not sign themselves; skip it there, verify everything
+    // else as before. (A publisher allowlist for anchors is the follow-up
+    // that would make relay-sourced stops authenticated at all.)
+    pool = new AbstractSimplePool({
+      verifyEvent: (ev) => (ev.kind === 321 ? true : verifyEvent(ev)),
+      // SimplePool's own default (3e3), restated because the abstract
+      // constructor requires the field.
+      maxWaitForConnection: 3000,
+    })
     // Not in SimplePool's constructor options, but the abstract pool honours it:
     // when a relay proactively sends an AUTH challenge, authenticate with it.
     ;(pool as unknown as { automaticallyAuth?: () => typeof authSign }).automaticallyAuth = () => authSign

--- a/src/lib/space.test.ts
+++ b/src/lib/space.test.ts
@@ -29,8 +29,7 @@ import {
   trailingZeros,
   viewAxes,
   type Position,
-  type ViewAxes,
-} from './space'
+  type ViewAxes, pointCentre } from './space'
 import { alignedOrigin } from '../store/useCyberspace'
 
 describe('scale helpers', () => {
@@ -679,5 +678,31 @@ describe('origin re-anchor', () => {
       const shift = originShift(alignedOrigin(AVATAR, 20), alignedOrigin(to, 20), 20, axes)
       expect(shift.map((v) => v + 0)).toEqual([0, 0, 0])
     }
+  })
+})
+
+
+describe('pointCentre', () => {
+  // What would fail silently: a floor-snapped marker cloud reads as a
+  // systematic negative-octant skew at planetary zoom, sunk into one side of
+  // the globe and floating off the other, with nothing else looking wrong.
+  const axes = viewAxes(topDownQuaternion())
+
+  it('keeps the sub-cell fraction cellCentre floors away', () => {
+    const origin: Position = { x: 0n, y: 0n, z: 0n }
+    const half = stepFor(4) / 2n // mid-cell at scaleExp 4
+    const p: Position = { x: half, y: half, z: half }
+    const snapped = cellCentre(p, origin, 4, axes)
+    const exact = pointCentre(p, origin, 4, axes)
+    for (let i = 0; i < 3; i++) {
+      expect(Math.abs(Math.abs(exact[i]) - 0.5)).toBeLessThan(1e-9)
+      expect(snapped[i]).toBe(0)
+    }
+  })
+
+  it('agrees with cellCentre exactly on aligned values', () => {
+    const origin: Position = { x: 16n, y: 32n, z: 48n }
+    const p: Position = { x: 64n, y: 128n, z: 192n }
+    expect(pointCentre(p, origin, 4, axes)).toEqual(cellCentre(p, origin, 4, axes))
   })
 })

--- a/src/lib/space.ts
+++ b/src/lib/space.ts
@@ -122,6 +122,25 @@ export function cellCentre(
 }
 
 /**
+ * Continuous placement for point-like markers (hyperspace stops, bursts).
+ *
+ * cellCentre floor-snaps to the aligned cell, which is right for everything
+ * that lives on the movement grid but puts a marker up to a whole cell
+ * toward negative on every axis. At planetary zoom that half-cell average
+ * bias is hundreds of kilometres: the landfall cloud sat visibly sunk into
+ * the +X+Y+Z octant of the globe and floated off the -X-Y-Z one. Markers
+ * keep their sub-cell position instead, the same continuous math the Earth
+ * sphere's own centre uses, so the shell hugs the wireframe exactly.
+ */
+export function pointCentre(
+  p: Position, origin: Position, scaleExp: number, axes: ViewAxes,
+): [number, number, number] {
+  return [axes.right, axes.up, axes.out].map((a) =>
+    cellDelta(p[a.axis], origin[a.axis], scaleExp) * a.dir,
+  ) as [number, number, number]
+}
+
+/**
  * How far every render coordinate moves when the render origin is re-anchored
  * from `prev` to `next`, per screen axis, in cells.
  *

--- a/src/scene/CoveringBox.tsx
+++ b/src/scene/CoveringBox.tsx
@@ -17,17 +17,42 @@
  * shown and the thing you paid for are visibly the same object.
  */
 
-import { useMemo } from 'react'
-import { BoxGeometry, FrontSide } from 'three'
+import { useEffect, useMemo, useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { BoxGeometry, DoubleSide, FrontSide, Mesh, MeshBasicMaterial, PlaneGeometry } from 'three'
 import { GRID_RADIUS, cellCentre, formatOps, type ViewAxes } from '../lib/space'
 import { estimateHopCost } from 'cyberspace-core'
 import { boxEdges, coveringBox } from '../lib/covering'
 import { ACCENT, DANGER } from '../lib/palette'
 import { MAX_COMPUTE_HEIGHT, alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { WorldLabel } from './WorldLabel'
+import { useUiHints } from '../store/useUiHints'
 
 /** Clamp on the drawn extent; the reported cost is never clamped. */
 const MAX_CELLS = GRID_RADIUS * 3
+
+/** Seconds one outward breath of a clipped wall takes. */
+const WALL_CYCLE = 1.6
+
+/**
+ * Peak opacity of a breathing wall, well above the box fill's ceiling (0.09).
+ * The fill only whispers "this is a volume"; a breathing wall is the one active
+ * message in the scene, "the region continues past this face", and at fill
+ * strength it would read as a rendering artifact rather than a signal.
+ */
+const WALL_OPACITY = 0.25
+
+/** One face of the drawn box that the true region extends beyond. */
+interface Wall {
+  /** Render axis the face is perpendicular to: 0 right, 1 up, 2 out. */
+  slot: number
+  /** Which of the pair: +1 breathes toward +axis, -1 toward -axis. */
+  sign: 1 | -1
+  geometry: PlaneGeometry
+  rotation: [number, number, number]
+  /** Face centre at rest, in cells; each breath departs from here. */
+  base: [number, number, number]
+}
 
 interface Props {
   axes: ViewAxes
@@ -118,8 +143,94 @@ export function CoveringBox({ axes }: Props): JSX.Element | null {
       // Below it, because the cursor's own scale label hangs off the top right
       // and the two would otherwise print over each other.
       at: cellCentre(target, origin, scaleExp, axes),
+      // For the breathing walls: which faces to animate, and the extents to
+      // size their planes from.
+      size: c.size,
+      clippedAxes: c.clippedAxes,
     }
   }, [position, target, scaleExp, plane, axes, atHead])
+
+  // The HUD's zoom-out key echoes the clipped state (see useUiHints). Keyed on
+  // the boolean so it is written only when the state actually flips, never per
+  // frame and never per cursor step; the store guards once more on its side.
+  const clipped = box?.clipped ?? false
+  useEffect(() => {
+    useUiHints.getState().setCoveringClipped(clipped)
+  }, [clipped])
+  // The scene unmounting (view switch, controls torn down) must not strand the
+  // hint on with no covering box left to clear it.
+  useEffect(() => () => useUiHints.getState().setCoveringClipped(false), [])
+
+  // Walls that breathe outward on the clipped axes.
+  //
+  // A clipped box is drawn as a bracket around the endpoints, which is honest
+  // about where the region is and silent about how far it goes, and that
+  // silence was read as "small and broken" rather than "bigger than the view".
+  // So each wall perpendicular to a clipped axis repeatedly slides one cell
+  // outward while fading, then snaps back: motion pointing out of the box, on
+  // exactly the faces the true region continues through. The axis mapping is
+  // the box's own: coveringBox lays world axes out through [right, up, out],
+  // so a clipped world axis animates along the render slot that claimed it.
+  const walls = useMemo<Wall[]>(() => {
+    if (!box || !box.clipped) return []
+    const slots = [axes.right, axes.up, axes.out]
+    const out: Wall[] = []
+    for (const axis of box.clippedAxes) {
+      const slot = slots.findIndex((a) => a.axis === axis)
+      // PlaneGeometry faces +Z; rotate it to face the slot's render axis. Its
+      // extents are the face's own two render axes, so the plane is exactly
+      // the wall it stands in for.
+      const rotation: [number, number, number] =
+        slot === 0 ? [0, Math.PI / 2, 0] : slot === 1 ? [Math.PI / 2, 0, 0] : [0, 0, 0]
+      const w = slot === 0 ? box.size[2] : box.size[0]
+      const h = slot === 1 ? box.size[2] : box.size[1]
+      for (const sign of [1, -1] as const) {
+        const base: [number, number, number] = [box.centre[0], box.centre[1], box.centre[2]]
+        base[slot] += (sign * box.size[slot]) / 2
+        out.push({ slot, sign, geometry: new PlaneGeometry(w, h), rotation, base })
+      }
+    }
+    return out
+  }, [box, axes])
+
+  useEffect(() => () => { for (const w of walls) w.geometry.dispose() }, [walls])
+
+  // One material for all walls: every wall shares one phase, so they share one
+  // opacity, and the frame loop then touches a single object. DoubleSide,
+  // unlike the fill, because a breath that carries a wall past the camera
+  // still has to be readable from behind; depthWrite off, like the fill, so a
+  // translucent plane never punches a hole in what sits behind it.
+  const wallMaterial = useMemo(() => new MeshBasicMaterial({
+    color: ACCENT,
+    transparent: true,
+    opacity: WALL_OPACITY,
+    side: DoubleSide,
+    depthWrite: false,
+    toneMapped: false,
+  }), [])
+  useEffect(() => () => wallMaterial.dispose(), [wallMaterial])
+
+  const wallMeshes = useRef<Array<Mesh | null>>([])
+
+  useFrame((state) => {
+    if (walls.length === 0) return
+    // Free-running phase rather than a start time: the breath is a state, not
+    // an event, and a cycle restarted on every cursor step would stutter.
+    const t = (state.clock.elapsedTime % WALL_CYCLE) / WALL_CYCLE
+    // Ease-out: the wall departs briskly and decelerates as it fades, which
+    // reads as emanating from the box rather than drifting off it.
+    const eased = 1 - (1 - t) ** 3
+    wallMaterial.opacity = WALL_OPACITY * (1 - eased)
+    for (let i = 0; i < walls.length; i++) {
+      const mesh = wallMeshes.current[i]
+      if (!mesh) continue
+      const w = walls[i]
+      mesh.position.set(w.base[0], w.base[1], w.base[2])
+      // One cell exactly: the breath's reach names the lattice unit, so it
+      // reads as "at least one more cell that way", not as vague drift.
+      mesh.position.setComponent(w.slot, w.base[w.slot] + w.sign * eased)
+    }
+  })
 
   if (!box) return null
 
@@ -149,6 +260,21 @@ export function CoveringBox({ axes }: Props): JSX.Element | null {
           opacity={box.clipped ? 0.4 : 0.85}
         />
       </lineSegments>
+      {walls.map((w, i) => (
+        <group key={`${w.slot}${w.sign}`}>
+          <mesh
+            ref={(m) => { wallMeshes.current[i] = m }}
+            geometry={w.geometry}
+            material={wallMaterial}
+            rotation={w.rotation}
+            position={w.base}
+            frustumCulled={false}
+          />
+          {/* The remedy, written on the thing asking for it. Small and the
+              box's own blue: an instruction, not an alert. */}
+          <WorldLabel text="ZOOM OUT" color={ACCENT} at={w.base} px={11} align="center" />
+        </group>
+      ))}
       <WorldLabel text={box.label} color={box.color} at={box.at} offset={[1.5, -1.3, 0]} px={13} />
     </group>
   )

--- a/src/scene/Earth.tsx
+++ b/src/scene/Earth.tsx
@@ -21,6 +21,7 @@
  */
 
 import { useMemo } from 'react'
+import { BackSide } from 'three'
 import { EARTH } from '../lib/palette'
 import { GRID_RADIUS, cellDelta, stepFor, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
@@ -88,11 +89,14 @@ export function Earth({ axes }: Props): JSX.Element | null {
   return (
     <group position={globe.centre}>
       {/* The planet is drawn as wireframe, but it must still be a solid to
-          the depth buffer and the raycaster: this sphere writes depth without
-          colour, so far-hemisphere stops stop showing through the surface,
-          and a click on the globe recentres the orbit on Earth instead of
-          falling through to whatever point cloud is behind it. Slightly
-          under the true radius so surface landfalls are not z-fought away. */}
+          the depth buffer and the raycaster. Back faces only: the far
+          hemisphere writes depth, so the camera sees INTO the globe but not
+          THROUGH it. Culling the near hemisphere keeps labels and stops
+          between the camera and the centre readable instead of cut off by
+          the curvature of a surface that is drawn as sparse wires anyway,
+          and a click on the globe still recentres the orbit on Earth.
+          Slightly under the true radius so surface landfalls are not
+          z-fought away. */}
       <mesh
         onClick={(e) => {
           if (e.delta > 8) return
@@ -102,7 +106,7 @@ export function Earth({ axes }: Props): JSX.Element | null {
         }}
       >
         <sphereGeometry args={[globe.radius * 0.995, 32, 16]} />
-        <meshBasicMaterial colorWrite={false} />
+        <meshBasicMaterial colorWrite={false} side={BackSide} />
       </mesh>
       <mesh>
         <sphereGeometry args={[globe.radius, 48, 24]} />

--- a/src/scene/Earth.tsx
+++ b/src/scene/Earth.tsx
@@ -24,6 +24,7 @@ import { useMemo } from 'react'
 import { EARTH } from '../lib/palette'
 import { GRID_RADIUS, cellDelta, stepFor, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { ownHyperspaceView } from '../store/useHyperspace'
 import { WorldLabel } from './WorldLabel'
 
 /** §9.7: 1 km = 1000 * 2^33 gibsons. */
@@ -86,6 +87,23 @@ export function Earth({ axes }: Props): JSX.Element | null {
 
   return (
     <group position={globe.centre}>
+      {/* The planet is drawn as wireframe, but it must still be a solid to
+          the depth buffer and the raycaster: this sphere writes depth without
+          colour, so far-hemisphere stops stop showing through the surface,
+          and a click on the globe recentres the orbit on Earth instead of
+          falling through to whatever point cloud is behind it. Slightly
+          under the true radius so surface landfalls are not z-fought away. */}
+      <mesh
+        onClick={(e) => {
+          if (e.delta > 8) return
+          e.stopPropagation()
+          ownHyperspaceView()
+          useCyberspace.getState().focusOn({ x: CENTRE, y: CENTRE, z: CENTRE }, 0, 'EARTH')
+        }}
+      >
+        <sphereGeometry args={[globe.radius * 0.995, 32, 16]} />
+        <meshBasicMaterial colorWrite={false} />
+      </mesh>
       <mesh>
         <sphereGeometry args={[globe.radius, 48, 24]} />
         <meshBasicMaterial color={EARTH} wireframe transparent opacity={0.32} toneMapped={false} />

--- a/src/scene/HyperspaceCone.tsx
+++ b/src/scene/HyperspaceCone.tsx
@@ -1,0 +1,184 @@
+/**
+ * HyperspaceCone.tsx — the environment of the line itself.
+ *
+ * DECK-0001: hyperspace is a one-dimensional transit line threaded through
+ * cyberspace by proof of work. While the identity is riding it (transit is
+ * live) or the user is browsing it (scrubbing the line for a destination), the
+ * space should feel categorically different from ordinary movement, the way a
+ * tunnel feels different from a road.
+ *
+ * Drawn as a camera-pinned open cone the camera sits inside, looking down its
+ * throat: the group copies the camera's position AND orientation every frame,
+ * the same infinity trick as BlackSun. Pinning both means the tunnel has no
+ * parallax and no bearing — it is not at a place, it is a state you are in,
+ * which is exactly what being on the line is. The taper (narrow at the eye,
+ * wide at the far end) is what sells forward motion without moving anything:
+ * the flow bands read as rushing toward a distant mouth.
+ *
+ * The material is additive, never writes depth, and renders first
+ * (renderOrder -10), so the world draws over it and the cone can only ever
+ * tint what is behind everything: an aurora, not a wall.
+ */
+
+import { useEffect, useMemo, useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { AdditiveBlending, BackSide, CylinderGeometry, Group, ShaderMaterial } from 'three'
+import { useCyberspace } from '../store/useCyberspace'
+import { useHyperspace } from '../store/useHyperspace'
+
+/**
+ * Tube dimensions, in render units, measured from the camera.
+ *
+ * Bounded by the camera's far plane of 6000 and otherwise arbitrary, like
+ * BlackSun's DISTANCE: nothing is ever between the camera and the tunnel wall,
+ * so the numbers only set the proportions. Narrow at the eye and wide at the
+ * far end, so the wall sweeps past the edges of the view and the flow reads as
+ * motion toward a distant mouth.
+ */
+const NEAR_RADIUS = 250
+const FAR_RADIUS = 900
+const LENGTH = 3500
+const RADIAL_SEGMENTS = 64
+
+/**
+ * Vertex shader: hand the fragment stage a cylindrical coordinate.
+ *
+ * The angle comes from uv.x rather than atan(position.x, position.z). atan
+ * jumps from +pi to -pi at the seam, and interpolating across that jump sweeps
+ * the varying — and with it the hue — backwards through the whole spectrum in
+ * one segment, drawing a rainbow scar down the tube. uv.x runs 0..1 around the
+ * same circle, its seam lands on duplicated vertices, and fract() in the hue
+ * makes 1.0 and 0.0 the same colour, so the wrap is invisible.
+ */
+const vertexShader = /* glsl */ `
+  varying float vAngle;
+  varying float vAlong;
+
+  void main() {
+    vAngle = uv.x * 6.28318530718;
+    // 0 at the near (camera) end, 1 at the far mouth, from the cylinder's own
+    // local Y axis, which the mesh rotation maps onto the view direction.
+    vAlong = position.y / ${LENGTH.toFixed(1)} + 0.5;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`
+
+/**
+ * Fragment shader: a flowing rainbow, kept deliberately faint.
+ *
+ * Hue spirals: angular position plus distance along the tube minus time, so
+ * the colours corkscrew toward the mouth. Two slow sine bands running
+ * lengthwise at different rates give the flow a beat frequency, which reads as
+ * organic motion rather than a scrolling texture. Alpha peaks around 0.22 and
+ * the colour is scaled to about 0.25 before blending: the scene blooms
+ * everything above a luminance of 0.001, so an honest rainbow at full
+ * brightness would white the whole view out. Both ends fade to zero so the
+ * geometry's rims never show; the tunnel appears to continue past the eye and
+ * dissolve at the horizon.
+ *
+ * A custom ShaderMaterial takes no part in scene fog, which matters here: the
+ * scene fogs to black within ~96 units and the tube is 3500 long.
+ */
+const fragmentShader = /* glsl */ `
+  uniform float uTime;
+
+  varying float vAngle;
+  varying float vAlong;
+
+  vec3 hsl2rgb(vec3 c) {
+    vec3 rgb = clamp(abs(mod(c.x * 6.0 + vec3(0.0, 4.0, 2.0), 6.0) - 3.0) - 1.0, 0.0, 1.0);
+    return c.z + c.y * (rgb - 0.5) * (1.0 - abs(2.0 * c.z - 1.0));
+  }
+
+  void main() {
+    float h = fract(vAngle / 6.28318530718 + vAlong * 0.25 - uTime * 0.08);
+    vec3 color = hsl2rgb(vec3(h, 0.85, 0.55));
+
+    // Two lengthwise bands at incommensurate rates: their beat keeps the flow
+    // from ever visibly looping.
+    float bandA = 0.5 + 0.5 * sin(vAlong * 12.0 - uTime * 1.5);
+    float bandB = 0.5 + 0.5 * sin(vAlong * 5.0 + uTime * 0.9);
+
+    // Zero at both rims, so neither end of the open cylinder ever draws an
+    // edge on screen.
+    float ends = smoothstep(0.0, 0.18, vAlong) * (1.0 - smoothstep(0.80, 1.0, vAlong));
+
+    float alpha = (0.10 + 0.12 * (0.6 * bandA + 0.4 * bandB)) * ends;
+    gl_FragColor = vec4(color * 0.45, alpha);
+  }
+`
+
+/**
+ * The tunnel itself, mounted only while the line is active, so its GPU
+ * resources exist exactly as long as they are visible and unmounting is what
+ * disposes them.
+ */
+function Cone(): JSX.Element {
+  const group = useRef<Group>(null)
+
+  // Open-ended: the camera looks straight down the tube and capped ends would
+  // draw discs across the view. Top of the cylinder (local +Y) becomes the far
+  // end under the mesh rotation below, so the top radius is the wide one.
+  const geometry = useMemo(
+    () => new CylinderGeometry(FAR_RADIUS, NEAR_RADIUS, LENGTH, RADIAL_SEGMENTS, 1, true),
+    [],
+  )
+  useEffect(() => () => geometry.dispose(), [geometry])
+
+  const material = useMemo(() => new ShaderMaterial({
+    vertexShader,
+    fragmentShader,
+    uniforms: { uTime: { value: 0 } },
+    // BackSide: the camera is inside the tube, so the inward faces are the
+    // only ones it can see. Additive and depth-silent, so the tunnel can only
+    // brighten what is already there and can never occlude the world.
+    side: BackSide,
+    transparent: true,
+    depthWrite: false,
+    blending: AdditiveBlending,
+  }), [])
+  useEffect(() => () => material.dispose(), [material])
+
+  // Per frame rather than per render, for the same reason as BlackSun: the
+  // camera moves continuously under orbit and the rig's eased follow, neither
+  // of which React sees. Copying the quaternion too is what keeps the tube's
+  // axis on the view direction wherever the orbit points.
+  useFrame((state) => {
+    material.uniforms.uTime.value = state.clock.elapsedTime
+    const g = group.current
+    if (!g) return
+    g.position.copy(state.camera.position)
+    g.quaternion.copy(state.camera.quaternion)
+  })
+
+  return (
+    <group ref={group}>
+      {/*
+        The cylinder's own axis is local Y; rotating -90 degrees about X lays
+        +Y along -Z, the camera's view direction, and the position offset puts
+        the near rim at the eye and the far mouth LENGTH units down the view.
+        Frustum culling is off because the camera lives inside the geometry's
+        bounding volume, the case culling gets wrong.
+      */}
+      <mesh
+        geometry={geometry}
+        material={material}
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, 0, -LENGTH / 2]}
+        renderOrder={-10}
+        frustumCulled={false}
+      />
+    </group>
+  )
+}
+
+export function HyperspaceCone(): JSX.Element | null {
+  // "On the line" is either of two states: the identity has boarded and not
+  // yet arrived (transit), or the user is scrubbing the line for a destination
+  // (scrubHeight). Both are browsing hyperspace, so both get its sky.
+  const inTransit = useCyberspace((s) => s.transit) !== null
+  const scrubbing = useHyperspace((s) => s.scrubHeight) !== null
+
+  if (!inTransit && !scrubbing) return null
+  return <Cone />
+}

--- a/src/scene/HyperspaceCone.tsx
+++ b/src/scene/HyperspaceCone.tsx
@@ -3,8 +3,9 @@
  *
  * DECK-0001: hyperspace is a one-dimensional transit line threaded through
  * cyberspace by proof of work. While the identity is riding it (transit is
- * set) or the user is scrubbing the line (scrubHeight is set), the
- * environment should feel different.
+ * set) the environment should feel different; browsing the line instead gets
+ * per-block bursts (StopBurst), so the streaks read as living inside the
+ * blocks and boarding puts you among them.
  *
  * The first version was a full-screen additive cone: every pixel of every
  * frame paid transparent overdraw and then fed the bloom pass, which is why
@@ -23,7 +24,6 @@ import {
   ShaderMaterial,
 } from 'three'
 import { useCyberspace } from '../store/useCyberspace'
-import { useHyperspace } from '../store/useHyperspace'
 
 /** How many streaks; one draw call regardless. */
 const STREAKS = 420
@@ -80,12 +80,11 @@ const fragmentShader = /* glsl */ `
 `
 
 export function HyperspaceCone(): JSX.Element | null {
-  // The sky shows while the identity has boarded the line and not yet
-  // arrived (transit), or the user is scrubbing the line for a destination
-  // (scrubHeight). Both are browsing hyperspace, so both get its sky.
-  const inTransit = useCyberspace((s) => s.transit) !== null
-  const scrubbing = useHyperspace((s) => s.scrubHeight) !== null
-  const active = inTransit || scrubbing
+  // The sky belongs to being IN hyperspace: it shows only while boarded and
+  // not yet arrived. Browsing the line gets per-block bursts (StopBurst)
+  // instead, so the streaks read as living inside the blocks and boarding
+  // puts you among them.
+  const active = useCyberspace((s) => s.transit) !== null
 
   const geometry = useMemo(() => {
     const seeds = new Float32Array(STREAKS * 2)

--- a/src/scene/HyperspaceCone.tsx
+++ b/src/scene/HyperspaceCone.tsx
@@ -1,184 +1,151 @@
 /**
- * HyperspaceCone.tsx — the environment of the line itself.
+ * HyperspaceCone.tsx - the hyperspace sky, now as warp streaks.
  *
  * DECK-0001: hyperspace is a one-dimensional transit line threaded through
  * cyberspace by proof of work. While the identity is riding it (transit is
- * live) or the user is browsing it (scrubbing the line for a destination), the
- * space should feel categorically different from ordinary movement, the way a
- * tunnel feels different from a road.
+ * set) or the user is scrubbing the line (scrubHeight is set), the
+ * environment should feel different.
  *
- * Drawn as a camera-pinned open cone the camera sits inside, looking down its
- * throat: the group copies the camera's position AND orientation every frame,
- * the same infinity trick as BlackSun. Pinning both means the tunnel has no
- * parallax and no bearing — it is not at a place, it is a state you are in,
- * which is exactly what being on the line is. The taper (narrow at the eye,
- * wide at the far end) is what sells forward motion without moving anything:
- * the flow bands read as rushing toward a distant mouth.
- *
- * The material is additive, never writes depth, and renders first
- * (renderOrder -10), so the world draws over it and the cone can only ever
- * tint what is behind everything: an aurora, not a wall.
+ * The first version was a full-screen additive cone: every pixel of every
+ * frame paid transparent overdraw and then fed the bloom pass, which is why
+ * it dragged the whole browser. This version is a single LineSegments draw
+ * call: a few hundred thin rainbow streaks around the periphery rushing past
+ * the camera, positioned entirely in the vertex shader, so the fill cost is
+ * a few thousand line pixels instead of the whole screen.
  */
-
 import { useEffect, useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
-import { AdditiveBlending, BackSide, CylinderGeometry, Group, ShaderMaterial } from 'three'
+import {
+  AdditiveBlending,
+  BufferGeometry,
+  Float32BufferAttribute,
+  Group,
+  ShaderMaterial,
+} from 'three'
 import { useCyberspace } from '../store/useCyberspace'
 import { useHyperspace } from '../store/useHyperspace'
 
-/**
- * Tube dimensions, in render units, measured from the camera.
- *
- * Bounded by the camera's far plane of 6000 and otherwise arbitrary, like
- * BlackSun's DISTANCE: nothing is ever between the camera and the tunnel wall,
- * so the numbers only set the proportions. Narrow at the eye and wide at the
- * far end, so the wall sweeps past the edges of the view and the flow reads as
- * motion toward a distant mouth.
- */
-const NEAR_RADIUS = 250
-const FAR_RADIUS = 900
-const LENGTH = 3500
-const RADIAL_SEGMENTS = 64
+/** How many streaks; one draw call regardless. */
+const STREAKS = 420
+/** Depth of the field along the view axis, in render units. */
+const RANGE = 2200
+/** The streak ring: clear in the middle so the world stays legible. */
+const R_MIN = 120
+const R_MAX = 520
 
-/**
- * Vertex shader: hand the fragment stage a cylindrical coordinate.
- *
- * The angle comes from uv.x rather than atan(position.x, position.z). atan
- * jumps from +pi to -pi at the seam, and interpolating across that jump sweeps
- * the varying — and with it the hue — backwards through the whole spectrum in
- * one segment, drawing a rainbow scar down the tube. uv.x runs 0..1 around the
- * same circle, its seam lands on duplicated vertices, and fract() in the hue
- * makes 1.0 and 0.0 the same colour, so the wrap is invisible.
- */
 const vertexShader = /* glsl */ `
-  varying float vAngle;
-  varying float vAlong;
+  attribute float aSeed;
+  attribute float aAngle;
+  attribute float aRadius;
+  attribute float aLen;
+  attribute float aEnd;
+  uniform float uTime;
+  varying float vSeed;
+  varying float vFade;
 
   void main() {
-    vAngle = uv.x * 6.28318530718;
-    // 0 at the near (camera) end, 1 at the far mouth, from the cylinder's own
-    // local Y axis, which the mesh rotation maps onto the view direction.
-    vAlong = position.y / ${LENGTH.toFixed(1)} + 0.5;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    // The streak's head position cycles toward the camera; the tail trails
+    // behind it by aLen. Everything lives in camera-pinned group space where
+    // -Z is ahead.
+    float speed = 260.0 + aSeed * 340.0;
+    float zHead = -${RANGE.toFixed(1)} + mod(aSeed * ${RANGE.toFixed(1)} + uTime * speed, ${RANGE.toFixed(1)});
+    float z = zHead - aEnd * aLen;
+    vec3 pos = vec3(cos(aAngle) * aRadius, sin(aAngle) * aRadius, z);
+    // Fade in at the far end, out just before the camera plane.
+    float depth = -z / ${RANGE.toFixed(1)};
+    vFade = smoothstep(0.0, 0.12, depth) * (1.0 - smoothstep(0.82, 1.0, depth));
+    vSeed = aSeed;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
   }
 `
 
-/**
- * Fragment shader: a flowing rainbow, kept deliberately faint.
- *
- * Hue spirals: angular position plus distance along the tube minus time, so
- * the colours corkscrew toward the mouth. Two slow sine bands running
- * lengthwise at different rates give the flow a beat frequency, which reads as
- * organic motion rather than a scrolling texture. Alpha peaks around 0.22 and
- * the colour is scaled to about 0.25 before blending: the scene blooms
- * everything above a luminance of 0.001, so an honest rainbow at full
- * brightness would white the whole view out. Both ends fade to zero so the
- * geometry's rims never show; the tunnel appears to continue past the eye and
- * dissolve at the horizon.
- *
- * A custom ShaderMaterial takes no part in scene fog, which matters here: the
- * scene fogs to black within ~96 units and the tube is 3500 long.
- */
 const fragmentShader = /* glsl */ `
   uniform float uTime;
+  varying float vSeed;
+  varying float vFade;
 
-  varying float vAngle;
-  varying float vAlong;
-
-  vec3 hsl2rgb(vec3 c) {
-    vec3 rgb = clamp(abs(mod(c.x * 6.0 + vec3(0.0, 4.0, 2.0), 6.0) - 3.0) - 1.0, 0.0, 1.0);
-    return c.z + c.y * (rgb - 0.5) * (1.0 - abs(2.0 * c.z - 1.0));
+  vec3 hue2rgb(float h) {
+    vec3 p = abs(fract(h + vec3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0);
+    return clamp(p - 1.0, 0.0, 1.0);
   }
 
   void main() {
-    float h = fract(vAngle / 6.28318530718 + vAlong * 0.25 - uTime * 0.08);
-    vec3 color = hsl2rgb(vec3(h, 0.85, 0.55));
-
-    // Two lengthwise bands at incommensurate rates: their beat keeps the flow
-    // from ever visibly looping.
-    float bandA = 0.5 + 0.5 * sin(vAlong * 12.0 - uTime * 1.5);
-    float bandB = 0.5 + 0.5 * sin(vAlong * 5.0 + uTime * 0.9);
-
-    // Zero at both rims, so neither end of the open cylinder ever draws an
-    // edge on screen.
-    float ends = smoothstep(0.0, 0.18, vAlong) * (1.0 - smoothstep(0.80, 1.0, vAlong));
-
-    float alpha = (0.10 + 0.12 * (0.6 * bandA + 0.4 * bandB)) * ends;
-    gl_FragColor = vec4(color * 0.45, alpha);
+    // Each streak keeps one hue, slowly drifting, so the field reads as a
+    // moving rainbow without strobing. Kept dim: bloom amplifies everything.
+    vec3 color = hue2rgb(fract(vSeed * 7.13 + uTime * 0.03));
+    float a = vFade * 0.55;
+    if (a < 0.02) discard;
+    gl_FragColor = vec4(color * 0.7, a);
   }
 `
 
-/**
- * The tunnel itself, mounted only while the line is active, so its GPU
- * resources exist exactly as long as they are visible and unmounting is what
- * disposes them.
- */
-function Cone(): JSX.Element {
-  const group = useRef<Group>(null)
+export function HyperspaceCone(): JSX.Element | null {
+  // The sky shows while the identity has boarded the line and not yet
+  // arrived (transit), or the user is scrubbing the line for a destination
+  // (scrubHeight). Both are browsing hyperspace, so both get its sky.
+  const inTransit = useCyberspace((s) => s.transit) !== null
+  const scrubbing = useHyperspace((s) => s.scrubHeight) !== null
+  const active = inTransit || scrubbing
 
-  // Open-ended: the camera looks straight down the tube and capped ends would
-  // draw discs across the view. Top of the cylinder (local +Y) becomes the far
-  // end under the mesh rotation below, so the top radius is the wide one.
-  const geometry = useMemo(
-    () => new CylinderGeometry(FAR_RADIUS, NEAR_RADIUS, LENGTH, RADIAL_SEGMENTS, 1, true),
+  const geometry = useMemo(() => {
+    const seeds = new Float32Array(STREAKS * 2)
+    const angles = new Float32Array(STREAKS * 2)
+    const radii = new Float32Array(STREAKS * 2)
+    const lens = new Float32Array(STREAKS * 2)
+    const ends = new Float32Array(STREAKS * 2)
+    const positions = new Float32Array(STREAKS * 2 * 3) // shader-computed; attribute must exist
+    for (let i = 0; i < STREAKS; i++) {
+      const seed = (i * 0.6180339887) % 1 // golden-ratio spread, deterministic
+      const angle = seed * Math.PI * 2 * 13.7
+      const radius = R_MIN + ((i * 0.7548776662) % 1) * (R_MAX - R_MIN)
+      const len = 90 + ((i * 0.5698402911) % 1) * 260
+      for (const end of [0, 1]) {
+        const v = i * 2 + end
+        seeds[v] = seed
+        angles[v] = angle
+        radii[v] = radius
+        lens[v] = len
+        ends[v] = end
+      }
+    }
+    const geo = new BufferGeometry()
+    geo.setAttribute('position', new Float32BufferAttribute(positions, 3))
+    geo.setAttribute('aSeed', new Float32BufferAttribute(seeds, 1))
+    geo.setAttribute('aAngle', new Float32BufferAttribute(angles, 1))
+    geo.setAttribute('aRadius', new Float32BufferAttribute(radii, 1))
+    geo.setAttribute('aLen', new Float32BufferAttribute(lens, 1))
+    geo.setAttribute('aEnd', new Float32BufferAttribute(ends, 1))
+    return geo
+  }, [])
+
+  const material = useMemo(
+    () =>
+      new ShaderMaterial({
+        vertexShader,
+        fragmentShader,
+        uniforms: { uTime: { value: 0 } },
+        transparent: true,
+        depthWrite: false,
+        blending: AdditiveBlending,
+      }),
     [],
   )
-  useEffect(() => () => geometry.dispose(), [geometry])
 
-  const material = useMemo(() => new ShaderMaterial({
-    vertexShader,
-    fragmentShader,
-    uniforms: { uTime: { value: 0 } },
-    // BackSide: the camera is inside the tube, so the inward faces are the
-    // only ones it can see. Additive and depth-silent, so the tunnel can only
-    // brighten what is already there and can never occlude the world.
-    side: BackSide,
-    transparent: true,
-    depthWrite: false,
-    blending: AdditiveBlending,
-  }), [])
-  useEffect(() => () => material.dispose(), [material])
+  useEffect(() => () => { geometry.dispose(); material.dispose() }, [geometry, material])
 
-  // Per frame rather than per render, for the same reason as BlackSun: the
-  // camera moves continuously under orbit and the rig's eased follow, neither
-  // of which React sees. Copying the quaternion too is what keeps the tube's
-  // axis on the view direction wherever the orbit points.
+  const group = useRef<Group>(null)
   useFrame((state) => {
-    material.uniforms.uTime.value = state.clock.elapsedTime
     const g = group.current
     if (!g) return
     g.position.copy(state.camera.position)
     g.quaternion.copy(state.camera.quaternion)
+    material.uniforms.uTime.value = state.clock.elapsedTime
   })
 
+  if (!active) return null
   return (
     <group ref={group}>
-      {/*
-        The cylinder's own axis is local Y; rotating -90 degrees about X lays
-        +Y along -Z, the camera's view direction, and the position offset puts
-        the near rim at the eye and the far mouth LENGTH units down the view.
-        Frustum culling is off because the camera lives inside the geometry's
-        bounding volume, the case culling gets wrong.
-      */}
-      <mesh
-        geometry={geometry}
-        material={material}
-        rotation={[-Math.PI / 2, 0, 0]}
-        position={[0, 0, -LENGTH / 2]}
-        renderOrder={-10}
-        frustumCulled={false}
-      />
+      <lineSegments geometry={geometry} material={material} renderOrder={-10} frustumCulled={false} />
     </group>
   )
-}
-
-export function HyperspaceCone(): JSX.Element | null {
-  // "On the line" is either of two states: the identity has boarded and not
-  // yet arrived (transit), or the user is scrubbing the line for a destination
-  // (scrubHeight). Both are browsing hyperspace, so both get its sky.
-  const inTransit = useCyberspace((s) => s.transit) !== null
-  const scrubbing = useHyperspace((s) => s.scrubHeight) !== null
-
-  if (!inTransit && !scrubbing) return null
-  return <Cone />
 }

--- a/src/scene/PathTrail.tsx
+++ b/src/scene/PathTrail.tsx
@@ -25,6 +25,7 @@ export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
   const spectate = useCyberspace((s) => s.spectate)
   const anchor = useCyberspace((s) => s.anchor)
   const exploreIndex = useCyberspace((s) => s.exploreIndex)
+  const focus = useCyberspace((s) => s.focus)
 
   // Whose trail: the spectated avatar's chain, else your own.
   const positionHistory = useMemo(
@@ -69,7 +70,7 @@ export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
   // the head: in history nothing is travelling.
   const lastVertex = useRef<Float32Array | null>(null)
   useFrame(() => {
-    if (exploreIndex !== null || spectate) return
+    if (exploreIndex !== null || spectate || focus !== null) return
     const attr = geometry?.walked?.attributes.position
     if (!attr) return
     const arr = attr.array as Float32Array
@@ -82,7 +83,12 @@ export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
     attr.needsUpdate = true
   })
 
-  if (!geometry) return null
+  // A focus view (a hyperspace stop, EARTH, a shard) anchors the scene far
+  // from the chain, and the head-riding vertex above would pin the trail's
+  // last point to the render origin: a red line from your history straight
+  // into whatever is being viewed. The avatar hides under a focus; its trail
+  // does too.
+  if (!geometry || focus !== null) return null
 
   return (
     <>

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -31,6 +31,7 @@ import { GRID_RADIUS, claimScreenAxes, originShift, type Position } from '../lib
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { cameraPose } from '../lib/cameraPose'
 import { useTerrainVolume } from '../hooks/useTerrainVolume'
+import { useHyperspace } from '../store/useHyperspace'
 import { useViewWindow } from '../hooks/useViewWindow'
 import { useTargets } from '../hooks/useTargets'
 import { Avatar } from './Avatar'
@@ -42,6 +43,7 @@ import { Cursor } from './Cursor'
 import { HyperspaceCone } from './HyperspaceCone'
 import { StopField } from './StopField'
 import { StopCubes } from './StopCubes'
+import { StopBurst } from './StopBurst'
 import { PathTrail } from './PathTrail'
 import { Rooms } from './Rooms'
 import { SectorBox } from './SectorBox'
@@ -74,7 +76,10 @@ function World(): JSX.Element {
   const axes = useMemo(() => useCyberspace.getState().axes(), [view])
 
   const win = useViewWindow()
-  const volume = useTerrainVolume(win, axes)
+  // The gibson K field is meaningless wallpaper while an Earth or hyperspace
+  // view holds the camera, and its scans are real CPU: suspend both together.
+  const hyperView = useHyperspace((s) => s.viewOwned || s.scrubHeight !== null)
+  const volume = useTerrainVolume(win, axes, hyperView)
   const targets = useTargets()
 
   return (
@@ -84,7 +89,7 @@ function World(): JSX.Element {
       <TargetProjector axes={axes} targets={targets} />
       {/* At infinity, so it draws behind everything regardless of tree order. */}
       <BlackSun axes={axes} />
-      <ShaderPointField volume={volume} win={win} />
+      {!hyperView && <ShaderPointField volume={volume} win={win} />}
       <Rooms axes={axes} />
       <SectorBox axes={axes} />
       <Earth axes={axes} />
@@ -92,6 +97,7 @@ function World(): JSX.Element {
           planet: ports in ideaspace, landfalls on Earth's surface. */}
       <StopField axes={axes} />
       <StopCubes axes={axes} />
+      <StopBurst axes={axes} />
       <CoveringBox axes={axes} />
       <CrossingFlash axes={axes} />
       <PathTrail axes={axes} scaleExp={scaleExp} />

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -214,6 +214,12 @@ function Rig(): JSX.Element {
   const genesisId = useCyberspace((s) => s.genesisId)
   const focusPubkey = useCyberspace((s) => s.focusPubkey())
   const focusPoint = useCyberspace((s) => (s.focus ? s.focus.position.x.toString() : ''))
+  // Scrubbing the chain moves the anchor along history in steps that can be
+  // thousands of cells: the camera would stay parked (the orbit clamp holds
+  // it at maxDistance) while the place being looked at runs away. History is
+  // a cut, not a journey, so every explore step re-frames at START_DISTANCE,
+  // the same framing the app loads with.
+  const exploreIndex = useCyberspace((s) => s.exploreIndex)
   const controls = useRef<{
     object: { position: Vector3 }
     target: Vector3
@@ -271,7 +277,8 @@ function Rig(): JSX.Element {
     locked.current = true
     prevOrigin.current = null
     c.update()
-  }, [view, genesisId, focusPubkey, focusPoint])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view, genesisId, focusPubkey, focusPoint, exploreIndex])
 
   useFrame((_, dt) => {
     const c = controls.current

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -39,6 +39,8 @@ import { CoveringBox } from './CoveringBox'
 import { CrossingFlash } from './CrossingFlash'
 import { Earth } from './Earth'
 import { Cursor } from './Cursor'
+import { HyperspaceCone } from './HyperspaceCone'
+import { StopField } from './StopField'
 import { PathTrail } from './PathTrail'
 import { Rooms } from './Rooms'
 import { SectorBox } from './SectorBox'
@@ -85,6 +87,9 @@ function World(): JSX.Element {
       <Rooms axes={axes} />
       <SectorBox axes={axes} />
       <Earth axes={axes} />
+      {/* The hyperspace line's stops, placed true-size like the cage and the
+          planet: ports in ideaspace, landfalls on Earth's surface. */}
+      <StopField axes={axes} />
       <CoveringBox axes={axes} />
       <CrossingFlash axes={axes} />
       <PathTrail axes={axes} scaleExp={scaleExp} />
@@ -313,6 +318,9 @@ export function Scene(): JSX.Element {
       <CellMetric />
       <ScreenAxes />
       <World />
+      {/* Camera-pinned, so it lives outside the world group: hyperspace is a
+          state, not a place. Mounts only while riding or browsing the line. */}
+      <HyperspaceCone />
       {/*
         Bloom is what makes line geometry read as emitted light, and it is also
         by far the most expensive thing on screen: measured at 6fps with levels 9

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -176,6 +176,7 @@ function ScreenAxes(): null {
  * a React render per frame to move one HUD element is not worth it.
  */
 function CellMetric(): null {
+  const lastCellPx = useRef<string | null>(null)
   useFrame((state) => {
     // Share the camera's orientation with the compass, which renders in its own
     // Canvas and cannot reach this one's camera.
@@ -196,7 +197,13 @@ function CellMetric(): null {
     const [tx, ty, tz] = useCyberspace.getState().cursorOffset()
     const dist = Math.max(0.001, cam.position.distanceTo({ x: tx, y: ty, z: tz } as never))
     const projScale = state.size.height / (2 * Math.tan((cam.fov * Math.PI) / 360))
-    document.documentElement.style.setProperty('--cell-px', `${(projScale / dist).toFixed(2)}px`)
+    // Writing the same value re-dirties style on the root element; with the
+    // camera at rest that was a per-frame style pass for nothing.
+    const next = `${(projScale / dist).toFixed(2)}px`
+    if (next !== lastCellPx.current) {
+      lastCellPx.current = next
+      document.documentElement.style.setProperty('--cell-px', next)
+    }
   })
   return null
 }
@@ -362,7 +369,9 @@ export function Scene(): JSX.Element {
     <Canvas
       camera={{ fov: 55, position: [0, 0, START_DISTANCE], near: 0.05, far: 6000 }}
       dpr={[1, 2]}
-      gl={{ antialias: true }}
+      // high-performance: ask for the discrete GPU and against power-save
+      // clocking, so a visually quiet frame still ships on time.
+      gl={{ antialias: true, powerPreference: 'high-performance' }}
       style={{ background: BG }}
       frameloop="always"
     >

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -41,6 +41,7 @@ import { Earth } from './Earth'
 import { Cursor } from './Cursor'
 import { HyperspaceCone } from './HyperspaceCone'
 import { StopField } from './StopField'
+import { StopCubes } from './StopCubes'
 import { PathTrail } from './PathTrail'
 import { Rooms } from './Rooms'
 import { SectorBox } from './SectorBox'
@@ -90,6 +91,7 @@ function World(): JSX.Element {
       {/* The hyperspace line's stops, placed true-size like the cage and the
           planet: ports in ideaspace, landfalls on Earth's surface. */}
       <StopField axes={axes} />
+      <StopCubes axes={axes} />
       <CoveringBox axes={axes} />
       <CrossingFlash axes={axes} />
       <PathTrail axes={axes} scaleExp={scaleExp} />

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -27,7 +27,7 @@ import { useEffect, useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Vector3 } from 'three'
 import { BG } from '../lib/palette'
-import { GRID_RADIUS, claimScreenAxes, originShift, type Position } from '../lib/space'
+import { GRID_RADIUS, cellDelta, claimScreenAxes, originShift, type Position } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { cameraPose } from '../lib/cameraPose'
 import { useTerrainVolume } from '../hooks/useTerrainVolume'
@@ -68,6 +68,17 @@ const START_DISTANCE = 26
  * is applied whole, see the rig.
  */
 const FOLLOW_TAU = 0.09
+
+/**
+ * A click or scrub inside an owned hyperspace view is a move within one view
+ * of the world, not a change of subject, so the camera flies instead of
+ * cutting. The stretched time constant does the flying; the cell bound keeps
+ * a cross-space jump, whose start would be off in the dark anyway, an honest
+ * cut.
+ */
+const GLIDE_TAU = 0.45
+const GLIDE_SECONDS = 1.6
+const GLIDE_MAX_CELLS = 300
 
 function World(): JSX.Element {
   const view = useCyberspace((s) => s.view)
@@ -217,6 +228,11 @@ function Rig(): JSX.Element {
   const smooth = useRef(new Vector3())
   const prevOrigin = useRef<Position | null>(null)
   const prevScale = useRef(-1)
+  // Seconds of stretched follow left in a hyperspace fly-to, and the frame
+  // the previous focus effect saw, so the next one can tell a move within
+  // the same view from a change of subject.
+  const glideLeft = useRef(0)
+  const flyFrom = useRef<{ anchor: Position; plane: number; scaleExp: number; owned: boolean } | null>(null)
 
   // Re-framed on an axis snap and on a respawn. A respawn moves the render
   // origin home in one step, and the per-frame shift below would faithfully
@@ -226,7 +242,29 @@ function Rig(): JSX.Element {
   useEffect(() => {
     const c = controls.current
     if (!c) return
-    const [x, y, z] = useCyberspace.getState().cursorOffset()
+    const s = useCyberspace.getState()
+    const owned = useHyperspace.getState().viewOwned
+    const prev = flyFrom.current
+    flyFrom.current = { anchor: s.anchor, plane: s.anchorPlane, scaleExp: s.scaleExp, owned }
+    // Same plane, same zoom, both frames owned by hyperspace: skip the
+    // re-frame. The per-frame origin shift below carries the camera into the
+    // new frame still looking at the old stop, and the stretched follow
+    // eases it onto the new one, which is the fly.
+    if (owned && prev !== null && prev.owned && prev.plane === s.anchorPlane &&
+        prev.scaleExp === s.scaleExp && s.focus !== null) {
+      const cells = Math.max(
+        Math.abs(cellDelta(s.anchor.x, prev.anchor.x, s.scaleExp)),
+        Math.abs(cellDelta(s.anchor.y, prev.anchor.y, s.scaleExp)),
+        Math.abs(cellDelta(s.anchor.z, prev.anchor.z, s.scaleExp)),
+      )
+      if (cells > 0 && cells < GLIDE_MAX_CELLS) {
+        glideLeft.current = GLIDE_SECONDS
+        locked.current = true
+        return
+      }
+    }
+    glideLeft.current = 0
+    const [x, y, z] = s.cursorOffset()
     smooth.current.set(x, y, z)
     c.target.copy(smooth.current)
     c.object.position.set(x, y, z + START_DISTANCE)
@@ -275,8 +313,11 @@ function Rig(): JSX.Element {
     prevScale.current = s.scaleExp
 
     // Cursor movement, by contrast, IS motion, and eases. Exponential rather
-    // than a fixed fraction so the rate does not change with frame rate.
-    const k = 1 - Math.exp(-dt / FOLLOW_TAU)
+    // than a fixed fraction so the rate does not change with frame rate. A
+    // hyperspace fly-to stretches the time constant so the camera sails to
+    // the selected stop instead of flicking.
+    if (glideLeft.current > 0) glideLeft.current = Math.max(0, glideLeft.current - dt)
+    const k = 1 - Math.exp(-dt / (glideLeft.current > 0 ? GLIDE_TAU : FOLLOW_TAU))
     const dx = (tx - smooth.current.x) * k
     const dy = (ty - smooth.current.y) * k
     const dz = (tz - smooth.current.z) * k

--- a/src/scene/ShaderPointField.tsx
+++ b/src/scene/ShaderPointField.tsx
@@ -30,6 +30,29 @@ interface Props {
 }
 
 /**
+ * Seconds over which a newly loaded point fades in.
+ *
+ * Terrain now arrives in a burst when the cursor settles, and popping several
+ * thousand points on in a single frame reads as a flash. A quarter second is
+ * long enough to read as the field resolving out of the dark and short enough
+ * that it never feels behind the cursor it just caught up with. The ramp is
+ * one way, up, and each cell rides it exactly once, so nothing strobes and the
+ * effect stays acceptable under prefers-reduced-motion.
+ */
+const FADE_IN_S = 0.25
+
+/**
+ * When each visible cell first appeared, in performance.now() seconds, keyed
+ * by its cell offset from the anchor. Carried across geometry rebuilds so a
+ * cell that survives a rebuild keeps its age and stays solid; only genuinely
+ * new cells fade in. Rebuilding the map from the cells actually emitted keeps
+ * it from outgrowing one volume. A module singleton because the registry has
+ * to outlive any single geometry, and rebuilding it is idempotent, which is
+ * what StrictMode's doubled render requires.
+ */
+let births = new Map<string, number>()
+
+/**
  * Vertex shader: point size in pixels, from K.
  *
  * K = 0 has no size and disappears, as do cells outside the universe, which
@@ -38,6 +61,9 @@ interface Props {
  */
 const vertexShader = /* glsl */ `
   attribute float aK;
+  attribute float aBirth;
+  uniform float uNow;
+  uniform float uFadeIn;
   uniform float uTime;
   uniform float uFarPx;
   uniform float uNearPx;
@@ -71,6 +97,12 @@ const vertexShader = /* glsl */ `
     // expose the face it overhung.
     float rim = distance(position, uCentre);
     vFade = 1.0 - smoothstep(uFadeStart, uFadeRadius, rim);
+
+    // Newly loaded cells resolve in over uFadeIn seconds instead of popping.
+    // aBirth is fixed at the cell's first appearance and survives rebuilds, so
+    // a cell that was already visible never dips or flashes.
+    float grow = clamp((uNow - aBirth) / uFadeIn, 0.0, 1.0);
+    vFade *= grow * grow * (3.0 - 2.0 * grow);
 
     // K = 0 keeps zero size and disappears, which is also how cells outside the
     // universe read, since they arrive as 0.
@@ -187,6 +219,11 @@ function buildGeometry(volume: TerrainVolume, win: ViewWindow): BufferGeometry {
 
   const positions = new Float32Array(count * 3)
   const kValues = new Float32Array(count)
+  const birthValues = new Float32Array(count)
+
+  // On the same clock the uNow uniform runs on, so ages line up exactly.
+  const now = performance.now() / 1000
+  const nextBirths = new Map<string, number>()
 
   let v = 0
   for (let depth = 0; depth < N; depth++) {
@@ -196,18 +233,29 @@ function buildGeometry(volume: TerrainVolume, win: ViewWindow): BufferGeometry {
         const k = values[slice + col]
         if (k === UNKNOWN) continue
 
-        positions[v * 3] = win.right + (col - R)
-        positions[v * 3 + 1] = win.up + (row - R)
-        positions[v * 3 + 2] = win.out + (depth - R)
+        const x = win.right + (col - R)
+        const y = win.up + (row - R)
+        const z = win.out + (depth - R)
+        positions[v * 3] = x
+        positions[v * 3 + 1] = y
+        positions[v * 3 + 2] = z
         kValues[v] = k
+
+        // First seen now, or however long ago the registry remembers.
+        const key = `${x},${y},${z}`
+        const born = births.get(key) ?? now
+        nextBirths.set(key, born)
+        birthValues[v] = born
         v++
       }
     }
   }
+  births = nextBirths
 
   const geometry = new BufferGeometry()
   geometry.setAttribute('position', new Float32BufferAttribute(positions, 3))
   geometry.setAttribute('aK', new Float32BufferAttribute(kValues, 1))
+  geometry.setAttribute('aBirth', new Float32BufferAttribute(birthValues, 1))
 
   // Lets the browser verifier read what actually reached the GPU.
   if (import.meta.env.DEV) {
@@ -233,6 +281,10 @@ export function ShaderPointField({ volume, win }: Props): JSX.Element {
     fragmentShader,
     uniforms: {
       uTime: { value: 0 },
+      /** The births clock, in performance.now() seconds; see buildGeometry. */
+      uNow: { value: performance.now() / 1000 },
+      /** How long a newly loaded point takes to reach full alpha. */
+      uFadeIn: { value: FADE_IN_S },
       // Small and flat across the common K values, growing sharply at the top.
       /** Diameter of an ordinary gibson, in CSS pixels. The field is dust. */
       uFarPx: { value: 1.3 },
@@ -264,6 +316,10 @@ export function ShaderPointField({ volume, win }: Props): JSX.Element {
     if (!mat.uniforms) return
 
     mat.uniforms.uTime.value = state.clock.elapsedTime
+
+    // The fade-in ages against the same clock buildGeometry stamped births
+    // with, which the r3f clock is not: it starts at zero and can be paused.
+    mat.uniforms.uNow.value = performance.now() / 1000
 
     // Focus is what the camera orbits: the cursor. Live, so the magnification
     // under the cursor keeps up with the keypress.

--- a/src/scene/StopBurst.tsx
+++ b/src/scene/StopBurst.tsx
@@ -4,15 +4,16 @@
  * Setting a stop as the destination emits a one-shot radial burst of rainbow
  * streaks from its cube, fading in about a second and a half. Your station
  * (the stop nearest your avatar, the one boarding sets you down at) instead
- * pulses the same burst continuously while you are viewing it: that block is
- * your entry to the line, so the lines never quite leave it. The full
- * surrounding warp (HyperspaceCone) stays reserved for actually being in
- * transit, so the three read together as: the lines live inside the blocks,
- * the ones at your door keep spilling out, and boarding puts you among them.
+ * wears a continuous aura while you are viewing it: the same streaks, each
+ * cycling outward on its own phase like the transit warp's, fading as they
+ * get a little way from the block, so the flow is constant and smooth
+ * rather than a synchronized pulse. That block is your entry to the line;
+ * the lines never quite leave it. The full surrounding warp (HyperspaceCone)
+ * stays reserved for actually being in transit.
  *
- * One LineSegments draw call per burst (at most two: the station pulse and a
- * destination shot); positions come from the vertex shader, so a burst
- * allocates nothing per frame.
+ * One LineSegments draw call per emitter (at most two: the station aura and
+ * a destination shot); positions come from the vertex shader, so nothing is
+ * allocated per frame.
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useFrame } from '@react-three/fiber'
@@ -68,19 +69,34 @@ const fragmentShader = /* glsl */ `
   }
 `
 
-/** One emitting block: its own material (uAge is per-burst), shared shape. */
-function BurstLines({
-  centre,
-  bornAt,
-  loop,
-  onDone,
-}: {
-  centre: [number, number, number]
-  bornAt: number
-  loop?: boolean
-  onDone?: () => void
-}): JSX.Element {
-  const geometry = useMemo(() => {
+/** The aura: per-streak phase, so the flow never restarts as a whole. */
+const auraVertexShader = /* glsl */ `
+  attribute vec3 aDir;
+  attribute float aSeed;
+  attribute float aEnd;
+  uniform float uTime;
+  varying float vSeed;
+  varying float vFade;
+
+  void main() {
+    // Each streak cycles outward on its own phase: the transit warp's trick,
+    // pointed radially out of one block, so the emission is constant and
+    // smooth instead of a synchronized pulse.
+    float rate = 0.30 + aSeed * 0.35;
+    float travel = fract(aSeed * 13.7 + uTime * rate);
+    float reach = ${REACH.toFixed(1)} * (0.5 + aSeed * 0.5);
+    float head = 0.15 + travel * reach;
+    float len = (0.35 + aSeed * 0.8) * (1.0 - 0.55 * travel);
+    vec3 pos = aDir * (head - aEnd * len);
+    // Born quietly at the block, gone before the tip of its reach: distance
+    // from the block is the whole fade axis.
+    vFade = smoothstep(0.0, 0.08, travel) * (1.0 - travel) * (1.0 - travel);
+    vSeed = aSeed;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+  }
+`
+
+function makeBurstGeometry(): BufferGeometry {
     const dirs = new Float32Array(STREAKS * 2 * 3)
     const seeds = new Float32Array(STREAKS * 2)
     const ends = new Float32Array(STREAKS * 2)
@@ -101,14 +117,25 @@ function BurstLines({
         ends[v] = end
       }
     }
-    const geo = new BufferGeometry()
-    geo.setAttribute('position', new Float32BufferAttribute(positions, 3))
-    geo.setAttribute('aDir', new Float32BufferAttribute(dirs, 3))
-    geo.setAttribute('aSeed', new Float32BufferAttribute(seeds, 1))
-    geo.setAttribute('aEnd', new Float32BufferAttribute(ends, 1))
-    return geo
-  }, [])
+  const geo = new BufferGeometry()
+  geo.setAttribute('position', new Float32BufferAttribute(positions, 3))
+  geo.setAttribute('aDir', new Float32BufferAttribute(dirs, 3))
+  geo.setAttribute('aSeed', new Float32BufferAttribute(seeds, 1))
+  geo.setAttribute('aEnd', new Float32BufferAttribute(ends, 1))
+  return geo
+}
 
+/** The one-shot: a block was just chosen as the destination. */
+function BurstLines({
+  centre,
+  bornAt,
+  onDone,
+}: {
+  centre: [number, number, number]
+  bornAt: number
+  onDone?: () => void
+}): JSX.Element {
+  const geometry = useMemo(makeBurstGeometry, [])
   const material = useMemo(
     () =>
       new ShaderMaterial({
@@ -127,13 +154,37 @@ function BurstLines({
   useEffect(() => { done.current = false }, [bornAt])
   useFrame(() => {
     const age = (performance.now() - bornAt) / 1000
-    // Looping restarts the emission each period: the station's beacon.
-    material.uniforms.uAge.value = loop ? age % LIFE : age
-    if (!loop && age > LIFE && !done.current) {
+    material.uniforms.uAge.value = age
+    if (age > LIFE && !done.current) {
       done.current = true
       onDone?.()
     }
   })
+
+  return (
+    <group position={centre}>
+      <lineSegments geometry={geometry} material={material} frustumCulled={false} renderOrder={5} />
+    </group>
+  )
+}
+
+/** The station's continuous aura while it is being viewed. */
+function StationAura({ centre }: { centre: [number, number, number] }): JSX.Element {
+  const geometry = useMemo(makeBurstGeometry, [])
+  const material = useMemo(
+    () =>
+      new ShaderMaterial({
+        vertexShader: auraVertexShader,
+        fragmentShader,
+        uniforms: { uTime: { value: 0 } },
+        transparent: true,
+        depthWrite: false,
+        blending: AdditiveBlending,
+      }),
+    [],
+  )
+  useEffect(() => () => { geometry.dispose(); material.dispose() }, [geometry, material])
+  useFrame((state) => { material.uniforms.uTime.value = state.clock.elapsedTime })
 
   return (
     <group position={centre}>
@@ -168,7 +219,7 @@ export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
 
   // The station: the stop nearest the avatar's committed position, i.e. the
   // block boarding would set you down at. While the owned view is on it, it
-  // pulses persistently: that block is your entry point.
+  // wears the aura persistently: that block is your entry point.
   const station = useMemo(() => {
     void indexVersion
     const index = getStopIndex()
@@ -198,7 +249,7 @@ export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
   if (inTransit) return null
   return (
     <>
-      {sustainedCentre && <BurstLines centre={sustainedCentre} bornAt={0} loop />}
+      {sustainedCentre && <StationAura centre={sustainedCentre} />}
       {shot && shotCentre && (
         <BurstLines centre={shotCentre} bornAt={shot.bornAt} onDone={() => setShot(null)} />
       )}

--- a/src/scene/StopBurst.tsx
+++ b/src/scene/StopBurst.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { AdditiveBlending, BufferGeometry, Float32BufferAttribute, ShaderMaterial } from 'three'
-import { cellCentre, type ViewAxes } from '../lib/space'
+import { pointCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopByHeight, useHyperspace } from '../store/useHyperspace'
 import { stopPlane, stopPosition } from '../hud/HyperspacePanel'
@@ -146,7 +146,7 @@ export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
     if (!burst) return null
     const stop = getStopByHeight(burst.height)
     if (!stop || stopPlane(stop) !== anchorPlane) return null
-    return cellCentre(stopPosition(stop), alignedOrigin(anchor, scaleExp), scaleExp, axes)
+    return pointCentre(stopPosition(stop), alignedOrigin(anchor, scaleExp), scaleExp, axes)
   }, [burst, anchor, anchorPlane, scaleExp, axes])
 
   if (!burst || !centre || inTransit) return null

--- a/src/scene/StopBurst.tsx
+++ b/src/scene/StopBurst.tsx
@@ -1,26 +1,31 @@
 /**
  * StopBurst.tsx - the rainbow lines living inside the blocks.
  *
- * Selecting a stop in the hyperspace UI (scrubbing to it, or setting it as
- * the destination) before boarding emits a short radial burst of rainbow
- * streaks from the block's cube, fading in about a second and a half. The
- * full surrounding warp (HyperspaceCone) is reserved for actually being in
- * transit, so the two together read as: the lines are inside the blocks, and
- * entering hyperspace puts you among them.
+ * Setting a stop as the destination emits a one-shot radial burst of rainbow
+ * streaks from its cube, fading in about a second and a half. Your station
+ * (the stop nearest your avatar, the one boarding sets you down at) instead
+ * pulses the same burst continuously while you are viewing it: that block is
+ * your entry to the line, so the lines never quite leave it. The full
+ * surrounding warp (HyperspaceCone) stays reserved for actually being in
+ * transit, so the three read together as: the lines live inside the blocks,
+ * the ones at your door keep spilling out, and boarding puts you among them.
  *
- * One LineSegments draw call; positions come from the vertex shader, so a
- * burst allocates nothing per frame.
+ * One LineSegments draw call per burst (at most two: the station pulse and a
+ * destination shot); positions come from the vertex shader, so a burst
+ * allocates nothing per frame.
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { AdditiveBlending, BufferGeometry, Float32BufferAttribute, ShaderMaterial } from 'three'
+import { xyzToCoord } from 'cyberspace-core'
 import { pointCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
-import { getStopByHeight, useHyperspace } from '../store/useHyperspace'
+import { getStopByHeight, getStopIndex, useHyperspace } from '../store/useHyperspace'
+import { nearestStops } from '../lib/hyperspace/station'
 import { stopPlane, stopPosition } from '../hud/HyperspacePanel'
 
 const STREAKS = 220
-/** Seconds from emission to gone. */
+/** Seconds from emission to gone (one pulse period when looping). */
 const LIFE = 1.6
 /** How far the streaks reach, in render cells. */
 const REACH = 6
@@ -63,30 +68,18 @@ const fragmentShader = /* glsl */ `
   }
 `
 
-interface Burst {
-  height: number
+/** One emitting block: its own material (uAge is per-burst), shared shape. */
+function BurstLines({
+  centre,
+  bornAt,
+  loop,
+  onDone,
+}: {
+  centre: [number, number, number]
   bornAt: number
-}
-
-export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
-  const anchor = useCyberspace((s) => s.anchor)
-  const anchorPlane = useCyberspace((s) => s.anchorPlane)
-  const scaleExp = useCyberspace((s) => s.scaleExp)
-  const inTransit = useCyberspace((s) => s.transit) !== null
-  const scrubHeight = useHyperspace((s) => s.scrubHeight)
-  const destination = useHyperspace((s) => s.destination)
-
-  const [burst, setBurst] = useState<Burst | null>(null)
-
-  // A new selection is a new emission; the full warp owns transit, so bursts
-  // stand down once boarded.
-  useEffect(() => {
-    if (scrubHeight !== null && !inTransit) setBurst({ height: scrubHeight, bornAt: performance.now() })
-  }, [scrubHeight, inTransit])
-  useEffect(() => {
-    if (destination !== null && !inTransit) setBurst({ height: destination, bornAt: performance.now() })
-  }, [destination, inTransit])
-
+  loop?: boolean
+  onDone?: () => void
+}): JSX.Element {
   const geometry = useMemo(() => {
     const dirs = new Float32Array(STREAKS * 2 * 3)
     const seeds = new Float32Array(STREAKS * 2)
@@ -131,28 +124,84 @@ export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
   useEffect(() => () => { geometry.dispose(); material.dispose() }, [geometry, material])
 
   const done = useRef(false)
+  useEffect(() => { done.current = false }, [bornAt])
   useFrame(() => {
-    if (!burst) return
-    const age = (performance.now() - burst.bornAt) / 1000
-    material.uniforms.uAge.value = age
-    if (age > LIFE && !done.current) {
+    const age = (performance.now() - bornAt) / 1000
+    // Looping restarts the emission each period: the station's beacon.
+    material.uniforms.uAge.value = loop ? age % LIFE : age
+    if (!loop && age > LIFE && !done.current) {
       done.current = true
-      setBurst(null)
+      onDone?.()
     }
   })
-  useEffect(() => { done.current = false }, [burst])
 
-  const centre = useMemo(() => {
-    if (!burst) return null
-    const stop = getStopByHeight(burst.height)
-    if (!stop || stopPlane(stop) !== anchorPlane) return null
-    return pointCentre(stopPosition(stop), alignedOrigin(anchor, scaleExp), scaleExp, axes)
-  }, [burst, anchor, anchorPlane, scaleExp, axes])
-
-  if (!burst || !centre || inTransit) return null
   return (
     <group position={centre}>
       <lineSegments geometry={geometry} material={material} frustumCulled={false} renderOrder={5} />
     </group>
+  )
+}
+
+interface Shot {
+  height: number
+  bornAt: number
+}
+
+export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const position = useCyberspace((s) => s.position)
+  const plane = useCyberspace((s) => s.plane)
+  const inTransit = useCyberspace((s) => s.transit) !== null
+  const destination = useHyperspace((s) => s.destination)
+  const viewedStop = useHyperspace((s) => s.viewedStop)
+  const indexVersion = useHyperspace((s) => s.indexVersion)
+
+  // The one-shot: exactly when a block is SET as the destination, never on a
+  // scrub (browsing is looking, not choosing). The full warp owns transit,
+  // so shots stand down once boarded.
+  const [shot, setShot] = useState<Shot | null>(null)
+  useEffect(() => {
+    if (destination !== null && !inTransit) setShot({ height: destination, bornAt: performance.now() })
+  }, [destination, inTransit])
+
+  // The station: the stop nearest the avatar's committed position, i.e. the
+  // block boarding would set you down at. While the owned view is on it, it
+  // pulses persistently: that block is your entry point.
+  const station = useMemo(() => {
+    void indexVersion
+    const index = getStopIndex()
+    if (index.permCount === 0) return null
+    const here = xyzToCoord(position.x, position.y, position.z, plane)
+    return nearestStops(index, here, 1)[0]?.stop.height ?? null
+  }, [position, plane, indexVersion])
+  const sustained = viewedStop !== null && viewedStop === station ? station : null
+
+  const centreOf = (height: number | null): [number, number, number] | null => {
+    if (height === null) return null
+    const stop = getStopByHeight(height)
+    if (!stop || stopPlane(stop) !== anchorPlane) return null
+    return pointCentre(stopPosition(stop), alignedOrigin(anchor, scaleExp), scaleExp, axes)
+  }
+  const sustainedCentre = useMemo(
+    () => centreOf(sustained),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sustained, anchor, anchorPlane, scaleExp, axes, indexVersion],
+  )
+  const shotCentre = useMemo(
+    () => (shot !== null && shot.height !== sustained ? centreOf(shot.height) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [shot, sustained, anchor, anchorPlane, scaleExp, axes, indexVersion],
+  )
+
+  if (inTransit) return null
+  return (
+    <>
+      {sustainedCentre && <BurstLines centre={sustainedCentre} bornAt={0} loop />}
+      {shot && shotCentre && (
+        <BurstLines centre={shotCentre} bornAt={shot.bornAt} onDone={() => setShot(null)} />
+      )}
+    </>
   )
 }

--- a/src/scene/StopBurst.tsx
+++ b/src/scene/StopBurst.tsx
@@ -1,0 +1,158 @@
+/**
+ * StopBurst.tsx - the rainbow lines living inside the blocks.
+ *
+ * Selecting a stop in the hyperspace UI (scrubbing to it, or setting it as
+ * the destination) before boarding emits a short radial burst of rainbow
+ * streaks from the block's cube, fading in about a second and a half. The
+ * full surrounding warp (HyperspaceCone) is reserved for actually being in
+ * transit, so the two together read as: the lines are inside the blocks, and
+ * entering hyperspace puts you among them.
+ *
+ * One LineSegments draw call; positions come from the vertex shader, so a
+ * burst allocates nothing per frame.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { AdditiveBlending, BufferGeometry, Float32BufferAttribute, ShaderMaterial } from 'three'
+import { cellCentre, type ViewAxes } from '../lib/space'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { getStopByHeight, useHyperspace } from '../store/useHyperspace'
+import { stopPlane, stopPosition } from '../hud/HyperspacePanel'
+
+const STREAKS = 220
+/** Seconds from emission to gone. */
+const LIFE = 1.6
+/** How far the streaks reach, in render cells. */
+const REACH = 6
+
+const vertexShader = /* glsl */ `
+  attribute vec3 aDir;
+  attribute float aSeed;
+  attribute float aEnd;
+  uniform float uAge;
+  varying float vSeed;
+  varying float vFade;
+
+  void main() {
+    float t = clamp(uAge / ${LIFE.toFixed(2)}, 0.0, 1.0);
+    // Ease out: fast leaving the block, slowing as it dies.
+    float travel = 1.0 - (1.0 - t) * (1.0 - t);
+    float reach = ${REACH.toFixed(1)} * (0.4 + aSeed * 0.6);
+    float head = 0.15 + travel * reach;
+    float len = (0.5 + aSeed * 1.2) * (1.0 - 0.6 * t);
+    vec3 pos = aDir * (head - aEnd * len);
+    vFade = (1.0 - t) * (1.0 - t);
+    vSeed = aSeed;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+  }
+`
+
+const fragmentShader = /* glsl */ `
+  varying float vSeed;
+  varying float vFade;
+
+  vec3 hue2rgb(float h) {
+    vec3 p = abs(fract(h + vec3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0);
+    return clamp(p - 1.0, 0.0, 1.0);
+  }
+
+  void main() {
+    float a = vFade * 0.75;
+    if (a < 0.02) discard;
+    gl_FragColor = vec4(hue2rgb(fract(vSeed * 9.31)) * 0.75, a);
+  }
+`
+
+interface Burst {
+  height: number
+  bornAt: number
+}
+
+export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const inTransit = useCyberspace((s) => s.transit) !== null
+  const scrubHeight = useHyperspace((s) => s.scrubHeight)
+  const destination = useHyperspace((s) => s.destination)
+
+  const [burst, setBurst] = useState<Burst | null>(null)
+
+  // A new selection is a new emission; the full warp owns transit, so bursts
+  // stand down once boarded.
+  useEffect(() => {
+    if (scrubHeight !== null && !inTransit) setBurst({ height: scrubHeight, bornAt: performance.now() })
+  }, [scrubHeight, inTransit])
+  useEffect(() => {
+    if (destination !== null && !inTransit) setBurst({ height: destination, bornAt: performance.now() })
+  }, [destination, inTransit])
+
+  const geometry = useMemo(() => {
+    const dirs = new Float32Array(STREAKS * 2 * 3)
+    const seeds = new Float32Array(STREAKS * 2)
+    const ends = new Float32Array(STREAKS * 2)
+    const positions = new Float32Array(STREAKS * 2 * 3)
+    for (let i = 0; i < STREAKS; i++) {
+      // Golden-angle sphere spread: deterministic, no clumping at the poles.
+      const z = 1 - (2 * (i + 0.5)) / STREAKS
+      const r = Math.sqrt(Math.max(0, 1 - z * z))
+      const phi = i * 2.399963229728653
+      const dir = [r * Math.cos(phi), z, r * Math.sin(phi)]
+      const seed = (i * 0.6180339887) % 1
+      for (const end of [0, 1]) {
+        const v = i * 2 + end
+        dirs[v * 3] = dir[0]
+        dirs[v * 3 + 1] = dir[1]
+        dirs[v * 3 + 2] = dir[2]
+        seeds[v] = seed
+        ends[v] = end
+      }
+    }
+    const geo = new BufferGeometry()
+    geo.setAttribute('position', new Float32BufferAttribute(positions, 3))
+    geo.setAttribute('aDir', new Float32BufferAttribute(dirs, 3))
+    geo.setAttribute('aSeed', new Float32BufferAttribute(seeds, 1))
+    geo.setAttribute('aEnd', new Float32BufferAttribute(ends, 1))
+    return geo
+  }, [])
+
+  const material = useMemo(
+    () =>
+      new ShaderMaterial({
+        vertexShader,
+        fragmentShader,
+        uniforms: { uAge: { value: 0 } },
+        transparent: true,
+        depthWrite: false,
+        blending: AdditiveBlending,
+      }),
+    [],
+  )
+  useEffect(() => () => { geometry.dispose(); material.dispose() }, [geometry, material])
+
+  const done = useRef(false)
+  useFrame(() => {
+    if (!burst) return
+    const age = (performance.now() - burst.bornAt) / 1000
+    material.uniforms.uAge.value = age
+    if (age > LIFE && !done.current) {
+      done.current = true
+      setBurst(null)
+    }
+  })
+  useEffect(() => { done.current = false }, [burst])
+
+  const centre = useMemo(() => {
+    if (!burst) return null
+    const stop = getStopByHeight(burst.height)
+    if (!stop || stopPlane(stop) !== anchorPlane) return null
+    return cellCentre(stopPosition(stop), alignedOrigin(anchor, scaleExp), scaleExp, axes)
+  }, [burst, anchor, anchorPlane, scaleExp, axes])
+
+  if (!burst || !centre || inTransit) return null
+  return (
+    <group position={centre}>
+      <lineSegments geometry={geometry} material={material} frustumCulled={false} renderOrder={5} />
+    </group>
+  )
+}

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -20,8 +20,11 @@ import { type Stop } from '../lib/hyperspace/stops'
 import { stopPlane, stopPosition } from '../hud/HyperspacePanel'
 import { WorldLabel } from './WorldLabel'
 
-/** v1's HYPERJUMP colour. */
-const CUBE_COLOR = '#ffff00'
+/** The fleet: toned-down bitcoin orange. Only the chosen destination gets
+ * v1's bright HYPERJUMP yellow, glowing and spinning, so one cube in the
+ * scene means "this is where you are going" and nothing else competes. */
+const CUBE_COLOR = '#f7931a'
+const DEST_COLOR = '#ffff00'
 /** At most this many cubes; the point field carries the rest. */
 const MAX_CUBES = 24
 /** A cube never renders smaller than this many cells (visibility floor). */
@@ -39,7 +42,7 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
   const cubes = useMemo(() => {
     void indexVersion
     const index = getStopIndex()
-    if (index.stops.length === 0) return []
+    if (index.size === 0) return []
     const origin = alignedOrigin(anchor, scaleExp)
     const anchorCoord = xyzToCoord(anchor.x, anchor.y, anchor.z, anchorPlane)
     const candidates: Stop[] = []
@@ -81,22 +84,32 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
 
   return (
     <>
-      <group ref={spin}>
-        {cubes.map(({ stop, centre }) => (
+      {cubes.map(({ stop, centre }) =>
+        stop.height === destination ? null : (
           <mesh key={stop.height} position={centre}>
             <boxGeometry args={[side, side, side]} />
-            <meshBasicMaterial color={CUBE_COLOR} toneMapped={false} />
+            <meshBasicMaterial color={CUBE_COLOR} transparent opacity={0.75} />
           </mesh>
-        ))}
+        ),
+      )}
+      <group ref={spin}>
+        {cubes.map(({ stop, centre }) =>
+          stop.height === destination ? (
+            <mesh key={stop.height} position={centre}>
+              <boxGeometry args={[side, side, side]} />
+              <meshBasicMaterial color={DEST_COLOR} toneMapped={false} />
+            </mesh>
+          ) : null,
+        )}
       </group>
       {cubes.map(({ stop, centre }) => (
         <WorldLabel
           key={`l${stop.height}`}
           text={`BLOCK ${stop.height}`}
-          color={CUBE_COLOR}
+          color={stop.height === destination ? DEST_COLOR : CUBE_COLOR}
           at={[centre[0], centre[1] + side * 0.9 + 0.3, centre[2]]}
           px={11}
-          opacity={0.85}
+          opacity={stop.height === destination ? 0.95 : 0.7}
         />
       ))}
     </>

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -1,0 +1,104 @@
+/**
+ * StopCubes.tsx - the hyperjumps themselves, drawn the way v1 drew them: a
+ * bright yellow rotating cube, one gibson along each edge.
+ *
+ * The StopField's points say "there are stops over there"; a cube says "you
+ * are AT a stop". One gibson is 2^-scaleExp render cells, so the cube is only
+ * honestly visible near gibson scale; below a floor it is clamped so a stop
+ * you have flown to never vanishes into a subpixel while still reading as a
+ * small landmark rather than a billboard.
+ */
+import { useMemo, useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { Group } from 'three'
+import { xyzToCoord } from 'cyberspace-core'
+import { cellCentre, GRID_RADIUS, type ViewAxes } from '../lib/space'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { getStopByHeight, getStopIndex, useHyperspace } from '../store/useHyperspace'
+import { nearestStops } from '../lib/hyperspace/station'
+import { type Stop } from '../lib/hyperspace/stops'
+import { stopPlane, stopPosition } from '../hud/HyperspacePanel'
+import { WorldLabel } from './WorldLabel'
+
+/** v1's HYPERJUMP colour. */
+const CUBE_COLOR = '#ffff00'
+/** At most this many cubes; the point field carries the rest. */
+const MAX_CUBES = 24
+/** A cube never renders smaller than this many cells (visibility floor). */
+const MIN_CELLS = 0.3
+const REACH = GRID_RADIUS * 8
+
+export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const indexVersion = useHyperspace((s) => s.indexVersion)
+  const scrubHeight = useHyperspace((s) => s.scrubHeight)
+  const destination = useHyperspace((s) => s.destination)
+
+  const cubes = useMemo(() => {
+    void indexVersion
+    const index = getStopIndex()
+    if (index.stops.length === 0) return []
+    const origin = alignedOrigin(anchor, scaleExp)
+    const anchorCoord = xyzToCoord(anchor.x, anchor.y, anchor.z, anchorPlane)
+    const candidates: Stop[] = []
+    const seen = new Set<number>()
+    const consider = (stop: Stop | undefined): void => {
+      if (!stop || seen.has(stop.height)) return
+      seen.add(stop.height)
+      candidates.push(stop)
+    }
+    // The stop being viewed and the chosen destination always get a cube;
+    // then the prefix-nearest stops fill the rest.
+    consider(scrubHeight !== null ? getStopByHeight(scrubHeight) : undefined)
+    consider(destination !== null ? getStopByHeight(destination) : undefined)
+    for (const near of nearestStops(index, anchorCoord, MAX_CUBES * 2)) consider(near.stop)
+
+    const out: Array<{ stop: Stop; centre: [number, number, number] }> = []
+    for (const stop of candidates) {
+      if (out.length >= MAX_CUBES) break
+      if (stopPlane(stop) !== anchorPlane) continue
+      const centre = cellCentre(stopPosition(stop), origin, scaleExp, axes)
+      if (Math.abs(centre[0]) > REACH || Math.abs(centre[1]) > REACH || Math.abs(centre[2]) > REACH) continue
+      out.push({ stop, centre })
+    }
+    return out
+  }, [indexVersion, anchor, anchorPlane, scaleExp, axes, scrubHeight, destination])
+
+  const spin = useRef<Group>(null)
+  useFrame((_, dt) => {
+    const g = spin.current
+    if (!g) return
+    for (const child of g.children) {
+      child.rotation.y += dt * 0.9
+      child.rotation.x += dt * 0.45
+    }
+  })
+
+  if (cubes.length === 0) return null
+  const side = Math.max(2 ** -scaleExp, MIN_CELLS)
+
+  return (
+    <>
+      <group ref={spin}>
+        {cubes.map(({ stop, centre }) => (
+          <mesh key={stop.height} position={centre}>
+            <boxGeometry args={[side, side, side]} />
+            <meshBasicMaterial color={CUBE_COLOR} toneMapped={false} />
+          </mesh>
+        ))}
+      </group>
+      {cubes.map(({ stop, centre }) => (
+        <WorldLabel
+          key={`l${stop.height}`}
+          text={`BLOCK ${stop.height}`}
+          color={CUBE_COLOR}
+          at={[centre[0], centre[1] + side * 0.9 + 0.3, centre[2]]}
+          px={11}
+          opacity={0.85}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -52,11 +52,17 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
       seen.add(stop.height)
       candidates.push(stop)
     }
-    // The stop being viewed and the chosen destination always get a cube;
-    // then the prefix-nearest stops fill the rest.
+    // The stop being viewed and the chosen destination always get a cube.
     consider(scrubHeight !== null ? getStopByHeight(scrubHeight) : undefined)
     consider(destination !== null ? getStopByHeight(destination) : undefined)
-    for (const near of nearestStops(index, anchorCoord, MAX_CUBES * 2)) consider(near.stop)
+    // The nearest-stop fleet exists for ideaspace, where ports are sparse
+    // landmarks worth making solid and clickable. On the landfall shell the
+    // dots ARE the landmarks, and a fleet keyed on the anchor just trails
+    // the selection around the globe; only the viewed stop and the
+    // destination earn a cube there.
+    if (anchorPlane === 1) {
+      for (const near of nearestStops(index, anchorCoord, MAX_CUBES * 2)) consider(near.stop)
+    }
 
     const out: Array<{ stop: Stop; centre: [number, number, number] }> = []
     // A cube that would sit against one already placed adds nothing but

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -12,7 +12,7 @@ import { useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Group } from 'three'
 import { xyzToCoord } from 'cyberspace-core'
-import { cellCentre, GRID_RADIUS, type ViewAxes } from '../lib/space'
+import { GRID_RADIUS, pointCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopByHeight, getStopIndex, useHyperspace } from '../store/useHyperspace'
 import { nearestStops } from '../lib/hyperspace/station'
@@ -28,7 +28,7 @@ const DEST_COLOR = '#ffff00'
 /** At most this many cubes; the point field carries the rest. */
 const MAX_CUBES = 24
 /** A cube never renders smaller than this many cells (visibility floor). */
-const MIN_CELLS = 0.3
+const MIN_CELLS = 0.2
 const REACH = GRID_RADIUS * 8
 
 export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
@@ -62,7 +62,7 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
     for (const stop of candidates) {
       if (out.length >= MAX_CUBES) break
       if (stopPlane(stop) !== anchorPlane) continue
-      const centre = cellCentre(stopPosition(stop), origin, scaleExp, axes)
+      const centre = pointCentre(stopPosition(stop), origin, scaleExp, axes)
       if (Math.abs(centre[0]) > REACH || Math.abs(centre[1]) > REACH || Math.abs(centre[2]) > REACH) continue
       out.push({ stop, centre })
     }
@@ -81,13 +81,16 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
 
   if (cubes.length === 0) return null
   const side = Math.max(2 ** -scaleExp, MIN_CELLS)
+  // The fleet reads at half the selected block's size: present, but never
+  // competing with the one cube that means "this is where you are going".
+  const inertSide = side * 0.5
 
   return (
     <>
       {cubes.map(({ stop, centre }) =>
         stop.height === destination ? null : (
           <mesh key={stop.height} position={centre}>
-            <boxGeometry args={[side, side, side]} />
+            <boxGeometry args={[inertSide, inertSide, inertSide]} />
             <meshBasicMaterial color={CUBE_COLOR} transparent opacity={0.75} />
           </mesh>
         ),

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -102,16 +102,18 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
           ) : null,
         )}
       </group>
-      {cubes.map(({ stop, centre }) => (
-        <WorldLabel
-          key={`l${stop.height}`}
-          text={`BLOCK ${stop.height}`}
-          color={stop.height === destination ? DEST_COLOR : CUBE_COLOR}
-          at={[centre[0], centre[1] + side * 0.9 + 0.3, centre[2]]}
-          px={11}
-          opacity={stop.height === destination ? 0.95 : 0.7}
-        />
-      ))}
+      {cubes
+        .filter(({ stop }) => stop.height === destination)
+        .map(({ stop, centre }) => (
+          <WorldLabel
+            key={`l${stop.height}`}
+            text={`BLOCK ${stop.height}`}
+            color={DEST_COLOR}
+            at={[centre[0], centre[1] + side * 0.9 + 0.3, centre[2]]}
+            px={11}
+            opacity={0.95}
+          />
+        ))}
     </>
   )
 }

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -59,11 +59,29 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
     for (const near of nearestStops(index, anchorCoord, MAX_CUBES * 2)) consider(near.stop)
 
     const out: Array<{ stop: Stop; centre: [number, number, number] }> = []
+    // A cube that would sit against one already placed adds nothing but
+    // clutter: the point field already says stops are there, and a clump of
+    // cubes around the selection reads as selection spill. The viewed stop
+    // and the destination are considered first, so the fleet yields to them,
+    // never the other way around.
+    const minSep = Math.max(2 ** -scaleExp, MIN_CELLS) * 2.5
+    const minSep2 = minSep * minSep
     for (const stop of candidates) {
       if (out.length >= MAX_CUBES) break
       if (stopPlane(stop) !== anchorPlane) continue
       const centre = pointCentre(stopPosition(stop), origin, scaleExp, axes)
       if (Math.abs(centre[0]) > REACH || Math.abs(centre[1]) > REACH || Math.abs(centre[2]) > REACH) continue
+      let crowded = false
+      for (const o of out) {
+        const dx = centre[0] - o.centre[0]
+        const dy = centre[1] - o.centre[1]
+        const dz = centre[2] - o.centre[2]
+        if (dx * dx + dy * dy + dz * dz < minSep2) {
+          crowded = true
+          break
+        }
+      }
+      if (crowded) continue
       out.push({ stop, centre })
     }
     return out

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -17,7 +17,7 @@ import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopByHeight, getStopIndex, useHyperspace } from '../store/useHyperspace'
 import { nearestStops } from '../lib/hyperspace/station'
 import { type Stop } from '../lib/hyperspace/stops'
-import { stopPlane, stopPosition } from '../hud/HyperspacePanel'
+import { selectStopInScene, stopPlane, stopPosition } from '../hud/HyperspacePanel'
 import { WorldLabel } from './WorldLabel'
 
 /** The fleet: toned-down bitcoin orange. Only the chosen destination gets
@@ -28,7 +28,7 @@ const DEST_COLOR = '#ffff00'
 /** At most this many cubes; the point field carries the rest. */
 const MAX_CUBES = 24
 /** A cube never renders smaller than this many cells (visibility floor). */
-const MIN_CELLS = 0.2
+const MIN_CELLS = 0.15
 const REACH = GRID_RADIUS * 8
 
 export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
@@ -89,7 +89,18 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
     <>
       {cubes.map(({ stop, centre }) =>
         stop.height === destination ? null : (
-          <mesh key={stop.height} position={centre}>
+          <mesh
+            key={stop.height}
+            position={centre}
+            // A cube is an exact target in a way the point cloud is not:
+            // the raycast hits its faces, so a click selects THIS stop and
+            // never a neighbour within some threshold of the ray.
+            onClick={(e) => {
+              if (e.delta > 8) return
+              e.stopPropagation()
+              selectStopInScene(stop.height)
+            }}
+          >
             <boxGeometry args={[inertSide, inertSide, inertSide]} />
             <meshBasicMaterial color={CUBE_COLOR} transparent opacity={0.75} />
           </mesh>
@@ -98,7 +109,15 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
       <group ref={spin}>
         {cubes.map(({ stop, centre }) =>
           stop.height === destination ? (
-            <mesh key={stop.height} position={centre}>
+            <mesh
+              key={stop.height}
+              position={centre}
+              onClick={(e) => {
+                if (e.delta > 8) return
+                e.stopPropagation()
+                selectStopInScene(stop.height)
+              }}
+            >
               <boxGeometry args={[side, side, side]} />
               <meshBasicMaterial color={DEST_COLOR} toneMapped={false} />
             </mesh>

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -14,17 +14,23 @@
  * Number. One GL_POINTS draw for the whole cloud, coloured per vertex
  * (landfall warm-blue EARTH, port purple SIDESTEP), and clicking a point
  * selects that stop as the ride's destination.
+ *
+ * The cloud reads straight off the columnar index: the kind byte first (a
+ * port is plane 1, a landfall plane 0, so the plane filter never has to
+ * decode the wrong half of the line), then the cached per-row decode
+ * (xyzAt de-interleaves each row once, ever). No Stop objects are
+ * materialized here — a million of them per rebuild is exactly what the
+ * columnar index exists to avoid — so picks carry heights, not stops.
  */
 
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useThree, type ThreeEvent } from '@react-three/fiber'
 import { BufferGeometry, Color, Float32BufferAttribute } from 'three'
-import { coordToXyz, type Xyz } from 'cyberspace-core'
 import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
-import { ACCENT, EARTH, SIDESTEP } from '../lib/palette'
+import { ACCENT, SIDESTEP } from '../lib/palette'
+import { heightAt, kindIsPort, xyzAt } from '../lib/hyperspace/compactIndex'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopIndex, useHyperspace } from '../store/useHyperspace'
-import type { Stop } from '../lib/hyperspace/stops'
 
 /** Same tap-vs-drag slop as every other clickable thing in the scene. */
 const TAP_SLOP = 8
@@ -50,26 +56,19 @@ const MAX_POINTS = 120_000
 const PICK_THRESHOLD = 0.35
 
 /**
- * Decoded-coordinate cache. coordToXyz de-interleaves 255 bits per stop, and
- * doing that for ~950k stops costs seconds — far too much to repeat on every
- * anchor move or zoom, which only change the cheap cellDelta step. Stops are
- * stable objects (the index replaces the array, not the entries), so a WeakMap
- * keyed on the Stop itself survives every rebuild that keeps an entry and lets
- * the GC reclaim what a rebuild drops.
+ * While the bulk sync churns, a rebuild is only worth its cost when the line
+ * grew substantially: the cloud's shape is hash-uniform, so 10k more dots in
+ * a field of half a million are invisible. Total index size is the cheap
+ * proxy for "stops in range" — positions are uniform, so range population
+ * grows in proportion.
  */
-const decoded = new WeakMap<Stop, Xyz>()
-
-function decode(stop: Stop): Xyz {
-  let d = decoded.get(stop)
-  if (!d) {
-    d = coordToXyz(stop.coordApprox)
-    decoded.set(stop, d)
-  }
-  return d
-}
+const REBUILD_MIN_GROWTH = 50_000
+const REBUILD_GROWTH_FRACTION = 0.15
 
 /** Per-vertex colours: landfalls in Earth's blue, ports in ideaspace purple. */
-const LANDFALL_COLOR = new Color(EARTH)
+// Landfalls read as embers of bitcoin orange on the globe; the old EARTH
+// blue made scrubbed stops look selected when nothing was.
+const LANDFALL_COLOR = new Color('#b06f14')
 const PORT_COLOR = new Color(SIDESTEP)
 
 interface Props {
@@ -78,8 +77,8 @@ interface Props {
 
 interface Built {
   geometry: BufferGeometry
-  /** Parallel to the geometry's vertices, so a picked index maps to its stop. */
-  stops: Stop[]
+  /** Parallel to the geometry's vertices, so a picked index maps to its stop's height. */
+  heights: number[]
   /** 1 = every stop in range is drawn; N = every Nth survived the cap. */
   stride: number
 }
@@ -89,26 +88,49 @@ export function StopField({ axes }: Props): JSX.Element | null {
   const anchorPlane = useCyberspace((s) => s.anchorPlane)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const indexVersion = useHyperspace((s) => s.indexVersion)
+  const syncStatus = useHyperspace((s) => s.sync.status)
   const destination = useHyperspace((s) => s.destination)
 
+  // The calm-down gate: while syncing, an indexVersion bump only triggers a
+  // geometry rebuild when the stop count changed materially. The ref carries
+  // the last version we honoured; honouring one updates it during render,
+  // which is safe because the decision is idempotent for a given version.
+  const gate = useRef({ version: -1, size: -1 })
+  {
+    const size = getStopIndex().size
+    const g = gate.current
+    if (g.version !== indexVersion) {
+      const syncing = syncStatus === 'syncing' || syncStatus === 'loading-cache'
+      const grownEnough =
+        size - g.size >= Math.max(REBUILD_MIN_GROWTH, g.size * REBUILD_GROWTH_FRACTION)
+      if (g.version === -1 || !syncing || grownEnough) {
+        g.version = indexVersion
+        g.size = size
+      }
+    }
+  }
+  const rebuildVersion = gate.current.version
+
   const built = useMemo((): Built | null => {
-    const { stops } = getStopIndex()
-    if (stops.length === 0) return null
+    const index = getStopIndex()
+    if (index.size === 0) return null
 
     const origin = alignedOrigin(anchor, scaleExp)
+    const wantPort = anchorPlane === 1
     const centres: number[] = []
-    const inRange: Stop[] = []
+    const inRange: number[] = []
 
-    for (const stop of stops) {
-      const d = decode(stop)
+    for (let row = 0; row < index.size; row++) {
       // Ports live on plane 1, landfalls on plane 0, so matching the anchor's
       // plane is what makes the Earth view show landfalls and the ideaspace
-      // view show ports, rather than superimposing two unrelated clouds.
-      if (d.plane !== anchorPlane) continue
+      // view show ports, rather than superimposing two unrelated clouds. The
+      // kind byte IS the plane bit, so the wrong half skips before decoding.
+      if (kindIsPort(index, row) !== wantPort) continue
+      const d = xyzAt(index, row)
       const c = cellCentre(d, origin, scaleExp, axes)
       if (Math.abs(c[0]) > REACH || Math.abs(c[1]) > REACH || Math.abs(c[2]) > REACH) continue
       centres.push(c[0], c[1], c[2])
-      inRange.push(stop)
+      inRange.push(row)
     }
 
     if (inRange.length === 0) return null
@@ -117,18 +139,18 @@ export function StopField({ axes }: Props): JSX.Element | null {
     const count = Math.ceil(inRange.length / stride)
     const positions = new Float32Array(count * 3)
     const colors = new Float32Array(count * 3)
-    const kept: Stop[] = new Array(count)
+    const heights: number[] = new Array(count)
 
     let v = 0
     for (let i = 0; i < inRange.length; i += stride) {
       positions[v * 3] = centres[i * 3]
       positions[v * 3 + 1] = centres[i * 3 + 1]
       positions[v * 3 + 2] = centres[i * 3 + 2]
-      const col = inRange[i].kind === 'landfall' ? LANDFALL_COLOR : PORT_COLOR
+      const col = kindIsPort(index, inRange[i]) ? PORT_COLOR : LANDFALL_COLOR
       colors[v * 3] = col.r
       colors[v * 3 + 1] = col.g
       colors[v * 3 + 2] = col.b
-      kept[v] = inRange[i]
+      heights[v] = heightAt(index, inRange[i])
       v++
     }
 
@@ -144,8 +166,8 @@ export function StopField({ axes }: Props): JSX.Element | null {
       }
     }
 
-    return { geometry, stops: kept, stride }
-  }, [indexVersion, anchor, scaleExp, axes, anchorPlane])
+    return { geometry, heights, stride }
+  }, [rebuildVersion, anchor, scaleExp, axes, anchorPlane])
 
   // GPU buffers are not garbage collected; release each one when replaced.
   useEffect(() => () => { built?.geometry.dispose() }, [built])
@@ -165,8 +187,8 @@ export function StopField({ axes }: Props): JSX.Element | null {
   // by identity because the destination can outlive a geometry rebuild.
   const highlight = useMemo((): [number, number, number] | null => {
     if (!built || destination === null) return null
-    for (let i = 0; i < built.stops.length; i++) {
-      if (built.stops[i].height === destination) {
+    for (let i = 0; i < built.heights.length; i++) {
+      if (built.heights[i] === destination) {
         const p = built.geometry.getAttribute('position')
         return [p.getX(i), p.getY(i), p.getZ(i)]
       }
@@ -188,10 +210,10 @@ export function StopField({ axes }: Props): JSX.Element | null {
     // An orbit-drag that happens to end on a dot is not a tap.
     if (e.delta > TAP_SLOP) return
     if (e.index === undefined) return
-    const stop = built.stops[e.index]
-    if (!stop) return
+    const height = built.heights[e.index]
+    if (height === undefined) return
     e.stopPropagation()
-    useHyperspace.getState().setDestination(stop.height)
+    useHyperspace.getState().setDestination(height)
   }
 
   return (

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -31,6 +31,7 @@ import { ACCENT, SIDESTEP } from '../lib/palette'
 import { heightAt, kindIsPort, xyzAt } from '../lib/hyperspace/compactIndex'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopIndex, useHyperspace } from '../store/useHyperspace'
+import { selectStopInScene } from '../hud/HyperspacePanel'
 
 /** Same tap-vs-drag slop as every other clickable thing in the scene. */
 const TAP_SLOP = 8
@@ -47,6 +48,15 @@ const REACH = GRID_RADIUS * 8
  * stride is as unbiased a sample as any.
  */
 const MAX_POINTS = 120_000
+
+/**
+ * The landfall shell needs its own, far smaller budget. Ports fill a volume,
+ * so 120k of them read as dust; landfalls crowd one planet's surface, and at
+ * any zoom that shows the globe a generous budget paints it solid orange.
+ * A hash-uniform stride down to this many, drawn attenuated at a fixed
+ * world size, keeps the crust reading as individual dots at every zoom.
+ */
+const MAX_LANDFALL_POINTS = 9_000
 
 /**
  * Raycast threshold for GL_POINTS, in render units. Points have no surface, so
@@ -135,7 +145,7 @@ export function StopField({ axes }: Props): JSX.Element | null {
 
     if (inRange.length === 0) return null
 
-    const stride = Math.max(1, Math.ceil(inRange.length / MAX_POINTS))
+    const stride = Math.max(1, Math.ceil(inRange.length / (wantPort ? MAX_POINTS : MAX_LANDFALL_POINTS)))
     const count = Math.ceil(inRange.length / stride)
     const positions = new Float32Array(count * 3)
     const colors = new Float32Array(count * 3)
@@ -205,31 +215,49 @@ export function StopField({ axes }: Props): JSX.Element | null {
   useEffect(() => () => { highlightGeometry?.dispose() }, [highlightGeometry])
 
   if (!built) return null
+  const portView = anchorPlane === 1
 
   const pick = (e: ThreeEvent<MouseEvent>): void => {
     // An orbit-drag that happens to end on a dot is not a tap.
     if (e.delta > TAP_SLOP) return
-    if (e.index === undefined) return
-    const height = built.heights[e.index]
+    // Points raycasting returns every dot within the threshold, sorted by
+    // distance along the ray, so the event's own index is whichever
+    // qualifying dot sits closest to the CAMERA. On the crowded landfall
+    // shell that is routinely a neighbour of the dot under the pointer; the
+    // dot the user means is the one nearest the ray itself.
+    let bestIndex: number | undefined
+    let bestDist = Infinity
+    for (const hit of e.intersections) {
+      if (hit.object !== e.eventObject || hit.index === undefined) continue
+      const d = hit.distanceToRay ?? 0
+      if (d < bestDist) {
+        bestDist = d
+        bestIndex = hit.index
+      }
+    }
+    if (bestIndex === undefined) return
+    const height = built.heights[bestIndex]
     if (height === undefined) return
     e.stopPropagation()
-    useHyperspace.getState().setDestination(height)
+    selectStopInScene(height)
   }
 
   return (
     <group>
       <points geometry={built.geometry} onClick={pick} frustumCulled={false}>
         {/*
-          Pixel-sized like the terrain dust (sizeAttenuation off), so the cloud
-          reads at every zoom instead of vanishing with distance. toneMapped
-          and fog both off for the BlackSun reason: these colours are the
-          encoding, and half the field sits beyond where the scene fog has
-          already gone to black.
+          Ports: pixel-sized like the terrain dust (sizeAttenuation off), so
+          the cloud reads at every zoom instead of vanishing with distance.
+          Landfalls: world-sized and attenuated, so the crust shrinks with the
+          planet instead of blooming into a solid orange disc when the globe
+          is small on screen. toneMapped and fog both off for the BlackSun
+          reason: these colours are the encoding, and half the field sits
+          beyond where the scene fog has already gone to black.
         */}
         <pointsMaterial
           vertexColors
-          size={9}
-          sizeAttenuation={false}
+          size={portView ? 6 : 0.24}
+          sizeAttenuation={!portView}
           transparent
           opacity={0.95}
           depthWrite={false}

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -9,7 +9,7 @@
  * the whole cube the ports are a uniform dust; snapped to Earth the landfalls
  * shrink-wrap the planet.
  *
- * Placement follows the house rule exactly: cellCentre against the anchor's
+ * Placement follows the house rule exactly: pointCentre against the anchor's
  * aligned origin, fixed-point bigint deltas, never a coordinate through
  * Number. One GL_POINTS draw for the whole cloud, coloured per vertex
  * (landfall warm-blue EARTH, port purple SIDESTEP), and clicking a point
@@ -26,7 +26,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useThree, type ThreeEvent } from '@react-three/fiber'
 import { BufferGeometry, Color, Float32BufferAttribute } from 'three'
-import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
+import { GRID_RADIUS, pointCentre, type ViewAxes } from '../lib/space'
 import { ACCENT, SIDESTEP } from '../lib/palette'
 import { heightAt, kindIsPort, xyzAt } from '../lib/hyperspace/compactIndex'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
@@ -127,7 +127,7 @@ export function StopField({ axes }: Props): JSX.Element | null {
       // kind byte IS the plane bit, so the wrong half skips before decoding.
       if (kindIsPort(index, row) !== wantPort) continue
       const d = xyzAt(index, row)
-      const c = cellCentre(d, origin, scaleExp, axes)
+      const c = pointCentre(d, origin, scaleExp, axes)
       if (Math.abs(c[0]) > REACH || Math.abs(c[1]) > REACH || Math.abs(c[2]) > REACH) continue
       centres.push(c[0], c[1], c[2])
       inRange.push(row)
@@ -228,7 +228,7 @@ export function StopField({ axes }: Props): JSX.Element | null {
         */}
         <pointsMaterial
           vertexColors
-          size={3}
+          size={9}
           sizeAttenuation={false}
           transparent
           opacity={0.95}

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -26,7 +26,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useThree, type ThreeEvent } from '@react-three/fiber'
 import { BufferGeometry, Color, Float32BufferAttribute } from 'three'
-import { GRID_RADIUS, pointCentre, type ViewAxes } from '../lib/space'
+import { GRID_RADIUS, cellDelta, originShift, pointCentre, type Position, type ViewAxes } from '../lib/space'
 import { ACCENT, SIDESTEP } from '../lib/palette'
 import { heightAt, kindIsPort, xyzAt } from '../lib/hyperspace/compactIndex'
 import { coverageRuns } from '../lib/hyperspace/station'
@@ -100,6 +100,16 @@ interface Built {
   heights: number[]
   /** 1 = every stop in range is drawn; N = every Nth survived the cap. */
   stride: number
+  /** The aligned origin the positions were computed against; the render
+   * rebases the whole cloud by originShift when the anchor has since moved. */
+  origin: Position
+  /** The anchor at build time, for measuring how far the view has drifted. */
+  anchor: Position
+  /** Plane, zoom and axes of the build. A mismatch is a different frame
+   * entirely: those positions are never drawn, and a rebuild starts. */
+  frameKey: string
+  /** The rebuildVersion the rows were read at. */
+  version: number
 }
 
 export function StopField({ axes }: Props): JSX.Element | null {
@@ -131,26 +141,45 @@ export function StopField({ axes }: Props): JSX.Element | null {
   const rebuildVersion = gate.current.version
 
   const [built, setBuilt] = useState<Built | null>(null)
+  const builtRef = useRef<Built | null>(null)
 
-  // The spatial frame the current geometry was built in. A sync bump keeps
-  // the stale field visible while the rebuild runs (its positions are still
-  // right); a change of anchor, plane, zoom or axes clears it first, because
-  // every drawn position is relative to exactly those.
-  const spatialKey = `${anchor.x} ${anchor.y} ${anchor.z} ${anchorPlane} ${scaleExp} ` +
+  const frameKey = `${anchorPlane} ${scaleExp} ` +
     `${axes.right.axis}${axes.right.dir} ${axes.up.axis}${axes.up.dir} ${axes.out.axis}${axes.out.dir}`
-  const prevSpatial = useRef('')
+  const anchorKey = `${anchor.x} ${anchor.y} ${anchor.z}`
 
   useEffect(() => {
     const job = { cancelled: false }
-    if (prevSpatial.current !== spatialKey) {
-      prevSpatial.current = spatialKey
+
+    // A pure translation of the anchor does not invalidate the geometry:
+    // the render rebases the whole cloud by originShift. Rebuild only when
+    // the frame itself changed, stops arrived, or the view has drifted far
+    // enough into the REACH margin that fresh content is due. This is what
+    // keeps clicking a block (which re-anchors the scene on it) from
+    // blanking and rebuilding the field mid-burst.
+    const cur = builtRef.current
+    if (cur && cur.frameKey === frameKey && cur.version === rebuildVersion) {
+      const drift = Math.max(
+        Math.abs(cellDelta(anchor.x, cur.anchor.x, scaleExp)),
+        Math.abs(cellDelta(anchor.y, cur.anchor.y, scaleExp)),
+        Math.abs(cellDelta(anchor.z, cur.anchor.z, scaleExp)),
+      )
+      if (drift < REACH / 4) return
+    }
+    // Positions from another frame cannot be shown while the rebuild runs;
+    // a same-frame rebuild keeps the old cloud visible (rebased) instead.
+    if (cur && cur.frameKey !== frameKey) {
+      builtRef.current = null
       setBuilt(null)
     }
 
     const index = getStopIndex()
     const wantPort = anchorPlane === 1
     const budget = wantPort ? MAX_POINTS : MAX_LANDFALL_POINTS
-    const commit = (next: Built | null): void => { if (!job.cancelled) setBuilt(next) }
+    const commit = (next: Built | null): void => {
+      if (job.cancelled) return
+      builtRef.current = next
+      setBuilt(next)
+    }
 
     if (index.size === 0 || index.permCount === 0) {
       commit(null)
@@ -230,7 +259,15 @@ export function StopField({ axes }: Props): JSX.Element | null {
           rendered: count, inRange: kept.length, stride: preStride * stride, runTotal,
         }
       }
-      commit({ geometry, heights, stride: preStride * stride })
+      commit({
+        geometry,
+        heights,
+        stride: preStride * stride,
+        origin,
+        anchor: { ...anchor },
+        frameKey,
+        version: rebuildVersion,
+      })
     }
 
     // Chip away between frames. The first slice runs synchronously, so the
@@ -264,10 +301,10 @@ export function StopField({ axes }: Props): JSX.Element | null {
     slice()
 
     return () => { job.cancelled = true }
-    // The spatial deps ride in spatialKey on purpose: listing the objects
-    // too would re-run the build on identity changes that changed nothing.
+    // The spatial deps ride in the keys on purpose: listing the objects too
+    // would re-run the build on identity changes that changed nothing.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rebuildVersion, spatialKey])
+  }, [rebuildVersion, frameKey, anchorKey])
 
   // GPU buffers are not garbage collected; release each one when replaced.
   useEffect(() => () => { built?.geometry.dispose() }, [built])
@@ -304,8 +341,11 @@ export function StopField({ axes }: Props): JSX.Element | null {
   }, [highlight])
   useEffect(() => () => { highlightGeometry?.dispose() }, [highlightGeometry])
 
-  if (!built) return null
+  if (!built || built.frameKey !== frameKey) return null
   const portView = anchorPlane === 1
+  // Rebase the cloud into the current frame: a re-anchor is a change of
+  // origin, not of where the stops are.
+  const rebase = originShift(built.origin, alignedOrigin(anchor, scaleExp), scaleExp, axes)
 
   const pick = (e: ThreeEvent<MouseEvent>): void => {
     // An orbit-drag that happens to end on a dot is not a tap.
@@ -318,7 +358,12 @@ export function StopField({ axes }: Props): JSX.Element | null {
     let bestIndex: number | undefined
     let bestDist = Infinity
     for (const hit of e.intersections) {
-      if (hit.object !== e.eventObject || hit.index === undefined) continue
+      // The list is sorted by distance, so the first hit that is not a dot
+      // is something solid in front of the rest (the Earth occluder): dots
+      // beyond it are on the far side of the planet and not clickable, even
+      // when one of them lines up with the ray better than any near dot.
+      if (hit.object !== e.eventObject) break
+      if (hit.index === undefined) continue
       const d = hit.distanceToRay ?? 0
       if (d < bestDist) {
         bestDist = d
@@ -333,7 +378,7 @@ export function StopField({ axes }: Props): JSX.Element | null {
   }
 
   return (
-    <group>
+    <group position={rebase}>
       <points geometry={built.geometry} onClick={pick} frustumCulled={false}>
         {/*
           Ports: pixel-sized like the terrain dust (sizeAttenuation off), so

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -23,12 +23,13 @@
  * columnar index exists to avoid — so picks carry heights, not stops.
  */
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useThree, type ThreeEvent } from '@react-three/fiber'
 import { BufferGeometry, Color, Float32BufferAttribute } from 'three'
 import { GRID_RADIUS, pointCentre, type ViewAxes } from '../lib/space'
 import { ACCENT, SIDESTEP } from '../lib/palette'
 import { heightAt, kindIsPort, xyzAt } from '../lib/hyperspace/compactIndex'
+import { coverageRuns } from '../lib/hyperspace/station'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopIndex, useHyperspace } from '../store/useHyperspace'
 import { selectStopInScene } from '../hud/HyperspacePanel'
@@ -64,6 +65,14 @@ const MAX_LANDFALL_POINTS = 9_000
  * "I clicked that dot" without making neighbours ambiguous.
  */
 const PICK_THRESHOLD = 0.35
+
+/**
+ * Main-thread budget per build slice, in milliseconds. The scan chips away
+ * between frames instead of blocking: rows are processed in small batches,
+ * and when the budget is spent the loop yields through setTimeout so input
+ * and rendering run before the next slice.
+ */
+const SLICE_MS = 12
 
 /**
  * While the bulk sync churns, a rebuild is only worth its cost when the line
@@ -121,63 +130,144 @@ export function StopField({ axes }: Props): JSX.Element | null {
   }
   const rebuildVersion = gate.current.version
 
-  const built = useMemo((): Built | null => {
+  const [built, setBuilt] = useState<Built | null>(null)
+
+  // The spatial frame the current geometry was built in. A sync bump keeps
+  // the stale field visible while the rebuild runs (its positions are still
+  // right); a change of anchor, plane, zoom or axes clears it first, because
+  // every drawn position is relative to exactly those.
+  const spatialKey = `${anchor.x} ${anchor.y} ${anchor.z} ${anchorPlane} ${scaleExp} ` +
+    `${axes.right.axis}${axes.right.dir} ${axes.up.axis}${axes.up.dir} ${axes.out.axis}${axes.out.dir}`
+  const prevSpatial = useRef('')
+
+  useEffect(() => {
+    const job = { cancelled: false }
+    if (prevSpatial.current !== spatialKey) {
+      prevSpatial.current = spatialKey
+      setBuilt(null)
+    }
+
     const index = getStopIndex()
-    if (index.size === 0) return null
-
-    const origin = alignedOrigin(anchor, scaleExp)
     const wantPort = anchorPlane === 1
-    const centres: number[] = []
-    const inRange: number[] = []
+    const budget = wantPort ? MAX_POINTS : MAX_LANDFALL_POINTS
+    const commit = (next: Built | null): void => { if (!job.cancelled) setBuilt(next) }
 
-    for (let row = 0; row < index.size; row++) {
-      // Ports live on plane 1, landfalls on plane 0, so matching the anchor's
-      // plane is what makes the Earth view show landfalls and the ideaspace
-      // view show ports, rather than superimposing two unrelated clouds. The
-      // kind byte IS the plane bit, so the wrong half skips before decoding.
-      if (kindIsPort(index, row) !== wantPort) continue
-      const d = xyzAt(index, row)
-      const c = pointCentre(d, origin, scaleExp, axes)
-      if (Math.abs(c[0]) > REACH || Math.abs(c[1]) > REACH || Math.abs(c[2]) > REACH) continue
-      centres.push(c[0], c[1], c[2])
-      inRange.push(row)
+    if (index.size === 0 || index.permCount === 0) {
+      commit(null)
+      return
     }
 
-    if (inRange.length === 0) return null
-
-    const stride = Math.max(1, Math.ceil(inRange.length / (wantPort ? MAX_POINTS : MAX_LANDFALL_POINTS)))
-    const count = Math.ceil(inRange.length / stride)
-    const positions = new Float32Array(count * 3)
-    const colors = new Float32Array(count * 3)
-    const heights: number[] = new Array(count)
-
-    let v = 0
-    for (let i = 0; i < inRange.length; i += stride) {
-      positions[v * 3] = centres[i * 3]
-      positions[v * 3 + 1] = centres[i * 3 + 1]
-      positions[v * 3 + 2] = centres[i * 3 + 2]
-      const col = kindIsPort(index, inRange[i]) ? PORT_COLOR : LANDFALL_COLOR
-      colors[v * 3] = col.r
-      colors[v * 3 + 1] = col.g
-      colors[v * 3 + 2] = col.b
-      heights[v] = heightAt(index, inRange[i])
-      v++
+    // The sorted view bounds the scan to rows that can possibly be in range
+    // (coverageRuns), so a spawn-scale build touches a handful of rows
+    // instead of cold-decoding a million to keep none of them. That cold
+    // decode, measured at ~7 microseconds a row, was the six-second boot
+    // freeze once the index snapshot began delivering the whole line at
+    // once, and the same freeze on VIEW NEAREST STOP.
+    const runs = coverageRuns(index, anchor.x, anchor.y, anchor.z, scaleExp, REACH + 2)
+    let runTotal = 0
+    for (const [runStart, runEnd] of runs) runTotal += runEnd - runStart
+    if (runTotal === 0) {
+      commit(null)
+      return
     }
 
-    const geometry = new BufferGeometry()
-    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3))
-    geometry.setAttribute('color', new Float32BufferAttribute(colors, 3))
-
-    // Same dev hook style as ShaderPointField: lets the browser harness read
-    // what actually reached the GPU, decimation factor included.
-    if (import.meta.env.DEV) {
-      ;(window as unknown as { __stopField?: unknown }).__stopField = {
-        rendered: count, inRange: inRange.length, stride,
+    // Decimate BEFORE decoding: the run total already bounds the in-range
+    // population, so sampling down to about twice the point budget cuts a
+    // dense view's decode work by an order of magnitude, and the post-filter
+    // stride below still lands the budget. Row ids are copied out up front
+    // because a background merge may re-sort perm between slices; the rows
+    // themselves never move.
+    const preStride = Math.max(1, Math.floor(runTotal / (budget * 2)))
+    const rows = new Uint32Array(Math.ceil(runTotal / preStride))
+    let w = 0
+    {
+      let i = 0
+      let next = 0
+      for (const [runStart, runEnd] of runs) {
+        for (let pos = runStart; pos < runEnd; pos++, i++) {
+          if (i === next) {
+            rows[w++] = index.perm[pos]
+            next += preStride
+          }
+        }
       }
     }
 
-    return { geometry, heights, stride }
-  }, [rebuildVersion, anchor, scaleExp, axes, anchorPlane])
+    const origin = alignedOrigin(anchor, scaleExp)
+    const kept: number[] = []
+    const centres: number[] = []
+    let i = 0
+
+    const finish = (): void => {
+      if (kept.length === 0) {
+        commit(null)
+        return
+      }
+      const stride = Math.max(1, Math.ceil(kept.length / budget))
+      const count = Math.ceil(kept.length / stride)
+      const positions = new Float32Array(count * 3)
+      const colors = new Float32Array(count * 3)
+      const heights: number[] = new Array(count)
+      let v = 0
+      for (let k = 0; k < kept.length; k += stride) {
+        positions[v * 3] = centres[k * 3]
+        positions[v * 3 + 1] = centres[k * 3 + 1]
+        positions[v * 3 + 2] = centres[k * 3 + 2]
+        const col = kindIsPort(index, kept[k]) ? PORT_COLOR : LANDFALL_COLOR
+        colors[v * 3] = col.r
+        colors[v * 3 + 1] = col.g
+        colors[v * 3 + 2] = col.b
+        heights[v] = heightAt(index, kept[k])
+        v++
+      }
+      const geometry = new BufferGeometry()
+      geometry.setAttribute('position', new Float32BufferAttribute(positions, 3))
+      geometry.setAttribute('color', new Float32BufferAttribute(colors, 3))
+      // Same dev hook style as ShaderPointField: lets the browser harness
+      // read what actually reached the GPU, decimation factor included.
+      if (import.meta.env.DEV) {
+        ;(window as unknown as { __stopField?: unknown }).__stopField = {
+          rendered: count, inRange: kept.length, stride: preStride * stride, runTotal,
+        }
+      }
+      commit({ geometry, heights, stride: preStride * stride })
+    }
+
+    // Chip away between frames. The first slice runs synchronously, so the
+    // common case after the coverage cull (a small view) commits in the same
+    // React flush as the clear above and never flickers through an empty
+    // frame.
+    const slice = (): void => {
+      if (job.cancelled) return
+      const t0 = performance.now()
+      while (i < w) {
+        const batchEnd = Math.min(w, i + 1024)
+        for (; i < batchEnd; i++) {
+          const row = rows[i]
+          // Ports live on plane 1, landfalls on plane 0, so matching the
+          // anchor's plane shows one cloud instead of superimposing two
+          // unrelated ones; the kind byte IS the plane bit.
+          if (kindIsPort(index, row) !== wantPort) continue
+          const d = xyzAt(index, row)
+          const c = pointCentre(d, origin, scaleExp, axes)
+          if (Math.abs(c[0]) > REACH || Math.abs(c[1]) > REACH || Math.abs(c[2]) > REACH) continue
+          kept.push(row)
+          centres.push(c[0], c[1], c[2])
+        }
+        if (performance.now() - t0 >= SLICE_MS) {
+          setTimeout(slice, 0)
+          return
+        }
+      }
+      finish()
+    }
+    slice()
+
+    return () => { job.cancelled = true }
+    // The spatial deps ride in spatialKey on purpose: listing the objects
+    // too would re-run the build on identity changes that changed nothing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rebuildVersion, spatialKey])
 
   // GPU buffers are not garbage collected; release each one when replaced.
   useEffect(() => () => { built?.geometry.dispose() }, [built])

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -1,0 +1,236 @@
+/**
+ * StopField.tsx — every stop on the hyperspace line, as a point you can pick.
+ *
+ * DECK-0001: every Bitcoin block is a stop. A merkle root with plane bit 1 is
+ * a port in ideaspace at the root's own coordinate; plane bit 0 has fallen to
+ * Earth as a landfall on the WGS84 surface. Nobody chose any of these
+ * positions, which is why seeing them all at once matters: the cloud IS the
+ * shape proof of work has scattered through the space. From a bird's-eye of
+ * the whole cube the ports are a uniform dust; snapped to Earth the landfalls
+ * shrink-wrap the planet.
+ *
+ * Placement follows the house rule exactly: cellCentre against the anchor's
+ * aligned origin, fixed-point bigint deltas, never a coordinate through
+ * Number. One GL_POINTS draw for the whole cloud, coloured per vertex
+ * (landfall warm-blue EARTH, port purple SIDESTEP), and clicking a point
+ * selects that stop as the ride's destination.
+ */
+
+import { useEffect, useMemo } from 'react'
+import { useThree, type ThreeEvent } from '@react-three/fiber'
+import { BufferGeometry, Color, Float32BufferAttribute } from 'three'
+import { coordToXyz, type Xyz } from 'cyberspace-core'
+import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
+import { ACCENT, EARTH, SIDESTEP } from '../lib/palette'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { getStopIndex, useHyperspace } from '../store/useHyperspace'
+import type { Stop } from '../lib/hyperspace/stops'
+
+/** Same tap-vs-drag slop as every other clickable thing in the scene. */
+const TAP_SLOP = 8
+
+/** Same reach as WorldMessages and the sector cage: beyond this a stop is off-grid at this scale. */
+const REACH = GRID_RADIUS * 8
+
+/**
+ * Hard ceiling on points actually built. The chain is near a million blocks;
+ * a full-cube view puts half of them (one plane's worth) in range at once, and
+ * a million-vertex transparent point cloud under bloom is overdraw the frame
+ * budget does not have. Past the cap the field is decimated to every Nth stop,
+ * which preserves the cloud's shape — the positions are hash-uniform, so a
+ * stride is as unbiased a sample as any.
+ */
+const MAX_POINTS = 120_000
+
+/**
+ * Raycast threshold for GL_POINTS, in render units. Points have no surface, so
+ * picking is "within this distance of the ray"; a third of a cell reads as
+ * "I clicked that dot" without making neighbours ambiguous.
+ */
+const PICK_THRESHOLD = 0.35
+
+/**
+ * Decoded-coordinate cache. coordToXyz de-interleaves 255 bits per stop, and
+ * doing that for ~950k stops costs seconds — far too much to repeat on every
+ * anchor move or zoom, which only change the cheap cellDelta step. Stops are
+ * stable objects (the index replaces the array, not the entries), so a WeakMap
+ * keyed on the Stop itself survives every rebuild that keeps an entry and lets
+ * the GC reclaim what a rebuild drops.
+ */
+const decoded = new WeakMap<Stop, Xyz>()
+
+function decode(stop: Stop): Xyz {
+  let d = decoded.get(stop)
+  if (!d) {
+    d = coordToXyz(stop.coordApprox)
+    decoded.set(stop, d)
+  }
+  return d
+}
+
+/** Per-vertex colours: landfalls in Earth's blue, ports in ideaspace purple. */
+const LANDFALL_COLOR = new Color(EARTH)
+const PORT_COLOR = new Color(SIDESTEP)
+
+interface Props {
+  axes: ViewAxes
+}
+
+interface Built {
+  geometry: BufferGeometry
+  /** Parallel to the geometry's vertices, so a picked index maps to its stop. */
+  stops: Stop[]
+  /** 1 = every stop in range is drawn; N = every Nth survived the cap. */
+  stride: number
+}
+
+export function StopField({ axes }: Props): JSX.Element | null {
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const indexVersion = useHyperspace((s) => s.indexVersion)
+  const destination = useHyperspace((s) => s.destination)
+
+  const built = useMemo((): Built | null => {
+    const { stops } = getStopIndex()
+    if (stops.length === 0) return null
+
+    const origin = alignedOrigin(anchor, scaleExp)
+    const centres: number[] = []
+    const inRange: Stop[] = []
+
+    for (const stop of stops) {
+      const d = decode(stop)
+      // Ports live on plane 1, landfalls on plane 0, so matching the anchor's
+      // plane is what makes the Earth view show landfalls and the ideaspace
+      // view show ports, rather than superimposing two unrelated clouds.
+      if (d.plane !== anchorPlane) continue
+      const c = cellCentre(d, origin, scaleExp, axes)
+      if (Math.abs(c[0]) > REACH || Math.abs(c[1]) > REACH || Math.abs(c[2]) > REACH) continue
+      centres.push(c[0], c[1], c[2])
+      inRange.push(stop)
+    }
+
+    if (inRange.length === 0) return null
+
+    const stride = Math.max(1, Math.ceil(inRange.length / MAX_POINTS))
+    const count = Math.ceil(inRange.length / stride)
+    const positions = new Float32Array(count * 3)
+    const colors = new Float32Array(count * 3)
+    const kept: Stop[] = new Array(count)
+
+    let v = 0
+    for (let i = 0; i < inRange.length; i += stride) {
+      positions[v * 3] = centres[i * 3]
+      positions[v * 3 + 1] = centres[i * 3 + 1]
+      positions[v * 3 + 2] = centres[i * 3 + 2]
+      const col = inRange[i].kind === 'landfall' ? LANDFALL_COLOR : PORT_COLOR
+      colors[v * 3] = col.r
+      colors[v * 3 + 1] = col.g
+      colors[v * 3 + 2] = col.b
+      kept[v] = inRange[i]
+      v++
+    }
+
+    const geometry = new BufferGeometry()
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3))
+    geometry.setAttribute('color', new Float32BufferAttribute(colors, 3))
+
+    // Same dev hook style as ShaderPointField: lets the browser harness read
+    // what actually reached the GPU, decimation factor included.
+    if (import.meta.env.DEV) {
+      ;(window as unknown as { __stopField?: unknown }).__stopField = {
+        rendered: count, inRange: inRange.length, stride,
+      }
+    }
+
+    return { geometry, stops: kept, stride }
+  }, [indexVersion, anchor, scaleExp, axes, anchorPlane])
+
+  // GPU buffers are not garbage collected; release each one when replaced.
+  useEffect(() => () => { built?.geometry.dispose() }, [built])
+
+  // Points raycast by distance-to-ray, and the default threshold of 1 render
+  // unit makes a click grab dots half a screen away. Scoped to this
+  // component's lifetime and restored on unmount, because the raycaster is
+  // shared by everything clickable in the Canvas.
+  const raycaster = useThree((s) => s.raycaster)
+  useEffect(() => {
+    const prev = raycaster.params.Points.threshold
+    raycaster.params.Points.threshold = PICK_THRESHOLD
+    return () => { raycaster.params.Points.threshold = prev }
+  }, [raycaster])
+
+  // The chosen destination, re-marked in ACCENT. Found by height rather than
+  // by identity because the destination can outlive a geometry rebuild.
+  const highlight = useMemo((): [number, number, number] | null => {
+    if (!built || destination === null) return null
+    for (let i = 0; i < built.stops.length; i++) {
+      if (built.stops[i].height === destination) {
+        const p = built.geometry.getAttribute('position')
+        return [p.getX(i), p.getY(i), p.getZ(i)]
+      }
+    }
+    return null
+  }, [built, destination])
+
+  const highlightGeometry = useMemo(() => {
+    if (!highlight) return null
+    const g = new BufferGeometry()
+    g.setAttribute('position', new Float32BufferAttribute(new Float32Array(highlight), 3))
+    return g
+  }, [highlight])
+  useEffect(() => () => { highlightGeometry?.dispose() }, [highlightGeometry])
+
+  if (!built) return null
+
+  const pick = (e: ThreeEvent<MouseEvent>): void => {
+    // An orbit-drag that happens to end on a dot is not a tap.
+    if (e.delta > TAP_SLOP) return
+    if (e.index === undefined) return
+    const stop = built.stops[e.index]
+    if (!stop) return
+    e.stopPropagation()
+    useHyperspace.getState().setDestination(stop.height)
+  }
+
+  return (
+    <group>
+      <points geometry={built.geometry} onClick={pick} frustumCulled={false}>
+        {/*
+          Pixel-sized like the terrain dust (sizeAttenuation off), so the cloud
+          reads at every zoom instead of vanishing with distance. toneMapped
+          and fog both off for the BlackSun reason: these colours are the
+          encoding, and half the field sits beyond where the scene fog has
+          already gone to black.
+        */}
+        <pointsMaterial
+          vertexColors
+          size={3}
+          sizeAttenuation={false}
+          transparent
+          opacity={0.95}
+          depthWrite={false}
+          toneMapped={false}
+          fog={false}
+        />
+      </points>
+      {highlightGeometry && (
+        <points geometry={highlightGeometry} frustumCulled={false}>
+          {/* No click handler: a click on the marker should fall through to
+              the dot beneath it rather than re-picking by a foreign index. */}
+          <pointsMaterial
+            color={ACCENT}
+            size={9}
+            sizeAttenuation={false}
+            transparent
+            opacity={0.9}
+            depthWrite={false}
+            toneMapped={false}
+            fog={false}
+          />
+        </points>
+      )}
+    </group>
+  )
+}

--- a/src/store/hyperspaceView.test.ts
+++ b/src/store/hyperspaceView.test.ts
@@ -1,0 +1,63 @@
+/**
+ * What would fail silently without these tests: a stale focus surviving into a
+ * spectate hides the avatar and pins the rig to the old point, so a friend's
+ * chain "never loads" while every store field looks plausible; and an exit
+ * path that clears a focus it does not own would yank the camera out of a
+ * shard inspection. These pin the ownership rules down.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useCyberspace } from './useCyberspace'
+import { exitHyperspaceView, ownHyperspaceView, useHyperspace } from './useHyperspace'
+
+const PK = 'ab'.repeat(32)
+
+beforeEach(() => {
+  useCyberspace.getState().endSpectate()
+  useCyberspace.getState().clearFocus()
+  useHyperspace.setState({ scrubHeight: null, viewOwned: false })
+})
+
+describe('spectate vs focus', () => {
+  it('beginSpectate clears a standing focus', () => {
+    useCyberspace.getState().focusOn({ x: 5n, y: 6n, z: 7n }, 0, 'EARTH', 52)
+    expect(useCyberspace.getState().focus).not.toBeNull()
+    useCyberspace.getState().beginSpectate(PK)
+    expect(useCyberspace.getState().focus).toBeNull()
+    expect(useCyberspace.getState().spectate?.pubkey).toBe(PK)
+  })
+
+  it('a new spectate closes the scrubber and drops hyperspace view ownership', () => {
+    useHyperspace.setState({ scrubHeight: 1234, viewOwned: true })
+    useCyberspace.getState().beginSpectate(PK)
+    expect(useHyperspace.getState().scrubHeight).toBeNull()
+    expect(useHyperspace.getState().viewOwned).toBe(false)
+  })
+})
+
+describe('exitHyperspaceView', () => {
+  it('clears a focus hyperspace owns and returns the anchor home', () => {
+    ownHyperspaceView()
+    useCyberspace.getState().focusOn({ x: 5n, y: 6n, z: 7n }, 0, 'BLOCK 42 · PORT', 34)
+    exitHyperspaceView()
+    expect(useCyberspace.getState().focus).toBeNull()
+    expect(useHyperspace.getState().viewOwned).toBe(false)
+    expect(useHyperspace.getState().scrubHeight).toBeNull()
+  })
+
+  it('leaves a foreign focus alone', () => {
+    useCyberspace.getState().focusOn({ x: 5n, y: 6n, z: 7n }, 0, 'SHARD', 20)
+    exitHyperspaceView()
+    expect(useCyberspace.getState().focus).not.toBeNull()
+    useCyberspace.getState().clearFocus()
+  })
+
+  it('never clears focus while a spectate is running', () => {
+    ownHyperspaceView()
+    useCyberspace.getState().beginSpectate(PK)
+    // ownership was already dropped by the subscription; even if it were not,
+    // exiting must not touch the spectate's state
+    useHyperspace.setState({ viewOwned: true })
+    exitHyperspaceView()
+    expect(useCyberspace.getState().spectate?.pubkey).toBe(PK)
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -987,6 +987,9 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     set({
       spectate: { pubkey, npub: nip19.npubEncode(pubkey), events: [], actions: [], lastActive: null, status: 'loading' },
       exploreIndex: null,
+      // A standing focus (a shard, EARTH, a viewed stop) would hide the
+      // avatar and keep the rig on the old point: spectating replaces it.
+      focus: null,
       anchor: spawn.position,
       anchorPlane: spawn.plane,
     })

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -74,6 +74,7 @@ import {
   hyperjumpTemplate,
 } from '../lib/events'
 import { cancelProof, postProof, type ProofMode, type ProofResponse } from '../lib/workers'
+import { recommendedHopHeight } from '../lib/calibration'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
 
@@ -185,6 +186,8 @@ export interface CompletedRide {
   toCoordHex: string
   fromHeight: number
   toHeight: number
+  /** The station set bound declared in the event (as_of tag). */
+  asOf?: number
   rootHex: string
   mp: string
 }
@@ -744,14 +747,20 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     // fits, otherwise a Merkle sidestep across the blocking wall(s). The
     // sidestep lands 1 gibson past the boundary, not at the cursor; the
     // cursor keeps the rest of the journey for the next commit.
+    // The ceiling this commit will actually attempt: the protocol's hard cap,
+    // lowered to what calibration measured THIS machine finishing in budget
+    // (lib/calibration.ts). Routing, the sidestep landing and the worker all
+    // use the same number, so a hop the machine cannot finish becomes a
+    // sidestep at the real ceiling instead of a stalled tab.
+    const ceiling = Math.min(MAX_COMPUTE_HEIGHT, recommendedHopHeight())
     const estimate = estimateHopCost(
       position.x, position.y, position.z,
       cursor.x, cursor.y, cursor.z,
       plane,
-      MAX_COMPUTE_HEIGHT,
+      ceiling,
     )
     const mode: ProofMode = estimate.exceedsLimit ? 'sidestep' : 'hop'
-    const to = mode === 'sidestep' ? sidestepTarget(position, cursor) : { ...cursor }
+    const to = mode === 'sidestep' ? sidestepTarget(position, cursor, ceiling) : { ...cursor }
     if (samePosition(position, to) && plane === headPlane) return
 
     const id = ++requestId
@@ -767,7 +776,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       to,
       plane,
       prevEventId,
-      maxComputeHeight: MAX_COMPUTE_HEIGHT,
+      maxComputeHeight: ceiling,
     })
   },
 
@@ -1096,6 +1105,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       toCoordHex: ride.toCoordHex,
       fromHeight: ride.fromHeight,
       toHeight: ride.toHeight,
+      asOf: ride.asOf,
       rootHex: ride.rootHex,
       mp: ride.mp,
     })
@@ -1385,10 +1395,12 @@ export function samePosition(a: Position, b: Position): boolean {
  * Where a sidestep commit toward `cursor` actually lands: each axis whose
  * crossing is beyond the Cantor ceiling steps 1 gibson past its wall; every
  * other axis stays put, because a spec-valid sidestep only crosses walls.
+ * The ceiling defaults to the hard cap; commit passes the calibrated one so
+ * the landing agrees with the routing decision that chose a sidestep.
  */
-export function sidestepTarget(position: Position, cursor: Position): Position {
+export function sidestepTarget(position: Position, cursor: Position, ceiling: number = MAX_COMPUTE_HEIGHT): Position {
   const land = (p: bigint, c: bigint): bigint =>
-    findLcaHeight(p, c) > MAX_COMPUTE_HEIGHT ? sidestepLanding(p, c) : p
+    findLcaHeight(p, c) > ceiling ? sidestepLanding(p, c) : p
   return {
     x: land(position.x, cursor.x),
     y: land(position.y, cursor.y),

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -1357,7 +1357,19 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
    * screen centre, so zooming tracks the cursor instead of the avatar.
    */
   cursorOffset: (): [number, number, number] => {
-    const { anchor, cursor, scaleExp, view } = get()
+    const { anchor, cursor, scaleExp, view, focus } = get()
+    const focusAxes = viewAxes(view)
+    // A focus is a continuous point (a stop, Earth's centre), and everything
+    // drawn at it uses pointCentre. Framing [0,0,0], the aligned CORNER of
+    // its cell, put the viewed block up-and-right of screen centre by the
+    // sub-cell fraction (always positive, so always the same corner). Frame
+    // the point itself, with the same continuous math it is drawn with.
+    if (focus !== null) {
+      const focusOrigin = alignedOrigin(anchor, scaleExp)
+      return [focusAxes.right, focusAxes.up, focusAxes.out].map(
+        (a) => cellDelta(anchor[a.axis], focusOrigin[a.axis], scaleExp) * a.dir,
+      ) as [number, number, number]
+    }
     // Off your own head there is no cursor to frame; the camera sits on the anchor.
     if (!get().atHead()) return [0, 0, 0]
     const axes = viewAxes(view)

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -41,6 +41,7 @@ import {
   hexToCoord,
   sectorTag,
   sidestepLanding,
+  xyzToCoord,
   xyzToSectorId,
   type Plane,
 } from 'cyberspace-core'
@@ -69,8 +70,11 @@ import {
   type ActionEvent,
   type EventTemplate,
   type NostrEvent,
+  enterHyperspaceTemplate,
+  hyperjumpTemplate,
 } from '../lib/events'
 import { cancelProof, postProof, type ProofMode, type ProofResponse } from '../lib/workers'
+import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
 
 /**
@@ -167,6 +171,22 @@ export interface TrackedTarget {
   plane: Plane
   lastActive: number | null
   status: 'resolving' | 'live' | 'spawn' | 'error'
+}
+
+/** Hyperspace transit (DECK-0001 v3): the identity has boarded and not yet arrived. */
+export interface TransitState {
+  stage: 'boarded'
+  enterEventId: string
+  enterCoordHex: string
+}
+
+/** A finished ride, as the worker pool hands it back (§5.4 and §5.5). */
+export interface CompletedRide {
+  toCoordHex: string
+  fromHeight: number
+  toHeight: number
+  rootHex: string
+  mp: string
 }
 
 export interface CyberspaceState {
@@ -266,6 +286,14 @@ export interface CyberspaceState {
   focusOn: (position: Position, plane: Plane, label: string, scaleExp?: number) => void
   /** Stop looking; the scene returns to your avatar. */
   clearFocus: () => void
+  /** Hyperspace transit: non-null from boarding until arrival (DECK-0001 v3). */
+  transit: TransitState | null
+  /** §3: sign and queue an enter-hyperspace event from the current position. */
+  boardHyperspace: () => Promise<void>
+  /** §5: sign and queue the hyperjump for a computed ride, arriving at the stop. */
+  completeRide: (ride: CompletedRide) => Promise<void>
+  /** Forget the boarding locally; the next hop cancels it on the wire (§3.3). */
+  cancelTransit: () => void
   addTarget: (pubkey: string, name?: string | null) => void
   removeTarget: (pubkey: string) => void
   toggleTarget: (pubkey: string, name?: string | null) => void
@@ -625,6 +653,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       publishError: null,
       spectate: null,
       focus: null,
+      transit: null,
     })
     if (local) saveChain(base.events, base.published, base.chain)
   }
@@ -634,6 +663,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   ...initial,
   spectate: null,
   focus: null,
+  transit: null,
   targets: loadTargets(),
   cursor: initial.position,
   pendingTarget: null,
@@ -1010,6 +1040,91 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     set({ focus: null, anchor: position, anchorPlane: headPlane })
   },
 
+  boardHyperspace: async () => {
+    const { events, genesisId, prevEventId, position, plane, proof, transit } = get()
+    if (transit !== null || proof.status === 'computing') return
+    if (get().exploreIndex !== null || get().spectate !== null || get().focus !== null) return
+    // A provisional identity has no chain to board from; move once first.
+    if (events.length === 0 || !genesisId || !prevEventId) return
+    const head = events[events.length - 1]
+    const coord = xyzToCoord(position.x, position.y, position.z, plane)
+    const proofHash = computeEnterProof(coord, prevEventId)
+    const template = enterHyperspaceTemplate({
+      createdAt: nextCreatedAt(head),
+      genesisId,
+      previousId: prevEventId,
+      at: position,
+      plane,
+      proofHash,
+    })
+    let event: NostrEvent
+    try {
+      event = await get().signEvent(template)
+    } catch {
+      return
+    }
+    // The chain may have advanced while a remote signer thought about it.
+    if (get().prevEventId !== prevEventId) return
+    const published: Record<string, PublishStatus> = { ...get().published, [event.id]: 'queued' }
+    const nextEvents = [...get().events, event]
+    set({
+      events: nextEvents,
+      prevEventId: event.id,
+      published,
+      positionHistory: [...get().positionHistory, { ...position }],
+      transit: { stage: 'boarded', enterEventId: event.id, enterCoordHex: positionHex(position, plane) },
+    })
+    saveChain(nextEvents, published, get().chain)
+  },
+
+  completeRide: async (ride) => {
+    const { events, genesisId, prevEventId, transit } = get()
+    if (!transit || !genesisId || !prevEventId) return
+    const head = events[events.length - 1]
+    if (!head) return
+    // One ride per boarding for now; the spec allows chaining rides (§4.3) and
+    // the builder supports it, but the client boards fresh each time.
+    const prevCoordHex = head.tags.find((t) => t[0] === 'C')?.[1] ?? transit.enterCoordHex
+    const template = hyperjumpTemplate({
+      createdAt: nextCreatedAt(head),
+      genesisId,
+      previousId: prevEventId,
+      prevCoordHex,
+      toCoordHex: ride.toCoordHex,
+      fromHeight: ride.fromHeight,
+      toHeight: ride.toHeight,
+      rootHex: ride.rootHex,
+      mp: ride.mp,
+    })
+    let event: NostrEvent
+    try {
+      event = await get().signEvent(template)
+    } catch {
+      return
+    }
+    if (get().prevEventId !== prevEventId) return
+    const dest = coordToXyz(hexToCoord(ride.toCoordHex))
+    const newPosition: Position = { x: dest.x, y: dest.y, z: dest.z }
+    const published: Record<string, PublishStatus> = { ...get().published, [event.id]: 'queued' }
+    const nextEvents = [...get().events, event]
+    set({
+      events: nextEvents,
+      prevEventId: event.id,
+      published,
+      position: newPosition,
+      cursor: { ...newPosition },
+      plane: dest.plane,
+      headPlane: dest.plane,
+      positionHistory: [...get().positionHistory, newPosition],
+      anchor: { ...newPosition },
+      anchorPlane: dest.plane,
+      transit: null,
+    })
+    saveChain(nextEvents, published, get().chain)
+  },
+
+  cancelTransit: () => set({ transit: null }),
+
   addTarget: (pubkey, name = null) => {
     const { targets } = get()
     if (targets[pubkey]) {
@@ -1189,7 +1304,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
   actions: () => parsedChain(get().events),
 
-  atHead: () => get().exploreIndex === null && get().spectate === null && get().focus === null,
+  atHead: () =>
+    get().exploreIndex === null &&
+    get().spectate === null &&
+    get().focus === null &&
+    get().transit === null,
 
   focusChain: () => {
     const { spectate } = get()

--- a/src/store/useHyperspace.ts
+++ b/src/store/useHyperspace.ts
@@ -41,6 +41,9 @@ interface HyperspaceState {
   /** The zoom to restore when the owned view exits; captured when hyperspace
    * first takes the focus, because its views re-frame at their own scales. */
   returnScaleExp: number | null
+  /** The stop height the owned hyperspace focus is on, or null when the
+   * focus is not a stop (EARTH's centre) or hyperspace has no view. */
+  viewedStop: number | null
   /** The chosen destination stop height; null = none. */
   destination: number | null
   startSync: () => void
@@ -59,6 +62,7 @@ export const useHyperspace = create<HyperspaceState>((set) => ({
   scrubHeight: null,
   viewOwned: false,
   returnScaleExp: null,
+  viewedStop: null,
   destination: null,
 
   startSync: () => {
@@ -106,13 +110,19 @@ export function ownHyperspaceView(): void {
   useHyperspace.setState({ viewOwned: true, returnScaleExp: useCyberspace.getState().scaleExp })
 }
 
+/** Record which stop the owned focus is on (null for a non-stop focus like
+ * EARTH's centre), so the scene can treat the viewed block specially. */
+export function markViewedStop(height: number | null): void {
+  useHyperspace.setState({ viewedStop: height })
+}
+
 /**
  * Leave the hyperspace view: close the scrubber, and clear the focus only if
  * hyperspace set it (never a shard's focus, never a running spectate).
  */
 export function exitHyperspaceView(): void {
   const { viewOwned: owned, returnScaleExp } = useHyperspace.getState()
-  useHyperspace.setState({ scrubHeight: null, viewOwned: false, returnScaleExp: null })
+  useHyperspace.setState({ scrubHeight: null, viewOwned: false, returnScaleExp: null, viewedStop: null })
   const cs = useCyberspace.getState()
   if (owned && cs.spectate === null && cs.focus !== null) cs.clearFocus()
   // Back at the zoom the user left, not whatever a stop view chose.
@@ -129,7 +139,7 @@ useCyberspace.subscribe((s, prev) => {
     if (hs.scrubHeight !== null || hs.viewOwned) {
       // No zoom restore here: the spectate is taking the camera somewhere
       // else on purpose, and yanking the scale under it would fight that.
-      useHyperspace.setState({ scrubHeight: null, viewOwned: false, returnScaleExp: null })
+      useHyperspace.setState({ scrubHeight: null, viewOwned: false, returnScaleExp: null, viewedStop: null })
     }
   }
 })

--- a/src/store/useHyperspace.ts
+++ b/src/store/useHyperspace.ts
@@ -2,16 +2,18 @@
  * useHyperspace.ts: sync state and UI selections for the hyperspace line.
  *
  * The store holds only what React should re-render on: sync progress, the
- * tip, the scrubber position and the chosen destination. The ~950k stops
- * themselves live in module-level singletons owned by the anchors engine
- * (the cameraPose convention: per-frame and bulk data must not flow through
- * state). Components read them through getStopIndex / getStopByHeight and
- * subscribe to indexVersion to learn that stops changed; the engine batches
- * bumps to at most one per 500 ms during the bulk load.
+ * tip, the scrubber position and the chosen destination. The ~1M stops
+ * themselves live in a module-level columnar singleton owned by the anchors
+ * engine (the cameraPose convention: per-frame and bulk data must not flow
+ * through state). Components read them through getStopIndex / getStopByHeight
+ * and subscribe to indexVersion to learn that stops changed; the engine
+ * batches bumps to at most one per 2.5 s during the bulk load and one per
+ * 500 ms once ready.
  */
 
 import { create } from 'zustand'
-import { anchorIndex, anchorsByHeight, runAnchorSync } from '../lib/hyperspace/anchors'
+import { anchorIndex, runAnchorSync, type SyncSource } from '../lib/hyperspace/anchors'
+import { stopByHeight } from '../lib/hyperspace/compactIndex'
 import type { Stop } from '../lib/hyperspace/stops'
 import type { StopIndex } from '../lib/hyperspace/station'
 import { useCyberspace } from './useCyberspace'
@@ -23,6 +25,8 @@ export interface HyperspaceSync {
   /** tipHeight + 1 when known, else 0. */
   total: number
   error: string | null
+  /** Where stops have come from: verified header blobs, the relay, or both. */
+  source: SyncSource
 }
 
 interface HyperspaceState {
@@ -46,7 +50,7 @@ interface HyperspaceState {
 let started = false
 
 export const useHyperspace = create<HyperspaceState>((set) => ({
-  sync: { status: 'idle', loaded: 0, total: 0, error: null },
+  sync: { status: 'idle', loaded: 0, total: 0, error: null, source: 'relay' },
   indexVersion: 0,
   tipHeight: null,
   scrubHeight: null,
@@ -64,6 +68,7 @@ export const useHyperspace = create<HyperspaceState>((set) => ({
     }
     void runAnchorSync({
       onStatus: (status, error) => set((s) => ({ sync: { ...s.sync, status, error: error ?? null } })),
+      onSource: (source) => set((s) => ({ sync: { ...s.sync, source } })),
       onLoaded: (loaded) => set((s) => ({ sync: { ...s.sync, loaded } })),
       onTip: (tip) => set((s) => ({ tipHeight: tip, sync: { ...s.sync, total: tip + 1 } })),
       onIndexChanged: () => set((s) => ({ indexVersion: s.indexVersion + 1 })),
@@ -80,11 +85,11 @@ export function getStopIndex(): StopIndex {
 }
 
 export function getStopByHeight(height: number): Stop | undefined {
-  return anchorsByHeight.get(height)
+  return stopByHeight(anchorIndex, height)
 }
 
 export function stopCount(): number {
-  return anchorsByHeight.size
+  return anchorIndex.size
 }
 
 
@@ -114,3 +119,18 @@ useCyberspace.subscribe((s, prev) => {
     }
   }
 })
+
+
+// DEV window handle, the house pattern (__store, __shards): lets a headless
+// smoke test drive the scrubber and destination without waiting for a full
+// relay sync to unlock the rail UI.
+declare global {
+  interface Window { __hyper?: unknown }
+}
+try {
+  if (typeof window !== 'undefined' && import.meta.env.DEV) {
+    window.__hyper = { store: useHyperspace, getStopByHeight, stopCount }
+  }
+} catch {
+  // node or a locked-down context: the handle is a convenience only
+}

--- a/src/store/useHyperspace.ts
+++ b/src/store/useHyperspace.ts
@@ -1,0 +1,84 @@
+/**
+ * useHyperspace.ts: sync state and UI selections for the hyperspace line.
+ *
+ * The store holds only what React should re-render on: sync progress, the
+ * tip, the scrubber position and the chosen destination. The ~950k stops
+ * themselves live in module-level singletons owned by the anchors engine
+ * (the cameraPose convention: per-frame and bulk data must not flow through
+ * state). Components read them through getStopIndex / getStopByHeight and
+ * subscribe to indexVersion to learn that stops changed; the engine batches
+ * bumps to at most one per 500 ms during the bulk load.
+ */
+
+import { create } from 'zustand'
+import { anchorIndex, anchorsByHeight, runAnchorSync } from '../lib/hyperspace/anchors'
+import type { Stop } from '../lib/hyperspace/stops'
+import type { StopIndex } from '../lib/hyperspace/station'
+
+export interface HyperspaceSync {
+  status: 'idle' | 'loading-cache' | 'syncing' | 'ready' | 'error'
+  /** Unique heights currently in the index. */
+  loaded: number
+  /** tipHeight + 1 when known, else 0. */
+  total: number
+  error: string | null
+}
+
+interface HyperspaceState {
+  sync: HyperspaceSync
+  /** Bumped whenever stops are added to the index. */
+  indexVersion: number
+  tipHeight: number | null
+  /** The stop being viewed on the line; null = scrubber off. */
+  scrubHeight: number | null
+  /** The chosen destination stop height; null = none. */
+  destination: number | null
+  startSync: () => void
+  setScrubHeight: (h: number | null) => void
+  setDestination: (h: number | null) => void
+}
+
+// A module flag rather than store state, the publisher/tracker pattern:
+// React's dev double-mount must not start two sync pipelines.
+let started = false
+
+export const useHyperspace = create<HyperspaceState>((set) => ({
+  sync: { status: 'idle', loaded: 0, total: 0, error: null },
+  indexVersion: 0,
+  tipHeight: null,
+  scrubHeight: null,
+  destination: null,
+
+  startSync: () => {
+    if (started) return
+    started = true
+    // vitest runs this module under node, where neither API exists; the
+    // guard keeps the store importable and startSync callable anywhere.
+    if (typeof indexedDB === 'undefined' || typeof WebSocket === 'undefined') {
+      set((s) => ({ sync: { ...s.sync, status: 'error', error: 'IndexedDB or WebSocket is unavailable in this environment' } }))
+      return
+    }
+    void runAnchorSync({
+      onStatus: (status, error) => set((s) => ({ sync: { ...s.sync, status, error: error ?? null } })),
+      onLoaded: (loaded) => set((s) => ({ sync: { ...s.sync, loaded } })),
+      onTip: (tip) => set((s) => ({ tipHeight: tip, sync: { ...s.sync, total: tip + 1 } })),
+      onIndexChanged: () => set((s) => ({ indexVersion: s.indexVersion + 1 })),
+    })
+  },
+
+  setScrubHeight: (h) => set({ scrubHeight: h }),
+  setDestination: (h) => set({ destination: h }),
+}))
+
+/** The live, mutable index instance; identity is stable for the page. */
+export function getStopIndex(): StopIndex {
+  return anchorIndex
+}
+
+export function getStopByHeight(height: number): Stop | undefined {
+  return anchorsByHeight.get(height)
+}
+
+export function stopCount(): number {
+  return anchorsByHeight.size
+}

--- a/src/store/useHyperspace.ts
+++ b/src/store/useHyperspace.ts
@@ -14,6 +14,7 @@ import { create } from 'zustand'
 import { anchorIndex, anchorsByHeight, runAnchorSync } from '../lib/hyperspace/anchors'
 import type { Stop } from '../lib/hyperspace/stops'
 import type { StopIndex } from '../lib/hyperspace/station'
+import { useCyberspace } from './useCyberspace'
 
 export interface HyperspaceSync {
   status: 'idle' | 'loading-cache' | 'syncing' | 'ready' | 'error'
@@ -31,6 +32,8 @@ interface HyperspaceState {
   tipHeight: number | null
   /** The stop being viewed on the line; null = scrubber off. */
   scrubHeight: number | null
+  /** True while hyperspace UI owns the camera focus (VIEW, EARTH, the scrubber). */
+  viewOwned: boolean
   /** The chosen destination stop height; null = none. */
   destination: number | null
   startSync: () => void
@@ -47,6 +50,7 @@ export const useHyperspace = create<HyperspaceState>((set) => ({
   indexVersion: 0,
   tipHeight: null,
   scrubHeight: null,
+  viewOwned: false,
   destination: null,
 
   startSync: () => {
@@ -82,3 +86,31 @@ export function getStopByHeight(height: number): Stop | undefined {
 export function stopCount(): number {
   return anchorsByHeight.size
 }
+
+
+/** Mark the current camera focus as hyperspace's, so RETURN and Escape know to clear it. */
+export function ownHyperspaceView(): void {
+  useHyperspace.setState({ viewOwned: true })
+}
+
+/**
+ * Leave the hyperspace view: close the scrubber, and clear the focus only if
+ * hyperspace set it (never a shard's focus, never a running spectate).
+ */
+export function exitHyperspaceView(): void {
+  const owned = useHyperspace.getState().viewOwned
+  useHyperspace.setState({ scrubHeight: null, viewOwned: false })
+  const cs = useCyberspace.getState()
+  if (owned && cs.spectate === null && cs.focus !== null) cs.clearFocus()
+}
+
+// Spectating a person replaces any hyperspace view: drop the scrubber and the
+// ownership without touching the focus (beginSpectate already cleared it).
+useCyberspace.subscribe((s, prev) => {
+  if (s.spectate !== null && prev.spectate === null) {
+    const hs = useHyperspace.getState()
+    if (hs.scrubHeight !== null || hs.viewOwned) {
+      useHyperspace.setState({ scrubHeight: null, viewOwned: false })
+    }
+  }
+})

--- a/src/store/useHyperspace.ts
+++ b/src/store/useHyperspace.ts
@@ -38,6 +38,9 @@ interface HyperspaceState {
   scrubHeight: number | null
   /** True while hyperspace UI owns the camera focus (VIEW, EARTH, the scrubber). */
   viewOwned: boolean
+  /** The zoom to restore when the owned view exits; captured when hyperspace
+   * first takes the focus, because its views re-frame at their own scales. */
+  returnScaleExp: number | null
   /** The chosen destination stop height; null = none. */
   destination: number | null
   startSync: () => void
@@ -55,6 +58,7 @@ export const useHyperspace = create<HyperspaceState>((set) => ({
   tipHeight: null,
   scrubHeight: null,
   viewOwned: false,
+  returnScaleExp: null,
   destination: null,
 
   startSync: () => {
@@ -95,7 +99,11 @@ export function stopCount(): number {
 
 /** Mark the current camera focus as hyperspace's, so RETURN and Escape know to clear it. */
 export function ownHyperspaceView(): void {
-  useHyperspace.setState({ viewOwned: true })
+  if (useHyperspace.getState().viewOwned) return
+  // First ownership: remember the zoom the user was actually at, because the
+  // hyperspace views re-frame at their own scales and RETURN must not strand
+  // the camera there.
+  useHyperspace.setState({ viewOwned: true, returnScaleExp: useCyberspace.getState().scaleExp })
 }
 
 /**
@@ -103,10 +111,14 @@ export function ownHyperspaceView(): void {
  * hyperspace set it (never a shard's focus, never a running spectate).
  */
 export function exitHyperspaceView(): void {
-  const owned = useHyperspace.getState().viewOwned
-  useHyperspace.setState({ scrubHeight: null, viewOwned: false })
+  const { viewOwned: owned, returnScaleExp } = useHyperspace.getState()
+  useHyperspace.setState({ scrubHeight: null, viewOwned: false, returnScaleExp: null })
   const cs = useCyberspace.getState()
   if (owned && cs.spectate === null && cs.focus !== null) cs.clearFocus()
+  // Back at the zoom the user left, not whatever a stop view chose.
+  if (owned && returnScaleExp !== null && returnScaleExp !== cs.scaleExp) {
+    useCyberspace.setState({ scaleExp: returnScaleExp })
+  }
 }
 
 // Spectating a person replaces any hyperspace view: drop the scrubber and the
@@ -115,7 +127,9 @@ useCyberspace.subscribe((s, prev) => {
   if (s.spectate !== null && prev.spectate === null) {
     const hs = useHyperspace.getState()
     if (hs.scrubHeight !== null || hs.viewOwned) {
-      useHyperspace.setState({ scrubHeight: null, viewOwned: false })
+      // No zoom restore here: the spectate is taking the camera somewhere
+      // else on purpose, and yanking the scale under it would fight that.
+      useHyperspace.setState({ scrubHeight: null, viewOwned: false, returnScaleExp: null })
     }
   }
 })

--- a/src/store/useUiHints.ts
+++ b/src/store/useUiHints.ts
@@ -1,0 +1,34 @@
+/**
+ * useUiHints.ts - things the scene knows that the HUD should echo.
+ *
+ * The covering box lives inside the canvas and the touch pad lives above it,
+ * with no shared parent below the app root, so a prop would have to thread
+ * through the whole tree to connect them. A module-scope store is the house
+ * answer to that (see useRideRun in HyperspacePanel): the scene writes, the
+ * HUD subscribes, and neither knows the other exists.
+ *
+ * Everything in here is a hint about presentation, never protocol state, so
+ * losing it all on reload costs nothing.
+ */
+
+import { create } from 'zustand'
+
+interface UiHints {
+  /**
+   * True while the covering box on screen is a clipped stand-in: the region a
+   * lined-up move covers extends past the drawable window, and zooming out is
+   * the only way to see its true extent.
+   */
+  coveringClipped: boolean
+  setCoveringClipped: (clipped: boolean) => void
+}
+
+export const useUiHints = create<UiHints>((set, get) => ({
+  coveringClipped: false,
+  // No-op on an unchanged value. The writer is an effect keyed on the flag, so
+  // this is belt and braces, but zustand notifies subscribers on every set and
+  // a redundant write here would nudge the HUD for nothing.
+  setCoveringClipped: (clipped) => {
+    if (get().coveringClipped !== clipped) set({ coveringClipped: clipped })
+  },
+}))

--- a/src/styles.css
+++ b/src/styles.css
@@ -3424,15 +3424,23 @@ kbd {
 }
 
 /* The overlay reads as a ticket: FROM your station at the top, TO the block
-   the rail is pointing at. */
+   the rail is pointing at. Same voice as the panel's group headings: the
+   station in bitcoin orange, the destination in selected-block yellow. */
 .linescrub__headline {
-  font-size: 8px;
-  letter-spacing: 0.18em;
-  color: var(--dim);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: #f7931a;
 }
 
 .linescrub__headline--to {
-  margin-top: 4px;
+  color: #ffff00;
+}
+
+.linescrub__hr {
+  width: 100%;
+  border: 0;
+  border-top: 1px solid rgba(0, 229, 255, 0.18);
+  margin: 4px 0 1px;
 }
 
 .linescrub__fromrow {
@@ -3472,9 +3480,12 @@ kbd {
    buttons in their own right-aligned column so they line up under the rail's
    end button instead of being pushed below the text. */
 .linescrub__meta {
+  /* Stacked: the block readout, then the action row left-aligned under the
+     latlon line, so SET DESTINATION sits still when the clear X docks on. */
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
-  gap: 8px;
+  gap: 6px;
 }
 
 .linescrub__info {
@@ -3486,7 +3497,6 @@ kbd {
 }
 
 .linescrub__actions {
-  margin-left: auto;
   display: flex;
   align-items: stretch;
   flex-shrink: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2705,6 +2705,29 @@ kbd {
   transform: scale(0.95);
 }
 
+/* ---------- Zoom-out hint ----------
+ *
+ * The scene's covering box is clipped: the true region extends past the
+ * drawable window and its walls are breathing outward to say so. This key is
+ * the remedy (coarser scale IS zoom out), so it echoes the message in the same
+ * accent blue as the walls, at low alpha and a slow ease. A hint about where
+ * relief lives, not an alarm about a fault. */
+.touchpad__key.is-zoomhint {
+  animation: zoomhint-pulse 2s ease-in-out infinite;
+}
+
+@keyframes zoomhint-pulse {
+  0%, 100% {
+    border-color: var(--border, #1d3547);
+    box-shadow: 0 0 0 0 rgba(0, 229, 255, 0);
+  }
+  50% {
+    border-color: rgba(0, 229, 255, 0.55);
+    box-shadow: 0 0 9px 1px rgba(0, 229, 255, 0.28);
+    color: var(--accent, #00e5ff);
+  }
+}
+
 /* The compass sat bottom-centre, directly under the action row, so the controls
  * buried it. On a phone it moves out of the thumb zone entirely. */
 @media (max-width: 1100px) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3423,6 +3423,43 @@ kbd {
   border-bottom-right-radius: 0;
 }
 
+/* The overlay reads as a ticket: FROM your station at the top, TO the block
+   the rail is pointing at. */
+.linescrub__headline {
+  font-size: 8px;
+  letter-spacing: 0.18em;
+  color: var(--dim);
+}
+
+.linescrub__headline--to {
+  margin-top: 4px;
+}
+
+.linescrub__fromrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.linescrub__view {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  padding: 3px 7px;
+  border-radius: 5px;
+  color: #f7931a;
+  background: rgba(247, 147, 26, 0.06);
+  border: 1px solid rgba(247, 147, 26, 0.5);
+  cursor: pointer;
+  touch-action: none;
+}
+
+.linescrub__view:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
 .linescrub__kind--port {
   color: var(--sidestep);
 }
@@ -3481,6 +3518,14 @@ kbd {
 
 .hyper__progress {
   margin: 10px 0 4px;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--warn);
+}
+
+/* Why BOARD is dark right now, in one line. */
+.hyper__why {
+  margin: 6px 0 0;
   font-size: 9px;
   letter-spacing: 0.1em;
   color: var(--warn);

--- a/src/styles.css
+++ b/src/styles.css
@@ -3237,24 +3237,8 @@ kbd {
  * (boarding requires your own head), but a collision would hide the one way
  * out of one of them, so they get separate slots anyway. */
 .hyperbar {
-  position: fixed;
-  top: 64px;
-  right: 14px;
-  z-index: 101;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 7px 8px 7px 12px;
-  border-radius: 9px;
-  color: var(--fg);
-  background: rgba(6, 14, 22, 0.82);
-  border: 1px solid rgba(247, 147, 26, 0.5);
-  backdrop-filter: blur(8px);
-  box-shadow: 0 0 14px rgba(247, 147, 26, 0.18);
-  font-size: 9px;
-  letter-spacing: 0.1em;
-  max-width: calc(100vw - 24px);
-}
+    margin-top: 6px;
+  }
 
 .hyperbar__glyph {
   color: #f7931a;
@@ -3327,6 +3311,39 @@ kbd {
 
 .linescrub .explorer__body {
   border-color: rgba(247, 147, 26, 0.35);
+  /* The meta row's content changes length between PORT and LANDFALL stops;
+     a fixed body width keeps the rail from resizing under the pointer. */
+  width: 380px;
+  max-width: calc(100vw - 28px);
+  box-sizing: border-box;
+}
+
+.linescrub .explorer__type {
+  min-width: 96px;
+}
+
+.linescrub__kind {
+  display: inline-block;
+  min-width: 64px;
+}
+
+.linescrub .explorer__when {
+  display: inline-block;
+  min-width: 110px;
+  white-space: nowrap;
+}
+
+.linescrub__clear {
+  font-family: inherit;
+  font-size: 9px;
+  line-height: 1;
+  padding: 3px 6px;
+  border-radius: 5px;
+  color: var(--danger);
+  background: transparent;
+  border: 1px solid var(--danger);
+  cursor: pointer;
+  touch-action: none;
 }
 
 .linescrub__kind--port {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3589,6 +3589,10 @@ kbd {
 }
 
 .hyper__btn--earth {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   width: 100%;
   margin-top: 6px;
   color: #2f81f7;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1186,9 +1186,20 @@ kbd {
 }
 
 /* ---------- Secret modal (a hidden thing, tapped in the world) ---------- */
+/* Aligned to the top of the screen, not centred: the card's height varies
+   wildly with the message, and a fixed anchor keeps the close control where
+   the hand last found it. */
+.modal--top {
+  align-items: flex-start;
+}
+
 .modal__card.secret {
   border-color: rgba(0, 229, 255, 0.5);
   max-width: 440px;
+  /* Never taller than the screen; anything longer scrolls inside. */
+  max-height: calc(100vh - 32px);
+  max-height: calc(100dvh - 32px);
+  overflow-y: auto;
 }
 
 .secret__head {
@@ -1229,7 +1240,12 @@ kbd {
   cursor: pointer;
 }
 
+/* A long message scrolls in place instead of growing the card past every
+   control that could close it. */
 .secret__message {
+  max-height: 40vh;
+  max-height: 40dvh;
+  overflow-y: auto;
   margin: 0 0 14px;
   padding: 10px 12px;
   font-size: 14px;
@@ -2425,8 +2441,8 @@ kbd {
 
 .hamburger-menu {
   position: fixed;
-  bottom: 24px;
-  left: 24px;
+  bottom: 12px;
+  left: 12px;
   width: 56px;
   height: 56px;
   border-radius: 50%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -456,7 +456,9 @@ body {
   position: absolute;
   top: 12px;
   left: 8px;
-  z-index: 2;
+  /* Above the 3D compass (10) and its rotation submenu (101): the
+     instrument stack is what is being read, nothing may cover it. */
+  z-index: 102;
   pointer-events: none;
   display: flex;
   flex-direction: column;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3347,12 +3347,21 @@ kbd {
 }
 
 .linescrub .explorer__body {
-  border-color: rgba(247, 147, 26, 0.35);
-  /* The meta row's content changes length between PORT and LANDFALL stops;
+  /* The border stays the chain explorer's colour on purpose: the two
+     expanded rails are the same instrument pointed at different lines.
+     The meta row's content changes length between PORT and LANDFALL stops;
      a fixed body width keeps the rail from resizing under the pointer. */
   width: 380px;
   max-width: calc(100vw - 28px);
   box-sizing: border-box;
+}
+
+/* The rail stretches to fill the row so the fast-forward button is the
+   rightmost thing in the UI, and the grab ball keeps clear air between
+   itself and the step buttons. */
+.linescrub .explorer__rail {
+  max-width: none;
+  margin: 0 1rem;
 }
 
 .linescrub .explorer__type {
@@ -3369,17 +3378,25 @@ kbd {
   white-space: nowrap;
 }
 
+/* The clear X docks onto SET DESTINATION's right edge as an attachment, so
+   the pair reads as one control and the X never floats on its own line. */
 .linescrub__clear {
   font-family: inherit;
   font-size: 9px;
   line-height: 1;
-  padding: 3px 6px;
-  border-radius: 5px;
+  padding: 3px 7px;
+  border-radius: 0 5px 5px 0;
   color: var(--danger);
   background: transparent;
   border: 1px solid var(--danger);
+  border-left: 0;
   cursor: pointer;
   touch-action: none;
+}
+
+.linescrub__set--attached {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .linescrub__kind--port {
@@ -3401,6 +3418,7 @@ kbd {
 
 .linescrub__info {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: 3px;
   min-width: 0;
@@ -3409,9 +3427,7 @@ kbd {
 .linescrub__actions {
   margin-left: auto;
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  align-items: flex-end;
+  align-items: stretch;
   flex-shrink: 0;
 }
 
@@ -3503,4 +3519,36 @@ kbd {
 
 .hyper__btn--earth:hover:not(:disabled) {
   background: rgba(47, 129, 247, 0.16);
+}
+
+/* VIEW NEAREST STOP: one full-width action under the station readout, in the
+   station's bitcoin orange so it reads as part of that group. */
+.hyper__btn--view {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  text-align: center;
+  color: #f7931a;
+  border-color: rgba(247, 147, 26, 0.5);
+  background: rgba(247, 147, 26, 0.06);
+}
+
+.hyper__btn--view:hover:not(:disabled) {
+  background: rgba(247, 147, 26, 0.16);
+}
+
+/* The group headings borrow the scrubber's voice (the world font at 9px):
+   the station in bitcoin orange, the destination in selected-block yellow. */
+.hyper__kicker {
+  font-family: 'Monaspace Krypton', var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+}
+
+.hyper__kicker--nearest {
+  color: #f7931a;
+}
+
+.hyper__kicker--destination {
+  color: #ffff00;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,6 +54,12 @@ body {
   display: block;
   width: 100%;
   max-width: 290px;
+  /* The width/height ATTRIBUTES exist to hand the browser the intrinsic
+     aspect ratio before the file arrives (no layout shift). Without an
+     explicit CSS height the attribute's 354px applies literally against the
+     capped width and squashes the wordmark square; auto restores the ratio
+     while keeping the reservation. */
+  height: auto;
 }
 
 .brand p {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3237,8 +3237,25 @@ kbd {
  * (boarding requires your own head), but a collision would hide the one way
  * out of one of them, so they get separate slots anyway. */
 .hyperbar {
-    margin-top: 6px;
-  }
+  /* The pill, unchanged from its floating days, now parked in the instrument
+     stack under the hyperspace scrubber. The instruments container is
+     pointer-events: none, so the bar must opt back in or its buttons die. */
+  position: relative;
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px 7px 12px;
+  border-radius: 9px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.82);
+  border: 1px solid rgba(247, 147, 26, 0.5);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 0 14px rgba(247, 147, 26, 0.18);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  max-width: calc(100vw - 24px);
+}
 
 .hyperbar__glyph {
   color: #f7931a;
@@ -3283,12 +3300,9 @@ kbd {
 }
 
 @media (max-width: 1100px) {
-  /* Same shore as the spectate bar on a phone, one slot up. */
+  /* In the instrument stack now; nothing to reposition on a phone. */
   .hyperbar {
-    top: auto;
-    right: 14px;
-    bottom: 66px;
-    left: 92px;
+    margin-top: 6px;
   }
 
   .hyperbar__meta {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3229,3 +3229,201 @@ kbd {
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* ---------- Hyperspace ---------- */
+
+/* The transit mode bar: SpectateBar's shape in the line's Bitcoin orange,
+ * stacked below it. Transit and spectate are mutually exclusive in practice
+ * (boarding requires your own head), but a collision would hide the one way
+ * out of one of them, so they get separate slots anyway. */
+.hyperbar {
+  position: fixed;
+  top: 64px;
+  right: 14px;
+  z-index: 101;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px 7px 12px;
+  border-radius: 9px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.82);
+  border: 1px solid rgba(247, 147, 26, 0.5);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 0 14px rgba(247, 147, 26, 0.18);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  max-width: calc(100vw - 24px);
+}
+
+.hyperbar__glyph {
+  color: #f7931a;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.hyperbar__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.hyperbar__label {
+  color: #f7931a;
+  font-weight: 700;
+}
+
+.hyperbar__meta {
+  color: var(--dim);
+  white-space: nowrap;
+}
+
+.hyperbar__end {
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 6px;
+  color: #05070d;
+  background: #f7931a;
+  border: 1px solid #f7931a;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.hyperbar__end:hover {
+  background: #ffb04d;
+}
+
+@media (max-width: 1100px) {
+  /* Same shore as the spectate bar on a phone, one slot up. */
+  .hyperbar {
+    top: auto;
+    right: 14px;
+    bottom: 66px;
+    left: 92px;
+  }
+
+  .hyperbar__meta {
+    white-space: normal;
+  }
+}
+
+/* The line scrubber: ChainExplorer's rail, retinted so a glance says which
+ * one-dimensional thing you are walking. Kind colours follow the scene's
+ * assignments: ideaspace purple for ports, Earth blue for landfalls. */
+.linescrub .explorer__walked {
+  background: #f7931a;
+  box-shadow: 0 0 6px rgba(247, 147, 26, 0.6);
+}
+
+.linescrub .explorer__mark {
+  background: #f7931a;
+  box-shadow: 0 0 8px #f7931a;
+}
+
+.linescrub .explorer__body {
+  border-color: rgba(247, 147, 26, 0.35);
+}
+
+.linescrub__kind--port {
+  color: var(--sidestep);
+}
+
+.linescrub__kind--landfall {
+  color: #2f81f7;
+}
+
+.linescrub__set {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  padding: 3px 7px;
+  border-radius: 5px;
+  color: #05070d;
+  background: #f7931a;
+  border: 1px solid #f7931a;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.linescrub__set:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+/* Panel groupings and actions. */
+.hyper__group {
+  margin-top: 12px;
+}
+
+.hyper__progress {
+  margin: 10px 0 4px;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--warn);
+}
+
+.hyper__actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.hyper__btn {
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 3px;
+  color: var(--accent);
+  background: rgba(0, 229, 255, 0.06);
+  border: 1px solid rgba(0, 229, 255, 0.5);
+  cursor: pointer;
+}
+
+.hyper__btn:hover:not(:disabled) {
+  background: rgba(0, 229, 255, 0.16);
+}
+
+.hyper__btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.hyper__btn--ride {
+  color: #05070d;
+  background: #f7931a;
+  border-color: #f7931a;
+  font-weight: 700;
+}
+
+.hyper__btn--ride:hover:not(:disabled) {
+  background: #ffb04d;
+}
+
+.hyper__btn--abort {
+  color: #05070d;
+  background: var(--danger);
+  border-color: var(--danger);
+  font-weight: 700;
+}
+
+.hyper__btn--earth {
+  width: 100%;
+  margin-top: 6px;
+  color: #2f81f7;
+  border-color: rgba(47, 129, 247, 0.5);
+  background: rgba(47, 129, 247, 0.06);
+}
+
+.hyper__btn--earth:hover:not(:disabled) {
+  background: rgba(47, 129, 247, 0.16);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3338,7 +3338,6 @@ kbd {
 
 .linescrub__kind {
   display: inline-block;
-  min-width: 64px;
 }
 
 .linescrub .explorer__when {
@@ -3368,8 +3367,32 @@ kbd {
   color: #2f81f7;
 }
 
-.linescrub__set {
+/* The meta area: block, kind and place stacked on the left; the action
+   buttons in their own right-aligned column so they line up under the rail's
+   end button instead of being pushed below the text. */
+.linescrub__meta {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.linescrub__info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.linescrub__actions {
   margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+  flex-shrink: 0;
+}
+
+.linescrub__set {
   font-family: inherit;
   font-size: 8px;
   letter-spacing: 0.12em;

--- a/src/workers/calibrate.worker.ts
+++ b/src/workers/calibrate.worker.ts
@@ -1,0 +1,114 @@
+/**
+ * calibrate.worker.ts - a quiet one-shot movement benchmark.
+ *
+ * The app's nominal Cantor ceiling is h20, but a real h20 hop computes up to
+ * three axis trees plus terrain, and the BigInt levels of one big tree alone
+ * allocate hundreds of megabytes: on real machines the tab stalls or dies well
+ * below the nominal cap. Rather than let the UI promise a hop the machine
+ * cannot finish, this worker measures what THIS machine actually does: single
+ * axis Cantor trees at increasing heights, and the raw SHA-256 rate that
+ * bounds a Merkle sidestep. lib/calibration.ts turns the timings into the
+ * recommended ceilings.
+ *
+ * The benchmark is budgeted so the cure is not the disease: it climbs past
+ * h16 only while total time stays under ~12 s AND the next height's projected
+ * cost (growth fitted from the last two measurements, floored at 3x per
+ * height) stays under ~8 s. It never touches h21+, and it stops BEFORE the
+ * measurement that would have wedged this thread, not after.
+ */
+
+import { AXIS_CENTER, computeAxisMerkleRoot, computeSubtreeCantor } from 'cyberspace-core'
+
+export interface CalibrateRequest {
+  id: number
+}
+
+export type CalibrateResponse =
+  | {
+      type: 'result'
+      id: number
+      /** Wall-clock ms for ONE axis tree at each height actually measured. */
+      cantorMsByHeight: Record<number, number>
+      /** Measured SHA-256 throughput, hashes per second. */
+      sha256PerSec: number
+    }
+  | { type: 'error'; id: number; message: string }
+
+/** Always measured: cheap everywhere, and enough points to fit the growth. */
+const BASE_HEIGHTS = [12, 14, 16]
+/** Climbed one at a time, each step gated by the budgets below. */
+const CLIMB_HEIGHTS = [17, 18, 19, 20]
+/** Once total benchmark time passes this, stop climbing. */
+const TOTAL_BUDGET_MS = 12_000
+/** Never start a measurement projected to take longer than this. */
+const NEXT_STEP_CAP_MS = 8_000
+/** Cantor cost roughly triples per height (2x the leaves times widening
+ * BigInts). The gate assumes at least this much growth so an optimistic pair
+ * of fast timings cannot talk it into a tree it will never finish. */
+const GROWTH_FLOOR = 3
+/** Above every height measured here, so the core never refuses a tree. */
+const BENCH_MAX_COMPUTE_HEIGHT = 22
+
+/** An awaited macrotask between measurements, so a terminate() from the main
+ * thread lands between trees instead of only after all of them. */
+function breathe(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+self.onmessage = async (event: MessageEvent<CalibrateRequest>) => {
+  const { id } = event.data
+  try {
+    const cantorMsByHeight: Record<number, number> = {}
+    let total = 0
+    const measure = (h: number): void => {
+      const t0 = performance.now()
+      // AXIS_CENTER is 2^84, so it is the aligned base of its own subtree at
+      // every height used here: the timing is a real tree, not an error path.
+      computeSubtreeCantor(AXIS_CENTER, h, BENCH_MAX_COMPUTE_HEIGHT)
+      const elapsed = performance.now() - t0
+      cantorMsByHeight[h] = elapsed
+      total += elapsed
+    }
+
+    for (const h of BASE_HEIGHTS) {
+      measure(h)
+      await breathe()
+    }
+
+    let prev = BASE_HEIGHTS[BASE_HEIGHTS.length - 2]
+    let last = BASE_HEIGHTS[BASE_HEIGHTS.length - 1]
+    for (const h of CLIMB_HEIGHTS) {
+      if (total >= TOTAL_BUDGET_MS) break
+      // Project the next step from the last two timings. Coarse timers can
+      // report ~0 ms at low heights; clamping keeps the ratio finite.
+      const msPrev = Math.max(cantorMsByHeight[prev], 0.5)
+      const msLast = Math.max(cantorMsByHeight[last], 0.5)
+      const perHeight = Math.max(GROWTH_FLOOR, Math.pow(msLast / msPrev, 1 / (last - prev)))
+      if (msLast * Math.pow(perHeight, h - last) >= NEXT_STEP_CAP_MS) break
+      measure(h)
+      prev = last
+      last = h
+      await breathe()
+    }
+    await breathe()
+
+    // Sidesteps are pure SHA-256 in O(h) memory, so one mid-size tree gives
+    // the rate: +2^16 puts the LCA at h17, which is 2^17 leaf hashes plus
+    // 2^17 - 1 internal nodes.
+    const SIDESTEP_HASHES = 2 ** 18 - 1
+    const t0 = performance.now()
+    computeAxisMerkleRoot(AXIS_CENTER, AXIS_CENTER + (1n << 16n))
+    const sidestepMs = Math.max(performance.now() - t0, 0.5)
+    const sha256PerSec = SIDESTEP_HASHES / (sidestepMs / 1000)
+
+    const response: CalibrateResponse = { type: 'result', id, cantorMsByHeight, sha256PerSec }
+    self.postMessage(response)
+  } catch (err) {
+    const response: CalibrateResponse = {
+      type: 'error',
+      id,
+      message: err instanceof Error ? err.message : String(err),
+    }
+    self.postMessage(response)
+  }
+}

--- a/src/workers/headers.worker.ts
+++ b/src/workers/headers.worker.ts
@@ -1,0 +1,182 @@
+/**
+ * headers.worker.ts - downloads, verifies and derives the header blobs.
+ *
+ * Roughly two million sha256 evaluations for the full chain plus a landfall
+ * derivation for every plane-0 block: seconds of work that must never touch
+ * the main thread. The worker walks the manifest's blobs in order, carrying
+ * the chain state (prev hash + bits window) across blob boundaries, and posts
+ * each verified blob back as flat columns with transferred buffers, so the
+ * handoff is a pointer move rather than a million-object structured clone.
+ *
+ * Raw blob bytes are kept in the Cache API keyed by URL: a reload skips the
+ * network entirely but still re-verifies, which is cheap here and means the
+ * cache is never trusted, only reused. Every browser-only API is feature
+ * checked so importing this module under node (tests, SSR tooling) is safe.
+ */
+
+import { sha256Hex } from 'cyberspace-core'
+import { EMBEDDED_CHECKPOINTS } from '../lib/hyperspace/checkpoints'
+import {
+  checkpointState,
+  genesisState,
+  verifyAndDerive,
+  type BlobColumns,
+  type ChainState,
+} from '../lib/hyperspace/headers'
+import type { HeadersManifest } from '../lib/hyperspace/headerSync'
+
+export interface HeadersRequest {
+  type: 'sync'
+  manifest: HeadersManifest
+  manifestUrl: string
+}
+
+export type HeadersResponse =
+  | { type: 'progress'; startHeight: number; verified: number; count: number }
+  | { type: 'blob'; columns: BlobColumns }
+  | { type: 'blob-failed'; startHeight: number; count: number; reason: string }
+  | { type: 'done' }
+
+const CACHE_NAME = 'onosendai:headers-v1'
+
+/** Throttle progress posts; per-record reporting would flood the channel. */
+const PROGRESS_INTERVAL_MS = 120
+
+/** Digest bytes with the platform's native hash when present (the blobs are
+ * megabytes); the pure-JS fallback keeps node imports working. */
+async function digestHex(bytes: Uint8Array): Promise<string> {
+  const subtle = globalThis.crypto?.subtle
+  if (subtle) {
+    const digest = await subtle.digest('SHA-256', bytes as BufferSource)
+    return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('')
+  }
+  return sha256Hex(bytes)
+}
+
+async function openCache(): Promise<Cache | null> {
+  if (typeof caches === 'undefined') return null
+  try {
+    return await caches.open(CACHE_NAME)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The blob's bytes, from cache when the digest still matches, else the
+ * network. Throws with a human reason; the caller turns that into a
+ * blob-failed message.
+ */
+async function loadBlobBytes(url: string, expectedSha256: string): Promise<Uint8Array> {
+  const cache = await openCache()
+  if (cache) {
+    try {
+      const hit = await cache.match(url)
+      if (hit) {
+        const bytes = new Uint8Array(await hit.arrayBuffer())
+        if ((await digestHex(bytes)) === expectedSha256) return bytes
+        // Stale or corrupt cache entry (e.g. the release was re-cut): drop it
+        // and fall through to the network.
+        await cache.delete(url)
+      }
+    } catch { /* a broken cache read is just a cache miss */ }
+  }
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${url}`)
+  const bytes = new Uint8Array(await res.arrayBuffer())
+  if ((await digestHex(bytes)) !== expectedSha256) {
+    throw new Error('blob bytes do not match the manifest sha256')
+  }
+  if (cache) {
+    try {
+      await cache.put(url, new Response(bytes))
+    } catch { /* cache write is best effort */ }
+  }
+  return bytes
+}
+
+function post(msg: HeadersResponse, transfer?: Transferable[]): void {
+  if (transfer) self.postMessage(msg, { transfer })
+  else self.postMessage(msg)
+}
+
+self.onmessage = async (event: MessageEvent<HeadersRequest>) => {
+  const { manifest, manifestUrl } = event.data
+  const embedded = new Map(EMBEDDED_CHECKPOINTS.map((c) => [c.height, c.blockHash]))
+  const manifestCp = new Map(manifest.checkpoints.map((c) => [c.height, c.blockHash]))
+
+  // Chain state carried blob to blob; null after a discarded blob, until the
+  // next one can be re-seeded from a checkpoint.
+  let state: ChainState | null = genesisState()
+
+  for (const blob of manifest.blobs) {
+    const fail = (reason: string): void => {
+      post({ type: 'blob-failed', startHeight: blob.startHeight, count: blob.count, reason })
+      state = null
+    }
+    const finalHeight = blob.startHeight + blob.count - 1
+    const finalHashHex = manifestCp.get(finalHeight)
+    if (finalHashHex === undefined) {
+      fail('manifest has no checkpoint for this blob')
+      continue
+    }
+    // The embedded list is the stronger opinion: a manifest checkpoint that
+    // disagrees with it means the manifest host is wrong (or hostile).
+    const pinned = embedded.get(finalHeight)
+    if (pinned !== undefined && pinned !== finalHashHex) {
+      fail('manifest checkpoint disagrees with the embedded checkpoint')
+      continue
+    }
+    if (state === null) {
+      // The previous blob was discarded, so its final hash cannot seed the
+      // linkage. Re-seed from the previous blob's checkpoint, cross-checked
+      // against the embedded copy when we have one.
+      const prevCp = manifestCp.get(blob.startHeight - 1)
+      const prevPinned = embedded.get(blob.startHeight - 1)
+      if (prevCp === undefined || (prevPinned !== undefined && prevPinned !== prevCp)) {
+        fail('no trustworthy linkage seed after a discarded blob')
+        continue
+      }
+      state = checkpointState(prevCp)
+    }
+
+    let bytes: Uint8Array
+    try {
+      bytes = await loadBlobBytes(new URL(blob.file, manifestUrl).toString(), blob.sha256)
+    } catch (err) {
+      fail(err instanceof Error ? err.message : String(err))
+      continue
+    }
+
+    let lastProgress = 0
+    const verdict = verifyAndDerive(
+      bytes,
+      blob.startHeight,
+      blob.count,
+      state,
+      { finalHashHex, embedded },
+      (verified) => {
+        const now = performance.now()
+        if (now - lastProgress < PROGRESS_INTERVAL_MS) return
+        lastProgress = now
+        post({ type: 'progress', startHeight: blob.startHeight, verified, count: blob.count })
+      },
+    )
+    if (!verdict.ok) {
+      fail(verdict.reason)
+      continue
+    }
+    state = verdict.state
+    const c = verdict.columns
+    post({ type: 'blob', columns: c }, [
+      c.keys.buffer,
+      c.kinds.buffer,
+      c.merkles.buffer,
+      c.hashes.buffer,
+      c.coords.buffer,
+      c.order.buffer,
+    ])
+  }
+
+  post({ type: 'done' })
+}

--- a/src/workers/ride.worker.ts
+++ b/src/workers/ride.worker.ts
@@ -1,0 +1,48 @@
+/**
+ * ride.worker.ts: computes ride leaves off the main thread (DECK-0001 §5.3).
+ *
+ * A ride averages ~40k Cantor pairings per block with a worst block of 2^22,
+ * and a full ride is 300k+ blocks, so this is hours of aggregate work. The
+ * pool (lib/hyperspace/ridePool.ts) hands each worker a chunk of blocks and
+ * the worker streams one message per finished leaf: a leaf lands every ~100 ms
+ * on average, so per-leaf posting is both the progress signal and the
+ * persistence trigger with no extra throttling needed. The pool terminates
+ * workers outright to cancel; partial chunks cost nothing because every
+ * finished leaf has already been posted and persisted.
+ */
+
+import { bytesToHex } from 'cyberspace-core'
+import { computeRideLeaf } from '../lib/hyperspace/ride'
+
+export interface RideChunkRequest {
+  id: number
+  previousEventIdHex: string
+  chunk: Array<{ height: number; blockHash: string }>
+}
+
+export type RideChunkResponse =
+  | { type: 'leaf'; id: number; height: number; leafHex: string }
+  | { type: 'error'; id: number; message: string }
+
+self.onmessage = (event: MessageEvent<RideChunkRequest>) => {
+  const { id, previousEventIdHex, chunk } = event.data
+  try {
+    for (const { height, blockHash } of chunk) {
+      const leaf = computeRideLeaf(previousEventIdHex, height, blockHash)
+      const response: RideChunkResponse = {
+        type: 'leaf',
+        id,
+        height,
+        leafHex: bytesToHex(leaf),
+      }
+      self.postMessage(response)
+    }
+  } catch (err) {
+    const response: RideChunkResponse = {
+      type: 'error',
+      id,
+      message: err instanceof Error ? err.message : String(err),
+    }
+    self.postMessage(response)
+  }
+}


### PR DESCRIPTION
Implements DECK-0001 v3 (arkin0x/cyberspace#18) end to end, from the 2026-08-24 design session.

## What works

- **Consensus core** (`src/lib/hyperspace/`): landfall derivation byte-identical to the spec's Python reference on all eight golden vectors; stop parsing for v3 and legacy kind 321 anchors; the station as a longest-common-prefix search over sorted interleaved coordinates (brute-force cross-checked in tests); ride proofs (seeded per-block Cantor work at K_b + 6, Merkle aggregation, 32 sampled openings) with a full prover-verifier round trip in tests; entry proof; `enter-hyperspace` and `hyperjump` templates and parsing wired into the chain layer and publisher.
- **Anchor sync**: kind 321 backfill into IndexedDB in resumable 500-height batches with a live tail; ~964k stops; legacy landfalls get fast float64 coordinates for the index and exact decimal coordinates on demand.
- **Transit flow**: BOARD signs the enter event from wherever you stand; the panel shows your station, the ride length, and a calibrated time estimate before you commit; RIDE computes the per-block work across a worker pool (progress, abort, resume across reloads keyed to the enter event id) and signs the hyperjump; you arrive exactly at the stop; leaving is an ordinary hop.
- **Viewing tools**: `H` opens a scrubber over the whole line (0 to tip) that spectates each stop; the stop point cloud renders in-scene (click to set destination); EARTH snaps the camera to where landfalls cluster; a flowing rainbow tunnel wraps the camera while in hyperspace.

## Verification

Typecheck clean, 215 tests passing (55 new), production build clean, headless-browser smoke against the live relay (panel renders, sync runs, nearest stop resolves; screenshots in the session workspace).

## Known follow-ups

- A typical 320k-block ride measures ~187 ms per block single-threaded in browser JS (~16.6 h / worker count, so roughly 2 to 3 h on a desktop). WASM bignums or revisiting K_LINE are the levers if that is too slow.
- First sync transfers the full anchor corpus (~hundreds of MB of events); a compact snapshot blob is the planned upgrade to free the local bloat.
- The toll is reserved in the DECK; boarding currently carries the temporal-axis proof only.
- NTH v3 anchors (M tag + landfall C) are on the `v3-anchors` branch of arkin0x/nth, not deployed; the client handles the legacy corpus without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)