### PR TITLE
HOSAKA: a thank-you modal when the invoice is paid; "1 of 1 actions"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { SecretModal } from './hud/SecretModal'
 import { FocusBar } from './hud/FocusBar'
 import { KeyFoundChip } from './hud/KeyFoundChip'
 import { LootDetail } from './hud/LootDetail'
-import { CloudApproval, InvoiceModal } from './hud/InvoiceModal'
+import { CloudApproval, InvoiceModal, PaidModal } from './hud/InvoiceModal'
 import { HosakaOffer } from './hud/HosakaOffer'
 import { useOfferView } from './store/useOffer'
 import { useDiscovery } from './hooks/useDiscovery'
@@ -162,6 +162,7 @@ export default function App(): JSX.Element {
       <HosakaOffer hidden={crowded || secretOpen} />
       <CloudApproval />
       <InvoiceModal />
+      <PaidModal />
       <button
         className="hamburger-menu"
         onContextMenu={(e) => e.preventDefault()}

--- a/src/hud/ConfirmModal.tsx
+++ b/src/hud/ConfirmModal.tsx
@@ -19,11 +19,14 @@ interface Props {
   danger?: boolean
   /** An extra class on the card, for a border that is not the destructive red. */
   cardClassName?: string
+  /** The cancel button's label; null for a modal with nothing to cancel,
+   * which has the one button. Tapping the backdrop still calls onCancel. */
+  cancelLabel?: string | null
   onConfirm: () => void
   onCancel: () => void
 }
 
-export function ConfirmModal({ banner, title, body, figure, busy = false, confirmLabel, danger = true, cardClassName, onConfirm, onCancel }: Props): JSX.Element {
+export function ConfirmModal({ banner, title, body, figure, busy = false, confirmLabel, danger = true, cardClassName, cancelLabel = 'CANCEL', onConfirm, onCancel }: Props): JSX.Element {
   return (
     <div className="modal" role="dialog" aria-modal="true" aria-label={title} onPointerDown={onCancel}>
       <div className={`modal__card ${cardClassName ?? ''}`} onPointerDown={(e) => e.stopPropagation()}>
@@ -32,7 +35,7 @@ export function ConfirmModal({ banner, title, body, figure, busy = false, confir
         {figure !== undefined && <div className="modal__figure">{figure}</div>}
         <p className="modal__body">{body}</p>
         <div className="modal__row">
-          <button className="modal__cancel" onClick={onCancel} disabled={busy}>CANCEL</button>
+          {cancelLabel !== null && <button className="modal__cancel" onClick={onCancel} disabled={busy}>{cancelLabel}</button>}
           <button className={`modal__confirm ${danger ? 'modal__confirm--danger' : ''} ${busy ? 'is-busy' : ''}`} onClick={onConfirm} disabled={busy}>
             {busy && <span className="spin" aria-hidden="true" />}{confirmLabel}
           </button>

--- a/src/hud/InvoiceModal.tsx
+++ b/src/hud/InvoiceModal.tsx
@@ -14,7 +14,7 @@ import { HosakaBanner } from './HosakaOffer'
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import QRCode from 'qrcode'
-import { formatClock, satsLabel } from '../lib/cloud'
+import { depositSettled, formatClock, satsLabel } from '../lib/cloud'
 import { useNow } from '../hooks/useNow'
 import { useCyberspace } from '../store/useCyberspace'
 import { ConfirmModal } from './ConfirmModal'
@@ -30,7 +30,7 @@ export function CloudApproval(): JSX.Element | null {
   const body = q.route
     ? (
       <>
-        {`HOSAKA will calculate ${steps.cloudSteps} of ${steps.steps} action${steps.steps === 1 ? '' : 's'}. Estimate wait is ${q.estTime ?? 'unknown'}.`}
+        {`HOSAKA will calculate ${steps.cloudSteps} of ${steps.steps} actions. Estimate wait is ${q.estTime ?? 'unknown'}.`}
         <br />
         Your payment will apply to your HOSAKA balance and leftover funds may be used for future jobs.
       </>
@@ -155,5 +155,36 @@ export function CheckPaymentButton({ className = 'secret__act' }: { className?: 
     <button className={`${className} ${checking ? 'is-busy' : ''} ${fresh && !checking ? 'is-checked' : ''}`} onClick={() => useCyberspace.getState().checkCloudPayment()} disabled={checking}>
       {checking && <span className="spin" aria-hidden="true" />}{label}
     </button>
+  )
+}
+
+/**
+ * The invoice was paid: one modal says so, since the invoice simply vanished
+ * the moment the payment was detected and the job went on in the menu, out
+ * of sight. Mounted permanently and watching the status, because the invoice
+ * modal itself unmounts on exactly the transition this needs to see.
+ */
+export function PaidModal(): JSX.Element | null {
+  const status = useCyberspace((s) => s.cloud.status)
+  const prev = useRef(status)
+  const [open, setOpen] = useState(false)
+  useEffect(() => {
+    if (depositSettled(prev.current, status)) setOpen(true)
+    prev.current = status
+  }, [status])
+  if (!open) return null
+  const close = (): void => setOpen(false)
+  return (
+    <ConfirmModal
+      banner={<HosakaBanner />}
+      title="Thanks for using HOSAKA!"
+      body="Open the menu to see the job's progress."
+      confirmLabel="OK"
+      cancelLabel={null}
+      danger={false}
+      cardClassName="cloud"
+      onConfirm={close}
+      onCancel={close}
+    />
   )
 }

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -13,9 +13,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computeSidestepProof, bytesToHex } from 'cyberspace-core'
 import {
   CloudFlowError,
-  cloudProofResponse,
   clearCloudJob,
+  cloudProofResponse,
   defaultCloudPrefs,
+  depositSettled,
   driveCloudJob,
   formatClock,
   loadCloudJob,
@@ -24,11 +25,11 @@ import {
   positionFromWire,
   retainsRecord,
   routeCommit,
+  satsOf,
   saveCloudJob,
   saveCloudPrefs,
-  satsOf,
-  wirePosition,
   type PendingCloudJob,
+  wirePosition,
 } from './cloud'
 import { HosakaError, type HosakaClient, type HosakaDeposit, type HosakaJob, type HosakaLimits } from './hosaka'
 
@@ -235,5 +236,18 @@ describe('cloudProofResponse', () => {
       lcaHeights: [13, 0, 0],
     })
     expect(msg.source).toBe('cloud')
+  })
+})
+
+describe('depositSettled', () => {
+  it('is the invoice wait ending in a paid deposit, and nothing else', () => {
+    expect(depositSettled('awaiting_payment', 'paid')).toBe(true)
+    expect(depositSettled('awaiting_payment', 'computing')).toBe(true)
+    expect(depositSettled('awaiting_payment', 'verifying')).toBe(true)
+    expect(depositSettled('awaiting_payment', 'idle')).toBe(false)
+    expect(depositSettled('awaiting_payment', 'error')).toBe(false)
+    expect(depositSettled('awaiting_payment', 'awaiting_payment')).toBe(false)
+    expect(depositSettled('paid', 'computing')).toBe(false)
+    expect(depositSettled('funding', 'awaiting_payment')).toBe(false)
   })
 })

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -14,6 +14,7 @@
  * finds it and resumes; a chain whose head has moved since discards it,
  * because the temporal binding (5.3) makes the proof worthless anyway.
  */
+import type { CloudStatus } from '../store/useCyberspace'
 
 import { findLcaHeight, type Plane } from 'cyberspace-core'
 import type { ProofResponse } from '../workers/proof.worker'
@@ -533,4 +534,14 @@ export function saveCloudDeposit(d: PendingCloudDeposit): void {
 
 export function clearCloudDeposit(): void {
   try { localStorage.removeItem(DEPOSIT_KEY) } catch { /* storage unavailable */ }
+}
+
+/**
+ * Did this status change mean the invoice was paid? True exactly when the
+ * last status was the invoice waiting and the new one is the deposit moving
+ * on (paid, computing, or already verifying), never when the wait was
+ * cancelled (idle) or failed (error). Drives the one thank-you modal.
+ */
+export function depositSettled(prev: CloudStatus, next: CloudStatus): boolean {
+  return prev === 'awaiting_payment' && (next === 'paid' || next === 'computing' || next === 'verifying')
 }


### PR DESCRIPTION
The invoice modal vanished the moment the payment was detected and the job went on in the menu, out of sight. Now a modal under the HOSAKA banner says **Thanks for using HOSAKA!** with *Open the menu to see the job's progress.* and one OK button.

It is mounted permanently and watches the cloud status, because the invoice modal itself unmounts on exactly the transition it needs to see. The rule is a pure function with a test: the wait ends in paid, computing or verifying; a cancel (idle) or an error shows nothing. `ConfirmModal` learned a null cancel label for a modal with nothing to cancel.

Also: the estimate reads "1 of 1 actions", plural.

Verified headlessly by driving the cloud status: nothing while waiting, the modal on paid with exactly one button, gone on OK, nothing on a cancel. 431 tests, type check clean. Screenshot in the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc