### PR TITLE
Stash: count what you have hidden, not what your scans found

### DIFF
--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -32,7 +32,6 @@ export function ShardsPanel(): JSX.Element {
   const mine = useShards((s) => s.mine)
   const inspecting = useShards((s) => s.inspecting)
   const scanning = useShards((s) => s.scanning)
-  const discovered = useShards((s) => s.discovered)
   const [deleteModel, setDeleteModel] = useState<string | null>(null)
   const [composing, setComposing] = useState(false)
   const [message, setMessage] = useState('')

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -39,7 +39,7 @@ export function ShardsPanel(): JSX.Element {
 
   const target = models.find((m) => m.id === deleteModel)
   const deployedCount = (id: string): number => mine.filter((d) => d.type === 'shard' && d.shard?.id === id).length
-  const foundCount = Object.keys(discovered).length
+  const hiddenCount = mine.length
 
   const goTo = (d: MyDeployment): void => {
     useShards.getState().inspect(d.eventId)
@@ -59,7 +59,7 @@ export function ShardsPanel(): JSX.Element {
     <section className="panel panel--shards">
       <header className="panel__head">
         <h2>Stash</h2>
-        <span className={`tag ${scanning ? 'tag--scan' : ''}`}>{scanning ? 'SCANNING' : `${foundCount} FOUND`}</span>
+        <span className={`tag ${scanning ? 'tag--scan' : ''}`}>{scanning ? 'SCANNING' : hiddenCount === 0 ? 'NOTHING HIDDEN' : `${hiddenCount} HIDDEN`}</span>
       </header>
 
       <div className="shards__section">
@@ -133,9 +133,8 @@ export function ShardsPanel(): JSX.Element {
         Encrypt by location: a shard is coloured vertices (SOLID / POINTS / LINES);
         a message is text. Both are hidden at a location and found only by someone
         who computes its region key (spec section 7). Tap a deployment to fly to it and prove it
-        with TEST DISCOVERY. FOUND counts the items your own scans have opened
-        this session, at every place you have looked, not only where you stand
-        now.
+        with TEST DISCOVERY. The tag counts what you have hidden; what your scans
+        have found is on the Loot panel.
       </Explanation>
 
       {target && (


### PR DESCRIPTION
arkinox saw **16 FOUND** on the Stash with nothing of their own hidden. That tag counted the items every scan had opened (16 items inside the 10 bags the Loot panel marks FOUND), which is Loot's business. The Stash tag now reads `N HIDDEN` for your own deployments, or `NOTHING HIDDEN`, with `SCANNING` while a scan runs, and its explanation points at Loot for finds. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc