### PR TITLE
The scene follows the lined-up plane; Hyperspace panel leads the menu while a destination is set

### DIFF
--- a/src/hooks/useTargets.ts
+++ b/src/hooks/useTargets.ts
@@ -24,6 +24,7 @@ export function useTargets(): CyberTarget[] {
   const spectating = useCyberspace((s) => s.spectate !== null)
   const focused = useCyberspace((s) => s.focus !== null)
   const position = useCyberspace((s) => s.position)
+  const headPlane = useCyberspace((s) => s.headPlane)
   const tracked = useCyberspace((s) => s.targets)
   const focus = useCyberspace((s) => s.focusPubkey())
 
@@ -31,12 +32,19 @@ export function useTargets(): CyberTarget[] {
     const out: CyberTarget[] = []
     // Tracked pubkeys first, except the one the scene is looking through: a
     // marker for the avatar you are standing on would sit on your own centre.
-    for (const t of useCyberspace.getState().targetList()) if (t.id !== focus) out.push(t)
+    // Only targets in the plane the scene is showing: a coordinate in the
+    // other plane is not a place in this one (§2.4).
+    for (const t of useCyberspace.getState().targetList()) {
+      if (t.id === focus) continue
+      const tr = tracked[t.id]
+      if (tr && tr.plane !== plane) continue
+      out.push(t)
+    }
     // While the camera is anywhere you are not (someone else's eyes, a
     // hyperspace stop, EARTH, a shard), the way home is a thing worth
     // pointing at from anywhere; the projector's distance readout doubles as
     // how far the viewed place is from where you actually stand.
-    if (spectating || focused) out.push({ id: 'you', label: 'YOU', color: YOU, at: position })
+    if ((spectating || focused) && headPlane === plane) out.push({ id: 'you', label: 'YOU', color: YOU, at: position })
     // Ideaspace has no physical mapping, so there is no planet in it to point at.
     if (plane === 0) {
       out.push({
@@ -50,5 +58,5 @@ export function useTargets(): CyberTarget[] {
     return out
     // tracked is what targetList reads; listed so the memo follows it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [plane, spectating, focused, position, tracked, focus])
+  }, [plane, headPlane, spectating, focused, position, tracked, focus])
 }

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -16,6 +16,7 @@ import { LootPanel } from './LootPanel'
 import { ChainPanel } from './ChainPanel'
 import { DerezzPanel } from './DerezzPanel'
 import { HyperspacePanel } from './HyperspacePanel'
+import { useHyperspace } from '../store/useHyperspace'
 import { RelaysPanel } from './RelaysPanel'
 import { TargetsPanel } from './TargetsPanel'
 import { ShardsPanel } from './ShardsPanel'
@@ -230,10 +231,14 @@ function Controls(): JSX.Element {
 }
 
 export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
+  // With a destination picked, the ride is the thing you are doing: the
+  // Hyperspace panel leads the left column until the destination is cleared.
+  const rideSet = useHyperspace((s) => s.destination !== null)
   return (
     <div className={menuOpen ? 'hud hud--menu' : 'hud'}>
       <div className="hud__col hud__col--left">
         <Brand />
+        {rideSet && <HyperspacePanel />}
         <IdentityPanel />
         <LootPanel />
         <ShardsPanel />
@@ -246,7 +251,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <PositionPanel />
         <ProofPanel />
         <ChainPanel />
-        <HyperspacePanel />
+        {!rideSet && <HyperspacePanel />}
         <Legend />
         <Controls />
         <DerezzPanel />

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -429,5 +429,8 @@ export function selectStopInScene(height: number): void {
 export function viewEarth(): void {
   ownHyperspaceView()
   markViewedStop(null)
+  // Earth is a dataspace thing (§9.1): looking at it lines up dataspace, so
+  // that RETURN, and the next commit, stay in the plane the planet is in.
+  useCyberspace.getState().setPlane(0)
   useCyberspace.getState().focusOn({ x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }, 0, 'EARTH', 52)
 }

--- a/src/scene/SpawnMarker.tsx
+++ b/src/scene/SpawnMarker.tsx
@@ -20,7 +20,7 @@
 
 import { Suspense, useMemo } from 'react'
 import { useGLTF } from '@react-three/drei'
-import { coordToXyz, hexToCoord } from 'cyberspace-core'
+import { coordToXyz, hexToCoord, type Plane } from 'cyberspace-core'
 import type { Material, Mesh, MeshStandardMaterial } from 'three'
 import { GRID_RADIUS, cellCentre, type Position, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
@@ -63,6 +63,11 @@ const PARTS: Array<[node: string, material: string]> = [
   ['SmallTriadBottom', 'SmallTriad'],
 ]
 
+/** The plane a pubkey spawns in: the coordinate's plane bit. */
+export function spawnPlane(pubkey: string): Plane {
+  return coordToXyz(hexToCoord(pubkey)).plane
+}
+
 /** Where a pubkey spawns: its own bits, read as a coordinate. */
 export function spawnPosition(pubkey: string): Position {
   const { x, y, z } = coordToXyz(hexToCoord(pubkey))
@@ -76,6 +81,7 @@ interface Props {
 
 function Model({ pubkey, axes }: Props): JSX.Element | null {
   const position = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const gltf = useGLTF(MODEL) as unknown as {
     nodes: Record<string, Mesh>
@@ -83,6 +89,8 @@ function Model({ pubkey, axes }: Props): JSX.Element | null {
   }
 
   const at = useMemo(() => {
+    // A spawn is a coordinate in one plane; in the other plane it is not here.
+    if (spawnPlane(pubkey) !== anchorPlane) return null
     const spawn = spawnPosition(pubkey)
     // Physical scaling, the shard rule: 2^(0 - scaleExp) render cells per
     // model unit. Zooming out shrinks the mark smoothly to nothing, which

--- a/src/scene/TargetAvatars.tsx
+++ b/src/scene/TargetAvatars.tsx
@@ -24,6 +24,7 @@ interface Props {
 export function TargetAvatars({ axes }: Props): JSX.Element | null {
   const targets = useCyberspace((s) => s.targets)
   const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const focus = useCyberspace((s) => s.focusPubkey())
   const geometry = useMemo(() => new EdgesGeometry(new IcosahedronGeometry(0.5, 1)), [])
@@ -32,12 +33,13 @@ export function TargetAvatars({ axes }: Props): JSX.Element | null {
     const origin = alignedOrigin(anchor, scaleExp)
     const list = useCyberspace.getState().targetList()
     return list
-      .filter((t) => t.id !== focus)
+      // Someone standing in the other plane is not here (§2.4).
+      .filter((t) => t.id !== focus && targets[t.id]?.plane === anchorPlane)
       .map((t) => ({ ...t, centre: cellCentre(t.at, origin, scaleExp, axes) }))
       .filter((t) => Math.hypot(...t.centre) <= REACH)
     // targets is what targetList reads.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [targets, anchor, scaleExp, axes, focus])
+  }, [targets, anchor, anchorPlane, scaleExp, axes, focus])
 
   if (near.length === 0) return null
 

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -267,6 +267,8 @@ export interface CyberspaceState {
   resetView: () => void
   canonicalView: () => void
   togglePlane: () => void
+  /** Line up a plane for the next commit; the scene switches to it at once. */
+  setPlane: (plane: Plane) => void
   applyProofMessage: (msg: ProofResponse) => void
   setLive: (live: boolean) => void
   setPublishStatus: (id: string, status: PublishStatus, reason?: string) => void
@@ -798,7 +800,9 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       return
     }
     // Not computing: recall the cursor, plane included, to where you stand.
-    set({ cursor: { ...position }, plane: headPlane })
+    // The view follows the lined-up plane, so at your own head it comes back too.
+    const atHead = get().exploreIndex === null && get().focus === null && get().spectate === null
+    set(atHead ? { cursor: { ...position }, plane: headPlane, anchorPlane: headPlane } : { cursor: { ...position }, plane: headPlane })
   },
 
   adjustScale: (delta) => {
@@ -833,13 +837,23 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     set({ view: canonicalQuaternion(), viewHistory: [...viewHistory, view.clone()] })
   },
 
-  togglePlane: () => {
+  setPlane: (plane) => {
     // A plane flip mid-proof would desync the in-flight terrain K.
     if (get().proof.status === 'computing') return
     // Someone else's plane is theirs; the terrain follows their chain.
     if (get().spectate) return
-    set({ plane: get().plane === 0 ? 1 : 0, proof: IDLE_PROOF })
+    if (get().plane === plane) return
+    // The view follows the lined-up plane the way it follows the cursor: at
+    // your own head, or in a focus view such as EARTH, the scene switches
+    // planes now, so the planet, the landfalls, other avatars and everything
+    // else of the other plane disappear at once. Only history keeps its own
+    // plane, because each action there records the plane it was in.
+    const next: Partial<CyberspaceState> = { plane, proof: IDLE_PROOF }
+    if (get().exploreIndex === null) next.anchorPlane = plane
+    set(next)
   },
+
+  togglePlane: () => { get().setPlane(get().plane === 0 ? 1 : 0) },
 
   applyProofMessage: async (msg) => {
     // Stale responses from a cancelled commit must not overwrite fresh state.
@@ -1038,8 +1052,9 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   },
 
   endSpectate: () => {
-    const { position, headPlane } = get()
-    set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: headPlane })
+    // Back to your own head, in the plane you have lined up there.
+    const { position, plane } = get()
+    set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: plane })
   },
 
   focusOn: (position, plane, label, scaleExp) => {
@@ -1057,11 +1072,13 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   },
 
   clearFocus: () => {
-    const { position, headPlane, focusReturnScale, scaleExp } = get()
+    // Home is your position in the plane you have lined up, which is what
+    // the scene showed before the focus began.
+    const { position, plane, focusReturnScale, scaleExp } = get()
     set({
       focus: null,
       anchor: position,
-      anchorPlane: headPlane,
+      anchorPlane: plane,
       // Back at the zoom the user left, not whatever the viewed thing chose.
       scaleExp: focusReturnScale ?? scaleExp,
       focusReturnScale: null,


### PR DESCRIPTION
Two requests from arkinox.

**1. Planes mean something again.** The scene draws in `anchorPlane`, but the plane toggle only changed `plane` (the plane the next commit lands in), so toggling to ideaspace left Earth and every dataspace object on screen until a hop committed. Now the view follows the lined-up plane the way it follows the cursor: toggling at your head or in a focus view switches `anchorPlane` at once, and everything already gated on it (Earth, the Earth patch, landfalls and ports, shards, messages) switches with it. History keeps its own plane. `EARTH` lines up dataspace before focusing, so RETURN and the next commit stay with the planet. Targets (HUD pointers and scene avatars) and the spawn marker now filter by plane as well, per spec §2.4: a coordinate in the other plane is not a place in this one.

Verified in the browser: toggle at the head flips the plane and the Earth target appears or vanishes; EARTH from the view menu lines up dataspace and focuses; toggling while viewing Earth drops Earth; RETURN stays in the lined-up plane; toggling back brings it home.

**2. Hyperspace panel placement.** With a destination set, the Hyperspace panel sits at the very top of the left column; cleared, it returns to its place in the right column. Verified both ways.

Typecheck, 328 tests, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc