### PR TITLE
Earth at every scale: curvature patch, geographic graticule, equator and prime meridian

### DIFF
--- a/src/lib/earthSurface.test.ts
+++ b/src/lib/earthSurface.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { axesToLatLon } from './hyperspace/landfall'
+import {
+  earthRadiusCells,
+  graticuleStep,
+  latLonToCsMetres,
+  originCsMetres,
+  surfaceDetailOpacity,
+  WGS84_A_M,
+  WGS84_B_M,
+  GIBSONS_PER_M,
+} from './earthSurface'
+
+const CENTRE = 1n << 84n
+
+describe('latLonToCsMetres', () => {
+  it('puts the reference points where WGS84 puts them', () => {
+    // Equator at the prime meridian: +X_ecef = +X_cs, one semi-major out.
+    const eq = latLonToCsMetres(0, 0)
+    expect(eq.x).toBeCloseTo(WGS84_A_M, 6)
+    expect(eq.y).toBeCloseTo(0, 6)
+    expect(eq.z).toBeCloseTo(0, 6)
+    // North pole: +Z_ecef, which the §9.4 permutation makes +Y_cs.
+    const np = latLonToCsMetres(90, 0)
+    expect(np.y).toBeCloseTo(WGS84_B_M, 3)
+    expect(Math.abs(np.x)).toBeLessThan(1e-3)
+    expect(Math.abs(np.z)).toBeLessThan(1e-3)
+    // Equator at 90E: +Y_ecef, which is +Z_cs.
+    const e90 = latLonToCsMetres(0, 90)
+    expect(e90.z).toBeCloseTo(WGS84_A_M, 6)
+    expect(Math.abs(e90.x)).toBeLessThan(1e-3)
+  })
+
+  it('round-trips through the landfall inverse', () => {
+    for (const [lat, lon, alt] of [
+      [31.6, -98.8, 0],
+      [-45.2, 12.9, 0],
+      [89, 170, 0],
+      [0.001, 0.001, 5000],
+    ]) {
+      const m = latLonToCsMetres(lat, lon, alt)
+      const u = (v: number): bigint => CENTRE + BigInt(Math.round(v * GIBSONS_PER_M))
+      const back = axesToLatLon(u(m.x), u(m.y), u(m.z))
+      expect(back.lat).toBeCloseTo(lat, 6)
+      expect(back.lon).toBeCloseTo(lon, 6)
+      expect(back.altM).toBeCloseTo(alt, 2)
+    }
+  })
+})
+
+describe('originCsMetres', () => {
+  it('is exact at the mapping centre and metre-true nearby', () => {
+    const at = originCsMetres({ x: CENTRE, y: CENTRE, z: CENTRE })
+    expect(at).toEqual({ x: 0, y: 0, z: 0 })
+    const oneKm = originCsMetres({ x: CENTRE + BigInt(1000 * GIBSONS_PER_M), y: CENTRE, z: CENTRE })
+    expect(oneKm.x).toBeCloseTo(1000, 6)
+  })
+})
+
+describe('earthRadiusCells', () => {
+  it('crosses the 96-cell globe gate between 2^49 and 2^50', () => {
+    // The globe draws while its diameter fits GRID_RADIUS * 8 = 192 cells;
+    // the patch owns everything below. 2^49 is exactly where the user
+    // watched the old wire sphere disappear.
+    expect(earthRadiusCells(49) * 2).toBeGreaterThan(192)
+    expect(earthRadiusCells(50) * 2).toBeLessThan(192)
+  })
+})
+
+describe('graticuleStep', () => {
+  it('picks chart-like rulings', () => {
+    expect(graticuleStep(60)).toBe(10)
+    expect(graticuleStep(6)).toBe(1)
+    expect(graticuleStep(0.06)).toBe(0.01)
+    expect(graticuleStep(0.8)).toBe(0.1)
+  })
+
+  it('never returns more than the window over the line count', () => {
+    for (const w of [179, 43, 7.7, 1.3, 0.21, 0.033, 0.0041]) {
+      expect(graticuleStep(w)).toBeLessThanOrEqual(w / 6)
+      expect(graticuleStep(w)).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('surfaceDetailOpacity', () => {
+  it('is full at human scale, gone below metre scale', () => {
+    expect(surfaceDetailOpacity(49)).toBe(1)
+    expect(surfaceDetailOpacity(34)).toBe(1)
+    expect(surfaceDetailOpacity(33)).toBeCloseTo(2 / 3, 5)
+    expect(surfaceDetailOpacity(31)).toBe(0)
+    expect(surfaceDetailOpacity(0)).toBe(0)
+  })
+})

--- a/src/lib/earthSurface.ts
+++ b/src/lib/earthSurface.ts
@@ -1,0 +1,135 @@
+/**
+ * earthSurface.ts - float64 WGS84 helpers for drawing Earth's surface.
+ *
+ * The planet spans about forty binary orders of magnitude of zoom, and the
+ * old renderer could only draw it at the top six: a sphere mesh built around
+ * Earth's CENTRE stops fitting the grid below 2^50 (its radius is
+ * 2^(55.6 - scaleExp) render cells), and a sphere big enough to stand on
+ * would need float32 vertices at magnitudes where they quantize visibly.
+ *
+ * The way out is the render convention the whole scene already lives by:
+ * never hand a large absolute to the GPU. Surface vertices are produced as
+ * DELTAS from the render origin, computed in float64 METRES. Both the vertex
+ * and the origin carry about a nanometre of representation error at
+ * Earth-radius magnitudes (float64 ulp, tens of gibsons), so their
+ * difference does too, and a few nanometres is invisible at every scale the
+ * surface draws at. No Decimal derivation is needed anywhere in the render
+ * path; the consensus-critical decimal profile stays in landfall.ts where
+ * verifiers need it.
+ *
+ * Everything here is pure: the scene components own subscription, geometry
+ * and materials.
+ */
+
+import type { AxisDirection, Position, ViewAxes } from './space'
+
+export const WGS84_A_M = 6378137
+export const WGS84_F = 1 / 298.257223563
+export const WGS84_B_M = WGS84_A_M * (1 - WGS84_F)
+const E2 = WGS84_F * (2 - WGS84_F)
+
+/** §9.7: 1 metre = 2^33 gibsons (Cantor height 34 is 2 metres). */
+export const GIBSONS_PER_M = 2 ** 33
+
+/** §9.7: the WGS84 mapping is centred on the half-axis point. */
+const CENTRE = 1n << 84n
+
+/** Mean radius in km, the same summary Earth.tsx has always drawn. */
+export const EARTH_RADIUS_KM = 6371
+
+/** Cyberspace axis values in metres from the mapping centre (float64). */
+export interface CsMetres {
+  x: number
+  y: number
+  z: number
+}
+
+/**
+ * Geodetic latitude/longitude (degrees) and height above the ellipsoid
+ * (metres) to cyberspace axis metres. Standard geodetic-to-ECEF, then the
+ * §9.4 permutation: X_cs = X_ecef, Y_cs = Z_ecef, Z_cs = Y_ecef.
+ */
+export function latLonToCsMetres(latDeg: number, lonDeg: number, altM = 0): CsMetres {
+  const lat = (latDeg * Math.PI) / 180
+  const lon = (lonDeg * Math.PI) / 180
+  const s = Math.sin(lat)
+  const c = Math.cos(lat)
+  const n = WGS84_A_M / Math.sqrt(1 - E2 * s * s)
+  const X = (n + altM) * c * Math.cos(lon)
+  const Y = (n + altM) * c * Math.sin(lon)
+  const Z = (n * (1 - E2) + altM) * s
+  return { x: X, y: Z, z: Y }
+}
+
+/**
+ * The render origin's axis values in metres from the mapping centre. The
+ * bigint subtraction happens first, so the Number conversion sees a value
+ * of Earth-radius magnitude (or the origin's true offset), never 2^84.
+ */
+export function originCsMetres(origin: Position): CsMetres {
+  return {
+    x: Number(origin.x - CENTRE) / GIBSONS_PER_M,
+    y: Number(origin.y - CENTRE) / GIBSONS_PER_M,
+    z: Number(origin.z - CENTRE) / GIBSONS_PER_M,
+  }
+}
+
+/**
+ * A surface point as a render-space vertex: metre deltas from the origin,
+ * to cells at this scale, through the screen axis mapping, with the
+ * continuous family's -0.5 shift (the one pointCentre and the globe's own
+ * centre apply), so the surface stays glued to the landfall shell and the
+ * cell-drawn world around it.
+ */
+export function surfaceVertex(
+  latDeg: number,
+  lonDeg: number,
+  altM: number,
+  originM: CsMetres,
+  scaleExp: number,
+  axes: ViewAxes,
+): [number, number, number] {
+  const m = latLonToCsMetres(latDeg, lonDeg, altM)
+  const step = Number(1n << BigInt(scaleExp))
+  const cell = (a: AxisDirection): number =>
+    (((m[a.axis] - originM[a.axis]) * GIBSONS_PER_M) / step - 0.5) * a.dir
+  return [cell(axes.right), cell(axes.up), cell(axes.out)]
+}
+
+/** Earth's mean radius in render cells at this scale: 2^(55.6 - scaleExp). */
+export function earthRadiusCells(scaleExp: number): number {
+  return (EARTH_RADIUS_KM * 1000 * GIBSONS_PER_M) / Number(1n << BigInt(scaleExp))
+}
+
+/**
+ * The largest 1, 2 or 5 times a power of ten (in degrees) that fits at
+ * least `minLines` graticule lines across a window, the way a chart picks
+ * its rulings: whole degrees while they are readable, tenths and hundredths
+ * as the ground closes in.
+ */
+export function graticuleStep(windowDeg: number, minLines = 6): number {
+  const target = windowDeg / minLines
+  if (!Number.isFinite(target) || target <= 0) return 1e-7
+  const k = Math.floor(Math.log10(target))
+  for (const mant of [5, 2, 1]) {
+    const step = mant * 10 ** k
+    if (step <= target) return step
+  }
+  return 10 ** k
+}
+
+/**
+ * How strongly surface detail (the graticule patch, and later the
+ * coastlines) is drawn at this scale. Full strength down to 2^34, the
+ * spec's human scale, then fading out through metre scale: below that the
+ * shore and the grid of places stop being what the view is about, and the
+ * fade is the scale itself teaching that. Zero at and below 2^31.
+ */
+export const SURFACE_DETAIL_FULL = 34
+export const SURFACE_DETAIL_GONE = 31
+
+export function surfaceDetailOpacity(scaleExp: number): number {
+  if (scaleExp >= SURFACE_DETAIL_FULL) return 1
+  if (scaleExp <= SURFACE_DETAIL_GONE) return 0
+  return (scaleExp - SURFACE_DETAIL_GONE) / (SURFACE_DETAIL_FULL - SURFACE_DETAIL_GONE)
+}

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -46,6 +46,13 @@ export const LATTICE = '#4b3fa7'
  */
 export const EARTH = '#2f81f7'
 /**
+ * The geographic reference lines: equator and prime meridian, and their
+ * labels. This is v1's dataspace green (0x4bc9a7), revived on purpose: green
+ * against EARTH's blue is how v1 marked these two lines, and at the zooms a
+ * graticule appears nothing else is speaking green.
+ */
+export const MERIDIAN = '#4bc9a7'
+/**
  * The black sun: the one absolute bearing in cyberspace (§11.2).
  *
  * Purple per the spec, and its own constant rather than SIDESTEP, which is also

--- a/src/scene/Earth.tsx
+++ b/src/scene/Earth.tsx
@@ -20,10 +20,11 @@
  * there, and until you do this draws nothing.
  */
 
-import { useMemo } from 'react'
-import { BackSide } from 'three'
-import { EARTH } from '../lib/palette'
+import { useEffect, useMemo } from 'react'
+import { BackSide, BufferGeometry, Float32BufferAttribute } from 'three'
+import { EARTH, MERIDIAN } from '../lib/palette'
 import { GRID_RADIUS, cellDelta, stepFor, type ViewAxes } from '../lib/space'
+import { EARTH_RADIUS_KM, originCsMetres, surfaceVertex } from '../lib/earthSurface'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { ownHyperspaceView } from '../store/useHyperspace'
 import { WorldLabel } from './WorldLabel'
@@ -87,43 +88,92 @@ export function Earth({ axes }: Props): JSX.Element | null {
     return { centre, radius }
   }, [position, scaleExp, plane, axes])
 
-  if (!globe) return null
+  // The graticule, replacing the old view-relative wireframe: a sphere
+  // mesh's poles follow the camera's up axis, so its "meridians" were
+  // decoration that reoriented with the view. These rings are geographic,
+  // poles where §9.4 puts them, so the lines MEAN latitude and longitude
+  // and the equator and prime meridian can be named. Vertices are float64
+  // metre deltas from the render origin on the true ellipsoid
+  // (earthSurface.ts), absolute in render space, so they live outside the
+  // centred group below.
+  const graticule = useMemo(() => {
+    if (!globe) return null
+    const originM = originCsMetres(alignedOrigin(position, scaleExp))
+    const at = (lat: number, lon: number, altM = 0): [number, number, number] =>
+      surfaceVertex(lat, lon, altM, originM, scaleExp, axes)
+    const blue: number[] = []
+    const green: number[] = []
+    const ring = (
+      out: number[], fix: 'lat' | 'lon', v: number, from: number, to: number, n: number,
+    ): void => {
+      let prev: [number, number, number] | null = null
+      for (let i = 0; i <= n; i++) {
+        const t = from + ((to - from) * i) / n
+        const p = fix === 'lat' ? at(v, t) : at(t, v)
+        if (prev) out.push(...prev, ...p)
+        prev = p
+      }
+    }
+    for (let lat = -75; lat <= 75; lat += 15) ring(lat === 0 ? green : blue, 'lat', lat, -180, 180, 96)
+    for (let lon = -165; lon <= 180; lon += 15) if (lon !== 0) ring(blue, 'lon', lon, -90, 90, 24)
+    // The prime meridian proper: the Greenwich half, pole to pole at lon 0.
+    ring(green, 'lon', 0, -90, 90, 24)
+    const lift = EARTH_RADIUS_KM * 1000 * 0.06
+    const make = (v: number[]): BufferGeometry => {
+      const g = new BufferGeometry()
+      g.setAttribute('position', new Float32BufferAttribute(v, 3))
+      return g
+    }
+    return { blue: make(blue), green: make(green), equatorAt: at(0, 90, lift), meridianAt: at(50, 0, lift) }
+  }, [globe, position, scaleExp, axes])
+
+  useEffect(() => () => {
+    if (!graticule) return
+    graticule.blue.dispose()
+    graticule.green.dispose()
+  }, [graticule])
+
+  if (!globe || !graticule) return null
 
   return (
-    <group position={globe.centre}>
-      {/* The planet is drawn as wireframe, but it must still be a solid to
-          the depth buffer and the raycaster. Back faces only: the far
-          hemisphere writes depth, so the camera sees INTO the globe but not
-          THROUGH it. Culling the near hemisphere keeps labels and stops
-          between the camera and the centre readable instead of cut off by
-          the curvature of a surface that is drawn as sparse wires anyway,
-          and a click on the globe still recentres the orbit on Earth.
-          Slightly under the true radius so surface landfalls are not
-          z-fought away. */}
-      <mesh
-        onClick={(e) => {
-          if (e.delta > 8) return
-          e.stopPropagation()
-          ownHyperspaceView()
-          useCyberspace.getState().focusOn({ x: CENTRE, y: CENTRE, z: CENTRE }, 0, 'EARTH')
-        }}
-      >
-        <sphereGeometry args={[globe.radius * 0.995, 32, 16]} />
-        <meshBasicMaterial colorWrite={false} side={BackSide} />
-      </mesh>
-      <mesh>
-        <sphereGeometry args={[globe.radius, 48, 24]} />
-        <meshBasicMaterial color={EARTH} wireframe transparent opacity={0.32} toneMapped={false} />
-      </mesh>
-      <WorldLabel
-        text={`EARTH\nr 6371 km`}
-        color={EARTH}
-        at={[0, globe.radius, 0]}
-        align="center"
-        offset={[0, 0.8, 0]}
-        px={11}
-        opacity={0.9}
-      />
-    </group>
+    <>
+      <group position={globe.centre}>
+        {/* The surface is drawn as lines, but the planet must still be a
+            solid to the depth buffer and the raycaster. Back faces only:
+            the far hemisphere writes depth, so the camera sees INTO the
+            globe but not THROUGH it, and stops between the camera and the
+            centre stay readable. Slightly under the true radius so surface
+            landfalls and the graticule are not z-fought away. A click
+            still recentres the orbit on Earth. */}
+        <mesh
+          onClick={(e) => {
+            if (e.delta > 8) return
+            e.stopPropagation()
+            ownHyperspaceView()
+            useCyberspace.getState().focusOn({ x: CENTRE, y: CENTRE, z: CENTRE }, 0, 'EARTH')
+          }}
+        >
+          <sphereGeometry args={[globe.radius * 0.995, 32, 16]} />
+          <meshBasicMaterial colorWrite={false} side={BackSide} />
+        </mesh>
+        <WorldLabel
+          text={`EARTH\nr 6371 km`}
+          color={EARTH}
+          at={[0, globe.radius, 0]}
+          align="center"
+          offset={[0, 0.8, 0]}
+          px={11}
+          opacity={0.9}
+        />
+      </group>
+      <lineSegments geometry={graticule.blue} frustumCulled={false}>
+        <lineBasicMaterial color={EARTH} transparent opacity={0.32} toneMapped={false} />
+      </lineSegments>
+      <lineSegments geometry={graticule.green} frustumCulled={false}>
+        <lineBasicMaterial color={MERIDIAN} transparent opacity={0.75} toneMapped={false} />
+      </lineSegments>
+      <WorldLabel text="EQUATOR" color={MERIDIAN} at={graticule.equatorAt} px={10} opacity={0.85} align="center" />
+      <WorldLabel text="PRIME MERIDIAN" color={MERIDIAN} at={graticule.meridianAt} px={10} opacity={0.85} align="center" />
+    </>
   )
 }

--- a/src/scene/EarthPatch.tsx
+++ b/src/scene/EarthPatch.tsx
@@ -1,0 +1,204 @@
+/**
+ * EarthPatch.tsx - the ground: Earth's surface drawn where you actually are.
+ *
+ * The globe in Earth.tsx exists only while the whole planet fits the grid,
+ * which is scale 2^50 and coarser; below that the renderer used to draw
+ * nothing, and the planet you were standing on vanished. This fills that
+ * dead band. From 2^49 down to human scale the surface is a graticule
+ * PATCH: the piece of the true WGS84 ellipsoid within reach of the anchor,
+ * with vertices computed as float64 metre deltas from the render origin
+ * (earthSurface.ts), so precision holds at every zoom with no Decimal
+ * anywhere in the render path.
+ *
+ * The curvature is never approximated: the patch IS the ellipsoid,
+ * evaluated only where the view can see it. Across the grid the sagitta is
+ * about 0.4 cells at 2^40, 12 cells at 2^45, and the full hemispheric wrap
+ * by 2^49, so the band where Earth visibly curves is exactly the band the
+ * globe could never reach.
+ *
+ * Below human scale (2^34) the patch fades, gone at 2^31: a graticule is a
+ * map of places, and metre scale is where the view stops being about
+ * places. The fade is deliberate teaching, zooming past the shoreline is
+ * supposed to feel like leaving geography for the microscopic.
+ *
+ * Graticule lines sit on 1/2/5-decade degree rulings anchored to the
+ * planet, so moving slides you across a fixed grid rather than dragging
+ * one along. The equator and prime meridian draw in v1's green with v1's
+ * labels. A depth-only ground mesh sits a couple of cells beneath the
+ * lines, so the far side of the horizon hides what is beyond it.
+ */
+
+import { useEffect, useMemo } from 'react'
+import { BufferGeometry, DoubleSide, Float32BufferAttribute } from 'three'
+import { EARTH, MERIDIAN } from '../lib/palette'
+import { GRID_RADIUS, type ViewAxes } from '../lib/space'
+import { axesToLatLon } from '../lib/hyperspace/landfall'
+import {
+  EARTH_RADIUS_KM,
+  earthRadiusCells,
+  graticuleStep,
+  originCsMetres,
+  surfaceDetailOpacity,
+  surfaceVertex,
+} from '../lib/earthSurface'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { WorldLabel } from './WorldLabel'
+
+const REACH = GRID_RADIUS * 8
+
+/** Samples per graticule line: smooth at hemispheric spans, cheap always. */
+const SAMPLES = 48
+
+/** Ground occluder resolution, quads per side. */
+const GROUND_N = 24
+
+interface BuiltPatch {
+  grid: BufferGeometry
+  green: BufferGeometry | null
+  ground: BufferGeometry
+  equatorAt: [number, number, number] | null
+  meridianAt: [number, number, number] | null
+  opacity: number
+}
+
+export function EarthPatch({ axes }: { axes: ViewAxes }): JSX.Element | null {
+  const anchor = useCyberspace((s) => s.anchor)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const plane = useCyberspace((s) => s.anchorPlane)
+
+  const built = useMemo((): BuiltPatch | null => {
+    // Ideaspace has no planet (§9.1); the globe regime belongs to Earth.tsx.
+    if (plane !== 0) return null
+    const opacity = surfaceDetailOpacity(scaleExp)
+    if (opacity <= 0) return null
+    if (earthRadiusCells(scaleExp) * 2 <= GRID_RADIUS * 8) return null
+
+    // Where the ground is: the geodetic foot of the anchor. If the surface
+    // is farther away than the view reaches, there is no ground in frame.
+    const geo = axesToLatLon(anchor.x, anchor.y, anchor.z)
+    const cellM = 2 ** (scaleExp - 33)
+    const reachM = REACH * cellM
+    if (Math.abs(geo.altM) > reachM * 1.5) return null
+
+    // The lat/lon window the reach can see, capped at a hemisphere: at the
+    // top of the regime the window IS the visible face of the planet, and
+    // the surface curling over the horizon is the point.
+    const radiusM = EARTH_RADIUS_KM * 1000
+    const halfLat = Math.min(90, (reachM / radiusM) * (180 / Math.PI) * 1.2)
+    const cosLat = Math.max(0.05, Math.cos((geo.lat * Math.PI) / 180))
+    const halfLon = Math.min(179.9, halfLat / cosLat)
+    const step = graticuleStep(halfLat * 2)
+
+    const originM = originCsMetres(alignedOrigin(anchor, scaleExp))
+    const at = (lat: number, lon: number, altM = 0): [number, number, number] =>
+      surfaceVertex(lat, lon, altM, originM, scaleExp, axes)
+
+    const blue: number[] = []
+    const greenArr: number[] = []
+    const polyline = (
+      out: number[], fix: 'lat' | 'lon', v: number, from: number, to: number,
+    ): void => {
+      let prev: [number, number, number] | null = null
+      for (let i = 0; i <= SAMPLES; i++) {
+        const t = from + ((to - from) * i) / SAMPLES
+        const p = fix === 'lat' ? at(v, t) : at(t, v)
+        if (prev) out.push(...prev, ...p)
+        prev = p
+      }
+    }
+
+    const latFrom = geo.lat - halfLat
+    const latTo = geo.lat + halfLat
+    const lonFrom = geo.lon - halfLon
+    const lonTo = geo.lon + halfLon
+    const latLo = Math.max(-90, latFrom)
+    const latHi = Math.min(90, latTo)
+
+    // Ruling multiples of the step, so the grid belongs to the planet. The
+    // zero rulings are the equator and the prime meridian, drawn in green.
+    for (let k = Math.ceil(latFrom / step); k * step <= latTo; k++) {
+      const lat = k * step
+      if (lat < -90 || lat > 90) continue
+      polyline(k === 0 ? greenArr : blue, 'lat', lat, lonFrom, lonTo)
+    }
+    for (let k = Math.ceil(lonFrom / step); k * step <= lonTo; k++) {
+      polyline(k === 0 ? greenArr : blue, 'lon', k * step, latLo, latHi)
+    }
+
+    // Labels ride a little above the ground so they never z-fight it.
+    const lift = 2 * cellM
+    const equatorAt = latFrom < 0 && latTo > 0 ? at(0, geo.lon, lift) : null
+    const meridianAt = lonFrom < 0 && lonTo > 0
+      ? at(Math.max(latLo, Math.min(latHi, geo.lat)), 0, lift)
+      : null
+
+    // The depth-only ground, sunk two cells under the lines: the camera can
+    // see the surface but not through it, so the far side of the horizon
+    // hides its stops the way the globe's occluder does at planetary zoom.
+    const ground: number[] = []
+    const idx: number[] = []
+    for (let r = 0; r <= GROUND_N; r++) {
+      const lat = latLo + ((latHi - latLo) * r) / GROUND_N
+      for (let c = 0; c <= GROUND_N; c++) {
+        const lon = lonFrom + ((lonTo - lonFrom) * c) / GROUND_N
+        ground.push(...at(lat, lon, -2 * cellM))
+      }
+    }
+    for (let r = 0; r < GROUND_N; r++) {
+      for (let c = 0; c < GROUND_N; c++) {
+        const a = r * (GROUND_N + 1) + c
+        const b = a + 1
+        const d = a + (GROUND_N + 1)
+        idx.push(a, b, d, b, d + 1, d)
+      }
+    }
+
+    const make = (v: number[]): BufferGeometry => {
+      const g = new BufferGeometry()
+      g.setAttribute('position', new Float32BufferAttribute(v, 3))
+      return g
+    }
+    const groundGeom = make(ground)
+    groundGeom.setIndex(idx)
+    return {
+      grid: make(blue),
+      green: greenArr.length > 0 ? make(greenArr) : null,
+      ground: groundGeom,
+      equatorAt,
+      meridianAt,
+      opacity,
+    }
+  }, [anchor, scaleExp, plane, axes])
+
+  // GPU buffers are not garbage collected; release each set when replaced.
+  useEffect(() => () => {
+    if (!built) return
+    built.grid.dispose()
+    built.green?.dispose()
+    built.ground.dispose()
+  }, [built])
+
+  if (!built) return null
+
+  return (
+    <group>
+      <mesh geometry={built.ground} frustumCulled={false} renderOrder={-1}>
+        <meshBasicMaterial colorWrite={false} side={DoubleSide} />
+      </mesh>
+      <lineSegments geometry={built.grid} frustumCulled={false}>
+        <lineBasicMaterial color={EARTH} transparent opacity={0.32 * built.opacity} toneMapped={false} />
+      </lineSegments>
+      {built.green && (
+        <lineSegments geometry={built.green} frustumCulled={false}>
+          <lineBasicMaterial color={MERIDIAN} transparent opacity={0.75 * built.opacity} toneMapped={false} />
+        </lineSegments>
+      )}
+      {built.equatorAt && (
+        <WorldLabel text="EQUATOR" color={MERIDIAN} at={built.equatorAt} px={10} opacity={0.85 * built.opacity} align="center" />
+      )}
+      {built.meridianAt && (
+        <WorldLabel text="PRIME MERIDIAN" color={MERIDIAN} at={built.meridianAt} px={10} opacity={0.85 * built.opacity} align="center" />
+      )}
+    </group>
+  )
+}

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -39,6 +39,7 @@ import { BlackSun } from './BlackSun'
 import { CoveringBox } from './CoveringBox'
 import { CrossingFlash } from './CrossingFlash'
 import { Earth } from './Earth'
+import { EarthPatch } from './EarthPatch'
 import { Cursor } from './Cursor'
 import { HyperspaceCone } from './HyperspaceCone'
 import { StopField } from './StopField'
@@ -106,6 +107,7 @@ function World(): JSX.Element {
       <Rooms axes={axes} />
       <SectorBox axes={axes} />
       <Earth axes={axes} />
+      <EarthPatch axes={axes} />
       {/* The hyperspace line's stops, placed true-size like the cage and the
           planet: ports in ideaspace, landfalls on Earth's surface. */}
       <StopField axes={axes} />

--- a/src/styles.css
+++ b/src/styles.css
@@ -2644,6 +2644,18 @@ kbd {
   border-radius: 9px;
   background: rgba(0, 229, 255, 0.08);
   border: 1px solid rgba(0, 229, 255, 0.22);
+  cursor: pointer;
+}
+
+/* The hub is clickable (it resets to 2^0), so it answers the pointer the way
+ * its neighbours do; before this it read as a passive readout. */
+.touchpad__hub:hover {
+  background: rgba(0, 229, 255, 0.16);
+}
+
+.touchpad__hub:active {
+  background: rgba(0, 229, 255, 0.3);
+  border-color: var(--accent, #00e5ff);
 }
 
 /* COMMIT is the only control here that spends anything, so it is the only one


### PR DESCRIPTION
## The dead band

Earth's radius is 2^(55.6 - scaleExp) render cells, so the whole-globe sphere stops fitting the 192-cell grid below 2^50 (exactly the 2^49 disappearance you observed) and the old renderer drew nothing from there down to human scale. A sphere built around the planet's centre can never fill that band: float32 vertices quantize visibly at those magnitudes.

## Two regimes, one convention

Every surface vertex is a float64 metre delta from the render origin (`src/lib/earthSurface.ts`). Both the vertex and the origin carry about a nanometre of ulp error at Earth-radius magnitudes, so their difference does too, invisible at every scale drawn. No Decimal in the render path; the consensus decimal profile stays in landfall.ts.

**Globe (2^50 and coarser), restyled:** the old wireframe's poles followed the camera's up axis, so its rings meant nothing. The new rings are geographic (poles where section 9.4 puts them), on the true ellipsoid, with the equator and the Greenwich half-meridian in v1's green (0x4bc9a7) and EQUATOR / PRIME MERIDIAN labels, reviving v1's Grid.tsx treatment at the protocol's honest scale. Occluder and click-to-focus unchanged.

**Patch (2^49 down to 2^31), new:** `EarthPatch.tsx` draws the piece of the ellipsoid within reach of the anchor as graticule lines on 1/2/5-decade degree rulings anchored to the planet. Curvature is exact by construction. The visible band: sagitta ~0.4 cells at 2^40, ~12 cells at 2^45, hemispheric wrap at 2^49. A depth-only ground mesh sunk two cells under the lines makes the horizon hide what is beyond it. The equator and prime meridian draw green with labels whenever they cross the window. Full strength to 2^34, fading out by 2^31: below metre scale the map of places bows out to the microscopic, as discussed.

Also rides along: the touchpad scale hub (2^N) gets cursor/hover/active states, since it is clickable (resets to 2^0).

## Tests

7 new tests in `earthSurface.test.ts`: WGS84 reference points through the section 9.4 permutation, round-trip against the landfall inverse, the 96-cell globe/patch handoff landing exactly between 2^49 and 2^50, chart-ruling selection, and the fade envelope. tsc clean, 299/299 green.

Coastlines (110m + 50m + 10m Natural Earth) come next as their own PR on top of this surface machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)