### PR TITLE
Ride calibration in a ride worker, kept per device; sync goes full tilt after the panels paint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,9 @@ import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
 import { useHyperspace } from './store/useHyperspace'
 import { setSyncPriority } from './lib/hyperspace/anchors'
+
+/** How long after the panels open the anchor sync goes full tilt. */
+const SYNC_PRIORITY_DELAY_MS = 1500
 import { useShards } from './store/useShards'
 
 export default function App(): JSX.Element {
@@ -90,8 +93,15 @@ export default function App(): JSX.Element {
 
   // The anchor backfill runs full tilt while the panels are open (the sync
   // numbers are being watched) and breathes between batches while they are
-  // closed, so playing in the scene gets the frames.
-  useEffect(() => { setSyncPriority(showPanels) }, [showPanels])
+  // closed, so playing in the scene gets the frames. Full tilt starts a
+  // moment after the panels open, not with them: on a phone the batches
+  // (index merges, signature checks) landed in the very frames the menu was
+  // trying to paint and the open took over a second.
+  useEffect(() => {
+    if (!showPanels) { setSyncPriority(false); return }
+    const t = window.setTimeout(() => setSyncPriority(true), SYNC_PRIORITY_DELAY_MS)
+    return () => window.clearTimeout(t)
+  }, [showPanels])
 
   const [padOpen, setPadOpen] = useState(true)
   const [viewMenuOpen, setViewMenuOpen] = useState(false)

--- a/src/lib/hyperspace/ride.test.ts
+++ b/src/lib/hyperspace/ride.test.ts
@@ -7,9 +7,11 @@
 import { describe, expect, it } from 'vitest'
 import { bytesToHex, sha256 } from 'cyberspace-core'
 import {
+  CALIBRATION_KS,
   K_LINE,
   SAMPLES,
   buildRideProof,
+  calibrationHashes,
   computeRideLeaf,
   decodeOpenings,
   encodeOpenings,
@@ -21,6 +23,7 @@ import {
   rideBlocks,
   rideSeed,
   sampleIndices,
+  timeCalibrationSample,
   verifyInclusion,
   verifyRideLevel1,
 } from './ride'
@@ -218,5 +221,18 @@ describe('rideTrail', () => {
     expect(rideTrail(10, 15, 3, 5, 2)).toEqual([12, 13])
     expect(rideTrail(10, 15, 0, 5, 100)).toEqual([10])
     expect(rideTrail(7, 7, 0, 0, 100)).toEqual([7])
+  })
+})
+
+describe('calibration sample', () => {
+  it('is one block per calibration K, in K order, and deterministic', () => {
+    const hashes = calibrationHashes()
+    expect(hashes.map(lineTerrainK)).toEqual(CALIBRATION_KS)
+    expect(calibrationHashes()).toEqual(hashes)
+  })
+  it('times the sample and reports its exact pairings', () => {
+    const { elapsedMs, pairs } = timeCalibrationSample()
+    expect(elapsedMs).toBeGreaterThan(0)
+    expect(pairs).toBe(exactRidePairs(calibrationHashes()))
   })
 })

--- a/src/lib/hyperspace/ride.ts
+++ b/src/lib/hyperspace/ride.ts
@@ -6,14 +6,7 @@
  *
  * Everything here is consensus-critical and pure; the worker pool wraps it.
  */
-import {
-  sha256,
-  hexToBytes,
-  bytesToHex,
-  intToBytesBE,
-  alignedBase,
-  computeSubtreeCantor,
-} from 'cyberspace-core'
+import { alignedBase, bytesToHex, computeSubtreeCantor, hexToBytes, intToBytesBE, sha256 } from 'cyberspace-core'
 
 export const K_LINE = 6
 export const RIDE_MAX_HEIGHT = 16 + K_LINE
@@ -296,4 +289,37 @@ export function exactRidePairs(blockHashes: string[]): number {
   let total = 0
   for (const h of blockHashes) total += 2 ** (lineTerrainK(h) + K_LINE)
   return total
+}
+
+/**
+ * The K values the calibration sample spans. Low through average, never the
+ * heavy tail: a K=16 block alone is 2^22 pairings and would make calibration
+ * itself seconds long. The measurement is normalized per pairing and scaled
+ * to the binomial mean block, so excluding the tail does not bias the result,
+ * it only bounds the cost.
+ */
+export const CALIBRATION_KS = [4, 5, 6, 7, 8, 9, 10, 11]
+
+/** One synthetic block hash per calibration K, in K order. Deterministic. */
+export function calibrationHashes(): string[] {
+  const enc = new TextEncoder()
+  const found = new Map<number, string>()
+  for (let counter = 0; found.size < CALIBRATION_KS.length && counter < 100_000; counter++) {
+    const hex = bytesToHex(sha256(enc.encode(`ride-calibration-${counter}`)))
+    const k = lineTerrainK(hex)
+    if (CALIBRATION_KS.includes(k) && !found.has(k)) found.set(k, hex)
+  }
+  return CALIBRATION_KS.filter((k) => found.has(k)).map((k) => found.get(k) as string)
+}
+
+/** The calibration sample, timed wherever it runs: elapsed wall-clock and the
+ * exact pairings it took, from which ms per mean block follows. */
+export function timeCalibrationSample(): { elapsedMs: number; pairs: number } {
+  const previousEventIdHex = 'ca'.repeat(32)
+  const hashes = calibrationHashes()
+  const started = performance.now()
+  for (let i = 0; i < hashes.length; i++) {
+    computeRideLeaf(previousEventIdHex, 1_000 + i, hashes[i])
+  }
+  return { elapsedMs: performance.now() - started, pairs: exactRidePairs(hashes) }
 }

--- a/src/lib/hyperspace/ridePool.test.ts
+++ b/src/lib/hyperspace/ridePool.test.ts
@@ -19,7 +19,9 @@ import { buildRideProof, computeRideLeaf, rideBlocks, verifyRideLevel1 } from '.
 import {
   RIDE_CHUNK_SIZE,
   assembleLeaves,
+  calibrate,
   computeRideProof,
+  leafBenchmarkMs,
   leafKey,
   pendingBlocks,
   planChunks,
@@ -159,5 +161,16 @@ describe('computeRideProof (sequential fallback under node)', () => {
     await expect(
       computeRideProof({ previousEventIdHex: PREV, blocks: syntheticBlocks(6, 10) }, () => {}, controller.signal),
     ).rejects.toThrow('aborted')
+  })
+})
+
+describe('calibrate (no workers under node)', () => {
+  it('measures once, shares the measurement, and publishes it', async () => {
+    const first = calibrate()
+    expect(calibrate()).toBe(first)
+    const ms = await first
+    expect(Number.isFinite(ms) && ms > 0).toBe(true)
+    expect(leafBenchmarkMs()).toBe(ms)
+    expect(await calibrate()).toBe(ms)
   })
 })

--- a/src/lib/hyperspace/ridePool.ts
+++ b/src/lib/hyperspace/ridePool.ts
@@ -25,15 +25,14 @@
  * settles, so an idle app holds no worker threads hostage.
  */
 
-import { bytesToHex, hexToBytes, sha256 } from 'cyberspace-core'
+import { bytesToHex, hexToBytes } from 'cyberspace-core'
 import {
   buildRideProof,
   computeRideLeaf,
-  exactRidePairs,
   expectedRidePairs,
-  lineTerrainK,
+  timeCalibrationSample,
 } from './ride'
-import type { RideChunkRequest, RideChunkResponse } from '../../workers/ride.worker'
+import type { CalibrateRequest, RideChunkRequest, RideChunkResponse } from '../../workers/ride.worker'
 
 export interface RideJob {
   /** 64 hex; the enter event id. Every leaf is seeded by it (§5.3). */
@@ -381,7 +380,7 @@ function computeInPool(
       const chunk = chunks[nextChunk++]
       const id = ++msgId
       remaining.set(id, chunk.length)
-      const request: RideChunkRequest = { id, previousEventIdHex, chunk }
+      const request: RideChunkRequest = { type: 'chunk', id, previousEventIdHex, chunk }
       worker.postMessage(request)
     }
 
@@ -403,6 +402,7 @@ function computeInPool(
           finish(new Error(msg.message))
           return
         }
+        if (msg.type !== 'leaf') return
         out.set(msg.height, msg.leafHex)
         persister.add(leafKey(previousEventIdHex, msg.height), msg.leafHex)
         progress.leafDone()
@@ -432,52 +432,86 @@ function computeInPool(
 // Calibration
 // ---------------------------------------------------------------------------
 
-let benchmarkMs: number | null = null
+/**
+ * Where the last measurement is kept between sessions. A phone's number is
+ * as good next week as today, and reading it back means the estimate shows a
+ * figure the moment the panel opens rather than CALIBRATING; the fresh
+ * measurement then replaces it.
+ */
+const BENCH_KEY = 'onosendai:ride-bench-ms'
+
+function loadBenchmark(): number | null {
+  try {
+    const raw = typeof localStorage === 'undefined' ? null : localStorage.getItem(BENCH_KEY)
+    const ms = raw === null ? NaN : Number(raw)
+    return Number.isFinite(ms) && ms > 0 ? ms : null
+  } catch {
+    return null
+  }
+}
+
+function storeBenchmark(ms: number): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(BENCH_KEY, String(ms))
+  } catch {
+    // Storage denied or full: the number still holds for this session.
+  }
+}
+
+let benchmarkMs: number | null = loadBenchmark()
 let calibrating: Promise<number> | null = null
 
-/**
- * The K values the calibration sample spans. Low through average, never the
- * heavy tail: a K=16 block alone is 2^22 pairings and would make calibration
- * itself seconds long. The measurement is normalized per pairing and scaled
- * to the binomial mean block, so excluding the tail does not bias the result,
- * it only bounds the cost.
- */
-const CALIBRATION_KS = [4, 5, 6, 7, 8, 9, 10, 11]
+/** ms per mean block from a timed sample (§5.7 expected pairings of one block). */
+function msPerBlock(sample: { elapsedMs: number; pairs: number }): number {
+  return (sample.elapsedMs / sample.pairs) * expectedRidePairs(1)
+}
 
-function calibrationHashes(): string[] {
-  const enc = new TextEncoder()
-  const found = new Map<number, string>()
-  for (let counter = 0; found.size < CALIBRATION_KS.length && counter < 100_000; counter++) {
-    const hex = bytesToHex(sha256(enc.encode(`ride-calibration-${counter}`)))
-    const k = lineTerrainK(hex)
-    if (CALIBRATION_KS.includes(k) && !found.has(k)) found.set(k, hex)
-  }
-  return CALIBRATION_KS.filter((k) => found.has(k)).map((k) => found.get(k) as string)
+/** The sample timed in a ride worker; the main thread only waits. */
+function timeSampleInWorker(): Promise<{ elapsedMs: number; pairs: number }> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL('../../workers/ride.worker.ts', import.meta.url), { type: 'module' })
+    const done = (fn: () => void) => { worker.terminate(); fn() }
+    worker.addEventListener('message', (event: MessageEvent<RideChunkResponse>) => {
+      const msg = event.data
+      if (msg.type === 'calibrated') done(() => resolve({ elapsedMs: msg.elapsedMs, pairs: msg.pairs }))
+      else if (msg.type === 'error') done(() => reject(new Error(msg.message)))
+    })
+    worker.addEventListener('error', (event) => done(() => reject(new Error(event.message || 'ride worker failed'))))
+    const request: CalibrateRequest = { type: 'calibrate', id: 1 }
+    worker.postMessage(request)
+  })
 }
 
 /**
- * Measure ms per average block on this machine, once. Times 8 synthetic
- * leaves on the main thread, derives ms per Cantor pairing, and scales to the
- * §5.7 expected pairings of the mean block. Idempotent; concurrent and later
- * calls share the first measurement.
+ * Measure ms per average block on this machine, once per session. Times 8
+ * synthetic leaves in a ride worker (on the main thread only where workers
+ * do not exist, or if the worker fails), derives ms per Cantor pairing, and
+ * scales to the §5.7 expected pairings of the mean block. Idempotent;
+ * concurrent and later calls share the first measurement. Until it resolves,
+ * leafBenchmarkMs() is the previous session's number, if there was one.
  */
 export function calibrate(): Promise<number> {
   if (calibrating) return calibrating
   calibrating = (async () => {
-    const previousEventIdHex = 'ca'.repeat(32)
-    const hashes = calibrationHashes()
-    const started = performance.now()
-    for (let i = 0; i < hashes.length; i++) {
-      computeRideLeaf(previousEventIdHex, 1_000 + i, hashes[i])
+    let sample: { elapsedMs: number; pairs: number }
+    if (typeof Worker === 'undefined') {
+      sample = timeCalibrationSample()
+    } else {
+      try {
+        sample = await timeSampleInWorker()
+      } catch {
+        sample = timeCalibrationSample()
+      }
     }
-    const elapsed = performance.now() - started
-    benchmarkMs = (elapsed / exactRidePairs(hashes)) * expectedRidePairs(1)
+    benchmarkMs = msPerBlock(sample)
+    storeBenchmark(benchmarkMs)
     return benchmarkMs
   })()
   return calibrating
 }
 
-/** The cached calibration, null until calibrate() first resolves. */
+/** The calibration: this session's once calibrate() resolves, else the
+ * stored one from an earlier session, else null. */
 export function leafBenchmarkMs(): number | null {
   return benchmarkMs
 }

--- a/src/workers/ride.worker.ts
+++ b/src/workers/ride.worker.ts
@@ -12,19 +12,42 @@
  */
 
 import { bytesToHex } from 'cyberspace-core'
-import { computeRideLeaf } from '../lib/hyperspace/ride'
+import { computeRideLeaf, timeCalibrationSample } from '../lib/hyperspace/ride'
 
 export interface RideChunkRequest {
+  type: 'chunk'
   id: number
   previousEventIdHex: string
   chunk: Array<{ height: number; blockHash: string }>
 }
 
+/** Time the calibration sample here, off the main thread: the first opening
+ * of the Hyperspace panel used to spend seconds of the main thread on it. */
+export interface CalibrateRequest {
+  type: 'calibrate'
+  id: number
+}
+
+export type RideWorkerRequest = RideChunkRequest | CalibrateRequest
+
 export type RideChunkResponse =
   | { type: 'leaf'; id: number; height: number; leafHex: string }
+  | { type: 'calibrated'; id: number; elapsedMs: number; pairs: number }
   | { type: 'error'; id: number; message: string }
 
-self.onmessage = (event: MessageEvent<RideChunkRequest>) => {
+self.onmessage = (event: MessageEvent<RideWorkerRequest>) => {
+  if (event.data.type === 'calibrate') {
+    const { id } = event.data
+    try {
+      const { elapsedMs, pairs } = timeCalibrationSample()
+      const response: RideChunkResponse = { type: 'calibrated', id, elapsedMs, pairs }
+      self.postMessage(response)
+    } catch (err) {
+      const response: RideChunkResponse = { type: 'error', id, message: err instanceof Error ? err.message : String(err) }
+      self.postMessage(response)
+    }
+    return
+  }
   const { id, previousEventIdHex, chunk } = event.data
   try {
     for (const { height, blockHash } of chunk) {


### PR DESCRIPTION
Opening the menu on a phone took two to three seconds the first time. Profiled on an emulated phone at 4x CPU throttle, 2.3 s of a 3.2 s open was Cantor pairing: the Hyperspace panel's mount effect ran the ride calibration (eight synthetic leaves) on the main thread.

- The ride worker now takes a `calibrate` job and times the sample there; the main thread only waits. The measurement is stored per device (one number in localStorage), so a later session shows an estimate the moment the panel opens and the fresh measurement replaces it. Without workers (tests, headless embedders), or if the worker fails, the sample runs where it always did.
- The rest of the open was the anchor sync landing batches (index merges, signature checks) in the frames the menu was painting, because opening the panels switched the sync to full tilt at once. It now switches 1.5 s after they open; closing them still slows it immediately.

Tap to paint, same emulated phone:

| open | before | after |
|---|---|---|
| first | 3.2 s | 0.8 s |
| later | 0.6 to 1.4 s | 0.65 to 0.76 s |

Verified headlessly that the calibration runs in `ride.worker.ts` and the number lands in storage. Tests for the calibration sample and for `calibrate()` under node. 426 tests, type check and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc