### PR TITLE
CYBERSPACE view notes: no target avatars above 2^10, port field capped at a thousand

### DIFF
--- a/src/lib/hyperspace/stops.test.ts
+++ b/src/lib/hyperspace/stops.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { LANDFALL_SCALE_MAX, stopsDrawn } from './stops'
+
+describe('stopsDrawn', () => {
+  it('draws ports in ideaspace at every zoom', () => {
+    for (const k of [0, 34, 60, 61, 82, 85]) expect(stopsDrawn(1, k)).toBe(true)
+  })
+  it('draws landfalls in dataspace only at 2^60 and below', () => {
+    expect(LANDFALL_SCALE_MAX).toBe(60)
+    for (const k of [0, 34, 59, 60]) expect(stopsDrawn(0, k)).toBe(true)
+    for (const k of [61, 70, 82, 85]) expect(stopsDrawn(0, k)).toBe(false)
+  })
+})

--- a/src/lib/hyperspace/stops.ts
+++ b/src/lib/hyperspace/stops.ts
@@ -102,3 +102,16 @@ export function stopCoordExact(stop: Stop): bigint {
 export function stopCoordHex(stop: Stop): string {
   return coordToHex(stopCoordExact(stop))
 }
+
+/**
+ * In dataspace the stops are landfalls on Earth's surface, and above this
+ * scale Earth itself is a speck: the shell drew as a clot of dots at the
+ * planet's position with nothing to be on, right through the CYBERSPACE
+ * view. Ports in ideaspace are points in a volume and draw at every scale.
+ */
+export const LANDFALL_SCALE_MAX = 60
+
+/** Whether the stop layers (field, cubes, burst) draw at all in this plane at this zoom. */
+export function stopsDrawn(plane: 0 | 1, scaleExp: number): boolean {
+  return plane === 1 || scaleExp <= LANDFALL_SCALE_MAX
+}

--- a/src/scene/Rooms.tsx
+++ b/src/scene/Rooms.tsx
@@ -182,7 +182,11 @@ export function Rooms({ axes }: Props): JSX.Element {
         // height. Every boundary of the height-3 lattice is at least height 4,
         // but the one at a multiple of 128 is height 8, and the ruler of
         // nested walls means a cell's six faces can each cost differently.
-        label: `h${height}  ${formatOps(subtreeCantorOps(height + 1))}+ ops to leave`,
+        //
+        // Except the h85 box, which is the whole of cyberspace: there is no
+        // outside to leave to, so a price for leaving it is nonsense, and at
+        // the CYBERSPACE view it hung in the middle of the scene saying so.
+        label: height === AXIS_BITS ? null : `h${height}  ${formatOps(subtreeCantorOps(height + 1))}+ ops to leave`,
         // Dead centre of the cell. Each level captions its own box rather than
         // the three stacking into one block: a caption sitting inside the volume
         // it describes needs no reading order to connect it to its cell.
@@ -207,14 +211,16 @@ export function Rooms({ axes }: Props): JSX.Element {
           <lineSegments geometry={l.geometry} frustumCulled={false}>
             <lineBasicMaterial color={l.color} toneMapped={false} transparent opacity={l.opacity} />
           </lineSegments>
-          <WorldLabel
-            text={l.label}
-            color={l.color}
-            at={l.labelAt}
-            align="center"
-            px={9}
-            opacity={0.75}
-          />
+          {l.label !== null && (
+            <WorldLabel
+              text={l.label}
+              color={l.color}
+              at={l.labelAt}
+              align="center"
+              px={9}
+              opacity={0.75}
+            />
+          )}
         </group>
       ))}
     </group>

--- a/src/scene/StopBurst.tsx
+++ b/src/scene/StopBurst.tsx
@@ -24,6 +24,7 @@ import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopByHeight, getStopIndex, useHyperspace } from '../store/useHyperspace'
 import { findStation } from '../lib/hyperspace/station'
 import { stopPlane, stopPosition } from '../hud/HyperspacePanel'
+import { stopsDrawn } from '../lib/hyperspace/stops'
 
 const STREAKS = 220
 /** Seconds from emission to gone (one pulse period when looping). */
@@ -232,7 +233,7 @@ export function StopBurst({ axes }: { axes: ViewAxes }): JSX.Element | null {
   const sustained = viewedStop !== null && viewedStop === station ? station : null
 
   const centreOf = (height: number | null): [number, number, number] | null => {
-    if (height === null) return null
+    if (height === null || !stopsDrawn(anchorPlane, scaleExp)) return null
     const stop = getStopByHeight(height)
     if (!stop || stopPlane(stop) !== anchorPlane) return null
     return markerCentre(stopPosition(stop), alignedOrigin(anchor, scaleExp), scaleExp, axes)

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -17,7 +17,7 @@ import { GRID_RADIUS, markerCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopByHeight, getStopIndex, useHyperspace } from '../store/useHyperspace'
 import { nearestStops } from '../lib/hyperspace/station'
-import { type Stop } from '../lib/hyperspace/stops'
+import { stopsDrawn, type Stop } from '../lib/hyperspace/stops'
 import { selectStopInScene, stopPlane, stopPosition } from '../hud/HyperspacePanel'
 import { WorldLabel } from './WorldLabel'
 
@@ -44,6 +44,7 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
     void indexVersion
     const index = getStopIndex()
     if (index.size === 0) return []
+    if (!stopsDrawn(anchorPlane, scaleExp)) return []
     const origin = alignedOrigin(anchor, scaleExp)
     const anchorCoord = xyzToCoord(anchor.x, anchor.y, anchor.z, anchorPlane)
     const candidates: Stop[] = []

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -35,7 +35,7 @@ import { drawnSet, hashHeight, projectedPopulation, sampleThreshold } from '../l
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { getStopIndex, useHyperspace } from '../store/useHyperspace'
 import { selectStopInScene } from '../hud/HyperspacePanel'
-import { stopCoordExact } from '../lib/hyperspace/stops'
+import { stopCoordExact, stopsDrawn } from '../lib/hyperspace/stops'
 import { coordToXyz } from 'cyberspace-core'
 
 /** Same tap-vs-drag slop as every other clickable thing in the scene. */
@@ -189,6 +189,8 @@ export function StopField({ axes }: Props): JSX.Element | null {
 
     const index = getStopIndex()
     const wantPort = anchorPlane === 1
+    // Nothing to build where the stops are not drawn (landfalls above 2^60).
+    if (!stopsDrawn(anchorPlane, scaleExp)) return
     const budget = wantPort ? MAX_POINTS : MAX_LANDFALL_POINTS
     const commit = (next: Built | null): void => {
       if (job.cancelled) return
@@ -427,6 +429,7 @@ export function StopField({ axes }: Props): JSX.Element | null {
   useEffect(() => () => { highlightGeometry?.dispose() }, [highlightGeometry])
 
   if (!built || built.frameKey !== frameKey) return null
+  if (!stopsDrawn(anchorPlane, scaleExp)) return null
   const portView = anchorPlane === 1
   // Rebase the cloud into the current frame: a re-anchor is a change of
   // origin, not of where the stops are.

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -47,14 +47,16 @@ const REACH = GRID_RADIUS * 8
 /**
  * Hard ceiling on points actually built. The chain is near a million blocks;
  * a full-cube view puts half of them (one plane's worth) in range at once, and
- * a million-vertex transparent point cloud under bloom is overdraw the frame
- * budget does not have. Past the cap the field keeps the stops whose hashed
- * heights sort smallest (sample.ts): deterministic per block and nested as
- * the line grows, so the sample fills in and thins at the margin but never
- * reshuffles. The positions are hash-uniform, so a height-keyed subset is
- * as unbiased a sample as any.
+ * even the 120k the cap used to allow painted the whole of ideaspace
+ * wall-to-wall at the top of the ladder: a solid pink block, not a field. A
+ * thousand reads as what it is, stops scattered through a space, and it is
+ * the number arkinox chose to start from. Past the cap the field keeps the
+ * stops whose hashed heights sort smallest (sample.ts): deterministic per
+ * block and nested as the line grows, so the sample fills in and thins at
+ * the margin but never reshuffles. The positions are hash-uniform, so a
+ * height-keyed subset is as unbiased a sample as any.
  */
-const MAX_POINTS = 120_000
+const MAX_POINTS = 1_000
 
 /**
  * The landfall shell needs its own, far smaller budget. Ports fill a volume,

--- a/src/scene/TargetAvatars.tsx
+++ b/src/scene/TargetAvatars.tsx
@@ -17,6 +17,14 @@ import { WorldLabel } from './WorldLabel'
 /** Same cull as Earth and the spawn marker. */
 const REACH = GRID_RADIUS * 8
 
+/**
+ * Only at scales below 2^10 gibsons per cell. The icosahedron is a cell wide
+ * whatever the zoom, so at the top of the ladder it was an eighth of
+ * cyberspace, and it sits on the cell's centre while the HUD marker sits on
+ * the exact point, up to a cell apart. Far out, the marker is the target.
+ */
+const AVATAR_SCALE_LIMIT = 10
+
 interface Props {
   axes: ViewAxes
 }
@@ -30,6 +38,7 @@ export function TargetAvatars({ axes }: Props): JSX.Element | null {
   const geometry = useMemo(() => new EdgesGeometry(new IcosahedronGeometry(0.5, 1)), [])
 
   const near = useMemo(() => {
+    if (scaleExp >= AVATAR_SCALE_LIMIT) return []
     const origin = alignedOrigin(anchor, scaleExp)
     const list = useCyberspace.getState().targetList()
     return list


### PR DESCRIPTION
arkinox's notes on the CYBERSPACE view, except the fleet cubes (analysed separately, needs a decision).

- **Target avatars.** The icosahedron is a cell wide whatever the zoom, so at the top of the ladder it was an eighth of cyberspace, and it sat on its cell's centre while the HUD marker sits on the exact point. It now draws only below 2^10 gibsons per cell; farther out the marker is the target.
- **Ideaspace wall-to-wall.** The port field's cap was 120k points, which painted the whole cube solid at the CYBERSPACE view. Capped at a thousand, the starting figure from the note. Same deterministic, nested sample (a block is drawn or not by its own hash, and growth never reshuffles), smaller budget. Screenshot in the conversation.

- **No "ops to leave" on the h85 box.** The h85 box is the whole of cyberspace; there is no outside, so its caption was nonsense and hung mid-scene. The outline stays, the caption goes wherever that level is drawn (2^82, and the two coarser zooms where it is an outer level).
- **Dataspace stops only at 2^60 and below.** The landfall shell drew as a clot of dots at Earth's position with nothing to be on. The field, the cubes and the burst share one rule (`stopsDrawn`, tested): ports in ideaspace at every zoom, landfalls in dataspace at 2^60 and below.

The third note (the orange fleet cubes and what a click on one does) is analysed separately; it needs a decision before it is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc
