### PR TITLE
Open facing the black sun

### DIFF
--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -671,7 +671,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   cursor: initial.position,
   pendingTarget: null,
   scaleExp: 0,
-  view: topDownQuaternion(),
+  // Facing the black sun, the section 11.3 canonical orientation, the same
+  // one the SUN button restores. The spec's left/right/above/below language
+  // is defined against it, so it is what a first look should agree with; the
+  // map view is one TOP away and does not need to be where everyone starts.
+  view: canonicalQuaternion(),
   viewHistory: [],
   proof: IDLE_PROOF,
   publishError: null,


### PR DESCRIPTION
The default view was the top-down map. It is now the canonical orientation from CYBERSPACE_V2.md section 11.3, facing the black sun: the same view the SUN button restores.

Section 11.1 binds the axis semantics (left, right, above, below, ahead, behind) only when oriented canonically, so that is the orientation a first look should agree with. TOP is one button away for anyone who wants the map.

One line in `src/store/useCyberspace.ts`: the initial `view` is `canonicalQuaternion()` instead of `topDownQuaternion()`. The view is not persisted, so nothing else needed changing.

tsc clean, 304/304.