### PR TITLE
Loot panel: list every hidden bag on the relay (slice 1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Workshop } from './workshop/Workshop'
 import { DeployBar } from './hud/DeployBar'
 import { DeploymentDetail } from './hud/DeploymentDetail'
 import { SecretModal } from './hud/SecretModal'
+import { LootDetail } from './hud/LootDetail'
 import { useDiscovery } from './hooks/useDiscovery'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
@@ -132,6 +133,7 @@ export default function App(): JSX.Element {
       <DeployBar />
       <DeploymentDetail />
       <SecretModal />
+      <LootDetail />
       <button
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Workshop } from './workshop/Workshop'
 import { DeployBar } from './hud/DeployBar'
 import { DeploymentDetail } from './hud/DeploymentDetail'
 import { SecretModal } from './hud/SecretModal'
+import { FocusBar } from './hud/FocusBar'
 import { LootDetail } from './hud/LootDetail'
 import { useDiscovery } from './hooks/useDiscovery'
 import { Hud } from './hud/Hud'
@@ -109,6 +110,7 @@ export default function App(): JSX.Element {
               last. */}
           <LineScrubber />
           <HyperspaceBar />
+          <FocusBar />
           <ChainExplorer />
           <BitReadout />
         </div>

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -78,6 +78,8 @@ export function useKeyboard(): void {
         // Viewing a stop or EARTH: come home before anything else.
         const hs = useHyperspace.getState()
         if (hs.scrubHeight !== null || hs.viewOwned) { exitHyperspaceView(); return }
+        // Viewing a hidden thing or a loot item: same rule, come home first.
+        if (store.focus !== null && store.spectate === null) { store.clearFocus(); return }
         store.resetView()
         return
       }

--- a/src/hooks/useLoot.ts
+++ b/src/hooks/useLoot.ts
@@ -4,12 +4,15 @@
  * Same shape as useRecentAvatars: one backfill query for every kind:33330
  * envelope, one live subscription for new or rewritten ones, merged by bag key
  * so a republished bag replaces its older self instead of appearing twice.
+ * Re-runs when the relay set changes, so a relay added in the Relays panel is
+ * searched for loot without a reload.
  */
 
 import { useEffect, useState } from 'react'
 import { HIDDEN_KIND } from '../lib/hidden'
 import { mergeLoot, summarizeBag, type LootItem } from '../lib/loot'
 import { query, subscribe } from '../lib/relay'
+import { useRelays } from '../store/useRelays'
 
 export interface Loot {
   items: LootItem[]
@@ -22,9 +25,11 @@ export const LOOT_BACKFILL = 500
 export function useLoot(): Loot {
   const [items, setItems] = useState<LootItem[]>([])
   const [status, setStatus] = useState<Loot['status']>('loading')
+  const relays = useRelays((s) => s.relays)
 
   useEffect(() => {
     let alive = true
+    setStatus('loading')
     const since = Math.floor(Date.now() / 1000) - 60
     const close = subscribe({ kinds: [HIDDEN_KIND], since }, (ev) => {
       const item = summarizeBag(ev)
@@ -40,7 +45,7 @@ export function useLoot(): Loot {
       () => { if (alive) setStatus('error') },
     )
     return () => { alive = false; close() }
-  }, [])
+  }, [relays])
 
   return { items, status }
 }

--- a/src/hooks/useLoot.ts
+++ b/src/hooks/useLoot.ts
@@ -1,0 +1,46 @@
+/**
+ * useLoot.ts — the relay's bags, fetched once and kept live.
+ *
+ * Same shape as useRecentAvatars: one backfill query for every kind:33330
+ * envelope, one live subscription for new or rewritten ones, merged by bag key
+ * so a republished bag replaces its older self instead of appearing twice.
+ */
+
+import { useEffect, useState } from 'react'
+import { HIDDEN_KIND } from '../lib/hidden'
+import { mergeLoot, summarizeBag, type LootItem } from '../lib/loot'
+import { query, subscribe } from '../lib/relay'
+
+export interface Loot {
+  items: LootItem[]
+  status: 'loading' | 'ready' | 'error'
+}
+
+/** The relay holds a few dozen bags today; this leaves room without paging. */
+export const LOOT_BACKFILL = 500
+
+export function useLoot(): Loot {
+  const [items, setItems] = useState<LootItem[]>([])
+  const [status, setStatus] = useState<Loot['status']>('loading')
+
+  useEffect(() => {
+    let alive = true
+    const since = Math.floor(Date.now() / 1000) - 60
+    const close = subscribe({ kinds: [HIDDEN_KIND], since }, (ev) => {
+      const item = summarizeBag(ev)
+      if (alive && item) setItems((prev) => mergeLoot(prev, [item]))
+    })
+    query({ kinds: [HIDDEN_KIND], limit: LOOT_BACKFILL }).then(
+      (events) => {
+        if (!alive) return
+        const found = events.map(summarizeBag).filter((x): x is LootItem => x !== null)
+        setItems((prev) => mergeLoot(prev, found))
+        setStatus('ready')
+      },
+      () => { if (alive) setStatus('error') },
+    )
+    return () => { alive = false; close() }
+  }, [])
+
+  return { items, status }
+}

--- a/src/hud/AvatarsPanel.tsx
+++ b/src/hud/AvatarsPanel.tsx
@@ -17,6 +17,7 @@ import { ProfileBadge } from './ProfileBadge'
 import { targetColor } from '../lib/targets'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
+import { Explanation } from './Explanation'
 
 export function AvatarsPanel(): JSX.Element {
   const { avatars, status } = useRecentAvatars()
@@ -92,11 +93,11 @@ export function AvatarsPanel(): JSX.Element {
         )}
       </ul>
 
-      <p className="legend__note">
+      <Explanation>
         Newest kind:3333 action per pubkey on {CYBERSPACE_RELAY.replace('wss://', '')}.
         Spectating anchors the scene on their chain head and gives the chain
         explorer their history; the controls stand down until you end it.
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/hud/ChainPanel.tsx
+++ b/src/hud/ChainPanel.tsx
@@ -14,6 +14,7 @@ import { formatMs, formatOps } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { useRelays } from '../store/useRelays'
+import { Explanation } from './Explanation'
 
 export function ChainPanel(): JSX.Element {
   const chain = useCyberspace((s) => s.chain)
@@ -86,12 +87,12 @@ export function ChainPanel(): JSX.Element {
 
       {publishError && <p className="notice">{CYBERSPACE_RELAY}: {publishError}</p>}
 
-      <p className="legend__note">
+      <Explanation>
         Every committed action is a signed kind:3333 event naming the one
         before it (spec section 8). {live
           ? `Live publishes each one to your ${relayCount === 1 ? CYBERSPACE_RELAY.replace('wss://', '') : `${relayCount} relays`} as it lands.`
           : 'Local keeps them on this device; switching to Live publishes the whole chain in order.'}
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/hud/DeploymentDetail.tsx
+++ b/src/hud/DeploymentDetail.tsx
@@ -1,7 +1,7 @@
 /**
  * DeploymentDetail.tsx — a deployed thing, on the wire.
  *
- * Opened by tapping a row in the Shards panel, which also flies the scene to
+ * Opened by tapping a row in the Stash panel, which also flies the scene to
  * where it sits. This is the record that lives on relays: its event id, which
  * relays hold it, the lookup id it is filed under, its coordinate, the height
  * it is hidden at, and what it is (a shard or a message). TEST DISCOVERY proves

--- a/src/hud/DerezzPanel.tsx
+++ b/src/hud/DerezzPanel.tsx
@@ -14,6 +14,7 @@
 
 import { useState } from 'react'
 import { useCyberspace } from '../store/useCyberspace'
+import { Explanation } from './Explanation'
 
 export function DerezzPanel(): JSX.Element {
   const [armed, setArmed] = useState(false)
@@ -50,12 +51,12 @@ export function DerezzPanel(): JSX.Element {
         </>
       ) : (
         <>
-          <p className="legend__note">
+          <Explanation>
             Abandon this chain and spawn again at your pubkey. A new spawn event
             {live ? ' is published and ' : ' '}retires every action before it
             (spec section 3.2). Your identity and the relay's copy of the old
             chain are untouched.
-          </p>
+          </Explanation>
           <button className="derezz__arm" onClick={() => setArmed(true)}>DEREZZ</button>
         </>
       )}

--- a/src/hud/Explanation.tsx
+++ b/src/hud/Explanation.tsx
@@ -1,0 +1,24 @@
+/**
+ * Explanation.tsx — a panel's explanatory prose, folded behind a pill.
+ *
+ * Every panel used to end in a paragraph explaining itself. Read once, that
+ * paragraph is noise on every later visit, so it now sits behind an EXPLAIN
+ * pill: tap to open it in a well, tap again to fold it. The state belongs to
+ * the mounted component and is never persisted, so every visit starts folded.
+ * Status lines (empty states, machine ceilings, key hints) are not
+ * explanations and stay in view.
+ */
+
+import { useState, type ReactNode } from 'react'
+
+export function Explanation({ children }: { children: ReactNode }): JSX.Element {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className={`explain ${open ? 'is-open' : ''}`}>
+      <button type="button" className={`explain__pill ${open ? 'is-on' : ''}`} aria-expanded={open} onClick={() => setOpen((o) => !o)}>
+        {open ? 'HIDE' : 'EXPLAIN'}
+      </button>
+      {open && <div className="explain__well legend__note">{children}</div>}
+    </div>
+  )
+}

--- a/src/hud/FocusBar.tsx
+++ b/src/hud/FocusBar.tsx
@@ -1,0 +1,34 @@
+/**
+ * FocusBar.tsx - the way home from a plain focus view.
+ *
+ * GO TO IT on a hidden thing, VIEW on a loot item, or tapping one of your
+ * deployments flies the scene to a point that is not your avatar: the store's
+ * `focus` is set and the controls stand down. Spectating has SpectateBar,
+ * hyperspace views have HyperspaceBar, and your own deployments have the
+ * deployment detail's EXIT, but a focus reached any other way had no exit at
+ * all: on a keyboard Escape worked, on a phone nothing did. This bar is that
+ * exit. It shows whenever a focus is standing and no other bar owns it, and
+ * RETURN puts the anchor back on your avatar at the zoom you left.
+ */
+
+import { useCyberspace } from '../store/useCyberspace'
+import { useHyperspace } from '../store/useHyperspace'
+import { useShards } from '../store/useShards'
+
+export function FocusBar(): JSX.Element | null {
+  const focusLabel = useCyberspace((s) => s.focus?.label ?? null)
+  const spectating = useCyberspace((s) => s.spectate !== null)
+  const viewOwned = useHyperspace((s) => s.viewOwned)
+  const inspecting = useShards((s) => s.inspecting !== null)
+  if (focusLabel === null || spectating || viewOwned || inspecting) return null
+  return (
+    <div className="hyperbar hyperbar--focus" role="status">
+      <span className="hyperbar__glyph" aria-hidden="true">◈</span>
+      <span className="hyperbar__text">
+        <span className="hyperbar__label">VIEWING</span>
+        <span className="hyperbar__meta">{focusLabel}</span>
+      </span>
+      <button className="hyperbar__end" onClick={() => useCyberspace.getState().clearFocus()}>RETURN</button>
+    </div>
+  )
+}

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -12,6 +12,7 @@ import { useProfile } from '../hooks/useProfile'
 import { profileLabel } from '../store/useProfiles'
 import { LoginModal } from './LoginModal'
 import { AvatarsPanel } from './AvatarsPanel'
+import { LootPanel } from './LootPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
 import { HyperspacePanel } from './HyperspacePanel'
@@ -235,6 +236,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <IdentityPanel />
         <PositionPanel />
         <AvatarsPanel />
+        <LootPanel />
         <TargetsPanel />
         <ScalePanel />
         <LinksPanel />

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -22,6 +22,7 @@ import { ShardsPanel } from './ShardsPanel'
 import { Legend } from './Legend'
 import { ScaleLadder } from './ScaleLadder'
 import { ProofPanel } from './ProofPanel'
+import { Explanation } from './Explanation'
 
 const AXIS_LABEL: Record<string, string> = { x: 'X', y: 'Y', z: 'Z' }
 
@@ -72,14 +73,14 @@ function IdentityPanel(): JSX.Element {
         <button className="identity__change" onClick={() => setLoginOpen(true)}>CHANGE</button>
       </div>
 
-      <p className="legend__note">
+      <Explanation>
         Spawned at this key's coordinate: the 256-bit pubkey decodes directly
         to x / y / z / plane (spec section 8.3). Persisted locally so
         refreshing keeps your identity and position.
         {live
           ? ' LIVE: every action is signed and published to cyberspace.nostr1.com as it completes.'
           : ' LOCAL: actions are signed but stay on this device. Going live publishes the whole chain.'}
-      </p>
+      </Explanation>
 
       {loginOpen && <LoginModal onClose={() => setLoginOpen(false)} />}
     </section>
@@ -171,10 +172,10 @@ function ScalePanel(): JSX.Element {
         </div>
       </div>
 
-      <p className="legend__note">
+      <Explanation>
         Looking along {signed(axes.out.axis, -axes.out.dir)}. R and F travel the
         axis into and out of the screen.
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -235,19 +235,19 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
       <div className="hud__col hud__col--left">
         <Brand />
         <IdentityPanel />
-        <PositionPanel />
-        <AvatarsPanel />
         <LootPanel />
+        <ShardsPanel />
+        <AvatarsPanel />
         <TargetsPanel />
-        <ScalePanel />
         <LinksPanel />
       </div>
       <div className="hud__col hud__col--right">
+        <ScalePanel />
+        <PositionPanel />
         <ProofPanel />
         <ChainPanel />
         <HyperspacePanel />
         <Legend />
-        <ShardsPanel />
         <Controls />
         <DerezzPanel />
         <RelaysPanel />

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -36,6 +36,7 @@ function formatDuration(ms: number): string {
 }
 import { useCyberspace } from '../store/useCyberspace'
 import { markViewedStop, ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
+import { Explanation } from './Explanation'
 
 /**
  * Where a stop sits, for the camera. The float64-approximate coordinate is
@@ -310,12 +311,12 @@ export function HyperspacePanel(): JSX.Element {
                 </>
               )}
             </dl>
-            <p className="legend__note">
+            <Explanation>
               STATION is where boarding sets you down: your nearest block as
               of the synced tip, ties to the lowest height. The ride runs from
               it to the destination; all of the per-block work runs locally
               and resumes if interrupted.
-            </p>
+            </Explanation>
           </>
         )}
       </div>
@@ -370,7 +371,7 @@ export function HyperspacePanel(): JSX.Element {
       {sync.error && <p className="notice">{sync.error}</p>}
       {rideError && <p className="notice">{rideError}</p>}
 
-      <p className="legend__note">
+      <Explanation>
         Your STATION is your nearest block, ties to the lowest height:
         distance is the size of the smallest aligned cube holding you both,
         so far from the line several blocks are equally near and every
@@ -380,7 +381,7 @@ export function HyperspacePanel(): JSX.Element {
         for every block passed and sets you down exactly at the block.
         Leaving is an ordinary hop, so the last mile from any block is
         normal movement.
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/hud/Legend.tsx
+++ b/src/hud/Legend.tsx
@@ -4,6 +4,7 @@
 
 import { boundaryColor, terrainColor } from '../lib/palette'
 import { useCyberspace } from '../store/useCyberspace'
+import { Explanation } from './Explanation'
 
 const TERRAIN_SAMPLES = [0, 4, 6, 8, 10, 12, 14, 16]
 const HEIGHT_SAMPLES = [5, 20, 40, 60, 80]
@@ -53,14 +54,14 @@ export function Legend(): JSX.Element {
         </span>
       </div>
 
-      <p className="legend__note">
+      <Explanation>
         The subtree lattice takes its colour from the height of its own walls, so
         the grid climbs this ramp as you zoom out. Committing flashes the region
         the proof covered, striking white and settling into the same ramp at the
         height you paid. Height is the power-of-two boundary you cross, not how
         far you travel. The cyan box is the move you are lining up. Current
         scale: {scaleExp}.
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/hud/LootDetail.tsx
+++ b/src/hud/LootDetail.tsx
@@ -1,0 +1,172 @@
+/**
+ * LootDetail.tsx — one bag, opened from the Loot list.
+ *
+ * Everything a seeker can know about a bag without opening it: who hid it and
+ * when, the size of the region it is encrypted to, how much is inside, the
+ * riddle if the hider wrote one, and the wire identifiers. Where the bag is
+ * stays hidden until its hider adds a hint, and the view says so in plain
+ * words rather than leaving a number to be misread as a distance. A bag your
+ * own scan has already opened, or one of your own, lists its items with a
+ * VIEW button that flies the scene to each.
+ */
+
+import { nip19 } from 'nostr-tools'
+import type { Plane } from 'cyberspace-core'
+import { useState } from 'react'
+import { useProfile } from '../hooks/useProfile'
+import { messagePreview } from '../lib/hidden'
+import { formatBytes, regionLabel, type LootItem } from '../lib/loot'
+import type { Position } from '../lib/space'
+import { spectate } from '../lib/spectator'
+import { formatAgo, formatStamp, shortHex } from '../lib/time'
+import { useCyberspace } from '../store/useCyberspace'
+import { useLootView } from '../store/useLootView'
+import { profileLabel } from '../store/useProfiles'
+import { useShards } from '../store/useShards'
+import { ProfilePic } from './ProfileBadge'
+
+/** An item of this bag that this client can already see, from a scan or from its own deployments. */
+interface OpenedItem {
+  eventId: string
+  type: 'shard' | 'message'
+  label: string
+  at: Position
+  plane: Plane
+  unit: number
+}
+
+function safeNpub(pubkey: string): string {
+  try { return nip19.npubEncode(pubkey) } catch { return pubkey }
+}
+
+function Copyable({ label, value }: { label: string; value: string }): JSX.Element {
+  const [copied, setCopied] = useState(false)
+  const copy = (): void => {
+    void navigator.clipboard?.writeText(value).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1200)
+    })
+  }
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd><button className="lootd__copy" title={`${value} (click to copy)`} onClick={copy}>{copied ? 'copied' : shortHex(value, 12, 8)}</button></dd>
+    </>
+  )
+}
+
+/** The bag's items this client can see: found by its scan, or its own. */
+function openedItems(item: LootItem, discovered: ReturnType<typeof useShards.getState>['discovered'], mine: ReturnType<typeof useShards.getState>['mine']): OpenedItem[] {
+  const out = new Map<string, OpenedItem>()
+  for (const h of Object.values(discovered)) {
+    if (h.bagId !== item.bagId) continue
+    out.set(h.eventId, {
+      eventId: h.eventId,
+      type: h.type,
+      label: h.type === 'message' ? messagePreview(h.text ?? '', 48) : h.shard?.name ?? 'shard',
+      at: h.at,
+      plane: h.plane,
+      unit: h.type === 'shard' ? h.shard?.unit ?? 0 : 0,
+    })
+  }
+  for (const d of mine) {
+    if (d.bagId !== item.bagId || out.has(d.eventId)) continue
+    out.set(d.eventId, {
+      eventId: d.eventId,
+      type: d.type,
+      label: d.type === 'message' ? messagePreview(d.text ?? '', 48) : d.shard?.name ?? 'shard',
+      at: { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) },
+      plane: d.plane,
+      unit: d.type === 'shard' ? d.shard?.unit ?? 0 : 0,
+    })
+  }
+  return [...out.values()]
+}
+
+export function LootDetail(): JSX.Element | null {
+  const item = useLootView((s) => s.selected)
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const targeted = useCyberspace((s) => (item ? !!s.targets[item.author] : false))
+  const discovered = useShards((s) => s.discovered)
+  const mine = useShards((s) => s.mine)
+  const profile = useProfile(item?.author ?? null)
+
+  if (!item) return null
+
+  const npub = safeNpub(item.author)
+  const name = profileLabel(profile, npub)
+  const yours = item.author === me
+  const opened = openedItems(item, discovered, mine)
+  const close = (): void => useLootView.getState().select(null)
+
+  const view = (o: OpenedItem): void => {
+    close()
+    useCyberspace.getState().focusOn(o.at, o.plane, o.label, o.unit)
+  }
+  const watch = (): void => { close(); void spectate(item.author) }
+  const target = (): void => useCyberspace.getState().toggleTarget(item.author, profile?.name ?? null)
+
+  return (
+    <div className="modal modal--top" role="dialog" aria-modal="true" aria-label="Hidden bag" onPointerDown={close}>
+      <div className="modal__card secret lootd" onPointerDown={(e) => e.stopPropagation()}>
+        <div className="secret__head">
+          <span className="secret__badge">◈ LOOT</span>
+          {opened.length > 0 && <span className="tag tag--live">{yours ? 'YOURS' : 'FOUND'}</span>}
+          {yours && opened.length === 0 && <span className="secret__mine">YOURS</span>}
+          <button className="secret__close" onClick={close} aria-label="Close">✕</button>
+        </div>
+
+        {item.riddle && <blockquote className="secret__message" title="The hider's riddle, written in the clear">{item.riddle}</blockquote>}
+
+        <div className="secret__creator">
+          <span className="secret__label">Hidden by</span>
+          <div className="secret__person">
+            <ProfilePic pubkey={item.author} size={40} />
+            <div className="secret__person-text">
+              <span className="secret__name">{name}{yours ? ' (you)' : ''}</span>
+              {profile?.nip05 && <span className="secret__nip05">{profile.nip05.replace(/^_@/, '')}</span>}
+              <span className="secret__npub" title={npub}>{shortHex(npub, 14, 8)}</span>
+            </div>
+          </div>
+        </div>
+
+        <dl className="secret__facts lootd__facts">
+          <div><dt>Placed</dt><dd title={formatStamp(item.createdAt)}>{formatAgo(item.createdAt)}</dd></div>
+          <div><dt>Region</dt><dd>{regionLabel(item.height)} <span className="lootd__dim">(height {item.height})</span></dd></div>
+          <div><dt>Payload</dt><dd>{formatBytes(item.bytes)}</dd></div>
+          <div><dt>Where</dt><dd>{opened.length > 0 ? (opened[0].plane === 0 ? 'known · dataspace' : 'known · ideaspace') : 'hidden'}</dd></div>
+        </dl>
+
+        {opened.length > 0 ? (
+          <ul className="lootd__items">
+            {opened.map((o) => (
+              <li key={o.eventId} className="lootd__item">
+                <span className={`secret__badge secret__badge--${o.type}`}>{o.type === 'message' ? '✎' : '◇'}</span>
+                <span className="lootd__item-label" title={o.label}>{o.label}</span>
+                <button className="secret__act lootd__view" onClick={() => view(o)}>VIEW</button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="lootd__hidden">
+            This bag carries no hint, so nothing here says where it is. The region size above is how large an area it can be
+            found from, not how far away it is. Only a scan that computes its region key can open it. Hints that narrow the
+            search are the next step.
+          </p>
+        )}
+
+        <dl className="lootd__wire">
+          <Copyable label="lookup" value={item.lookupId} />
+          <Copyable label="bag" value={item.bagId} />
+        </dl>
+
+        {!yours && (
+          <div className="secret__actions">
+            <button className={`secret__act ${targeted ? 'is-on' : ''}`} onClick={target}>{targeted ? 'TARGETED' : 'TARGET'} HIDER</button>
+            <button className="secret__act" onClick={watch}>SPECTATE HIDER</button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -1,0 +1,68 @@
+/**
+ * LootPanel.tsx — what is hidden in cyberspace, as a list.
+ *
+ * Every kind:33330 bag on the relay: who hid it, the region height it can be
+ * found from, when, how much, and the riddle if there is one. Where each bag
+ * is stays hidden until hints land (the spec amendment is in progress); today
+ * the panel answers the question a newcomer asks first, whether there is
+ * anything out there at all. A bag your scan has already opened is marked
+ * FOUND; your own bags are marked YOURS.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { useLoot } from '../hooks/useLoot'
+import { messagePreview } from '../lib/hidden'
+import { formatBytes, heightLabel } from '../lib/loot'
+import { CYBERSPACE_RELAY } from '../lib/relay'
+import { formatAgo, formatStamp } from '../lib/time'
+import { useCyberspace } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+import { ProfileBadge } from './ProfileBadge'
+
+export function LootPanel(): JSX.Element {
+  const { items, status } = useLoot()
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const discovered = useShards((s) => s.discovered)
+  const found = useMemo(() => new Set(Object.values(discovered).map((h) => h.bagId)), [discovered])
+  const [now, setNow] = useState(() => Date.now() / 1000)
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now() / 1000), 10_000)
+    return () => window.clearInterval(t)
+  }, [])
+  const relayName = CYBERSPACE_RELAY.replace('wss://', '')
+
+  return (
+    <section className="panel panel--loot">
+      <header className="panel__head">
+        <h2>Loot</h2>
+        <span className="tag">{status === 'loading' ? 'LOADING' : `${items.length} HIDDEN`}</span>
+      </header>
+
+      {status === 'error' && <p className="notice">Could not reach {relayName}.</p>}
+
+      <ul className="avatars__list loot__list">
+        {items.map((it) => (
+          <li key={it.key} className="loot__row">
+            <div className="loot__top">
+              <ProfileBadge pubkey={it.author} />
+              {it.author === me && <span className="avatars__you">YOURS</span>}
+              {found.has(it.bagId) && <span className="tag tag--live">FOUND</span>}
+              <span className="avatars__when" title={formatStamp(it.createdAt)}>{formatAgo(it.createdAt, now)}</span>
+            </div>
+            <div className="loot__meta">{heightLabel(it.height)} · {formatBytes(it.bytes)}</div>
+            {it.riddle && <div className="loot__riddle" title={it.riddle}>“{messagePreview(it.riddle, 90)}”</div>}
+          </li>
+        ))}
+        {status === 'ready' && items.length === 0 && (
+          <li className="avatars__empty">Nothing hidden on the relay yet.</li>
+        )}
+      </ul>
+
+      <p className="legend__note">
+        Every kind:33330 bag on {relayName}. Where each one is stays hidden:
+        the lookup id reveals nothing, and only a scan that computes its region
+        key can open it. Hints that narrow the search are coming.
+      </p>
+    </section>
+  )
+}

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -19,6 +19,7 @@ import { useCyberspace } from '../store/useCyberspace'
 import { useLootView } from '../store/useLootView'
 import { useShards } from '../store/useShards'
 import { ProfileBadge } from './ProfileBadge'
+import { Explanation } from './Explanation'
 
 export function LootPanel(): JSX.Element {
   const { items, status } = useLoot()
@@ -65,11 +66,11 @@ export function LootPanel(): JSX.Element {
         )}
       </ul>
 
-      <p className="legend__note">
+      <Explanation>
         Every kind:33330 bag on {relayName}. The size is the region each bag is
         encrypted to, not its distance from you: where that region is stays hidden
         until its hider adds a hint. Tap a bag for its record.
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -1,21 +1,22 @@
 /**
  * LootPanel.tsx — what is hidden in cyberspace, as a list.
  *
- * Every kind:33330 bag on the relay: who hid it, the region height it can be
- * found from, when, how much, and the riddle if there is one. Where each bag
+ * Every kind:33330 bag on the relay: who hid it, the size of the region it is
+ * encrypted to, when, how much, and the riddle if there is one. Where each bag
  * is stays hidden until hints land (the spec amendment is in progress); today
  * the panel answers the question a newcomer asks first, whether there is
- * anything out there at all. A bag your scan has already opened is marked
- * FOUND; your own bags are marked YOURS.
+ * anything out there at all. Tapping a bag opens its record (LootDetail). A bag
+ * your scan has already opened is marked FOUND; your own bags are marked YOURS.
  */
 
 import { useEffect, useMemo, useState } from 'react'
 import { useLoot } from '../hooks/useLoot'
 import { messagePreview } from '../lib/hidden'
-import { formatBytes, heightLabel } from '../lib/loot'
+import { formatBytes, regionLabel } from '../lib/loot'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
+import { useLootView } from '../store/useLootView'
 import { useShards } from '../store/useShards'
 import { ProfileBadge } from './ProfileBadge'
 
@@ -24,6 +25,7 @@ export function LootPanel(): JSX.Element {
   const me = useCyberspace((s) => s.identity.pubkey)
   const discovered = useShards((s) => s.discovered)
   const found = useMemo(() => new Set(Object.values(discovered).map((h) => h.bagId)), [discovered])
+  const foundCount = useMemo(() => items.filter((it) => found.has(it.bagId)).length, [items, found])
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {
     const t = window.setInterval(() => setNow(Date.now() / 1000), 10_000)
@@ -35,7 +37,10 @@ export function LootPanel(): JSX.Element {
     <section className="panel panel--loot">
       <header className="panel__head">
         <h2>Loot</h2>
-        <span className="tag">{status === 'loading' ? 'LOADING' : `${items.length} HIDDEN`}</span>
+        <span className="loot__tags">
+          {foundCount > 0 && <span className="tag tag--live">{foundCount} FOUND</span>}
+          <span className="tag">{status === 'loading' ? 'LOADING' : `${items.length} HIDDEN`}</span>
+        </span>
       </header>
 
       {status === 'error' && <p className="notice">Could not reach {relayName}.</p>}
@@ -43,14 +48,16 @@ export function LootPanel(): JSX.Element {
       <ul className="avatars__list loot__list">
         {items.map((it) => (
           <li key={it.key} className="loot__row">
-            <div className="loot__top">
-              <ProfileBadge pubkey={it.author} />
-              {it.author === me && <span className="avatars__you">YOURS</span>}
-              {found.has(it.bagId) && <span className="tag tag--live">FOUND</span>}
-              <span className="avatars__when" title={formatStamp(it.createdAt)}>{formatAgo(it.createdAt, now)}</span>
-            </div>
-            <div className="loot__meta">{heightLabel(it.height)} · {formatBytes(it.bytes)}</div>
-            {it.riddle && <div className="loot__riddle" title={it.riddle}>“{messagePreview(it.riddle, 90)}”</div>}
+            <button className="loot__open" onClick={() => useLootView.getState().select(it)} title="Open this bag's record">
+              <div className="loot__top">
+                <ProfileBadge pubkey={it.author} />
+                {it.author === me && <span className="avatars__you">YOURS</span>}
+                {found.has(it.bagId) && <span className="tag tag--live">FOUND</span>}
+                <span className="avatars__when" title={formatStamp(it.createdAt)}>{formatAgo(it.createdAt, now)}</span>
+              </div>
+              <div className="loot__meta">{regionLabel(it.height)} · {formatBytes(it.bytes)}</div>
+              {it.riddle && <div className="loot__riddle" title={it.riddle}>“{messagePreview(it.riddle, 90)}”</div>}
+            </button>
           </li>
         ))}
         {status === 'ready' && items.length === 0 && (
@@ -59,9 +66,9 @@ export function LootPanel(): JSX.Element {
       </ul>
 
       <p className="legend__note">
-        Every kind:33330 bag on {relayName}. Where each one is stays hidden:
-        the lookup id reveals nothing, and only a scan that computes its region
-        key can open it. Hints that narrow the search are coming.
+        Every kind:33330 bag on {relayName}. The size is the region each bag is
+        encrypted to, not its distance from you: where that region is stays hidden
+        until its hider adds a hint. Tap a bag for its record.
       </p>
     </section>
   )

--- a/src/hud/RelaysPanel.tsx
+++ b/src/hud/RelaysPanel.tsx
@@ -73,8 +73,8 @@ export function RelaysPanel(): JSX.Element {
       {error && <p className="notice">Not a valid ws:// or wss:// URL.</p>}
 
       <Explanation>
-        Everything the client does fans out across these. The default is shared
-        by everyone and stays; yours are added on top and kept on this device.
+        Your actions are published to each relay, and cyberspace data is pulled
+        from each relay.
       </Explanation>
     </section>
   )

--- a/src/hud/RelaysPanel.tsx
+++ b/src/hud/RelaysPanel.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react'
 import { connected } from '../lib/relay'
 import { getPool } from '../lib/relay'
 import { DEFAULT_RELAY, useRelays } from '../store/useRelays'
+import { Explanation } from './Explanation'
 
 export function RelaysPanel(): JSX.Element {
   const relays = useRelays((s) => s.relays)
@@ -71,10 +72,10 @@ export function RelaysPanel(): JSX.Element {
       </form>
       {error && <p className="notice">Not a valid ws:// or wss:// URL.</p>}
 
-      <p className="legend__note">
+      <Explanation>
         Everything the client does fans out across these. The default is shared
         by everyone and stays; yours are added on top and kept on this device.
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -6,7 +6,7 @@
  * what you can do about the person: point at them, watch them, or go stand
  * where their content sits. Your own also offers to delete it.
  *
- * This is the "who is this and what do I do about them" view. The Shards panel's
+ * This is the "who is this and what do I do about them" view. The Stash panel's
  * deployment detail is the "manage my own on the wire" view; the two are
  * reached differently and answer different questions.
  */

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * ShardsPanel.tsx — your shards and hidden messages, in kinds.
+ * ShardsPanel.tsx — the Stash: your shards and hidden messages, in kinds.
  *
  * A MODEL is a named shard design that lives on this device; you open it in the
  * workshop and deploy copies. A DEPLOYED instance is one such copy, or a hidden
@@ -58,7 +58,7 @@ export function ShardsPanel(): JSX.Element {
   return (
     <section className="panel panel--shards">
       <header className="panel__head">
-        <h2>Shards &amp; messages</h2>
+        <h2>Stash</h2>
         <span className={`tag ${scanning ? 'tag--scan' : ''}`}>{scanning ? 'SCANNING' : `${foundCount} FOUND`}</span>
       </header>
 
@@ -130,9 +130,9 @@ export function ShardsPanel(): JSX.Element {
       )}
 
       <Explanation>
-        A shard is coloured vertices (SOLID / POINTS / LINES); a message is text.
-        Both are hidden at a location and found only by someone who computes its
-        region key (spec section 7). Tap a deployment to fly to it and prove it
+        Encrypt by location: a shard is coloured vertices (SOLID / POINTS / LINES);
+        a message is text. Both are hidden at a location and found only by someone
+        who computes its region key (spec section 7). Tap a deployment to fly to it and prove it
         with TEST DISCOVERY. FOUND counts the items your own scans have opened
         this session, at every place you have looked, not only where you stand
         now.

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -17,6 +17,7 @@ import { ConfirmModal } from './ConfirmModal'
 import { useCyberspace } from '../store/useCyberspace'
 import { useShards, type MyDeployment } from '../store/useShards'
 import { useWorkshop } from '../store/useWorkshop'
+import { Explanation } from './Explanation'
 
 function positionOf(d: MyDeployment): { x: bigint; y: bigint; z: bigint } {
   return { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) }
@@ -38,7 +39,7 @@ export function ShardsPanel(): JSX.Element {
 
   const target = models.find((m) => m.id === deleteModel)
   const deployedCount = (id: string): number => mine.filter((d) => d.type === 'shard' && d.shard?.id === id).length
-  const nearby = Object.keys(discovered).length
+  const foundCount = Object.keys(discovered).length
 
   const goTo = (d: MyDeployment): void => {
     useShards.getState().inspect(d.eventId)
@@ -58,7 +59,7 @@ export function ShardsPanel(): JSX.Element {
     <section className="panel panel--shards">
       <header className="panel__head">
         <h2>Shards &amp; messages</h2>
-        <span className={`tag ${scanning ? 'tag--scan' : ''}`}>{scanning ? 'SCANNING' : `${nearby} NEAR`}</span>
+        <span className={`tag ${scanning ? 'tag--scan' : ''}`}>{scanning ? 'SCANNING' : `${foundCount} FOUND`}</span>
       </header>
 
       <div className="shards__section">
@@ -128,12 +129,14 @@ export function ShardsPanel(): JSX.Element {
         </div>
       )}
 
-      <p className="legend__note">
+      <Explanation>
         A shard is coloured vertices (SOLID / POINTS / LINES); a message is text.
         Both are hidden at a location and found only by someone who computes its
         region key (spec section 7). Tap a deployment to fly to it and prove it
-        with TEST DISCOVERY.
-      </p>
+        with TEST DISCOVERY. FOUND counts the items your own scans have opened
+        this session, at every place you have looked, not only where you stand
+        now.
+      </Explanation>
 
       {target && (
         <ConfirmModal

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -21,6 +21,7 @@ import type { Position } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
 import { profileLabel, useProfiles } from '../store/useProfiles'
 import { ProfileBadge } from './ProfileBadge'
+import { Explanation } from './Explanation'
 
 export function TargetsPanel(): JSX.Element {
   const targets = useCyberspace((s) => s.targets)
@@ -179,13 +180,13 @@ export function TargetsPanel(): JSX.Element {
         )}
       </div>
 
-      <p className="legend__note">
+      <Explanation>
         A target is pointed at from anywhere, like Earth: reticle in frame,
         chevron on the edge, distance either way, and the avatar itself once
         you are near. Positions are chain heads on the relay, kept live; a key
         with no chain is pointed at its spawn coordinate. Follows come from
         kind 3 on {GENERAL_RELAYS.map((r) => r.replace('wss://', '')).join(', ')}.
-      </p>
+      </Explanation>
     </section>
   )
 }

--- a/src/lib/loot.test.ts
+++ b/src/lib/loot.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { NostrEvent } from './events'
-import { formatBytes, heightLabel, mergeLoot, payloadBytes, summarizeBag } from './loot'
+import { formatBytes, mergeLoot, payloadBytes, regionLabel, summarizeBag } from './loot'
 
 const pk = (n: number): string => n.toString(16).padStart(64, '0')
 const lookup = (n: number): string => (n + 1).toString(16).padStart(64, 'a')
@@ -60,9 +60,10 @@ describe('mergeLoot', () => {
 })
 
 describe('labels', () => {
-  it('names height 0 the exact gibson and larger heights by cell size', () => {
-    expect(heightLabel(0)).toBe('exact gibson')
-    expect(heightLabel(34)).toMatch(/^within /)
+  it('names the region as a size, never as a distance from the viewer', () => {
+    expect(regionLabel(0)).toBe('single gibson')
+    expect(regionLabel(34)).toBe('2 m cube')
+    expect(regionLabel(34)).not.toMatch(/within/)
   })
 
   it('formats bytes below a kilobyte and KB above', () => {

--- a/src/lib/loot.test.ts
+++ b/src/lib/loot.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import type { NostrEvent } from './events'
+import { formatBytes, heightLabel, mergeLoot, payloadBytes, summarizeBag } from './loot'
+
+const pk = (n: number): string => n.toString(16).padStart(64, '0')
+const lookup = (n: number): string => (n + 1).toString(16).padStart(64, 'a')
+
+function bag(over: Partial<NostrEvent> & { d?: string; h?: string; cipher?: string } = {}): NostrEvent {
+  const { d = lookup(1), h = '5', cipher = 'Zm9v', ...rest } = over
+  const tags: string[][] = [['d', d], ['encrypted', 'aes-256-gcm', cipher], ['version', '2']]
+  if (h !== '') tags.push(['h', h])
+  return { id: 'e1', pubkey: pk(1), created_at: 100, kind: 33330, content: '', sig: '', tags, ...rest }
+}
+
+describe('summarizeBag', () => {
+  it('reads author, lookup id, height, size and a trimmed riddle', () => {
+    const it = summarizeBag(bag({ content: '  where the\n  black sun  sets ', h: '12', cipher: 'Zm9vYmFy' }))
+    expect(it).toMatchObject({ bagId: 'e1', author: pk(1), lookupId: lookup(1), height: 12, createdAt: 100, bytes: 6, riddle: 'where the black sun sets' })
+    expect(it?.key).toBe(`${pk(1)}:${lookup(1)}`)
+  })
+
+  it('treats a missing height as 0 and an empty content as no riddle', () => {
+    const it = summarizeBag(bag({ h: '' }))
+    expect(it?.height).toBe(0)
+    expect(it?.riddle).toBe('')
+  })
+
+  it('rejects other kinds, envelopes without ciphertext, and malformed lookup ids', () => {
+    expect(summarizeBag({ ...bag(), kind: 3333 })).toBeNull()
+    expect(summarizeBag({ ...bag(), tags: [['d', lookup(1)]] })).toBeNull()
+    expect(summarizeBag(bag({ d: 'not-hex' }))).toBeNull()
+    expect(summarizeBag(bag({ d: lookup(1).slice(0, 40) }))).toBeNull()
+  })
+})
+
+describe('payloadBytes', () => {
+  it('halves hex and takes three quarters of base64 minus padding', () => {
+    expect(payloadBytes('deadbeef')).toBe(4)
+    expect(payloadBytes('Zm9v')).toBe(3)
+    expect(payloadBytes('Zm8=')).toBe(2)
+    expect(payloadBytes('Zg==')).toBe(1)
+    expect(payloadBytes('')).toBe(0)
+  })
+})
+
+describe('mergeLoot', () => {
+  const a = summarizeBag(bag({ id: 'a', created_at: 10 }))!
+  const b = summarizeBag(bag({ id: 'b', pubkey: pk(2), created_at: 30 }))!
+  const aNewer = summarizeBag(bag({ id: 'a2', created_at: 20 }))!
+
+  it('keeps one entry per bag key, newest version winning, newest first', () => {
+    const out = mergeLoot([a, b], [aNewer])
+    expect(out.map((x) => x.bagId)).toEqual(['b', 'a2'])
+  })
+
+  it('never lets an older republish overwrite a newer one', () => {
+    const out = mergeLoot([aNewer], [a])
+    expect(out.map((x) => x.bagId)).toEqual(['a2'])
+  })
+})
+
+describe('labels', () => {
+  it('names height 0 the exact gibson and larger heights by cell size', () => {
+    expect(heightLabel(0)).toBe('exact gibson')
+    expect(heightLabel(34)).toMatch(/^within /)
+  })
+
+  it('formats bytes below a kilobyte and KB above', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(2048)).toBe('2.0 KB')
+  })
+})

--- a/src/lib/loot.ts
+++ b/src/lib/loot.ts
@@ -1,0 +1,90 @@
+/**
+ * loot.ts — every bag on the relay, as a seeker sees it.
+ *
+ * A LootItem is the public face of a kind:33330 envelope: who hid it, the
+ * region height it can be found from (the height hint, spec §8.6), when, how
+ * much is inside, and the riddle if the hider wrote one into the content field
+ * (cyberspace-cli's --hint does this). Where it is stays hidden: the lookup id
+ * reveals nothing (spec §7.2). Geometric hints arrive with the spec amendment;
+ * until then this list answers the newcomer's first question, "is there
+ * anything out there?", with the count and the names.
+ */
+
+import type { NostrEvent } from './events'
+import { ciphertextOf, heightHint, HIDDEN_KIND } from './hidden'
+import { formatCellSize } from './scale'
+
+export interface LootItem {
+  /** The envelope's event id; changes when the hider rewrites the bag. */
+  bagId: string
+  /** The bag's stable identity: author plus lookup id (kind 33330 is addressable). */
+  key: string
+  author: string
+  lookupId: string
+  /** The height hint: the region height the bag is discoverable from. */
+  height: number
+  createdAt: number
+  /** Approximate size of the hidden payload, in bytes. */
+  bytes: number
+  /** The hider's plaintext riddle from the content field, trimmed; empty when none. */
+  riddle: string
+}
+
+const LOOKUP_ID = /^[0-9a-f]{64}$/
+
+/**
+ * Bytes behind an encoded ciphertext: hex is two chars a byte, base64 four
+ * chars per three. A base64 string made only of hex-alphabet characters reads
+ * as hex; random ciphertext of any real length never does, so the estimate is
+ * honest where it matters and this is only ever a size for a row.
+ */
+export function payloadBytes(ciphertext: string): number {
+  const s = ciphertext.trim()
+  if (!s) return 0
+  if (/^[0-9a-f]+$/i.test(s) && s.length % 2 === 0) return s.length / 2
+  const padding = s.endsWith('==') ? 2 : s.endsWith('=') ? 1 : 0
+  return Math.max(0, Math.floor((s.length * 3) / 4) - padding)
+}
+
+/** A kind:33330 event as a LootItem, or null when it is not a well-formed bag. */
+export function summarizeBag(ev: NostrEvent): LootItem | null {
+  if (ev.kind !== HIDDEN_KIND) return null
+  const ciphertext = ciphertextOf(ev)
+  if (!ciphertext) return null
+  const lookupId = ev.tags.find((t) => t[0] === 'd')?.[1]?.toLowerCase()
+  if (!lookupId || !LOOKUP_ID.test(lookupId)) return null
+  return {
+    bagId: ev.id,
+    key: `${ev.pubkey}:${lookupId}`,
+    author: ev.pubkey,
+    lookupId,
+    height: heightHint(ev),
+    createdAt: ev.created_at,
+    bytes: payloadBytes(ciphertext),
+    riddle: ev.content.trim().replace(/\s+/g, ' '),
+  }
+}
+
+/**
+ * Merge new items into a list: one entry per bag key, the newest version wins
+ * (a rewritten bag replaces its older self), newest first.
+ */
+export function mergeLoot(prev: LootItem[], incoming: LootItem[]): LootItem[] {
+  const byKey = new Map<string, LootItem>()
+  for (const it of [...prev, ...incoming]) {
+    const have = byKey.get(it.key)
+    if (!have || it.createdAt > have.createdAt || (it.createdAt === have.createdAt && it.bagId < have.bagId)) byKey.set(it.key, it)
+  }
+  return [...byKey.values()].sort((a, b) => b.createdAt - a.createdAt || a.key.localeCompare(b.key))
+}
+
+/** "exact gibson" at height 0, else the discovery radius as a cell size. */
+export function heightLabel(height: number): string {
+  return height === 0 ? 'exact gibson' : `within ${formatCellSize(height)}`
+}
+
+/** A payload size for a row: bytes below a kilobyte, one decimal of KB above. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  return `${(bytes / 1024).toFixed(1)} KB`
+}

--- a/src/lib/loot.ts
+++ b/src/lib/loot.ts
@@ -78,9 +78,14 @@ export function mergeLoot(prev: LootItem[], incoming: LootItem[]): LootItem[] {
   return [...byKey.values()].sort((a, b) => b.createdAt - a.createdAt || a.key.localeCompare(b.key))
 }
 
-/** "exact gibson" at height 0, else the discovery radius as a cell size. */
-export function heightLabel(height: number): string {
-  return height === 0 ? 'exact gibson' : `within ${formatCellSize(height)}`
+/**
+ * The region a bag is encrypted to, as a size: a single gibson at height 0,
+ * else the side of the aligned cube. Deliberately not "within X": on someone
+ * else's bag that reads as a distance from the viewer, and where the bag is
+ * stays hidden until its hider adds a hint.
+ */
+export function regionLabel(height: number): string {
+  return height === 0 ? 'single gibson' : `${formatCellSize(height)} cube`
 }
 
 /** A payload size for a row: bytes below a kilobyte, one decimal of KB above. */

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -244,6 +244,8 @@ export interface CyberspaceState {
    * the panel it is reached from is hidden while spectating.
    */
   focus: { position: Position; plane: Plane; label: string } | null
+  /** The zoom before the standing focus began, restored by clearFocus. */
+  focusReturnScale: number | null
   /** Pubkeys being pointed at, keyed by pubkey. Persisted. */
   targets: Record<string, TrackedTarget>
   /**
@@ -666,6 +668,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   ...initial,
   spectate: null,
   focus: null,
+  focusReturnScale: null,
   transit: null,
   targets: loadTargets(),
   cursor: initial.position,
@@ -1042,6 +1045,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   focusOn: (position, plane, label, scaleExp) => {
     const next: Partial<CyberspaceState> = {
       focus: { position: { ...position }, plane, label },
+      // Remember the zoom once, at the first focus; later focus changes keep it.
+      focusReturnScale: get().focus === null ? get().scaleExp : get().focusReturnScale,
       spectate: null,
       exploreIndex: null,
       anchor: { ...position },
@@ -1052,8 +1057,15 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   },
 
   clearFocus: () => {
-    const { position, headPlane } = get()
-    set({ focus: null, anchor: position, anchorPlane: headPlane })
+    const { position, headPlane, focusReturnScale, scaleExp } = get()
+    set({
+      focus: null,
+      anchor: position,
+      anchorPlane: headPlane,
+      // Back at the zoom the user left, not whatever the viewed thing chose.
+      scaleExp: focusReturnScale ?? scaleExp,
+      focusReturnScale: null,
+    })
   },
 
   boardHyperspace: async () => {

--- a/src/store/useLootView.ts
+++ b/src/store/useLootView.ts
@@ -1,0 +1,21 @@
+/**
+ * useLootView.ts — which bag the Loot list has open.
+ *
+ * The list lives in a panel and the detail is a modal at the App root, so the
+ * selection has to live outside both. Same reason SecretModal reads its
+ * selection from the shards store rather than from the panel that opened it:
+ * a modal rendered inside a panel is trapped under its sibling panels.
+ */
+
+import { create } from 'zustand'
+import type { LootItem } from '../lib/loot'
+
+interface LootViewState {
+  selected: LootItem | null
+  select: (item: LootItem | null) => void
+}
+
+export const useLootView = create<LootViewState>((set) => ({
+  selected: null,
+  select: (item) => set({ selected: item }),
+}))

--- a/src/styles.css
+++ b/src/styles.css
@@ -3695,3 +3695,94 @@ kbd {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Loot rows open the bag's record; the button is the whole row */
+.loot__tags {
+  display: flex;
+  gap: 6px;
+}
+.loot__open {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+.loot__open:hover .badge__name {
+  color: var(--accent);
+}
+
+/* Loot detail: a bag's record, on the secret modal's frame */
+.lootd__facts {
+  grid-template-columns: repeat(2, 1fr);
+}
+.lootd__dim {
+  color: var(--dim);
+}
+.lootd__items {
+  list-style: none;
+  margin: 0 0 14px;
+  padding: 0;
+}
+.lootd__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+  font-size: 11px;
+}
+.lootd__item:first-child {
+  border-top: 0;
+}
+.lootd__item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.lootd__view {
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 28px;
+  padding: 0 12px;
+}
+.lootd__hidden {
+  margin: 0 0 14px;
+  font-size: 10px;
+  line-height: 1.55;
+  color: var(--dim);
+}
+.lootd__wire {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 10px;
+  margin: 0 0 14px;
+  font-size: 10px;
+}
+.lootd__wire dt {
+  align-self: center;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+.lootd__wire dd {
+  margin: 0;
+}
+.lootd__copy {
+  padding: 0;
+  font: inherit;
+  font-size: 10px;
+  color: var(--fg);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3818,3 +3818,38 @@ kbd {
   background: rgba(0, 229, 255, 0.05);
   border: 1px solid rgba(0, 229, 255, 0.14);
 }
+
+/* A plain focus view (a hidden thing, a loot item): the same bar in the accent colour */
+.hyperbar--focus {
+  border-color: rgba(0, 229, 255, 0.5);
+  box-shadow: 0 0 14px rgba(0, 229, 255, 0.16);
+}
+.hyperbar--focus .hyperbar__label {
+  color: var(--accent);
+}
+.hyperbar--focus .hyperbar__end {
+  color: #05070d;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.hyperbar--focus .hyperbar__end:hover {
+  background: #66f0ff;
+}
+
+/* Invisible scrollbars on every HUD scroll container. The areas still scroll by
+   wheel, trackpad and touch; on Windows the classic bar no longer takes width.
+   Plain CSS, since this project does not use Tailwind: scrollbar-width covers
+   Firefox and current Chromium, the WebKit pseudo-element covers the rest. */
+.hud, .hud *, .modal, .modal *, .detail, .detail *, .workshop, .workshop *, .instruments, .instruments * {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.hud::-webkit-scrollbar, .hud *::-webkit-scrollbar,
+.modal::-webkit-scrollbar, .modal *::-webkit-scrollbar,
+.detail::-webkit-scrollbar, .detail *::-webkit-scrollbar,
+.workshop::-webkit-scrollbar, .workshop *::-webkit-scrollbar,
+.instruments::-webkit-scrollbar, .instruments *::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3658,3 +3658,40 @@ kbd {
 .hyper__kicker--destination {
   color: #ffff00;
 }
+
+/* Loot: what is hidden in cyberspace, one row per bag */
+.loot__row {
+  padding: 6px 0;
+  border-top: 1px solid rgba(0, 229, 255, 0.08);
+  font-size: 10px;
+}
+.loot__row:first-child {
+  border-top: 0;
+}
+.loot__top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.loot__top .badge {
+  flex: 1;
+  min-width: 0;
+}
+.loot__top .avatars__when {
+  margin-left: auto;
+}
+.loot__meta {
+  margin-top: 2px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+.loot__riddle {
+  margin-top: 3px;
+  font-style: italic;
+  color: var(--fg);
+  opacity: 0.85;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3786,3 +3786,35 @@ kbd {
   cursor: pointer;
   text-align: left;
 }
+
+/* Explanation: a panel's prose behind a pill, opened into a well */
+.explain {
+  margin-top: 8px;
+}
+.explain__pill {
+  font: inherit;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  padding: 3px 9px;
+  border-radius: 999px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid rgba(200, 245, 255, 0.25);
+  cursor: pointer;
+}
+.explain__pill:hover {
+  color: var(--fg);
+  border-color: rgba(200, 245, 255, 0.5);
+}
+.explain__pill.is-on {
+  color: var(--accent);
+  border-color: rgba(0, 229, 255, 0.5);
+  background: rgba(0, 229, 255, 0.06);
+}
+.explain__well {
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(0, 229, 255, 0.05);
+  border: 1px solid rgba(0, 229, 255, 0.14);
+}


### PR DESCRIPTION
## What

A **Loot** panel in the left HUD column, after Avatars: every kind 33330 bag on the cyberspace relay, newest first, with the hider (profile badge), the region height it can be found from, its age, payload size, and the hider's riddle when the content field carries one. Bags your own scan has opened are marked FOUND; your own are marked YOURS.

Where each bag is stays hidden. The lookup id reveals nothing (spec 7.2), and geometric hints arrive with the spec amendment (planning ticket arkin0x/onosendai-launch#12; this PR is slice 1, arkin0x/onosendai-launch#11).

## Why

The 2026-09-01 census found 29 bags from 19 keys (stl1988 7, hbyb 2, arkinox 1) and 338 v2 actions from 171 keys, yet nothing in the client says any of it exists. Cyberspace is unlit, not empty. This panel is the cheapest fix for the first thing a newcomer asks: is there anything out there?

## How

- `src/lib/loot.ts` (pure, tested): `summarizeBag` reads an envelope into a `LootItem`; `mergeLoot` keeps one entry per (author, lookup id) with the newest version winning, since kind 33330 is addressable and a rewritten bag must replace its older self; `payloadBytes` sizes hex or base64 ciphertext; `heightLabel` and `formatBytes` for the row.
- `src/hooks/useLoot.ts`: same shape as `useRecentAvatars`, one backfill query (limit 500) plus one live subscription.
- `src/hud/LootPanel.tsx` + a few `.loot__*` rules in `styles.css`; `Hud.tsx` mounts it.

## Verified

- `npm run typecheck` clean; `vitest run` 353 passed (7 new); `npm run build` clean.
- Playwright against the dev server with `onosendai:live` forced to `0` (nothing published): panel shows **23 HIDDEN**, names resolve (stl1988, Hands Behind Your Back!, npubs for anonymous hiders), rows read like `within 477 nm · 1.4 KB` and `exact gibson · 630 B`, zero console errors. 23 rather than 25 raw events because two bags were rewrites of the same (author, lookup id).

## Review notes

- The size is an estimate from the encoding; both the client and cyberspace-cli emit base64 `nonce||ciphertext||tag`, so it is exact for real bags.
- No location, no target, no seek yet: those are slices 2 to 4 and depend on the spec amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc
