### PR TITLE
Commit beyond the ceiling runs a route: hops to the wall, a one-gibson sidestep, hops on

### DIFF
--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -9,23 +9,24 @@
  */
 
 import { useMemo } from 'react'
-import { estimateHopCost, estimateSidestepCost } from 'cyberspace-core'
+import { estimateHopCost } from 'cyberspace-core'
 import { useCalibration } from '../lib/calibration'
+import { planSummary, type PlanSummary } from '../lib/movePlan'
 import { formatMs, formatOps } from '../lib/space'
-import { samePosition, sidestepTarget, useCyberspace } from '../store/useCyberspace'
-
-/** Rough single-thread JS hash rate, for the pre-commit wall-clock hint. */
-const HASHES_PER_SECOND = 1_500_000
+import { MAX_COMPUTE_HEIGHT, samePosition, useCyberspace, type MovePlan } from '../store/useCyberspace'
 
 function StatusLabel({ status }: { status: string }): JSX.Element {
   const label: Record<string, string> = {
     idle: 'IDLE',
     uncommitted: 'UNCOMMITTED',
-    'sidestep-ready': 'SIDESTEP READY',
+    'route-ready': 'ROUTE READY',
     computing: 'COMPUTING',
     hashing: 'HASHING',
+    signing: 'SIGN TO CONTINUE',
+    paused: 'ROUTE PAUSED',
+    failed: 'ROUTE FAILED',
     done: 'PROVEN',
-    infeasible: 'SIDESTEP REQUIRED',
+    infeasible: 'INFEASIBLE',
   }
   return <span className={`status status--${status}`}>{label[status] ?? status}</span>
 }
@@ -40,31 +41,39 @@ export function ProofPanel(): JSX.Element {
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
 
-  // Live preview of the action the cursor is lining up. Both estimates are
-  // closed-form, so cheap enough to run on every noodle.
+  const plan = useCyberspace((s) => s.plan)
+  const resumePlan = useCyberspace((s) => s.resumePlan)
+  const cancelPlan = useCyberspace((s) => s.cancelPlan)
+  // The ceiling a commit would use right now: the hard cap lowered to what
+  // calibration measured, the same number the store routes with.
+  const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
+
+  // Live preview of the action the cursor is lining up. The hop estimate is
+  // closed-form; the route summary walks the route's steps without keeping
+  // them, cheap for anything a person would line up.
   const preview = useMemo(() => {
     if (samePosition(position, cursor)) return null
     const hop = estimateHopCost(
       position.x, position.y, position.z,
       cursor.x, cursor.y, cursor.z,
       plane,
+      ceiling,
     )
-    if (!hop.exceedsLimit) return { hop, sidestep: null }
-    const landing = sidestepTarget(position, cursor)
-    const sidestep = estimateSidestepCost(
-      position.x, position.y, position.z,
-      landing.x, landing.y, landing.z,
-    )
-    return { hop, sidestep }
-  }, [position, cursor, plane])
+    if (!hop.exceedsLimit) return { hop, route: null as PlanSummary | null }
+    return { hop, route: planSummary(position, cursor, ceiling, 20_000) }
+  }, [position, cursor, plane, ceiling])
 
-  const previewing = preview !== null && proof.status !== 'computing'
+  const previewing = preview !== null && proof.status !== 'computing' && plan === null
   const status =
-    proof.status === 'computing'
-      ? proof.mode === 'sidestep' ? 'hashing' : 'computing'
-      : previewing
-        ? preview.sidestep ? 'sidestep-ready' : 'uncommitted'
-        : proof.status
+    plan
+      ? plan.status === 'paused' ? (plan.awaiting ? 'signing' : 'paused')
+        : plan.status === 'failed' ? 'failed'
+        : plan.step.kind === 'sidestep' ? 'hashing' : 'computing'
+      : proof.status === 'computing'
+        ? proof.mode === 'sidestep' ? 'hashing' : 'computing'
+        : previewing
+          ? preview.route ? 'route-ready' : 'uncommitted'
+          : proof.status
 
   return (
     <section className="panel panel--proof">
@@ -80,32 +89,40 @@ export function ProofPanel(): JSX.Element {
         />
       </div>
 
-      {previewing && preview.sidestep ? (
+      {plan ? (
+        <RouteView plan={plan} proof={proof} onResume={resumePlan} onCancel={cancelPlan} />
+      ) : previewing && preview.route ? (
         <>
           <dl className="stats">
             <div>
-              <dt>Wall height</dt>
-              <dd>2^{preview.sidestep.maxHeight}</dd>
+              <dt>Route</dt>
+              <dd>{routeLabel(preview.route)}</dd>
             </div>
             <div>
-              <dt>Est. SHA-256 hashes</dt>
-              <dd>{formatOps(preview.sidestep.totalHashes)}</dd>
+              <dt>Tallest wall</dt>
+              <dd>2^{preview.route.tallestWall}</dd>
             </div>
             <div>
               <dt>LCA x / y / z</dt>
-              <dd>{`${preview.sidestep.lcaX} / ${preview.sidestep.lcaY} / ${preview.sidestep.lcaZ}`}</dd>
+              <dd>{`${preview.hop.lcaX} / ${preview.hop.lcaY} / ${preview.hop.lcaZ}`}</dd>
             </div>
             <div>
-              <dt>Rough time</dt>
-              <dd>~{formatMs((preview.sidestep.totalHashes / HASHES_PER_SECOND) * 1000)}</dd>
+              <dt>Hop ceiling</dt>
+              <dd>h{ceiling}</dd>
             </div>
           </dl>
           <p className="notice notice--sidestep">
-            Beyond the 2^20 Cantor ceiling: the pairing tree would not fit in
-            memory. Space commits a Merkle SIDESTEP instead, landing 1 gibson
-            past the wall; the cursor keeps the rest of the journey for the
-            next commit. X cancels mid-hash.
+            {`A wall of 2^${preview.route.tallestWall} stands between you and the cursor, taller than this machine hops (h${ceiling}). `}
+            A sidestep buys exactly 1 gibson through a wall, so the route is hops
+            to the leaf touching the wall, the sidestep, then hops on, for every
+            wall on the way. Space runs the route one step at a time and asks for a
+            signature as each step lands. X stops it.
           </p>
+          {preview.route.steps > 64 && (
+            <p className="notice">
+              {`That is a long walk: ${preview.route.capped ? 'more than ' : ''}${preview.route.sidesteps} sidesteps, each a signed event. A cloud hop from HOSAKA reaches the wall in one move once it is deployed.`}
+            </p>
+          )}
         </>
       ) : previewing ? (
         <>
@@ -166,4 +183,98 @@ export function ProofPanel(): JSX.Element {
       <p className="legend__note">{`THIS MACHINE: HOP <= h${hopCeil} · SIDESTEP <= h${sidestepCeil}`}</p>
     </section>
   )
+}
+
+function routeLabel(r: PlanSummary): string {
+  const more = r.capped ? '+' : ''
+  const hops = `${r.hops}${more} hop${r.hops === 1 ? '' : 's'}`
+  const sides = `${r.sidesteps}${more} sidestep${r.sidesteps === 1 ? '' : 's'}`
+  return `${hops}, ${sides}`
+}
+
+/** The running route: where it is, what it is doing, and the two buttons. */
+function RouteView({ plan, proof, onResume, onCancel }: {
+  plan: MovePlan
+  proof: { progress: number; elapsedMs: number }
+  onResume: () => void
+  onCancel: () => void
+}): JSX.Element {
+  const total = plan.summary.steps
+  const n = plan.done + 1
+  const step = plan.step
+  const kind = step.kind === 'sidestep' ? 'SIDESTEP' : 'HOP'
+  const what =
+    step.kind === 'sidestep'
+      ? `1 gibson through the wall at 2^${step.maxHeight}`
+      : `up to the ${step.maxHeight === 0 ? 'same block' : `2^${step.maxHeight} block edge`}`
+  const doing =
+    plan.status === 'paused'
+      ? plan.awaiting ? 'proof done, waiting for your signature' : 'paused'
+      : plan.status === 'failed'
+        ? 'failed'
+        : `${step.kind === 'sidestep' ? 'hashing' : 'computing'} ${Math.round(proof.progress * 100)}%`
+  return (
+    <>
+      <dl className="stats">
+        <div>
+          <dt>Route</dt>
+          <dd>{`step ${n} of ${plan.summary.capped ? `${total}+` : total}`}</dd>
+        </div>
+        <div>
+          <dt>This step</dt>
+          <dd>{`${kind} ${what}`}</dd>
+        </div>
+        <div>
+          <dt>Signed so far</dt>
+          <dd>{`${plan.done} of ${total} (${plan.summary.hops} hops, ${plan.summary.sidesteps} sidesteps)`}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>{doing}</dd>
+        </div>
+      </dl>
+      <ol className="route">
+        {routeWindow(plan).map((r) => (
+          <li key={r.index} className={`route__step route__step--${r.state}`}>
+            <span className="route__index">{r.index + 1}</span>
+            <span className="route__kind">{r.kind}</span>
+            <span className="route__height">{r.height}</span>
+            <span className="route__state">{r.label}</span>
+          </li>
+        ))}
+      </ol>
+      {plan.message && <p className="notice">{plan.message}</p>}
+      <div className="route__row">
+        {plan.status === 'paused' && (
+          <button className="route__button route__button--resume" onClick={onResume}>
+            {plan.awaiting ? 'SIGN AND CONTINUE' : 'RESUME'}
+          </button>
+        )}
+        <button className="route__button" onClick={onCancel}>
+          {plan.status === 'running' ? 'STOP ROUTE' : 'CANCEL ROUTE'}
+        </button>
+      </div>
+      <p className="legend__note">
+        Steps already signed stay on the chain. Cancelling leaves you where the last one landed.
+      </p>
+    </>
+  )
+}
+
+/** The few steps around the current one, as the panel lists them. */
+function routeWindow(plan: MovePlan): Array<{ index: number; kind: string; height: string; state: string; label: string }> {
+  const rows: Array<{ index: number; kind: string; height: string; state: string; label: string }> = []
+  const first = Math.max(0, plan.done - 2)
+  for (let i = first; i < plan.done; i++) rows.push({ index: i, kind: '·', height: '', state: 'done', label: 'signed' })
+  const s = plan.step
+  rows.push({
+    index: plan.done,
+    kind: s.kind === 'sidestep' ? 'SIDESTEP' : 'HOP',
+    height: `h${s.maxHeight}`,
+    state: plan.status,
+    label: plan.status === 'running' ? 'now' : plan.status === 'paused' ? 'paused' : 'failed',
+  })
+  const remaining = plan.summary.steps - plan.done - 1
+  if (remaining > 0) rows.push({ index: plan.done + 1, kind: '·', height: '', state: 'next', label: `${plan.summary.capped ? `${remaining}+` : remaining} more` })
+  return rows
 }

--- a/src/lib/movePlan.test.ts
+++ b/src/lib/movePlan.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { findLcaHeight } from 'cyberspace-core'
+import { buildMovePlan, isSpecSidestep, isSpecSidestepMove, nextAxisMove, nextStep, planSummary, summarizePlan, wallSource, type PlanStep, type Position } from './movePlan'
+
+const P = (x: bigint, y: bigint = 5n, z: bigint = 5n): Position => ({ x, y, z })
+
+function checkPlan(steps: PlanStep[], from: Position, to: Position, ceiling: number): void {
+  let cur = from
+  for (const s of steps) {
+    expect(s.from).toEqual(cur)
+    if (s.kind === 'hop') {
+      for (const a of ['x', 'y', 'z'] as const) expect(findLcaHeight(s.from[a], s.to[a])).toBeLessThanOrEqual(ceiling)
+      expect(s.from).not.toEqual(s.to)
+    } else {
+      expect(isSpecSidestepMove(s.from, s.to)).toBe(true)
+    }
+    cur = s.to
+  }
+  expect(cur).toEqual(to)
+}
+
+describe('spec 6.3 geometry', () => {
+  it('names the leaf touching the wall on each side', () => {
+    // wall at h=4 between 7 and 8
+    expect(wallSource(0b0101n, 0b1000n, 4)).toBe(7n)
+    expect(wallSource(0b1011n, 0b0001n, 4)).toBe(8n)
+  })
+  it('accepts the worked examples and rejects the counterexamples', () => {
+    expect(isSpecSidestep(0b0111n, 0b1000n)).toBe(true)
+    expect(isSpecSidestep(0b1000n, 0b0111n)).toBe(true)
+    expect(isSpecSidestep(0b0101n, 0b1000n)).toBe(false) // source not at the wall
+    expect(isSpecSidestep(0b0111n, 0b1011n)).toBe(false) // destination past the neighbour
+    expect(isSpecSidestep(9n, 9n)).toBe(false)
+  })
+})
+
+describe('nextAxisMove', () => {
+  it('hops straight to the target within the ceiling', () => {
+    expect(nextAxisMove(5n, 100n, 8)).toEqual({ kind: 'hop', to: 100n, height: 7 })
+  })
+  it('sidesteps when standing at the wall', () => {
+    expect(nextAxisMove(7n, 12n, 2)).toEqual({ kind: 'sidestep', to: 8n, height: 4 })
+    expect(nextAxisMove(8n, 3n, 2)).toEqual({ kind: 'sidestep', to: 7n, height: 4 })
+  })
+  it('walks to the wall first, within the ceiling', () => {
+    // from 5 toward 12 with ceiling 2: the wall at h=4 is between 7 and 8; 5 -> 7 is an h=2 hop
+    expect(nextAxisMove(5n, 12n, 2)).toEqual({ kind: 'hop', to: 7n, height: 2 })
+  })
+  it('handles a wall on the way to a wall', () => {
+    // from 0 toward 2^20 + 3 with ceiling 4: the highest wall (h=21) is at 2^20 - 1 | 2^20;
+    // reaching 2^20 - 1 from 0 crosses lower walls at h=5..20, each a sidestep after a walk
+    const m = nextAxisMove(0n, (1n << 20n) + 3n, 4)
+    expect(m).toEqual({ kind: 'hop', to: 15n, height: 4 })
+  })
+})
+
+describe('buildMovePlan', () => {
+  it('one hop when it fits', () => {
+    const steps = buildMovePlan(P(5n), P(100n), 8)
+    expect(steps).toHaveLength(1)
+    expect(steps[0].kind).toBe('hop')
+  })
+  it('walks to the wall, sidesteps exactly one gibson, then hops on', () => {
+    const from = P(0b0101n)
+    const to = P(0b1011n)
+    const steps = buildMovePlan(from, to, 2)
+    expect(steps.map((s) => s.kind)).toEqual(['hop', 'sidestep', 'hop'])
+    expect(steps[1].from.x).toBe(7n)
+    expect(steps[1].to.x).toBe(8n)
+    checkPlan(steps, from, to, 2)
+  })
+  it('crosses the same wall downward', () => {
+    const from = P(0b1011n)
+    const to = P(0b0101n)
+    const steps = buildMovePlan(from, to, 2)
+    expect(steps.map((s) => s.kind)).toEqual(['hop', 'sidestep', 'hop'])
+    expect(steps[1].from.x).toBe(8n)
+    expect(steps[1].to.x).toBe(7n)
+    checkPlan(steps, from, to, 2)
+  })
+  it('the spawn-to-far-cursor case: many walls, every step legal', () => {
+    const from = P(123456789n, 987654321n, 555n)
+    const to = P(123456789n + (1n << 21n), 987654321n - (1n << 19n), 555n)
+    const steps = buildMovePlan(from, to, 17)
+    checkPlan(steps, from, to, 17)
+    const s = summarizePlan(steps)
+    expect(s.sidesteps).toBeGreaterThanOrEqual(2)
+    expect(s.tallestWall).toBe(Math.max(findLcaHeight(from.x, to.x), findLcaHeight(from.y, to.y)))
+  })
+  it('a sidestep moves only the axes standing at their walls', () => {
+    const from = P(7n, 7n, 3n)
+    const to = P(8n, 8n, 3n)
+    const steps = buildMovePlan(from, to, 1)
+    expect(steps).toHaveLength(1)
+    expect(steps[0].kind).toBe('sidestep')
+    expect(steps[0].to).toEqual(P(8n, 8n, 3n))
+  })
+  it('random routes always end at the cursor with legal steps', () => {
+    let seed = 7
+    const rnd = () => { seed = (seed * 1103515245 + 12345) & 0x7fffffff; return seed }
+    for (let i = 0; i < 40; i++) {
+      // walls up to h24 above a ceiling of 12..17: routes stay in the tens
+      const big = () => BigInt(rnd()) % (1n << 24n)
+      const from = P(big(), big(), big())
+      const to = P(big(), big(), big())
+      const ceiling = 12 + (rnd() % 6)
+      const steps = buildMovePlan(from, to, ceiling)
+      checkPlan(steps, from, to, ceiling)
+      const s = planSummary(from, to, ceiling)
+      expect(s.steps).toBe(steps.length)
+      expect(s.capped).toBe(false)
+    }
+  })
+  it('the walk is exponential in the wall height above the ceiling, as the spec accepts', () => {
+    // 0 -> 16 with ceiling 2: hop 0-3, sidestep 3-4, hop 4-7, sidestep 7-8, hop 8-11,
+    // sidestep 11-12, hop 12-15, sidestep 15-16
+    const steps = buildMovePlan(P(0n), P(16n), 2)
+    expect(steps.map((s) => `${s.kind}:${s.to.x}`)).toEqual([
+      'hop:3', 'sidestep:4', 'hop:7', 'sidestep:8', 'hop:11', 'sidestep:12', 'hop:15', 'sidestep:16',
+    ])
+    // one level taller wall, twice the walk
+    expect(planSummary(P(0n), P(32n), 2).sidesteps).toBe(8)
+    expect(planSummary(P(0n), P(1n << 30n), 17).sidesteps).toBe(1 << 13)
+  })
+  it('nextStep is what buildMovePlan repeats', () => {
+    const from = P(0b0101n)
+    const first = nextStep(from, P(0b1011n), 2)
+    expect(first?.kind).toBe('hop')
+    expect(first?.to.x).toBe(7n)
+    expect(nextStep(from, from, 2)).toBeNull()
+  })
+})

--- a/src/lib/movePlan.ts
+++ b/src/lib/movePlan.ts
@@ -1,0 +1,179 @@
+/**
+ * movePlan.ts - the route from the avatar to the cursor as a list of steps.
+ *
+ * One commit used to be one event. That was wrong whenever a wall stood in the
+ * way: a sidestep is the smallest move across a wall (CYBERSPACE_V2 6.3), so
+ * the avatar has to be standing on the leaf touching the wall before it
+ * sidesteps, and everything between here and there is ordinary hops. This
+ * module turns "go to the cursor" into that sequence: hops within the ceiling
+ * up to the wall, one sidestep of exactly 1 gibson across it, hops onward,
+ * repeated for every wall on the way. Each step becomes its own signed event.
+ *
+ * Pure functions over bigint axis values; the store executes the plan.
+ */
+
+import { findLcaHeight } from 'cyberspace-core'
+
+export interface Position {
+  x: bigint
+  y: bigint
+  z: bigint
+}
+
+export type PlanStepKind = 'hop' | 'sidestep'
+
+export interface PlanStep {
+  kind: PlanStepKind
+  from: Position
+  to: Position
+  /** Tallest per-axis LCA height of this step. */
+  maxHeight: number
+  /** Per-axis LCA heights, for the panel and for the sidestep tags. */
+  heights: { x: number; y: number; z: number }
+}
+
+export type AxisMove =
+  | { kind: 'none' }
+  | { kind: 'hop'; to: bigint; height: number }
+  | { kind: 'sidestep'; to: bigint; height: number }
+
+/**
+ * The leaf touching the wall on the source side, for the wall at height `h`
+ * between `current` and `target`: all bits below h-1 set going up, cleared
+ * going down (spec 6.3).
+ */
+export function wallSource(current: bigint, target: bigint, h: number): bigint {
+  const hb = BigInt(h)
+  const base = (current >> hb) << hb
+  const half = 1n << BigInt(h - 1)
+  return target > current ? base + half - 1n : base + half
+}
+
+/** Whether a single-axis move from `v1` to `v2` is a spec 6.3 sidestep. */
+export function isSpecSidestep(v1: bigint, v2: bigint): boolean {
+  if (v1 === v2) return false
+  const h = findLcaHeight(v1, v2)
+  if (h === 0) return false
+  return v1 === wallSource(v1, v2, h) && (v2 === v1 + 1n || v2 === v1 - 1n)
+}
+
+/** Whether a 3D move is a valid sidestep: every moving axis is a 6.3 crossing. */
+export function isSpecSidestepMove(from: Position, to: Position): boolean {
+  const axes: Array<[bigint, bigint]> = [[from.x, to.x], [from.y, to.y], [from.z, to.z]]
+  const moving = axes.filter(([a, b]) => a !== b)
+  return moving.length > 0 && moving.every(([a, b]) => isSpecSidestep(a, b))
+}
+
+/**
+ * The next move on one axis toward `target` with hops capped at `ceiling`.
+ *
+ * If the tallest boundary between here and the target fits the ceiling, one
+ * hop reaches the target. Otherwise that boundary is a wall: if we stand on
+ * the leaf touching it, the move is the sidestep across; if not, the move is
+ * whatever brings us toward that leaf, which is the same question asked again
+ * with the wall leaf as the target (the recursion bottoms out because each
+ * wall leaf is nearer and its own walls are lower).
+ */
+export function nextAxisMove(current: bigint, target: bigint, ceiling: number): AxisMove {
+  if (current === target) return { kind: 'none' }
+  const h = findLcaHeight(current, target)
+  if (h <= ceiling) return { kind: 'hop', to: target, height: h }
+  const wall = wallSource(current, target, h)
+  if (current === wall) {
+    return { kind: 'sidestep', to: target > current ? current + 1n : current - 1n, height: h }
+  }
+  return nextAxisMove(current, wall, ceiling)
+}
+
+/**
+ * The next step of the route from `cur` to `to`. Hops move every axis that
+ * can move at once; a sidestep moves exactly the axes that are standing at
+ * their walls (spec 6.9) and holds the others until it is done. Null when
+ * `cur` is `to`.
+ */
+export function nextStep(cur: Position, to: Position, ceiling: number): PlanStep | null {
+  if (ceiling < 1) throw new Error('ceiling must be at least 1')
+  if (cur.x === to.x && cur.y === to.y && cur.z === to.z) return null
+  const mx = nextAxisMove(cur.x, to.x, ceiling)
+  const my = nextAxisMove(cur.y, to.y, ceiling)
+  const mz = nextAxisMove(cur.z, to.z, ceiling)
+  const crossing = mx.kind === 'sidestep' || my.kind === 'sidestep' || mz.kind === 'sidestep'
+  const pick = (m: AxisMove, v: bigint): { to: bigint; h: number } => {
+    if (crossing) return m.kind === 'sidestep' ? { to: m.to, h: m.height } : { to: v, h: 0 }
+    return m.kind === 'hop' ? { to: m.to, h: m.height } : { to: v, h: 0 }
+  }
+  const px = pick(mx, cur.x)
+  const py = pick(my, cur.y)
+  const pz = pick(mz, cur.z)
+  return {
+    kind: crossing ? 'sidestep' : 'hop',
+    from: cur,
+    to: { x: px.to, y: py.to, z: pz.to },
+    maxHeight: Math.max(px.h, py.h, pz.h),
+    heights: { x: px.h, y: py.h, z: pz.h },
+  }
+}
+
+/**
+ * The whole route as a list. Under the strict rule a route can be very long
+ * (one sidestep per block boundary above the ceiling between here and every
+ * wall's edge), so the list is capped; `planSummary` counts without building.
+ */
+export function buildMovePlan(from: Position, to: Position, ceiling: number, cap: number = 10_000): PlanStep[] {
+  const steps: PlanStep[] = []
+  let cur: Position = { ...from }
+  for (let n = 0; n < cap; n++) {
+    const step = nextStep(cur, to, ceiling)
+    if (!step) return steps
+    steps.push(step)
+    cur = step.to
+  }
+  throw new Error(`move plan longer than ${cap} steps`)
+}
+
+export interface PlanSummary {
+  steps: number
+  hops: number
+  sidesteps: number
+  tallestWall: number
+  /** True when counting stopped at `cap`; `steps` is then a floor. */
+  capped: boolean
+}
+
+/**
+ * How long the route is, without keeping it: the panel shows this before a
+ * commit and the plan carries it while running. Walks the same steps the
+ * plan will take, so it is exact up to `cap`.
+ */
+export function planSummary(from: Position, to: Position, ceiling: number, cap: number = 100_000): PlanSummary {
+  let hops = 0
+  let sidesteps = 0
+  let tallestWall = 0
+  let cur: Position = { ...from }
+  for (let n = 0; n < cap; n++) {
+    const step = nextStep(cur, to, ceiling)
+    if (!step) return { steps: hops + sidesteps, hops, sidesteps, tallestWall, capped: false }
+    if (step.kind === 'hop') hops++
+    else {
+      sidesteps++
+      if (step.maxHeight > tallestWall) tallestWall = step.maxHeight
+    }
+    cur = step.to
+  }
+  return { steps: hops + sidesteps, hops, sidesteps, tallestWall, capped: true }
+}
+
+/** Counts for a one-line summary: "3 hops, 1 sidestep". */
+export function summarizePlan(steps: PlanStep[]): { hops: number; sidesteps: number; tallestWall: number } {
+  let hops = 0
+  let sidesteps = 0
+  let tallestWall = 0
+  for (const s of steps) {
+    if (s.kind === 'hop') hops++
+    else {
+      sidesteps++
+      tallestWall = Math.max(tallestWall, s.maxHeight)
+    }
+  }
+  return { hops, sidesteps, tallestWall }
+}

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -1,14 +1,14 @@
 /**
  * Cursor.tsx - the uncommitted destination.
  *
- * WASD moves this, not you. The dashed tether from the avatar is the action
- * you are lining up. When the hop fits the Cantor ceiling it is one amber
- * leg straight to the cursor. When a wall blocks it, the tether splits: a
- * purple leg to the sidestep landing (1 gibson past the wall, where Space
- * actually takes you) and a second leg for the remaining journey, amber if a
- * hop can finish it, red if another wall still stands. While a proof is
- * computing the display locks to the committed target instead of the live
- * cursor.
+ * WASD moves this, not you. The tether from the avatar is the route Space
+ * would run, drawn from the same planner the store executes (lib/movePlan.ts)
+ * so what you see is what you get: amber dashed legs are hops, purple legs
+ * are sidesteps of exactly 1 gibson through a wall, and a purple mark sits on
+ * every sidestep landing. When the hop fits the ceiling the route is one
+ * amber leg straight to the cursor. A route too long to draw in full ends in
+ * a red leg to the cursor. While a proof is computing the display locks to
+ * the committed target instead of the live cursor.
  */
 
 import { useLayoutEffect, useMemo, useRef } from 'react'
@@ -20,23 +20,81 @@ import {
   EdgesGeometry,
   Float32BufferAttribute,
   Line,
+  LineBasicMaterial,
   LineDashedMaterial,
   LineSegments,
   BoxGeometry,
 } from 'three'
-import { estimateHopCost } from 'cyberspace-core'
+import { useCalibration } from '../lib/calibration'
+import { nextStep, type PlanStep } from '../lib/movePlan'
 import { ACCENT, DANGER, SIDESTEP, WARN } from '../lib/palette'
 import { cellCentre, type Position, type ViewAxes } from '../lib/space'
 import {
   MAX_COMPUTE_HEIGHT,
   alignedOrigin,
   samePosition,
-  sidestepTarget,
   useCyberspace,
 } from '../store/useCyberspace'
 
+/** Steps drawn in full; past this the tether ends in one red leg. */
+const DRAWN_STEPS = 48
+
 interface Props {
   axes: ViewAxes
+}
+
+type Pt = readonly [number, number, number]
+
+function makeDashedSegments(geometry: BufferGeometry, color: number | string): LineSegments {
+  const legs = new LineSegments(
+    geometry,
+    new LineDashedMaterial({
+      color,
+      dashSize: 0.32,
+      gapSize: 0.2,
+      transparent: true,
+      opacity: 0.9,
+      toneMapped: false,
+      depthTest: false,
+    }),
+  )
+  legs.frustumCulled = false
+  legs.renderOrder = 10
+  return legs
+}
+
+function makeSolidSegments(geometry: BufferGeometry, color: number | string): LineSegments {
+  const legs = new LineSegments(
+    geometry,
+    new LineBasicMaterial({ color, transparent: true, opacity: 0.95, toneMapped: false, depthTest: false }),
+  )
+  legs.frustumCulled = false
+  legs.renderOrder = 10
+  return legs
+}
+
+/** Fill a segments geometry from (from, to) pairs; hidden when there are none. */
+function setSegments(legs: LineSegments, geometry: BufferGeometry, pairs: ReadonlyArray<readonly [Pt, Pt]>): void {
+  const arr = new Float32Array(pairs.length * 6)
+  pairs.forEach(([a, b], i) => {
+    arr[i * 6] = a[0]; arr[i * 6 + 1] = a[1]; arr[i * 6 + 2] = a[2]
+    arr[i * 6 + 3] = b[0]; arr[i * 6 + 4] = b[1]; arr[i * 6 + 5] = b[2]
+  })
+  geometry.setAttribute('position', new Float32BufferAttribute(arr, 3))
+  geometry.computeBoundingSphere()
+  legs.computeLineDistances()
+  legs.visible = pairs.length > 0
+}
+
+/** Move the final vertex of a segments geometry (the leg ending on the cursor). */
+function setLastVertex(legs: LineSegments, geometry: BufferGeometry, b: Pt): void {
+  const attr = geometry.getAttribute('position') as Float32BufferAttribute | undefined
+  if (!attr || attr.count === 0) return
+  const arr = attr.array as Float32Array
+  const i = (attr.count - 1) * 3
+  arr[i] = b[0]; arr[i + 1] = b[1]; arr[i + 2] = b[2]
+  attr.needsUpdate = true
+  legs.computeLineDistances()
 }
 
 function makeDashedLine(geometry: BufferGeometry): Line {
@@ -83,7 +141,6 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const cursor = useCyberspace((s) => s.cursor)
   const pendingTarget = useCyberspace((s) => s.pendingTarget)
   const scaleExp = useCyberspace((s) => s.scaleExp)
-  const plane = useCyberspace((s) => s.plane)
   const anchor = useCyberspace((s) => s.anchor)
   const atHead = useCyberspace((s) => s.atHead())
 
@@ -92,27 +149,28 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const target = atHead ? (pendingTarget ?? cursor) : anchor
   const active = atHead && !samePosition(position, target)
 
-  // The action being lined up: null legs when inactive; a landing splits the
-  // journey when the direct hop is beyond the Cantor ceiling.
-  const plan = useMemo(() => {
+  // The ceiling a commit would use right now, the same number the store
+  // routes with: the hard cap lowered to what calibration measured.
+  const hopCeil = useCalibration((s) => s.hopHeight)
+  const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
+
+  // The route Space would run, from the planner the store executes. Drawn
+  // step by step up to DRAWN_STEPS; a longer route is marked capped and its
+  // remainder becomes one red leg.
+  const route = useMemo(() => {
     if (!active) return null
-    const direct = estimateHopCost(
-      position.x, position.y, position.z,
-      target.x, target.y, target.z,
-      plane,
-      MAX_COMPUTE_HEIGHT,
-    )
-    if (!direct.exceedsLimit) return { landing: null, remainderBlocked: false }
-    const landing = sidestepTarget(position, target)
-    if (samePosition(landing, target)) return { landing: null, remainderBlocked: false }
-    const remainder = estimateHopCost(
-      landing.x, landing.y, landing.z,
-      target.x, target.y, target.z,
-      plane,
-      MAX_COMPUTE_HEIGHT,
-    )
-    return { landing, remainderBlocked: remainder.exceedsLimit }
-  }, [active, position, target, plane])
+    const steps: PlanStep[] = []
+    let cur = position
+    let capped = false
+    for (;;) {
+      const step = nextStep(cur, target, ceiling)
+      if (!step) break
+      if (steps.length >= DRAWN_STEPS) { capped = true; break }
+      steps.push(step)
+      cur = step.to
+    }
+    return { steps, capped, last: cur }
+  }, [active, position, target, ceiling])
 
   // Screen-space endpoints, at cell CENTRES.
   //
@@ -126,38 +184,42 @@ export function Cursor({ axes }: Props): JSX.Element | null {
     const origin = alignedOrigin(anchor, scaleExp)
     const centre = (p: Position) => cellCentre(p, origin, scaleExp, axes)
     const b = centre(target)
+    const steps = route?.steps ?? []
     return {
       a: centre(position),
       b,
-      landing: plan?.landing ? centre(plan.landing) : null,
+      hops: steps.filter((st) => st.kind === 'hop').map((st) => [centre(st.from), centre(st.to)] as const),
+      sidesteps: steps.filter((st) => st.kind === 'sidestep').map((st) => [centre(st.from), centre(st.to)] as const),
+      landings: steps.filter((st) => st.kind === 'sidestep').map((st) => centre(st.to)),
+      rest: route?.capped ? ([centre(route.last), b] as const) : null,
+      lastIsHop: steps.length > 0 && steps[steps.length - 1].kind === 'hop' && !route?.capped,
       targetCell: b,
     }
-  }, [position, target, plan, scaleExp, axes, anchor])
+  }, [position, target, route, scaleExp, axes, anchor])
 
-  const leg1Geometry = useMemo(() => new BufferGeometry(), [])
-  const leg2Geometry = useMemo(() => new BufferGeometry(), [])
-  const leg1 = useMemo(() => makeDashedLine(leg1Geometry), [leg1Geometry])
-  const leg2 = useMemo(() => makeDashedLine(leg2Geometry), [leg2Geometry])
+  const hopGeometry = useMemo(() => new BufferGeometry(), [])
+  const sideGeometry = useMemo(() => new BufferGeometry(), [])
+  const restGeometry = useMemo(() => new BufferGeometry(), [])
+  const hopLegs = useMemo(() => makeDashedSegments(hopGeometry, WARN), [hopGeometry])
+  const sideLegs = useMemo(() => makeSolidSegments(sideGeometry, SIDESTEP), [sideGeometry])
+  const restLeg = useMemo(() => makeDashedLine(restGeometry), [restGeometry])
 
   // A cube, not a square: the view orbits now, so the target cell has to read
   // as a volume from any angle rather than as a plane seen face-on.
   const cellOutline = useMemo(() => new EdgesGeometry(new BoxGeometry(1, 1, 1)), [])
 
-  const targetColor = plan?.landing
-    ? plan.remainderBlocked ? DANGER : WARN
-    : WARN
+  const targetColor = route?.capped ? DANGER : WARN
 
   useLayoutEffect(() => {
-    const { a, b, landing } = points
-    if (landing) {
-      setSegment(leg1, leg1Geometry, a, landing, SIDESTEP)
-      setSegment(leg2, leg2Geometry, landing, b, targetColor)
-      leg2.visible = true
+    setSegments(hopLegs, hopGeometry, points.hops)
+    setSegments(sideLegs, sideGeometry, points.sidesteps)
+    if (points.rest) {
+      setSegment(restLeg, restGeometry, points.rest[0], points.rest[1], DANGER)
+      restLeg.visible = true
     } else {
-      setSegment(leg1, leg1Geometry, a, b, targetColor)
-      leg2.visible = false
+      restLeg.visible = false
     }
-  }, [points, targetColor, leg1, leg2, leg1Geometry, leg2Geometry])
+  }, [points, hopLegs, sideLegs, restLeg, hopGeometry, sideGeometry, restGeometry])
 
   // The cursor's position is driven per frame, straight from the store, rather
   // than waiting for a React commit.
@@ -175,7 +237,9 @@ export function Cursor({ axes }: Props): JSX.Element | null {
     const live = s.atHead() ? (s.pendingTarget ?? s.cursor) : s.anchor
     const b = cellCentre(live, alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes)
     if (outline.current) outline.current.position.set(b[0], b[1], b[2])
-    setSegmentEnd(leg2.visible ? leg2 : leg1, leg2.visible ? leg2Geometry : leg1Geometry, b)
+    // The leg that ends on the cursor follows it within the frame.
+    if (restLeg.visible) setSegmentEnd(restLeg, restGeometry, b)
+    else if (points.lastIsHop) setLastVertex(hopLegs, hopGeometry, b)
   })
 
   return (
@@ -205,16 +269,17 @@ export function Cursor({ axes }: Props): JSX.Element | null {
 
       {active && (
         <>
-          <primitive object={leg1} />
-          <primitive object={leg2} />
+          <primitive object={hopLegs} />
+          <primitive object={sideLegs} />
+          <primitive object={restLeg} />
 
-          {/* Sidestep landing: where Space actually takes you */}
-          {points.landing && (
-            <mesh position={points.landing} renderOrder={10}>
+          {/* Every sidestep landing: 1 gibson through a wall */}
+          {points.landings.map((p, i) => (
+            <mesh key={i} position={p} renderOrder={10}>
               <circleGeometry args={[0.14, 4]} />
               <meshBasicMaterial color={SIDESTEP} toneMapped={false} transparent depthTest={false} />
             </mesh>
-          )}
+          ))}
 
           {/* The cell the lined-up action targets */}
           <lineSegments ref={outline} geometry={cellOutline} position={points.targetCell} frustumCulled={false} renderOrder={10}>

--- a/src/store/movePlan.test.ts
+++ b/src/store/movePlan.test.ts
@@ -1,0 +1,124 @@
+/**
+ * movePlan.test.ts - a commit beyond the ceiling runs a route step by step,
+ * one signature per step, pausing on a declined signature.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const posted: Array<{ id: number; mode: string; from: { x: bigint }; to: { x: bigint }; maxComputeHeight: number }> = []
+vi.mock('../lib/workers', () => ({
+  postProof: vi.fn((req: (typeof posted)[number]) => { posted.push(req) }),
+  cancelProof: vi.fn(),
+  setProofHandler: vi.fn(),
+}))
+vi.mock('../lib/calibration', async (orig) => {
+  const mod = await orig<typeof import('../lib/calibration')>()
+  return { ...mod, recommendedHopHeight: () => 2 }
+})
+
+import { parseAction } from '../lib/events'
+import { useCyberspace } from './useCyberspace'
+
+function done(req: (typeof posted)[number]) {
+  const sidestep = req.mode === 'sidestep'
+    ? { merkleRoots: ['aa'.repeat(32), 'bb'.repeat(32), 'cc'.repeat(32)] as [string, string, string], inclusionProofs: ['', '', ''] as [string, string, string], lcaHeights: [1, 0, 0] as [number, number, number] }
+    : undefined
+  return { type: 'done' as const, id: req.id, mode: req.mode as 'hop' | 'sidestep', elapsedMs: 5, proofHash: 'dd'.repeat(32), regionN: '1', terrainK: 3, lca: { x: 1, y: 0, z: 0 }, totalOps: 4, sidestep }
+}
+
+async function land(): Promise<void> {
+  const req = posted[posted.length - 1]
+  await useCyberspace.getState().applyProofMessage(done(req))
+}
+
+describe('a commit beyond the ceiling', () => {
+  beforeEach(async () => {
+    posted.length = 0
+    await useCyberspace.getState().respawn()
+  })
+
+  it('walks to the wall, sidesteps one gibson, hops on, signing each step', async () => {
+    const s = useCyberspace.getState()
+    const x0 = (s.position.x >> 4n) << 4n            // block base at h4
+    useCyberspace.setState({ position: { ...s.position, x: x0 + 5n }, cursor: { ...s.position, x: x0 + 11n } })
+    await useCyberspace.getState().commit()
+    let st = useCyberspace.getState()
+    expect(st.plan).not.toBeNull()
+    expect(st.plan!.summary).toMatchObject({ hops: 2, sidesteps: 1, tallestWall: 4 })
+    expect(posted).toHaveLength(1)
+    expect(posted[0]).toMatchObject({ mode: 'hop', to: { x: x0 + 7n }, maxComputeHeight: 2 })
+
+    await land()
+    st = useCyberspace.getState()
+    expect(st.position.x).toBe(x0 + 7n)
+    expect(st.plan!.done).toBe(1)
+    expect(posted[1]).toMatchObject({ mode: 'sidestep', from: { x: x0 + 7n }, to: { x: x0 + 8n } })
+
+    await land()
+    st = useCyberspace.getState()
+    expect(st.position.x).toBe(x0 + 8n)
+    expect(posted[2]).toMatchObject({ mode: 'hop', from: { x: x0 + 8n }, to: { x: x0 + 11n } })
+
+    await land()
+    st = useCyberspace.getState()
+    expect(st.position.x).toBe(x0 + 11n)
+    expect(st.plan).toBeNull()
+    expect(st.proof.status).toBe('done')
+    const kinds = st.events.map((e) => parseAction(e)?.type)
+    expect(kinds).toEqual(['spawn', 'hop', 'sidestep', 'hop'])
+    // every event links to the one before it
+    for (let i = 1; i < st.events.length; i++) {
+      const prev = st.events[i].tags.find((t) => t[0] === 'e' && t[3] === 'previous')?.[1]
+      expect(prev).toBe(st.events[i - 1].id)
+    }
+  })
+
+  it('pauses on a declined signature and continues with the same proof on resume', async () => {
+    const s = useCyberspace.getState()
+    const x0 = (s.position.x >> 4n) << 4n
+    useCyberspace.setState({ position: { ...s.position, x: x0 + 7n }, cursor: { ...s.position, x: x0 + 9n } })
+    await useCyberspace.getState().commit()
+    expect(posted[0].mode).toBe('sidestep')
+
+    const realSign = useCyberspace.getState().signEvent
+    useCyberspace.setState({ signEvent: async () => { throw new Error('user declined') } })
+    await land()
+    let st = useCyberspace.getState()
+    expect(st.plan!.status).toBe('paused')
+    expect(st.plan!.awaiting).not.toBeNull()
+    expect(st.plan!.message).toContain('declined')
+    expect(st.position.x).toBe(x0 + 7n)
+    expect(st.events).toHaveLength(1)
+    expect(posted).toHaveLength(1)                     // nothing recomputed
+
+    useCyberspace.setState({ signEvent: realSign })
+    useCyberspace.getState().resumePlan()
+    await new Promise((r) => setTimeout(r, 0))
+    st = useCyberspace.getState()
+    expect(st.position.x).toBe(x0 + 8n)
+    expect(posted).toHaveLength(2)                     // the next step was posted, not the old one again
+    expect(posted[1]).toMatchObject({ mode: 'hop', to: { x: x0 + 9n } })
+  })
+
+  it('cancelling a route keeps the signed steps and drops the rest', async () => {
+    const s = useCyberspace.getState()
+    const x0 = (s.position.x >> 4n) << 4n
+    useCyberspace.setState({ position: { ...s.position, x: x0 + 5n }, cursor: { ...s.position, x: x0 + 11n } })
+    await useCyberspace.getState().commit()
+    await land()
+    expect(useCyberspace.getState().events).toHaveLength(2)
+    useCyberspace.getState().cancel()
+    const st = useCyberspace.getState()
+    expect(st.plan).toBeNull()
+    expect(st.pendingTarget).toBeNull()
+    expect(st.events).toHaveLength(2)
+    expect(st.position.x).toBe(x0 + 7n)
+  })
+
+  it('a hop within the ceiling is still a single event, no route', async () => {
+    const s = useCyberspace.getState()
+    useCyberspace.setState({ cursor: { ...s.position, x: s.position.x ^ 1n } })
+    await useCyberspace.getState().commit()
+    expect(useCyberspace.getState().plan).toBeNull()
+    expect(posted[0].mode).toBe('hop')
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -75,6 +75,7 @@ import {
 } from '../lib/events'
 import { cancelProof, postProof, type ProofMode, type ProofResponse } from '../lib/workers'
 import { recommendedHopHeight } from '../lib/calibration'
+import { nextStep, planSummary, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
 
@@ -138,6 +139,36 @@ const IDLE_PROOF: ProofState = {
   message: null,
 }
 
+export type PlanStatus = 'running' | 'paused' | 'failed'
+
+/**
+ * A commit beyond the ceiling is a route, not one event: hops to the leaf
+ * touching the wall, a sidestep of exactly 1 gibson across it, hops on, for
+ * every wall between here and the cursor (spec 6.3, lib/movePlan.ts). The
+ * route runs one step at a time, each step its own proof and its own
+ * signature, and the next step is computed from wherever the last one
+ * landed. A declined signature pauses it with the finished proof kept, so
+ * RESUME asks for the signature again instead of recomputing.
+ */
+export interface MovePlan {
+  /** Where the route ends: the cursor at commit time. */
+  target: Position
+  /** The compute ceiling every hop is sized to. */
+  ceiling: number
+  /** Counts for the whole route, taken at commit time. */
+  summary: PlanSummary
+  /** Steps already signed and appended. */
+  done: number
+  /** The step in progress, or the one the route is paused on. */
+  step: PlanStep
+  status: PlanStatus
+  /** Why the route paused or failed; null while it runs. */
+  message: string | null
+  /** A finished proof waiting for its signature across a pause. */
+  awaiting: ProofResponse | null
+  startedAt: number
+}
+
 export interface ChainStats {
   /** Completed hops. The chain is contiguous by construction. */
   hops: number
@@ -199,6 +230,8 @@ export interface CyberspaceState {
   cursor: Position
   /** Destination of the in-flight proof; null when nothing is computing. */
   pendingTarget: Position | null
+  /** The route a commit beyond the ceiling is executing; null otherwise. */
+  plan: MovePlan | null
   /**
    * The plane the next commit lands in. Part of the lined-up action, like the
    * cursor: toggling it costs nothing until committed, and a commit with the
@@ -261,6 +294,12 @@ export interface CyberspaceState {
   setCursorAtCell: (row: number, col: number) => void
   commit: () => Promise<void>
   cancel: () => void
+  /** Continue a paused route: ask for the pending signature again, or restart the step. */
+  resumePlan: () => void
+  /** Abandon a route. Steps already signed stay on the chain; the avatar stays where they left it. */
+  cancelPlan: () => void
+  /** Sign and append a finished proof (the second half of applyProofMessage). */
+  finishProof: (msg: ProofResponse) => Promise<void>
   adjustScale: (delta: number) => void
   rotate: (dir: RotateDirection) => void
   popView: () => void
@@ -654,6 +693,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       ...base,
       cursor: base.position,
       pendingTarget: null,
+      plan: null,
       proof: IDLE_PROOF,
       publishError: null,
       spectate: null,
@@ -673,6 +713,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   targets: loadTargets(),
   cursor: initial.position,
   pendingTarget: null,
+  plan: null,
   scaleExp: 0,
   // Facing the black sun, the section 11.3 canonical orientation, the same
   // one the SUN button restores. The spec's left/right/above/below language
@@ -766,29 +807,63 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       plane,
       ceiling,
     )
-    const mode: ProofMode = estimate.exceedsLimit ? 'sidestep' : 'hop'
-    const to = mode === 'sidestep' ? sidestepTarget(position, cursor, ceiling) : { ...cursor }
-    if (samePosition(position, to) && plane === headPlane) return
+    if (!estimate.exceedsLimit) {
+      const to = { ...cursor }
+      const id = ++requestId
+      set({
+        pendingTarget: to,
+        plan: null,
+        proof: { ...IDLE_PROOF, status: 'computing', mode: 'hop' },
+      })
+      postProof({ id, mode: 'hop', from: position, to, plane, prevEventId, maxComputeHeight: ceiling })
+      return
+    }
 
-    const id = ++requestId
+    // A wall is in the way. A sidestep buys exactly 1 gibson through a wall
+    // (spec 6.3), so the route is hops to the leaf touching the wall, the
+    // sidestep, hops on, for every wall and every block boundary above the
+    // ceiling between here and the cursor. Each step is its own event; the
+    // route runs them in order and pauses when a signature is declined.
+    const step = nextStep(position, cursor, ceiling)
+    if (!step) return
     set({
-      pendingTarget: to,
-      proof: { ...IDLE_PROOF, status: 'computing', mode },
+      plan: {
+        target: { ...cursor },
+        ceiling,
+        summary: planSummary(position, cursor, ceiling),
+        done: 0,
+        step,
+        status: 'running',
+        message: null,
+        awaiting: null,
+        startedAt: Date.now(),
+      },
     })
+    startPlanStep()
+  },
 
-    postProof({
-      id,
-      mode,
-      from: position,
-      to,
-      plane,
-      prevEventId,
-      maxComputeHeight: ceiling,
-    })
+  resumePlan: () => {
+    const { plan } = get()
+    if (!plan || plan.status !== 'paused') return
+    if (plan.awaiting) {
+      const msg = plan.awaiting
+      set({ plan: { ...plan, status: 'running', message: null, awaiting: null } })
+      void get().finishProof(msg)
+      return
+    }
+    set({ plan: { ...plan, status: 'running', message: null } })
+    startPlanStep()
+  },
+
+  cancelPlan: () => {
+    if (get().proof.status === 'computing') cancelProof()
+    requestId++
+    set({ plan: null, pendingTarget: null, proof: IDLE_PROOF })
   },
 
   cancel: () => {
-    const { proof, position, headPlane } = get()
+    const { proof, position, headPlane, plan } = get()
+    if (plan) { get().cancelPlan(); return }
     if (proof.status === 'computing') {
       // A Cantor proof is one synchronous computation, so cancelling means
       // killing the worker thread. Position never moved; the chain is intact.
@@ -853,8 +928,10 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     }
 
     if (msg.type === 'error') {
+      const { plan } = get()
       set({
         pendingTarget: null,
+        plan: plan ? { ...plan, status: 'failed', message: msg.message, awaiting: null } : null,
         proof: {
           ...IDLE_PROOF,
           status: 'infeasible',
@@ -865,6 +942,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       return
     }
 
+    await get().finishProof(msg)
+  },
+
+  finishProof: async (msg) => {
+    if (msg.type !== 'done' || msg.id !== requestId) return
     // Capture the chain we are extending. A cancel or a respawn bumps requestId,
     // so for this id events/head stay valid across the await; only `published`
     // moves under us as the publisher drains, so that is re-read after signing.
@@ -887,7 +969,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
     let event: NostrEvent
     try {
-      event = await signEvent(
+      event = await get().signEvent(
         msg.mode === 'sidestep' && msg.sidestep
           ? sidestepTemplate({ ...link, ...msg.sidestep })
           : hopTemplate(link),
@@ -896,13 +978,23 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       // The signer refused, or a bunker dropped mid-handshake: the move does not
       // commit, and the avatar stays where the last committed hop left it.
       if (msg.id !== requestId) return
+      const reason = err instanceof Error ? err.message : String(err)
+      const { plan } = get()
+      if (plan) {
+        // The proof is done and kept; RESUME asks for the signature again.
+        set({
+          plan: { ...plan, status: 'paused', message: `Signature declined: ${reason}`, awaiting: msg },
+          proof: { ...get().proof, status: 'idle', progress: 1, elapsedMs: msg.elapsedMs },
+        })
+        return
+      }
       set({
         pendingTarget: null,
         proof: {
           ...IDLE_PROOF,
           status: 'infeasible',
           elapsedMs: msg.elapsedMs,
-          message: `Signing failed: ${err instanceof Error ? err.message : String(err)}`,
+          message: `Signing failed: ${reason}`,
         },
       })
       return
@@ -949,6 +1041,18 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     })
 
     saveChain(nextEvents, nextPublished, stats)
+
+    // A route continues from where this step landed, or ends here.
+    const { plan } = get()
+    if (plan && plan.status === 'running') {
+      const next = nextStep(newPosition, plan.target, plan.ceiling)
+      if (!next) {
+        set({ plan: null })
+      } else {
+        set({ plan: { ...plan, done: plan.done + 1, step: next, awaiting: null } })
+        startPlanStep()
+      }
+    }
   },
 
   setLive: (live) => {
@@ -963,6 +1067,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       cancelProof()
       requestId++
     }
+    if (get().plan) set({ plan: null })
     const { events } = get()
     const fresh = derive(await freshSpawnAsync(currentSigner, events[events.length - 1]))
     set({
@@ -1420,6 +1525,30 @@ export { SPAWN }
 /** Positions are equal when all three axes match. */
 export function samePosition(a: Position, b: Position): boolean {
   return a.x === b.x && a.y === b.y && a.z === b.z
+}
+
+/**
+ * Compute the route's current step: its proof request goes to the worker like
+ * any single commit, and applyProofMessage carries it through signing.
+ */
+function startPlanStep(): void {
+  const s = useCyberspace.getState()
+  const plan = s.plan
+  if (!plan || plan.status !== 'running') return
+  const id = ++requestId
+  useCyberspace.setState({
+    pendingTarget: plan.step.to,
+    proof: { ...IDLE_PROOF, status: 'computing', mode: plan.step.kind },
+  })
+  postProof({
+    id,
+    mode: plan.step.kind,
+    from: plan.step.from,
+    to: plan.step.to,
+    plane: s.plane,
+    prevEventId: s.prevEventId,
+    maxComputeHeight: plan.ceiling,
+  })
 }
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -3853,3 +3853,38 @@ kbd {
   width: 0;
   height: 0;
 }
+
+/* Movement route: the steps a commit beyond the ceiling runs one by one. */
+.route {
+  list-style: none;
+  margin: 0.4rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.15rem;
+  font-size: 0.72rem;
+}
+.route__step {
+  display: grid;
+  grid-template-columns: 1.6rem 5.5rem 3rem 1fr;
+  gap: 0.4rem;
+  padding: 0.15rem 0.3rem;
+  border: 1px solid transparent;
+}
+.route__step--running { border-color: var(--accent); }
+.route__step--paused { border-color: #e2b93b; }
+.route__step--failed { border-color: #d55; }
+.route__step--done, .route__step--next { opacity: 0.55; }
+.route__index { opacity: 0.7; }
+.route__row { display: flex; gap: 0.4rem; margin-top: 0.4rem; }
+.route__button {
+  flex: 1;
+  padding: 0.35rem 0.5rem;
+  background: transparent;
+  color: inherit;
+  border: 1px solid currentColor;
+  font: inherit;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+.route__button--resume { border-color: #e2b93b; color: #e2b93b; }


### PR DESCRIPTION
Fixes the behaviour you hit on the #50 preview: a sidestep carried the avatar from deep inside its half to the wall and one step across. Under the strict 6.3 reading (arkin0x/cyberspace#23) a sidestep is exactly one gibson through a wall, so the route to a cursor past a wall is hops to the leaf touching the wall, the sidestep, hops on, for every wall and every block boundary above the ceiling on the way.

## What changes

- `src/lib/movePlan.ts`: the geometry (`wallSource`, `isSpecSidestep`), the next step from any position, the whole route, and a capped summary counter.
- Store: a commit whose hop exceeds the ceiling builds a route and runs it step by step. Each step is its own proof and its own signed event, computed from where the previous one landed. A declined signature pauses the route with the finished proof kept; `resumePlan` asks for the signature again, `cancelPlan` (or X) leaves the avatar where the last signed step landed. Respawn and chain replacement clear the route.
- Proof panel: before commit, ROUTE READY with hops, sidesteps, tallest wall, hop ceiling and a plain-words notice; when the walk is long, a warning with the sidestep count and a pointer at HOSAKA. While running: step n of total, what this step does, signed so far, a short step list, SIGN AND CONTINUE / RESUME and STOP ROUTE / CANCEL ROUTE.

## Verified

- 346 tests pass (14 new in `lib/movePlan.test.ts`, 4 in `store/movePlan.test.ts`), `tsc --noEmit` and `npm run build` clean.
- Headless Chromium on the dev build: cursor past an h19 wall with an h17 ceiling previews "3 hops, 2 sidesteps, tallest wall 2^19"; the first signature declined pauses at step 1 with SIGN AND CONTINUE; after resume the route runs hop, sidestep h18, hop, sidestep h19, hop in 13 s, lands exactly on the cursor, every event linked to the one before, no console errors.

## After this

#50 (HOSAKA) rebases onto this: a cloud hop replaces the walk to the wall whenever HOSAKA's hop cap reaches it, and a cloud sidestep is the same one-gibson step with the Merkle work done remotely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc