### PR TITLE
Loot: what a found bag holds, and VIEW / DETAILS / COPY per item

### DIFF
--- a/src/hud/LootDetail.tsx
+++ b/src/hud/LootDetail.tsx
@@ -14,6 +14,8 @@ import { nip19 } from 'nostr-tools'
 import type { Plane } from 'cyberspace-core'
 import { useState } from 'react'
 import { useProfile } from '../hooks/useProfile'
+import type { ShardModel } from '../lib/shards'
+import { useWorkshop } from '../store/useWorkshop'
 import { messagePreview } from '../lib/hidden'
 import { formatBytes, regionLabel, type LootItem } from '../lib/loot'
 import type { Position } from '../lib/space'
@@ -33,6 +35,8 @@ interface OpenedItem {
   at: Position
   plane: Plane
   unit: number
+  shard?: ShardModel
+  text?: string
 }
 
 function safeNpub(pubkey: string): string {
@@ -67,6 +71,8 @@ function openedItems(item: LootItem, discovered: ReturnType<typeof useShards.get
       at: h.at,
       plane: h.plane,
       unit: h.type === 'shard' ? h.shard?.unit ?? 0 : 0,
+      shard: h.shard,
+      text: h.text,
     })
   }
   for (const d of mine) {
@@ -78,6 +84,8 @@ function openedItems(item: LootItem, discovered: ReturnType<typeof useShards.get
       at: { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) },
       plane: d.plane,
       unit: d.type === 'shard' ? d.shard?.unit ?? 0 : 0,
+      shard: d.shard,
+      text: d.text,
     })
   }
   return [...out.values()]
@@ -90,6 +98,9 @@ export function LootDetail(): JSX.Element | null {
   const discovered = useShards((s) => s.discovered)
   const mine = useShards((s) => s.mine)
   const profile = useProfile(item?.author ?? null)
+  // Which item's COPY just fired, for its brief COPIED label. Declared before
+  // the early return below: hooks must run in the same order every render.
+  const [copied, setCopied] = useState<string | null>(null)
 
   if (!item) return null
 
@@ -102,6 +113,18 @@ export function LootDetail(): JSX.Element | null {
   const view = (o: OpenedItem): void => {
     close()
     useCyberspace.getState().focusOn(o.at, o.plane, o.label, o.unit)
+  }
+  // Fly there and open the item's own modal (SecretModal) on top.
+  const details = (o: OpenedItem): void => {
+    view(o)
+    useShards.getState().selectSecret(o.eventId)
+  }
+  // A shard copies into your Stash as a model; a message copies its text.
+  const copy = (o: OpenedItem): void => {
+    if (o.type === 'shard' && o.shard) useWorkshop.getState().importShard(o.shard)
+    else if (o.text) void navigator.clipboard?.writeText(o.text)
+    setCopied(o.eventId)
+    window.setTimeout(() => setCopied((c) => (c === o.eventId ? null : c)), 1400)
   }
   const watch = (): void => { close(); void spectate(item.author) }
   const target = (): void => useCyberspace.getState().toggleTarget(item.author, profile?.name ?? null)
@@ -143,7 +166,13 @@ export function LootDetail(): JSX.Element | null {
               <li key={o.eventId} className="lootd__item">
                 <span className={`secret__badge secret__badge--${o.type}`}>{o.type === 'message' ? '✎' : '◇'}</span>
                 <span className="lootd__item-label" title={o.label}>{o.label}</span>
-                <button className="secret__act lootd__view" onClick={() => view(o)}>VIEW</button>
+                <span className="lootd__acts">
+                  <button className="secret__act lootd__view" onClick={() => view(o)}>VIEW</button>
+                  <button className="secret__act lootd__view" onClick={() => details(o)}>DETAILS</button>
+                  <button className="secret__act lootd__view" onClick={() => copy(o)} title={o.type === 'shard' ? 'Copy this model into your Stash' : 'Copy the text'}>
+                    {copied === o.eventId ? 'COPIED' : 'COPY'}
+                  </button>
+                </span>
               </li>
             ))}
           </ul>

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -25,7 +25,19 @@ export function LootPanel(): JSX.Element {
   const { items, status } = useLoot()
   const me = useCyberspace((s) => s.identity.pubkey)
   const discovered = useShards((s) => s.discovered)
-  const found = useMemo(() => new Set(Object.values(discovered).map((h) => h.bagId)), [discovered])
+  // What each found bag holds, oldest item first, as glyphs: ◇ a shard, ✎ a message.
+  const kinds = useMemo(() => {
+    const by = new Map<string, { at: number; glyph: string }[]>()
+    for (const h of Object.values(discovered)) {
+      const list = by.get(h.bagId) ?? []
+      list.push({ at: h.createdAt, glyph: h.type === 'message' ? '✎' : '◇' })
+      by.set(h.bagId, list)
+    }
+    const out = new Map<string, string>()
+    for (const [bag, list] of by) out.set(bag, list.sort((a, b) => a.at - b.at).map((x) => x.glyph).join(''))
+    return out
+  }, [discovered])
+  const found = useMemo(() => new Set(kinds.keys()), [kinds])
   const foundCount = useMemo(() => items.filter((it) => found.has(it.bagId)).length, [items, found])
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {
@@ -53,7 +65,7 @@ export function LootPanel(): JSX.Element {
               <div className="loot__top">
                 <ProfileBadge pubkey={it.author} />
                 {it.author === me && <span className="avatars__you">YOURS</span>}
-                {found.has(it.bagId) && <span className="tag tag--live">FOUND</span>}
+                {found.has(it.bagId) && <span className="tag tag--live loot__kinds" title={`Found: ${kinds.get(it.bagId)?.length ?? 0} items`}>{kinds.get(it.bagId)}</span>}
                 <span className="avatars__when" title={formatStamp(it.createdAt)}>{formatAgo(it.createdAt, now)}</span>
               </div>
               <div className="loot__meta">{regionLabel(it.height)} · {formatBytes(it.bytes)}</div>

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -13,7 +13,7 @@
 
 import { useEffect, useState } from 'react'
 import { nip19 } from 'nostr-tools'
-import { formatCellSize } from '../lib/scale'
+import { regionLabel } from '../lib/loot'
 import { formatAgo, formatStamp, shortHex } from '../lib/time'
 import { spectate } from '../lib/spectator'
 import { ProfilePic } from './ProfileBadge'
@@ -89,7 +89,7 @@ export function SecretModal(): JSX.Element | null {
 
         <dl className="secret__facts">
           <div><dt>Placed</dt><dd title={item.createdAt ? formatStamp(item.createdAt) : ''}>{item.createdAt ? formatAgo(item.createdAt) : 'unknown'}</dd></div>
-          <div><dt>Hidden at</dt><dd>{item.height === 0 ? 'exact gibson' : `within ${formatCellSize(item.height)}`}</dd></div>
+          <div><dt>Region</dt><dd>{regionLabel(item.height)}</dd></div>
           <div><dt>Plane</dt><dd>{item.plane === 0 ? 'dataspace' : 'ideaspace'}</dd></div>
         </dl>
 

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -11,7 +11,7 @@
  * reached differently and answer different questions.
  */
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { nip19 } from 'nostr-tools'
 import { formatCellSize } from '../lib/scale'
 import { formatAgo, formatStamp, shortHex } from '../lib/time'
@@ -21,6 +21,7 @@ import { useProfile } from '../hooks/useProfile'
 import { profileLabel } from '../store/useProfiles'
 import { useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
+import { useWorkshop } from '../store/useWorkshop'
 
 export function SecretModal(): JSX.Element | null {
   const selected = useShards((s) => s.selectedSecret)
@@ -29,6 +30,7 @@ export function SecretModal(): JSX.Element | null {
   const targeted = useCyberspace((s) => (item?.author ? !!s.targets[item.author] : false))
   const author = item?.author ?? ''
   const profile = useProfile(author || null)
+  const [copied, setCopied] = useState(false)
 
   // A selection that no longer resolves (deleted, scrolled out) closes itself.
   useEffect(() => { if (selected && !item) useShards.getState().selectSecret(null) }, [selected, item])
@@ -45,6 +47,13 @@ export function SecretModal(): JSX.Element | null {
     useCyberspace.getState().focusOn(item.at, item.plane, item.type === 'message' ? name : item.shard?.name ?? 'shard', item.type === 'shard' ? item.shard?.unit ?? 0 : 0)
   }
   const watch = (): void => { close(); void spectate(author) }
+  // A shard copies into your Stash as a model; a message copies its text.
+  const copy = (): void => {
+    if (item.type === 'shard' && item.shard) useWorkshop.getState().importShard(item.shard)
+    else if (item.text) void navigator.clipboard?.writeText(item.text)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1400)
+  }
   const target = (): void => useCyberspace.getState().toggleTarget(author, profile?.name ?? null)
 
   return (
@@ -86,6 +95,9 @@ export function SecretModal(): JSX.Element | null {
 
         <div className="secret__actions">
           <button className="secret__act" onClick={goTo}>GO TO IT</button>
+          <button className="secret__act" onClick={copy} title={item.type === 'shard' ? 'Copy this model into your Stash' : 'Copy the text'}>
+            {copied ? 'COPIED' : item.type === 'shard' ? 'COPY TO STASH' : 'COPY TEXT'}
+          </button>
           {!mine && (
             <>
               <button className={`secret__act ${targeted ? 'is-on' : ''}`} onClick={target}>{targeted ? 'TARGETED' : 'TARGET'} CREATOR</button>

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -41,6 +41,8 @@ export interface WorkshopState {
   color: [number, number, number]
 
   openWorkshop: (id?: string) => void
+  /** Add a deep copy of a model from elsewhere (a found shard) to your Stash; returns its new id. */
+  importShard: (model: ShardModel) => string
   closeWorkshop: () => void
   create: (name?: string) => string
   select: (id: string | null) => void
@@ -132,6 +134,15 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       const copy: ShardModel = { ...src, id: uuid(), name: `${src.name} copy`, vertices: src.vertices.map((v) => ({ p: [...v.p] as ShardVertex['p'], c: [...v.c] as ShardVertex['c'] })), faces: src.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
       const list = [...get().shards, copy]
       set({ shards: list, currentId: copy.id, selected: null, facePick: [] }); save(list)
+      return copy.id
+    },
+
+    importShard: (model) => {
+      const taken = new Set(get().shards.map((s) => s.name))
+      const name = taken.has(model.name) ? `${model.name} copy` : model.name
+      const copy: ShardModel = { ...model, id: uuid(), name, vertices: model.vertices.map((v) => ({ p: [...v.p] as ShardVertex['p'], c: [...v.c] as ShardVertex['c'] })), faces: model.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
+      const list = [...get().shards, copy]
+      set({ shards: list }); save(list)
       return copy.id
     },
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -4211,6 +4211,8 @@ kbd {
   font-weight: 700;
   font-size: 1.4rem;
   color: var(--cloud, #ffd27d);
+}
+
 /* Loot: what a found bag holds, as glyphs; per-item actions in the record */
 .loot__kinds {
   letter-spacing: 0.06em;

--- a/src/styles.css
+++ b/src/styles.css
@@ -4211,4 +4211,17 @@ kbd {
   font-weight: 700;
   font-size: 1.4rem;
   color: var(--cloud, #ffd27d);
+/* Loot: what a found bag holds, as glyphs; per-item actions in the record */
+.loot__kinds {
+  letter-spacing: 0.06em;
+}
+.lootd__acts {
+  display: flex;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+.lootd__acts .lootd__view {
+  height: 26px;
+  padding: 0 8px;
+  font-size: 8px;
 }


### PR DESCRIPTION
From arkinox's review while finding loot along spectated chains.

- **Row glyphs.** A found bag's row shows its contents in placement order, a diamond per shard and a pencil per message (`◇◇✎`), replacing the plain FOUND tag.
- **Per-item actions in the bag's record.** VIEW flies to the item. DETAILS flies there and opens the item's own modal on top. COPY puts a shard's model into your Stash (a deep copy, named after the original, "copy" appended if the name is taken) or a message's text onto the clipboard, with a brief COPIED label.
- **COPY in the item modal too**, next to GO TO IT: COPY TO STASH for a shard, COPY TEXT for a message.
- `useWorkshop.importShard` adds a model from elsewhere; a DEV handle `window.__shards` exposes the shards store for browser tests.

Verified in the browser with an injected found bag matching a live Loot row: glyphs, three actions per item, COPY lands the model in the Stash and the text on the clipboard, DETAILS opens the item modal with COPY TO STASH. Typecheck, 328 tests, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc