### PR TITLE
Workshop: stamp a shape, fill any loop, undo anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,25 @@ movement controls stand down and RETURN TO LIVE brings them back. The same
 instrument walks any other avatar's chain while spectating.
 
 **Shards.** The Shards panel opens the workshop: a full-screen bench where a
-shard is built from coloured vertices on an integer grid. ADD places a vertex
-where you tap, at the current level; SELECT picks one for the nudge pad
-(a unit along X, Y or Z), the colour input and DELETE; FACE joins three taps
-into a triangle. A shard renders SOLID (triangles, colours blended across
-faces), POINTS (every vertex a light) or LINES (a polyline through the
-vertices, colours blending along it), chosen per shard and previewed live.
-`unit` says what one grid unit is in gibsons (2^unit). Shards persist in
-localStorage. Keys on the bench: WASD / RF or arrows nudge, Del deletes,
-1 2 3 pick tools, [ ] change the level, Esc deselects then closes.
+shard is built on an integer grid. STAMP places a whole shape where you tap
+(BLOCK, WEDGE, PYRAMID, COLUMN, RING, STAR, ARROW), sized in whole units and
+turned a quarter at a time; a ghost shows where it will land before it does.
+ADD places one vertex at the current level; SELECT picks a point for the nudge
+pad (a unit along X, Y or Z), the colour input and DELETE; FACE picks corners
+in order and FILL joins them into a face, any number of corners, notches and
+all (tap the first corner again to close). A shard renders SOLID (triangles,
+colours blended across faces), POINTS (every vertex a light) or LINES (a
+polyline through the vertices, colours blending along it), chosen per shard
+and previewed live; a new shard starts in LINES and switches itself to SOLID
+the first time it gets faces. Stamps keep their own vertices even where they
+touch, so a red block against a blue one keeps a crisp seam (the wall between
+them is dropped rather than paid for), and a point that several vertices share
+moves, colours and deletes as one. `unit` says what one grid unit is in
+gibsons (2^unit). Every edit undoes. Shards persist in localStorage; COPY and
+PASTE in the shard list carry one through the clipboard in its wire form.
+Keys on the bench: 1 2 3 4 pick tools, Q turns a stamp, WASD / RF or arrows
+nudge, Del deletes, Enter fills, [ ] change the level, Ctrl+Z / Ctrl+Shift+Z
+undo and redo, Esc deselects then closes.
 
 **Comments.** A found shard or message, and each of your own deployments,
 carries a comment section: NIP-22 `kind:1111` events whose root scope is the

--- a/README.md
+++ b/README.md
@@ -86,19 +86,19 @@ shard is built on an integer grid. STAMP places a whole shape where you tap
 (BLOCK, WEDGE, PYRAMID, COLUMN, RING, STAR, ARROW), sized in whole units and
 turned a quarter at a time; a ghost shows where it will land before it does.
 ADD places one vertex at the current level; SELECT picks a point for the nudge
-pad (a unit along X, Y or Z), the colour input and DELETE; FACE picks corners
+pad (a unit along X, Y or Z), the color input and DELETE; FACE picks corners
 in order and FILL joins them into a face, any number of corners, notches and
 all (tap the first corner again to close), and a tap on a drawn face selects
-it for DELETE FACE. The colour picker paints live and puts each colour it
+it for DELETE FACE. The color picker paints live and puts each color it
 settles on at the front of the palette, which persists; hold a swatch to be
 asked whether to delete it. A shard renders SOLID (triangles,
-colours blended across faces), POINTS (every vertex a light) or LINES (a
-polyline through the vertices, colours blending along it), chosen per shard
+colors blended across faces), POINTS (every vertex a light) or LINES (a
+polyline through the vertices, colors blending along it), chosen per shard
 and previewed live; a new shard starts in LINES and switches itself to SOLID
 the first time it gets faces. Stamps keep their own vertices even where they
 touch, so a red block against a blue one keeps a crisp seam (the wall between
 them is dropped rather than paid for), and a point that several vertices share
-moves, colours and deletes as one. `unit` says what one grid unit is in
+moves, colors and deletes as one. `unit` says what one grid unit is in
 gibsons (2^unit), shown beside the control as a real size. Every edit undoes.
 While the bench is up the world canvas behind it stops drawing (its frameloop
 goes to `never`, with the clock kept across the pause), which on a phone was
@@ -177,7 +177,7 @@ when you cross a region boundary (spec section 7.5).
 **Targets.** The Targets panel points at any number of pubkeys the way the
 HUD points at Earth: a reticle in frame, a chevron on the nearest edge out of
 frame, the distance either way, and the avatar itself (a wireframe icosahedron
-in the target's own colour, named) once you are near. Add a key, toggle one
+in the target's own color, named) once you are near. Add a key, toggle one
 from the Avatars list, or load a kind 3 contact list for any npub and toggle
 follows. Positions are chain heads on the relay, kept live by a per-target
 subscription; a key with no chain is pointed at its spawn coordinate. Targets

--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ turned a quarter at a time; a ghost shows where it will land before it does.
 ADD places one vertex at the current level; SELECT picks a point for the nudge
 pad (a unit along X, Y or Z), the colour input and DELETE; FACE picks corners
 in order and FILL joins them into a face, any number of corners, notches and
-all (tap the first corner again to close). A shard renders SOLID (triangles,
+all (tap the first corner again to close), and a tap on a drawn face selects
+it for DELETE FACE. The colour picker paints live and puts each colour it
+settles on at the front of the palette, which persists; hold a swatch to be
+asked whether to delete it. A shard renders SOLID (triangles,
 colours blended across faces), POINTS (every vertex a light) or LINES (a
 polyline through the vertices, colours blending along it), chosen per shard
 and previewed live; a new shard starts in LINES and switches itself to SOLID
@@ -96,7 +99,10 @@ the first time it gets faces. Stamps keep their own vertices even where they
 touch, so a red block against a blue one keeps a crisp seam (the wall between
 them is dropped rather than paid for), and a point that several vertices share
 moves, colours and deletes as one. `unit` says what one grid unit is in
-gibsons (2^unit). Every edit undoes. Shards persist in localStorage; COPY and
+gibsons (2^unit), shown beside the control as a real size. Every edit undoes.
+While the bench is up the world canvas behind it stops drawing (its frameloop
+goes to `never`, with the clock kept across the pause), which on a phone was
+most of every frame. Shards persist in localStorage; COPY and
 PASTE in the shard list carry one through the clipboard in its wire form.
 Keys on the bench: 1 2 3 4 pick tools, Q turns a stamp, WASD / RF or arrows
 nudge, Del deletes, Enter fills, [ ] change the level, Ctrl+Z / Ctrl+Shift+Z

--- a/src/hooks/useTargets.ts
+++ b/src/hooks/useTargets.ts
@@ -12,7 +12,7 @@ import { EARTH } from '../lib/palette'
 import type { CyberTarget } from '../lib/targets'
 import { useCyberspace } from '../store/useCyberspace'
 
-/** The avatar's own red, so the marker for you is the colour you are drawn in. */
+/** The avatar's own red, so the marker for you is the color you are drawn in. */
 const YOU = '#ff2323'
 
 /** §9.7: dataspace is centred on the half-axis point, 1 km = 1000 * 2^33. */

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -445,7 +445,7 @@ export function viewEarth(): void {
 /**
  * The whole cube, camera on its centre, at a scale where its top and bottom
  * lattices are drawn: the view a hyperjump gives, held still. Stays in the
- * current plane; the lattices take that plane's colours.
+ * current plane; the lattices take that plane's colors.
  */
 export function viewCyberspace(): void {
   ownHyperspaceView()

--- a/src/hud/ProfileBadge.tsx
+++ b/src/hud/ProfileBadge.tsx
@@ -1,7 +1,7 @@
 /**
  * ProfileBadge.tsx — a pubkey as a face and a name.
  *
- * A round avatar (the kind:0 picture, or a colour-from-the-key fallback with an
+ * A round avatar (the kind:0 picture, or a color-from-the-key fallback with an
  * initial) and the name, or a shortened npub until the profile arrives. One
  * component so every list — follows, avatars, targets, a secret's creator —
  * shows a person the same way.

--- a/src/lib/bits.ts
+++ b/src/lib/bits.ts
@@ -15,7 +15,7 @@
  *
  * The leading run is the only part that means "shared". Zeroes below the highest
  * set bit are inside the differing region and buy nothing: 0b00001001 has three
- * interior zeroes and h is still 4. Colouring all zeroes alike would draw that
+ * interior zeroes and h is still 4. Coloring all zeroes alike would draw that
  * pattern as mostly-matched when it is nothing of the sort.
  */
 

--- a/src/lib/lattice.test.ts
+++ b/src/lib/lattice.test.ts
@@ -24,7 +24,7 @@ describe('lattice', () => {
     const ys = new Set(segs.map((s) => s.a[1]))
     expect([...ys].sort((a, b) => a - b)).toEqual([-0.5, 7.5])
     // v1's GridHelper: the two centre lines of each face are light purple,
-    // every other line the face's own colour: the logo's blue on top, its
+    // every other line the face's own color: the logo's blue on top, its
     // purple on the floor
     const centre = segs.filter((s) => s.color === 0x682db5)
     expect(centre).toHaveLength(4)

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -18,7 +18,7 @@ export const DANGER = '#ff3b6b'
 /** Merkle sidestep: the ideaspace purple, distinct from hop amber. */
 export const SIDESTEP = '#c07dff'
 /**
- * Sector lattice. Its own colour rather than WARN, which is amber and means
+ * Sector lattice. Its own color rather than WARN, which is amber and means
  * cost: a sector boundary is a fact about where you are, not a warning.
  *
  * Saturated orange because bloom desaturates. WARN sits at 255/176/32, already
@@ -63,7 +63,7 @@ export const MERIDIAN = '#4bc9a7'
  * mistaken for one of them.
  *
  * This was briefly a filled tint under the outline. The fill is gone and the
- * colour survived it, which is the right way round: the line was always the
+ * color survived it, which is the right way round: the line was always the
  * content and the fill was always the decoration.
  */
 export const COAST = '#4bc97d'
@@ -83,7 +83,7 @@ export const COAST = '#4bc97d'
  */
 export const BLACK_SUN = '#9258d1'
 /**
- * Colour for one level of the lattice: the LCA ramp for hue, lightness for level.
+ * Color for one level of the lattice: the LCA ramp for hue, lightness for level.
  *
  * The lattice belongs on the ramp. Its walls ARE crossings and their height is
  * exactly what the ramp was built to encode, so as you zoom out the grid should
@@ -96,11 +96,11 @@ export const BLACK_SUN = '#9258d1'
  * green, and the ramp does not reach orange until 55.
  *
  * The three levels are consecutive heights, so on a smooth ramp they land on
- * nearly the same colour, which is why hue alone cannot separate them. Lightness
+ * nearly the same color, which is why hue alone cannot separate them. Lightness
  * does that instead, and it darkens INWARD from the ramp rather than lightening
  * outward from it. Two reasons.
  *
- * The outermost box is then exactly the colour the legend swatch shows, so the
+ * The outermost box is then exactly the color the legend swatch shows, so the
  * key and the scene agree on one reading rather than on a family of them. And
  * lightening a saturated hue is how you get pastel: an orange lifted toward
  * white came out peach, which read as a different kind of thing rather than as
@@ -115,15 +115,15 @@ export function latticeShade(height: number, level: number): string {
   const c = boundaryColor(height).clone()
   const hsl = { h: 0, s: 0, l: 0 }
   c.getHSL(hsl)
-  // Hue and saturation held fixed: all three are the same colour at three
-  // weights, not three colours.
+  // Hue and saturation held fixed: all three are the same color at three
+  // weights, not three colors.
   c.setHSL(hsl.h, hsl.s, hsl.l * (LIGHTNESS[level] ?? 1))
   return `#${c.getHexString()}`
 }
 export const DIM = '#3a5566'
 
 /**
- * Terrain K colour ramp. K is Binomial(16, 0.5), so it clusters hard around 8;
+ * Terrain K color ramp. K is Binomial(16, 0.5), so it clusters hard around 8;
  * the ramp is tuned to spread the common 5..11 band rather than the full range.
  */
 const TERRAIN_STOPS: Array<[number, string]> = [
@@ -140,7 +140,7 @@ const TERRAIN_STOPS: Array<[number, string]> = [
 const cache = new Map<number, Color>()
 
 /**
- * Colour for a terrain K value in [0, 16].
+ * Color for a terrain K value in [0, 16].
  */
 export function terrainColor(k: number): Color {
   const hit = cache.get(k)
@@ -163,7 +163,7 @@ export function terrainColor(k: number): Color {
 }
 
 /**
- * Colour for an LCA boundary line.
+ * Color for an LCA boundary line.
  *
  * Uses a three-stop ramp from extremely dark blue (cheap crossings) through
  * purple (moderate cost) to light purple (expensive crossings). This gives

--- a/src/lib/shards.test.ts
+++ b/src/lib/shards.test.ts
@@ -34,7 +34,7 @@ describe('payload', () => {
     expect(fromPayload({ ...p, faces: [[0, 1, 9]] }, 'x')).toBeNull()
   })
 
-  it('refuses mismatched colours, unknown modes, bad units and other types', () => {
+  it('refuses mismatched colors, unknown modes, bad units and other types', () => {
     const p = toPayload(tri)
     expect(fromPayload({ ...p, colors: p.colors.slice(1) }, 'x')).toBeNull()
     expect(fromPayload({ ...p, mode: 'voxels' }, 'x')).toBeNull()
@@ -43,7 +43,7 @@ describe('payload', () => {
     expect(fromPayload('nope', 'x')).toBeNull()
   })
 
-  it('clamps colours into 0..1', () => {
+  it('clamps colors into 0..1', () => {
     const p = toPayload(tri)
     const back = fromPayload({ ...p, colors: [[2, -1, 0.5], [0, 0, 0], [0, 0, 0]] }, 'x')
     expect(back!.vertices[0].c).toEqual([1, 0, 0.5])

--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -57,8 +57,18 @@ export const GRID_HALF = 8
 export const MAX_VERTICES = 512
 export const MAX_FACES = 1024
 
+/**
+ * A new shard draws LINES: the first tap glows and the second draws a line,
+ * so the very first thing you do is visible. Faces switch it to SOLID when
+ * the first stamp with faces lands (see the workshop store).
+ */
 export function newShard(name = 'Untitled shard'): ShardModel {
-  return { id: uuid(), name, unit: 0, mode: 'solid', vertices: [], faces: [], updatedAt: Date.now() }
+  return { id: uuid(), name, unit: 0, mode: 'lines', vertices: [], faces: [], updatedAt: Date.now() }
+}
+
+/** A grid point as a map key, so "the same point" is one string compare. */
+export function pointKey(p: [number, number, number]): string {
+  return `${p[0]},${p[1]},${p[2]}`
 }
 
 export function uuid(): string {

--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -1,9 +1,9 @@
 /**
  * shards.ts — the shape of a shard, and nothing about where it goes.
  *
- * A shard is a small 3D object: vertices with colours, optional triangles,
+ * A shard is a small 3D object: vertices with colors, optional triangles,
  * and a render mode. The mesh is only one way to draw it. Vertices alone can
- * be lights, and a polyline through them blends their colours along the line
+ * be lights, and a polyline through them blends their colors along the line
  * the way a mesh blends across a face, so the same vertex list carries all
  * three and the mode is a property of the shard, not of the viewer.
  *
@@ -161,7 +161,7 @@ export function centroid(s: ShardModel): [number, number, number] {
   return sum.map((x) => x / s.vertices.length) as [number, number, number]
 }
 
-/** Hex <-> 0..1 triple, for the colour input. */
+/** Hex <-> 0..1 triple, for the color input. */
 export function hexToRgb(hex: string): [number, number, number] {
   const n = parseInt(hex.replace('#', ''), 16)
   return [((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255]

--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { GRID_HALF, MAX_VERTICES, newShard, validFace, validPoint, type ShardModel } from './shards'
-import { STAMPS, FACED, compile, preview, stamp, type Facing, type StampKind } from './stamps'
+import { STAMPS, FACED, compile, landing, preview, stamp, type Facing, type StampKind } from './stamps'
 
 const red: [number, number, number] = [1, 0, 0]
 const empty = (): ShardModel => ({ ...newShard('t'), mode: 'solid' })
@@ -101,7 +101,24 @@ describe('stamps', () => {
   })
 
   it('previews as a solid when it has faces and as lines when it does not', () => {
-    expect(preview('block', 1, 0, [0, 0, 0], red).mode).toBe('solid')
-    expect(preview('ring', 1, 0, [0, 0, 0], red).mode).toBe('lines')
+    expect(preview('block', 1, 0, red).mode).toBe('solid')
+    expect(preview('ring', 1, 0, red).mode).toBe('lines')
+  })
+})
+
+describe('ghost placement', () => {
+  const red: [number, number, number] = [1, 0, 0]
+  it('the preview moved to its landing is exactly the stamp, edge pushes included', () => {
+    for (const kind of STAMPS) {
+      for (const origin of [[0, 0, 0], [GRID_HALF, 0, GRID_HALF], [-GRID_HALF, 3, 2]] as Array<[number, number, number]>) {
+        const at = landing(kind, 4, 1, origin)
+        const ghost = preview(kind, 4, 1, red).vertices.map((v) => [v.p[0] + at[0], v.p[1] + at[1], v.p[2] + at[2]])
+        expect(ghost).toEqual(compile(kind, 4, 1, origin).points)
+      }
+    }
+  })
+  it('lands on the aim unless the grid edge pushes it back', () => {
+    expect(landing('block', 2, 0, [1, 0, 1])).toEqual([1, 0, 1])
+    expect(landing('block', 4, 0, [GRID_HALF, 0, GRID_HALF])[0]).toBeLessThan(GRID_HALF)
   })
 })

--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -1,0 +1,107 @@
+/**
+ * stamps.test.ts - every stamp is a valid shard at every size, stays inside
+ * the grid wherever it is tapped, turns with FACING, and two stamps that
+ * touch lose the wall between them rather than paying for it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { GRID_HALF, MAX_VERTICES, newShard, validFace, validPoint, type ShardModel } from './shards'
+import { STAMPS, FACED, compile, preview, stamp, type Facing, type StampKind } from './stamps'
+
+const red: [number, number, number] = [1, 0, 0]
+const empty = (): ShardModel => ({ ...newShard('t'), mode: 'solid' })
+
+describe('stamps', () => {
+  it('every kind at every size is integer, inside the grid, with faces that exist', () => {
+    for (const kind of STAMPS) for (let size = 1; size <= 4; size++) {
+      const s = compile(kind, size, 0, [0, 0, 0])
+      expect(s.points.length, `${kind} ${size}`).toBeGreaterThan(0)
+      for (const p of s.points) expect(validPoint(p), `${kind} ${size} ${p}`).toBe(true)
+      for (const f of s.faces) expect(validFace(f, s.points.length), `${kind} ${size} ${f}`).toBe(true)
+    }
+  })
+
+  it('has the expected budgets', () => {
+    const count = (k: StampKind, s = 1) => { const c = compile(k, s, 0, [0, 0, 0]); return [c.points.length, c.faces.length] }
+    expect(count('block')).toEqual([8, 12])
+    expect(count('column')).toEqual([8, 12])
+    expect(count('pyramid')).toEqual([5, 6])
+    expect(count('wedge')).toEqual([6, 8])
+    expect(count('ring')).toEqual([9, 0])
+    expect(count('arrow')).toEqual([8, 5])
+    expect(count('star')[1]).toBeGreaterThanOrEqual(6)
+  })
+
+  it('ring and flat shapes end where they start so LINES closes the loop', () => {
+    for (const kind of ['ring', 'star', 'arrow'] as StampKind[]) {
+      const { points } = compile(kind, 2, 0, [0, 0, 0])
+      expect(points[points.length - 1]).toEqual(points[0])
+    }
+  })
+
+  it('stands on the level and centres on the tap', () => {
+    const { points } = compile('block', 2, 0, [3, -2, 1])
+    expect(Math.min(...points.map((p) => p[1]))).toBe(-2)
+    expect(Math.max(...points.map((p) => p[1]))).toBe(0)
+    expect(Math.min(...points.map((p) => p[0]))).toBe(2)
+    expect(Math.max(...points.map((p) => p[0]))).toBe(4)
+  })
+
+  it('is pushed back inside the grid when tapped at the edge', () => {
+    for (const kind of STAMPS) {
+      const { points } = compile(kind, 4, 0, [GRID_HALF, GRID_HALF, GRID_HALF])
+      for (const p of points) expect(validPoint(p), `${kind} ${p}`).toBe(true)
+    }
+  })
+
+  it('turns the faced shapes a quarter turn about Y and leaves the rest alone', () => {
+    const tip = (f: Facing) => { const { points } = compile('arrow', 1, f, [0, 0, 0]); return points.reduce((a, b) => (Math.hypot(b[0], b[2]) > Math.hypot(a[0], a[2]) ? b : a)) }
+    expect(tip(0)).toEqual([3, 0, 0])
+    expect(tip(1)).toEqual([0, 0, 3])
+    expect(tip(2)).toEqual([-3, 0, 0])
+    expect(tip(3)).toEqual([0, 0, -3])
+    for (const kind of STAMPS) if (!FACED[kind]) expect(compile(kind, 2, 3, [0, 0, 0])).toEqual(compile(kind, 2, 0, [0, 0, 0]))
+  })
+
+  it('appends its own vertices in the given colour and keeps the shard valid', () => {
+    const one = stamp(empty(), 'pyramid', 1, 0, [0, 0, 0], red)!
+    expect(one.shard.vertices).toHaveLength(5)
+    expect(one.shard.vertices.every((v) => v.c.join() === '1,0,0')).toBe(true)
+    expect(one.shard.faces).toHaveLength(6)
+    expect(one.culled).toBe(0)
+    for (const f of one.shard.faces) expect(validFace(f, 5)).toBe(true)
+  })
+
+  it('drops the wall between two blocks that touch, on both sides', () => {
+    const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
+    const b = stamp(a.shard, 'block', 1, 0, [1, 0, 0], [0, 0, 1])!
+    expect(b.shard.vertices).toHaveLength(16)
+    expect(b.culled).toBe(4)
+    expect(b.shard.faces).toHaveLength(24 - 4)
+    // Stacked, the same: the top of one and the bottom of the other.
+    const c = stamp(a.shard, 'block', 1, 0, [0, 1, 0], red)!
+    expect(c.culled).toBe(4)
+    // Diagonal neighbours share an edge, not a wall: nothing to drop.
+    const d = stamp(a.shard, 'block', 1, 0, [1, 1, 0], red)!
+    expect(d.culled).toBe(0)
+  })
+
+  it('never merges vertices, so a seam between colours stays crisp', () => {
+    const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
+    const b = stamp(a.shard, 'block', 1, 0, [1, 0, 0], [0, 0, 1])!
+    const at = b.shard.vertices.filter((v) => v.p.join() === '1,0,0')
+    expect(at).toHaveLength(2)
+    expect(at.map((v) => v.c.join()).sort()).toEqual(['0,0,1', '1,0,0'])
+  })
+
+  it('refuses a stamp that would not fit the budget', () => {
+    const full: ShardModel = { ...empty(), vertices: Array.from({ length: MAX_VERTICES - 4 }, (_, i) => ({ p: [i % 17 - 8, 0, 0] as [number, number, number], c: red })) }
+    expect(stamp(full, 'pyramid', 1, 0, [0, 0, 0], red)).toBeNull()
+    expect(stamp(full, 'block', 1, 0, [0, 0, 0], red)).toBeNull()
+  })
+
+  it('previews as a solid when it has faces and as lines when it does not', () => {
+    expect(preview('block', 1, 0, [0, 0, 0], red).mode).toBe('solid')
+    expect(preview('ring', 1, 0, [0, 0, 0], red).mode).toBe('lines')
+  })
+})

--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -63,7 +63,7 @@ describe('stamps', () => {
     for (const kind of STAMPS) if (!FACED[kind]) expect(compile(kind, 2, 3, [0, 0, 0])).toEqual(compile(kind, 2, 0, [0, 0, 0]))
   })
 
-  it('appends its own vertices in the given colour and keeps the shard valid', () => {
+  it('appends its own vertices in the given color and keeps the shard valid', () => {
     const one = stamp(empty(), 'pyramid', 1, 0, [0, 0, 0], red)!
     expect(one.shard.vertices).toHaveLength(5)
     expect(one.shard.vertices.every((v) => v.c.join() === '1,0,0')).toBe(true)
@@ -86,7 +86,7 @@ describe('stamps', () => {
     expect(d.culled).toBe(0)
   })
 
-  it('never merges vertices, so a seam between colours stays crisp', () => {
+  it('never merges vertices, so a seam between colors stays crisp', () => {
     const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
     const b = stamp(a.shard, 'block', 1, 0, [1, 0, 0], [0, 0, 1])!
     const at = b.shard.vertices.filter((v) => v.p.join() === '1,0,0')

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -142,16 +142,18 @@ function turn(p: P3, k: number): P3 {
   return [x, y, z]
 }
 
-/**
- * The shape as it lands: turned to FACING, moved to the tap, and pushed back
- * inside the grid if any of it would poke out. Nothing here is wider than
- * the grid, so the push always succeeds.
- */
-export function compile(kind: StampKind, size: number, facing: Facing, origin: P3): Shape {
+/** The shape turned to FACING and sitting on the origin, before any push into the grid. */
+function turned(kind: StampKind, size: number, facing: Facing): Shape {
   const s = Math.max(MIN_SIZE, Math.min(MAX_SIZE, Math.round(size)))
   const base = local(kind, s)
   const k = FACED[kind] ? facing : 0
-  const points = base.points.map((p) => { const t = turn(p, k); return [t[0] + origin[0], t[1] + origin[1], t[2] + origin[2]] as P3 })
+  return { points: base.points.map((p) => turn(p, k)), faces: base.faces }
+}
+
+const moved = (points: P3[], by: P3): P3[] => points.map((p) => [p[0] + by[0], p[1] + by[1], p[2] + by[2]] as P3)
+
+/** The push that brings a shape back inside the grid: zero on an axis it already fits. */
+function fit(points: P3[]): P3 {
   const shift: P3 = [0, 0, 0]
   for (let a = 0; a < 3; a++) {
     let lo = Infinity, hi = -Infinity
@@ -159,7 +161,24 @@ export function compile(kind: StampKind, size: number, facing: Facing, origin: P
     if (lo < -GRID_HALF) shift[a] = -GRID_HALF - lo
     else if (hi > GRID_HALF) shift[a] = GRID_HALF - hi
   }
-  return { points: points.map((p) => [p[0] + shift[0], p[1] + shift[1], p[2] + shift[2]] as P3), faces: base.faces }
+  return shift
+}
+
+/**
+ * The shape as it lands: turned to FACING, moved to the tap, and pushed back
+ * inside the grid if any of it would poke out. Nothing here is wider than
+ * the grid, so the push always succeeds.
+ */
+export function compile(kind: StampKind, size: number, facing: Facing, origin: P3): Shape {
+  const t = turned(kind, size, facing)
+  const points = moved(t.points, origin)
+  return { points: moved(points, fit(points)), faces: t.faces }
+}
+
+/** Where a stamp aimed at `origin` lands: `origin` itself unless the grid's edge pushed it back. */
+export function landing(kind: StampKind, size: number, facing: Facing, origin: P3): P3 {
+  const shift = fit(moved(turned(kind, size, facing).points, origin))
+  return [origin[0] + shift[0], origin[1] + shift[1], origin[2] + shift[2]]
 }
 
 /** The corners of a triangle as one order-free key. */
@@ -204,9 +223,14 @@ export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: 
   return { shard: { ...shard, vertices, faces }, culled: drop.size * 2 }
 }
 
-/** What the stamp would be on its own: what the aim ghost draws. */
-export function preview(kind: StampKind, size: number, facing: Facing, origin: P3, color: [number, number, number]): ShardModel {
-  const shape = compile(kind, size, facing, origin)
+/**
+ * The stamp on its own at the origin: what the aim ghost draws, placed at
+ * `landing`. It depends on the shape and colour only, never on the aim, so the
+ * ghost's geometry is built once per shape and merely moved as the pointer
+ * crosses cells; building it afresh per cell was the ghost's whole cost.
+ */
+export function preview(kind: StampKind, size: number, facing: Facing, color: [number, number, number]): ShardModel {
+  const shape = turned(kind, size, facing)
   return {
     id: 'ghost',
     name: kind,

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -9,7 +9,7 @@
  * asymmetric ones (wedge, star, arrow) a quarter turn at a time about Y.
  *
  * A stamp brings its own vertices even where the shard already has one on
- * that point. That is deliberate: colours live on vertices, so sharing a
+ * that point. That is deliberate: colors live on vertices, so sharing a
  * corner between a red block and a blue block would blend the seam, and a
  * seam is where you want the edge crisp. What sharing would have saved is
  * budget, so the two triangles that face each other where two stamps touch
@@ -225,7 +225,7 @@ export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: 
 
 /**
  * The stamp on its own at the origin: what the aim ghost draws, placed at
- * `landing`. It depends on the shape and colour only, never on the aim, so the
+ * `landing`. It depends on the shape and color only, never on the aim, so the
  * ghost's geometry is built once per shape and merely moved as the pointer
  * crosses cells; building it afresh per cell was the ghost's whole cost.
  */

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -1,0 +1,219 @@
+/**
+ * stamps.ts — shapes you place with one tap.
+ *
+ * A stamp is a small parametric shape on the integer grid: a block, a wedge,
+ * a pyramid, a column, a ring, a star, an arrow. Each compiles to plain
+ * vertices and triangles in the shard's own wire form, so a stamped shard is
+ * exactly as portable as a hand-built one and the world needs to know nothing
+ * about stamps. SIZE scales a shape in whole units (1 to 4); FACING turns the
+ * asymmetric ones (wedge, star, arrow) a quarter turn at a time about Y.
+ *
+ * A stamp brings its own vertices even where the shard already has one on
+ * that point. That is deliberate: colours live on vertices, so sharing a
+ * corner between a red block and a blue block would blend the seam, and a
+ * seam is where you want the edge crisp. What sharing would have saved is
+ * budget, so the two triangles that face each other where two stamps touch
+ * are dropped instead: a hidden wall costs nothing. For that to work every
+ * box splits each face on the same diagonal, so two boxes meeting face to
+ * face produce triangles with identical corners that the cull can match.
+ *
+ * Pure: a stamp is a function of (kind, size, facing) and where you put it.
+ */
+
+import { GRID_HALF, MAX_FACES, MAX_VERTICES, pointKey, type ShardModel, type ShardVertex } from './shards'
+import { triangulate, type P3 } from './triangulate'
+
+export type StampKind = 'block' | 'wedge' | 'pyramid' | 'column' | 'ring' | 'star' | 'arrow'
+export const STAMPS: StampKind[] = ['block', 'wedge', 'pyramid', 'column', 'ring', 'star', 'arrow']
+
+/** Quarter turns about Y: 0 faces +X, 1 faces +Z, 2 faces −X, 3 faces −Z. */
+export type Facing = 0 | 1 | 2 | 3
+export const FACING_LABEL: Record<Facing, string> = { 0: '+X', 1: '+Z', 2: '−X', 3: '−Z' }
+
+/** The stamps a quarter turn changes. The rest look the same from every side. */
+export const FACED: Record<StampKind, boolean> = { block: false, wedge: true, pyramid: false, column: false, ring: false, star: true, arrow: true }
+
+export const MIN_SIZE = 1
+export const MAX_SIZE = 4
+
+/** One-line descriptions for the shape picker. */
+export const STAMP_HELP: Record<StampKind, string> = {
+  block: 'A cube, SIZE units on a side, standing on the level.',
+  wedge: 'A ramp, SIZE units wide and tall, sloping down toward FACING.',
+  pyramid: 'A pyramid twice SIZE wide and tall, its point straight up.',
+  column: 'A post one unit wide and twice SIZE tall.',
+  ring: 'A closed loop of points, SIZE units out from the tap. Best in POINTS or LINES.',
+  star: 'A five point star, twice SIZE across, flat on the level.',
+  arrow: 'A flat arrow pointing toward FACING.',
+}
+
+export interface Shape {
+  points: P3[]
+  faces: Array<[number, number, number]>
+}
+
+type Tri = [number, number, number]
+
+/** A quad's two triangles, always split from its first corner to its third. */
+function quad(a: number, b: number, c: number, d: number): Tri[] {
+  return [[a, b, c], [a, c, d]]
+}
+
+/**
+ * A box from (x0,y0,z0) to (x1,y1,z1). Corner order per side is fixed so a
+ * neighbouring box's facing side yields the same two triangles, corner for
+ * corner, which is what lets the cull find them.
+ */
+function box(x0: number, x1: number, y0: number, y1: number, z0: number, z1: number): Shape {
+  const points: P3[] = [
+    [x0, y0, z0], [x1, y0, z0], [x1, y0, z1], [x0, y0, z1],
+    [x0, y1, z0], [x1, y1, z0], [x1, y1, z1], [x0, y1, z1],
+  ]
+  const faces = [
+    ...quad(0, 1, 2, 3), // bottom
+    ...quad(4, 5, 6, 7), // top
+    ...quad(0, 1, 5, 4), // z0 side
+    ...quad(3, 2, 6, 7), // z1 side
+    ...quad(0, 3, 7, 4), // x0 side
+    ...quad(1, 2, 6, 5), // x1 side
+  ]
+  return { points, faces }
+}
+
+/** Where a shape of side s sits so the tap is at or near its middle: [−⌊s/2⌋, s − ⌊s/2⌋]. */
+function span(s: number): [number, number] {
+  const lo = -Math.floor(s / 2)
+  return [lo, lo + s]
+}
+
+/** Points on a circle of radius r at n even steps, snapped to the grid, runs of repeats collapsed. */
+function circle(r: number, n: number): P3[] {
+  const out: P3[] = []
+  for (let i = 0; i < n; i++) {
+    const a = (i / n) * Math.PI * 2
+    const p: P3 = [Math.round(r * Math.cos(a)), 0, Math.round(r * Math.sin(a))]
+    if (out.length && pointKey(out[out.length - 1]) === pointKey(p)) continue
+    out.push(p)
+  }
+  if (out.length > 1 && pointKey(out[0]) === pointKey(out[out.length - 1])) out.pop()
+  return out
+}
+
+/** A flat polygon on the level: its triangles, then the first point again so LINES closes the loop. */
+function flat(points: P3[]): Shape {
+  const faces = triangulate(points) ?? []
+  return { points: [...points, [...points[0]] as P3], faces }
+}
+
+/** The shape in its own frame: tap at the origin, level at y = 0, facing +X. */
+function local(kind: StampKind, s: number): Shape {
+  switch (kind) {
+    case 'block': { const [x0, x1] = span(s); const [z0, z1] = span(s); return box(x0, x1, 0, s, z0, z1) }
+    case 'column': return box(0, 1, 0, 2 * s, 0, 1)
+    case 'pyramid': return {
+      points: [[-s, 0, -s], [s, 0, -s], [s, 0, s], [-s, 0, s], [0, 2 * s, 0]],
+      faces: [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4], ...quad(0, 1, 2, 3)],
+    }
+    case 'wedge': {
+      const [x0, x1] = span(s); const [z0, z1] = span(s)
+      return {
+        points: [[x0, 0, z0], [x1, 0, z0], [x1, 0, z1], [x0, 0, z1], [x0, s, z0], [x0, s, z1]],
+        faces: [...quad(0, 1, 2, 3), ...quad(0, 3, 5, 4), ...quad(1, 2, 5, 4), [0, 1, 4], [3, 2, 5]],
+      }
+    }
+    case 'ring': { const pts = circle(s, 8 * s); return { points: [...pts, [...pts[0]] as P3], faces: [] } }
+    case 'star': {
+      const pts: P3[] = []
+      for (let i = 0; i < 10; i++) {
+        const r = i % 2 === 0 ? 2 * s : s, a = (i / 10) * Math.PI * 2
+        const p: P3 = [Math.round(r * Math.cos(a)), 0, Math.round(r * Math.sin(a))]
+        if (!pts.length || pointKey(pts[pts.length - 1]) !== pointKey(p)) pts.push(p)
+      }
+      return flat(pts)
+    }
+    case 'arrow': return flat([[-s, 0, -s], [s, 0, -s], [s, 0, -2 * s], [3 * s, 0, 0], [s, 0, 2 * s], [s, 0, s], [-s, 0, s]])
+  }
+}
+
+/** A quarter turn about Y takes +X to +Z. */
+function turn(p: P3, k: number): P3 {
+  let [x, y, z] = p
+  for (let i = 0; i < k; i++) [x, z] = [-z, x]
+  return [x, y, z]
+}
+
+/**
+ * The shape as it lands: turned to FACING, moved to the tap, and pushed back
+ * inside the grid if any of it would poke out. Nothing here is wider than
+ * the grid, so the push always succeeds.
+ */
+export function compile(kind: StampKind, size: number, facing: Facing, origin: P3): Shape {
+  const s = Math.max(MIN_SIZE, Math.min(MAX_SIZE, Math.round(size)))
+  const base = local(kind, s)
+  const k = FACED[kind] ? facing : 0
+  const points = base.points.map((p) => { const t = turn(p, k); return [t[0] + origin[0], t[1] + origin[1], t[2] + origin[2]] as P3 })
+  const shift: P3 = [0, 0, 0]
+  for (let a = 0; a < 3; a++) {
+    let lo = Infinity, hi = -Infinity
+    for (const p of points) { lo = Math.min(lo, p[a]); hi = Math.max(hi, p[a]) }
+    if (lo < -GRID_HALF) shift[a] = -GRID_HALF - lo
+    else if (hi > GRID_HALF) shift[a] = GRID_HALF - hi
+  }
+  return { points: points.map((p) => [p[0] + shift[0], p[1] + shift[1], p[2] + shift[2]] as P3), faces: base.faces }
+}
+
+/** The corners of a triangle as one order-free key. */
+function triKey(a: P3, b: P3, c: P3): string {
+  return [pointKey(a), pointKey(b), pointKey(c)].sort().join('|')
+}
+
+export interface Stamped {
+  shard: ShardModel
+  /** Triangles dropped because they faced an existing one across a shared wall (both sides counted). */
+  culled: number
+}
+
+/**
+ * The shard with the stamp added, or null when it would not fit the budget.
+ * The stamp's own vertices are appended (never merged, see the header), its
+ * triangles are re-indexed, and any triangle that exactly matches an existing
+ * one corner for corner is dropped along with the one it matched.
+ */
+export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: Facing, origin: P3, color: [number, number, number]): Stamped | null {
+  const shape = compile(kind, size, facing, origin)
+  const base = shard.vertices.length
+  const vertices: ShardVertex[] = [
+    ...shard.vertices,
+    ...shape.points.map((p) => ({ p: [...p] as P3, c: [...color] as [number, number, number] })),
+  ]
+  const existing = new Map<string, number[]>()
+  shard.faces.forEach((f, i) => {
+    const k = triKey(shard.vertices[f[0]].p, shard.vertices[f[1]].p, shard.vertices[f[2]].p)
+    existing.set(k, [...(existing.get(k) ?? []), i])
+  })
+  const drop = new Set<number>()
+  const added: Tri[] = []
+  for (const f of shape.faces) {
+    const k = triKey(shape.points[f[0]], shape.points[f[1]], shape.points[f[2]])
+    const hits = existing.get(k)
+    if (hits && hits.length) { drop.add(hits.pop() as number); continue }
+    added.push([f[0] + base, f[1] + base, f[2] + base])
+  }
+  const faces = [...shard.faces.filter((_, i) => !drop.has(i)), ...added]
+  if (vertices.length > MAX_VERTICES || faces.length > MAX_FACES) return null
+  return { shard: { ...shard, vertices, faces }, culled: drop.size * 2 }
+}
+
+/** What the stamp would be on its own: what the aim ghost draws. */
+export function preview(kind: StampKind, size: number, facing: Facing, origin: P3, color: [number, number, number]): ShardModel {
+  const shape = compile(kind, size, facing, origin)
+  return {
+    id: 'ghost',
+    name: kind,
+    unit: 0,
+    mode: shape.faces.length ? 'solid' : 'lines',
+    vertices: shape.points.map((p) => ({ p, c: [...color] as [number, number, number] })),
+    faces: shape.faces,
+    updatedAt: 0,
+  }
+}

--- a/src/lib/targets.ts
+++ b/src/lib/targets.ts
@@ -47,7 +47,7 @@ export interface TargetScreen {
 export const targetScreens: Record<string, TargetScreen> = {}
 
 /**
- * A colour for a pubkey, from its own bits, so a target keeps its colour
+ * A color for a pubkey, from its own bits, so a target keeps its color
  * across sessions and devices and two targets rarely share one. Hue only;
  * saturation and lightness are fixed so every one of them reads against the
  * dark field and none collides with Earth's blue or the avatar's red by being

--- a/src/lib/triangulate.test.ts
+++ b/src/lib/triangulate.test.ts
@@ -1,0 +1,74 @@
+/**
+ * triangulate.test.ts - loops become triangles, notches and all; non-polygons
+ * are refused rather than drawn wrong.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { triangulate, type P3 } from './triangulate'
+
+/** Twice the area of a 3D triangle, via the cross product. */
+function area2(a: P3, b: P3, c: P3): number {
+  const u = [b[0] - a[0], b[1] - a[1], b[2] - a[2]], v = [c[0] - a[0], c[1] - a[1], c[2] - a[2]]
+  const x = u[1] * v[2] - u[2] * v[1], y = u[2] * v[0] - u[0] * v[2], z = u[0] * v[1] - u[1] * v[0]
+  return Math.sqrt(x * x + y * y + z * z)
+}
+
+function totalArea(points: P3[], tris: Array<[number, number, number]>): number {
+  return tris.reduce((s, [a, b, c]) => s + area2(points[a], points[b], points[c]), 0) / 2
+}
+
+describe('triangulate', () => {
+  it('a triangle is itself', () => {
+    expect(triangulate([[0, 0, 0], [1, 0, 0], [0, 0, 1]])).toEqual([[0, 1, 2]])
+  })
+
+  it('a square is two triangles covering its area', () => {
+    const sq: P3[] = [[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]]
+    const t = triangulate(sq)!
+    expect(t).toHaveLength(2)
+    expect(totalArea(sq, t)).toBe(4)
+  })
+
+  it('an L (concave) gets n-2 triangles with the right area', () => {
+    const L: P3[] = [[0, 0, 0], [3, 0, 0], [3, 0, 1], [1, 0, 1], [1, 0, 3], [0, 0, 3]]
+    const t = triangulate(L)!
+    expect(t).toHaveLength(4)
+    expect(totalArea(L, t)).toBe(5)
+  })
+
+  it('winding direction does not matter', () => {
+    const cw: P3[] = [[0, 0, 0], [0, 0, 2], [2, 0, 2], [2, 0, 0]]
+    const t = triangulate(cw)!
+    expect(t).toHaveLength(2)
+    expect(totalArea(cw, t)).toBe(4)
+  })
+
+  it('works in a vertical plane', () => {
+    const wall: P3[] = [[0, 0, 0], [0, 2, 0], [0, 2, 3], [0, 0, 3]]
+    const t = triangulate(wall)!
+    expect(totalArea(wall, t)).toBe(6)
+  })
+
+  it('drops a corner that lies flat on an edge instead of making a sliver', () => {
+    const sq: P3[] = [[0, 0, 0], [1, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]]
+    const t = triangulate(sq)!
+    expect(totalArea(sq, t)).toBe(4)
+    for (const [a, b, c] of t) expect(area2(sq[a], sq[b], sq[c])).toBeGreaterThan(0)
+  })
+
+  it('refuses collinear points and too few points', () => {
+    expect(triangulate([[0, 0, 0], [1, 0, 0], [2, 0, 0]])).toBeNull()
+    expect(triangulate([[0, 0, 0], [1, 0, 0]])).toBeNull()
+  })
+
+  it('a five point star (concave, ten corners) fills completely', () => {
+    const star: P3[] = []
+    for (let i = 0; i < 10; i++) {
+      const r = i % 2 === 0 ? 4 : 2, a = (i / 10) * Math.PI * 2
+      star.push([Math.round(r * Math.cos(a)), 0, Math.round(r * Math.sin(a))])
+    }
+    const t = triangulate(star)!
+    expect(t.length).toBeGreaterThanOrEqual(6)
+    expect(totalArea(star, t)).toBeGreaterThan(20)
+  })
+})

--- a/src/lib/triangulate.ts
+++ b/src/lib/triangulate.ts
@@ -1,0 +1,85 @@
+/**
+ * triangulate.ts — a loop of corners into triangles.
+ *
+ * FILL takes the corners of a face in order, any number of them, and the wire
+ * form wants triangles. A fan from the first corner is right for a convex
+ * loop and wrong for anything with a notch (a star, an L, an arrow), so this
+ * is ear clipping: project the loop onto the plane it mostly lies in, walk it
+ * removing one convex corner (an "ear") at a time that no other corner sits
+ * inside, and every removed ear is a triangle. O(n^2) over loops of at most a
+ * few dozen corners, which is nothing.
+ *
+ * Returns loop-local indices; the caller maps them to shard indices. Returns
+ * null for a loop that is not a polygon: fewer than three corners, all
+ * collinear, or self-crossing so that no ear can be found. A corner that lies
+ * flat on the line between its neighbours (a vertex mid-edge, common on an
+ * integer grid) is dropped without a triangle rather than making a sliver.
+ *
+ * Pure.
+ */
+
+export type P3 = [number, number, number]
+type P2 = [number, number]
+
+/** Newell's method: the normal of a (possibly non-planar) loop, unnormalised. */
+function newell(points: P3[]): P3 {
+  const n: P3 = [0, 0, 0]
+  for (let i = 0; i < points.length; i++) {
+    const a = points[i], b = points[(i + 1) % points.length]
+    n[0] += (a[1] - b[1]) * (a[2] + b[2])
+    n[1] += (a[2] - b[2]) * (a[0] + b[0])
+    n[2] += (a[0] - b[0]) * (a[1] + b[1])
+  }
+  return n
+}
+
+/** Twice the signed area of triangle abc in 2D. */
+function cross(a: P2, b: P2, c: P2): number {
+  return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+}
+
+/** p inside or on the edge of triangle abc, given the loop's winding sign. */
+function inTriangle(a: P2, b: P2, c: P2, p: P2, sign: number): boolean {
+  return cross(a, b, p) * sign >= 0 && cross(b, c, p) * sign >= 0 && cross(c, a, p) * sign >= 0
+}
+
+export function triangulate(points: P3[]): Array<[number, number, number]> | null {
+  const n = points.length
+  if (n < 3) return null
+  const normal = newell(points)
+  const ax = Math.abs(normal[0]), ay = Math.abs(normal[1]), az = Math.abs(normal[2])
+  if (ax === 0 && ay === 0 && az === 0) return null
+  // Drop the axis the loop faces along; what is left is its own plane, near enough.
+  const drop = ax >= ay && ax >= az ? 0 : ay >= az ? 1 : 2
+  const pts: P2[] = points.map((p) => (drop === 0 ? [p[1], p[2]] : drop === 1 ? [p[2], p[0]] : [p[0], p[1]]))
+
+  let area = 0
+  for (let i = 0; i < n; i++) { const a = pts[i], b = pts[(i + 1) % n]; area += a[0] * b[1] - b[0] * a[1] }
+  if (area === 0) return null
+  const sign = area > 0 ? 1 : -1
+
+  const idx = Array.from({ length: n }, (_, i) => i)
+  const tris: Array<[number, number, number]> = []
+  while (idx.length > 3) {
+    let clipped = false
+    for (let i = 0; i < idx.length; i++) {
+      const ip = idx[(i - 1 + idx.length) % idx.length], ic = idx[i], inx = idx[(i + 1) % idx.length]
+      const c = cross(pts[ip], pts[ic], pts[inx]) * sign
+      if (c < 0) continue
+      if (c === 0) { idx.splice(i, 1); clipped = true; break }
+      let blocked = false
+      for (const j of idx) {
+        if (j === ip || j === ic || j === inx) continue
+        if (inTriangle(pts[ip], pts[ic], pts[inx], pts[j], sign)) { blocked = true; break }
+      }
+      if (blocked) continue
+      tris.push([ip, ic, inx])
+      idx.splice(i, 1)
+      clipped = true
+      break
+    }
+    if (!clipped) return null
+  }
+  if (idx.length === 3 && cross(pts[idx[0]], pts[idx[1]], pts[idx[2]]) !== 0) tris.push([idx[0], idx[1], idx[2]])
+  return tris.length ? tris : null
+}

--- a/src/scene/CoveringBox.tsx
+++ b/src/scene/CoveringBox.tsx
@@ -102,7 +102,7 @@ export function CoveringBox({ axes }: Props): JSX.Element | null {
       // among wireframe boxes, and at some heights it lands exactly on a lattice
       // cell and competes with it outright. A volume and a grid are different
       // KINDS of mark, which the eye separates without being told; two
-      // wireframes only differ once you have decoded their colours.
+      // wireframes only differ once you have decoded their colors.
       fill: new BoxGeometry(c.size[0], c.size[1], c.size[2]),
       centre: c.centre,
       // Faint in proportion to how big it is. A covering box grows by powers of

--- a/src/scene/CrossingFlash.tsx
+++ b/src/scene/CrossingFlash.tsx
@@ -111,7 +111,7 @@ export function CrossingFlash({ axes }: Props): JSX.Element | null {
     const k = 1 - t
     material.current.opacity = k * k
 
-    // Strikes white, then resolves into its cost colour over the first third.
+    // Strikes white, then resolves into its cost color over the first third.
     // The lattice and the covering box now hold fixed hues so they can be told
     // apart at a glance, which leaves the LCA ramp free to mean what it was
     // written to mean, here, where the number genuinely varies: a cheap crossing

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -31,7 +31,7 @@ import {
 import { useCalibration } from '../lib/calibration'
 import { nextActionFor } from '../store/useOffer'
 import { ACCENT, DANGER, SIDESTEP, WARN } from '../lib/palette'
-/** Paid legs: the cloud's warm gold, the colour the HUD uses for HOSAKA. */
+/** Paid legs: the cloud's warm gold, the color the HUD uses for HOSAKA. */
 const CLOUD = '#ffd27d'
 import { cellCentre, type Position, type ViewAxes } from '../lib/space'
 import {
@@ -248,7 +248,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   // while the cube waited a render out, and every long frame widened the gap.
   // Reading both from the same store in the same frame makes them simultaneous
   // by construction rather than by luck. Only the cube, the label and the live
-  // end of the tether move here; which legs exist and what colour they are stay
+  // end of the tether move here; which legs exist and what color they are stay
   // in React, because those change with the plan, not with the cursor.
   const outline = useRef<LineSegments>(null)
   const ghost = useRef<LineSegments>(null)

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -32,6 +32,7 @@ import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { cameraPose } from '../lib/cameraPose'
 import { useTerrainVolume } from '../hooks/useTerrainVolume'
 import { useHyperspace } from '../store/useHyperspace'
+import { useWorkshop } from '../store/useWorkshop'
 import { useViewWindow } from '../hooks/useViewWindow'
 import { useTargets } from '../hooks/useTargets'
 import { Avatar } from './Avatar'
@@ -495,7 +496,27 @@ function MemoryLog(): null {
   return null
 }
 
+/**
+ * R3F zeroes the clock whenever the frameloop changes. Several things here
+ * time themselves from clock.elapsedTime (fleet cube fades, the crossing
+ * flash, a glide), so a pause would leave them waiting for a time that had
+ * already passed. This keeps the last elapsed time seen and puts it back when
+ * drawing resumes: to everything in the scene the pause never happened.
+ */
+function ClockKeeper(): null {
+  const clock = useThree((s) => s.clock)
+  const frameloop = useThree((s) => s.frameloop)
+  const last = useRef(0)
+  useFrame(() => { last.current = clock.elapsedTime })
+  useEffect(() => { if (frameloop !== 'never' && last.current > 0) clock.elapsedTime = last.current }, [frameloop, clock])
+  return null
+}
+
 export function Scene(): JSX.Element {
+  // The workshop is an opaque, full-screen bench with its own canvas. Drawing
+  // the world under it is pure cost, and on a phone it was most of the frame:
+  // the bench measured 3 fps with the world running behind it.
+  const covered = useWorkshop((s) => s.open)
   return (
     <Canvas
       camera={{ fov: 55, position: [0, 0, START_DISTANCE], near: 0.05, far: 6000 }}
@@ -504,9 +525,10 @@ export function Scene(): JSX.Element {
       // clocking, so a visually quiet frame still ships on time.
       gl={{ antialias: true, powerPreference: 'high-performance' }}
       style={{ background: BG }}
-      frameloop="always"
+      frameloop={covered ? 'never' : 'always'}
     >
       <MemoryLog />
+      <ClockKeeper />
       {/* Fog to pure black: the only distance cue in an otherwise empty field. */}
       <fog attach="fog" args={[0x000000, GRID_RADIUS * 0.9, GRID_RADIUS * 4]} />
       <ambientLight intensity={0.8} />

--- a/src/scene/ShaderPointField.tsx
+++ b/src/scene/ShaderPointField.tsx
@@ -1,7 +1,7 @@
 /**
  * ShaderPointField.tsx — the terrain K field as GL_POINTS.
  *
- * One vertex per visible cell, sized and coloured by K in the shaders. The field
+ * One vertex per visible cell, sized and colored by K in the shaders. The field
  * is a cube around the view window, so this is at most VOLUME_SIZE^3 points, and
  * the CPU emits only cells it actually has.
  *
@@ -149,7 +149,7 @@ const vertexShader = /* glsl */ `
 `
 
 /**
- * Fragment shader: a solid disc, coloured by K. Stops match TERRAIN_STOPS.
+ * Fragment shader: a solid disc, colored by K. Stops match TERRAIN_STOPS.
  *
  * The disc is computed from gl_PointCoord rather than sampled from a gradient
  * texture. The texture faded linearly from the centre, so alpha was already

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -7,7 +7,7 @@
  *
  * With a `birth`, the shard is one this client has just found, and it does not
  * simply appear: for SHARD_DECODE_MS its vertices sit scattered through the
- * volume the model occupies in cyan static, then settle into place and colour
+ * volume the model occupies in cyan static, then settle into place and color
  * with an ease-out, jittering less as they land. Decryption made visible.
  */
 

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -11,8 +11,8 @@
  * with an ease-out, jittering less as they land. Decryption made visible.
  */
 
-import { useMemo, useRef } from 'react'
-import { useFrame } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import { useFrame, type ThreeEvent } from '@react-three/fiber'
 import {
   AdditiveBlending,
   BufferGeometry,
@@ -32,11 +32,13 @@ interface Props {
   ghost?: boolean
   /** performance.now() when this client opened the shard; runs the decode. */
   birth?: number
+  /** A tap on a SOLID face (its index is `e.faceIndex`); the workshop's FACE tool. */
+  onFaceClick?: (e: ThreeEvent<MouseEvent>) => void
 }
 
 const STATIC = [0, 0.9, 1] as const
 
-export function ShardMesh({ shard, scale = 1, ghost = false, birth }: Props): JSX.Element | null {
+export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick }: Props): JSX.Element | null {
   const { positions, colors, index } = useMemo(() => flatten(shard), [shard.vertices, shard.faces])
 
   // Live copies: the decode writes into these, the targets stay untouched.
@@ -64,6 +66,12 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth }: Props): JS
     l.frustumCulled = false
     return l
   }, [plain, ghost])
+
+  // A rebuild replaces these; nothing else lets the GPU buffers go. The line
+  // is a primitive, which R3F never disposes, so its material is ours too.
+  useEffect(() => () => { plain.dispose() }, [plain])
+  useEffect(() => () => { indexed.dispose() }, [indexed])
+  useEffect(() => () => { line.material.dispose() }, [line])
 
   // The scrambled start: each vertex thrown somewhere in the model's extent.
   const noise = useMemo(() => {
@@ -113,7 +121,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth }: Props): JS
   return (
     <group scale={scale}>
       {shard.mode === 'solid' && index.length > 0 && (
-        <mesh geometry={indexed} frustumCulled={false}>
+        <mesh geometry={indexed} frustumCulled={false} {...(onFaceClick ? { onClick: onFaceClick } : {})}>
           <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} />
         </mesh>
       )}

--- a/src/scene/SpawnMarker.tsx
+++ b/src/scene/SpawnMarker.tsx
@@ -103,7 +103,7 @@ function Model({ pubkey, axes }: Props): JSX.Element | null {
     return Math.hypot(...centre) > REACH ? null : { centre, scale }
   }, [pubkey, position, scaleExp, axes])
 
-  // The GLB's materials are black with an emissive colour, which is what lets
+  // The GLB's materials are black with an emissive color, which is what lets
   // them glow under bloom. The scene's tone mapping would dull that, so it is
   // switched off here the way every other lit line in the scene switches it off.
   const materials = useMemo(() => {

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -11,7 +11,7 @@
  *
  * Placement follows the house rule exactly: pointCentre against the anchor's
  * aligned origin, fixed-point bigint deltas, never a coordinate through
- * Number. One GL_POINTS draw for the whole cloud, coloured per vertex
+ * Number. One GL_POINTS draw for the whole cloud, colored per vertex
  * (landfall warm-blue EARTH, port purple SIDESTEP), and clicking a point
  * selects that stop as the ride's destination.
  *
@@ -101,7 +101,7 @@ let lastDrawn: { frameKey: string; set: Set<number> } | null = null
 const REBUILD_MIN_GROWTH = 50_000
 const REBUILD_GROWTH_FRACTION = 0.15
 
-/** Per-vertex colours: landfalls in Earth's blue, ports in ideaspace purple. */
+/** Per-vertex colors: landfalls in Earth's blue, ports in ideaspace purple. */
 // Landfalls read as embers of bitcoin orange on the globe; the old EARTH
 // blue made scrubbed stops look selected when nothing was.
 const LANDFALL_COLOR = new Color('#b06f14')
@@ -475,7 +475,7 @@ export function StopField({ axes }: Props): JSX.Element | null {
           Landfalls: world-sized and attenuated, so the crust shrinks with the
           planet instead of blooming into a solid orange disc when the globe
           is small on screen. toneMapped and fog both off for the BlackSun
-          reason: these colours are the encoding, and half the field sits
+          reason: these colors are the encoding, and half the field sits
           beyond where the scene fog has already gone to black.
         */}
         <pointsMaterial

--- a/src/scene/TargetAvatars.tsx
+++ b/src/scene/TargetAvatars.tsx
@@ -3,7 +3,7 @@
  *
  * The HUD marker says where a target is from any distance; this is the thing
  * itself when it is inside the drawn world: the same wireframe icosahedron you
- * are drawn as, in the target's own colour, with its name over it. The
+ * are drawn as, in the target's own color, with its name over it. The
  * position is the chain head the tracker keeps current, so a target that hops
  * while you watch moves here the same frame its marker does.
  */

--- a/src/scene/TransitAvatar.tsx
+++ b/src/scene/TransitAvatar.tsx
@@ -20,7 +20,7 @@ import { rideVisualHeight } from '../lib/hyperspace/ride'
 import { stopPlane, stopPosition, useRideRun } from '../hud/HyperspacePanel'
 import { WorldLabel } from './WorldLabel'
 
-/** The avatar's own red; the ghost is you, so it wears your colour. */
+/** The avatar's own red; the ghost is you, so it wears your color. */
 const YOU = '#ff2323'
 
 export function TransitAvatar({ axes }: { axes: ViewAxes }): JSX.Element | null {

--- a/src/scene/WorldMessages.tsx
+++ b/src/scene/WorldMessages.tsx
@@ -22,7 +22,7 @@ import { WorldLabel } from './WorldLabel'
 const TAP_SLOP = 8
 
 const REACH = GRID_RADIUS * 8
-/** The message colour: a warm note against the cool field. */
+/** The message color: a warm note against the cool field. */
 const NOTE = '#ffd27d'
 
 interface Props {

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -6,13 +6,13 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useWorkshop } from './useWorkshop'
+import { DEFAULT_PALETTE, useWorkshop } from './useWorkshop'
 
 const w = () => useWorkshop.getState()
 
 describe('workshop', () => {
   beforeEach(() => {
-    useWorkshop.setState({ shards: [], currentId: null, selected: null, facePick: [], level: 0, color: [0, 0.9, 1], past: [], future: [], aim: null, notice: null, tool: 'stamp', stampKind: 'block', stampSize: 1, stampFacing: 0 })
+    useWorkshop.setState({ shards: [], currentId: null, selected: null, selectedFace: null, facePick: [], palette: [...DEFAULT_PALETTE], level: 0, color: [0, 0.9, 1], past: [], future: [], aim: null, notice: null, tool: 'stamp', stampKind: 'block', stampSize: 1, stampFacing: 0 })
     w().create('t')
   })
 
@@ -199,5 +199,56 @@ describe('workshop', () => {
     const n = w().current()!.vertices.length
     expect(n).toBeLessThanOrEqual(512)
     expect(w().notice).toMatch(/No room/)
+  })
+})
+
+describe('faces and palette', () => {
+  beforeEach(() => {
+    useWorkshop.setState({ shards: [], currentId: null, selected: null, selectedFace: null, facePick: [], palette: [...DEFAULT_PALETTE], past: [], future: [], tool: 'stamp', stampKind: 'block', stampSize: 1, stampFacing: 0, color: [0, 0.9, 1] })
+    w().create('t')
+    w().placeStamp([0, 0, 0])
+    w().setTool('face')
+  })
+
+  it('selects a tapped face instead of the point, and DELETE FACE removes just that face, undoably', () => {
+    const before = w().current()!.faces.length
+    w().selectVertex(0)
+    w().selectFace(3)
+    expect(w().selected).toBeNull()
+    expect(w().selectedFace).toBe(3)
+    const gone = w().current()!.faces[3]
+    w().deleteSelectedFace()
+    expect(w().selectedFace).toBeNull()
+    expect(w().current()!.faces).toHaveLength(before - 1)
+    expect(w().current()!.faces).not.toContainEqual(gone)
+    w().undo()
+    expect(w().current()!.faces).toHaveLength(before)
+  })
+
+  it('drops the face when a point is selected, a corner picked, or the tool changes', () => {
+    w().selectFace(0); w().selectVertex(1); expect(w().selectedFace).toBeNull()
+    w().selectFace(0); w().pickForFace(2); expect(w().selectedFace).toBeNull()
+    w().clearFacePick()
+    w().selectFace(0); w().setTool('select'); expect(w().selectedFace).toBeNull()
+  })
+
+  it('remembers a picked colour at the front once, moves a repeat forward, ignores junk, forgets on request', () => {
+    w().rememberColor('#123456')
+    expect(w().palette[0]).toBe('#123456')
+    expect(w().palette).toHaveLength(DEFAULT_PALETTE.length + 1)
+    w().rememberColor('#FFFFFF')
+    expect(w().palette[0]).toBe('#ffffff')
+    expect(w().palette.filter((h) => h === '#ffffff')).toHaveLength(1)
+    w().rememberColor('nonsense')
+    expect(w().palette).toHaveLength(DEFAULT_PALETTE.length + 1)
+    w().forgetColor('#123456')
+    expect(w().palette).not.toContain('#123456')
+  })
+
+  it('keeps 24 colours, the oldest falling off the end', () => {
+    for (let i = 0; i < 30; i++) w().rememberColor('#' + i.toString(16).padStart(6, '0'))
+    expect(w().palette).toHaveLength(24)
+    expect(w().palette[0]).toBe('#00001d')
+    expect(w().palette).not.toContain('#ffffff')
   })
 })

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -66,7 +66,7 @@ describe('workshop', () => {
     expect(w().notice).toBeNull()
   })
 
-  it('moves, colours and deletes every vertex on the selected point together', () => {
+  it('moves, colors and deletes every vertex on the selected point together', () => {
     w().placeStamp([0, 0, 0])
     w().setColor([1, 0, 0])
     w().placeStamp([1, 0, 0])
@@ -149,7 +149,7 @@ describe('workshop', () => {
     expect(w().current()!.id).toBe(other)
   })
 
-  it('colours the selection or everything', () => {
+  it('colors the selection or everything', () => {
     w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0])
     w().selectVertex(1); w().colorSelected([1, 0, 0])
     expect(w().current()!.vertices[1].c).toEqual([1, 0, 0])
@@ -232,7 +232,7 @@ describe('faces and palette', () => {
     w().selectFace(0); w().setTool('select'); expect(w().selectedFace).toBeNull()
   })
 
-  it('remembers a picked colour at the front once, moves a repeat forward, ignores junk, forgets on request', () => {
+  it('remembers a picked color at the front once, moves a repeat forward, ignores junk, forgets on request', () => {
     w().rememberColor('#123456')
     expect(w().palette[0]).toBe('#123456')
     expect(w().palette).toHaveLength(DEFAULT_PALETTE.length + 1)
@@ -245,7 +245,7 @@ describe('faces and palette', () => {
     expect(w().palette).not.toContain('#123456')
   })
 
-  it('keeps 24 colours, the oldest falling off the end', () => {
+  it('keeps 24 colors, the oldest falling off the end', () => {
     for (let i = 0; i < 30; i++) w().rememberColor('#' + i.toString(16).padStart(6, '0'))
     expect(w().palette).toHaveLength(24)
     expect(w().palette[0]).toBe('#00001d')

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -1,6 +1,8 @@
 /**
- * useWorkshop.test.ts - edits keep the shard consistent: no two vertices on a
- * point, faces follow their vertices through deletions, duplicates are copies.
+ * useWorkshop.test.ts - edits keep the shard consistent: hand-added vertices
+ * never stack, stamped ones may and then move as one point, faces follow
+ * their vertices through deletions, every edit undoes, and a shard survives
+ * the clipboard.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -10,11 +12,16 @@ const w = () => useWorkshop.getState()
 
 describe('workshop', () => {
   beforeEach(() => {
-    useWorkshop.setState({ shards: [], currentId: null, selected: null, facePick: [], level: 0 })
+    useWorkshop.setState({ shards: [], currentId: null, selected: null, facePick: [], level: 0, color: [0, 0.9, 1], past: [], future: [], aim: null, notice: null, tool: 'stamp', stampKind: 'block', stampSize: 1, stampFacing: 0 })
     w().create('t')
   })
 
-  it('adds vertices at the level, never twice on one point, and selects them', () => {
+  it('starts a new shard in LINES with the stamp tool', () => {
+    expect(w().current()!.mode).toBe('lines')
+    expect(w().tool).toBe('stamp')
+  })
+
+  it('adds vertices at the level, never twice on one point by hand, and selects them', () => {
     w().setLevel(2)
     w().addVertex([1, 2, 3])
     w().addVertex([1, 2, 3])
@@ -25,32 +32,121 @@ describe('workshop', () => {
     expect(w().current()!.vertices).toHaveLength(1)
   })
 
-  it('nudges the selection and refuses to land on another vertex or leave the grid', () => {
+  it('nudges the selection, may land on another vertex, and never leaves the grid', () => {
     w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0])
     w().selectVertex(0)
-    w().moveSelected(0, 1)
-    expect(w().current()!.vertices[0].p).toEqual([0, 0, 0])
     w().moveSelected(1, 1)
     expect(w().current()!.vertices[0].p).toEqual([0, 1, 0])
+    w().moveSelected(1, -1); w().moveSelected(0, 1)
+    expect(w().current()!.vertices[0].p).toEqual([1, 0, 0])
     w().selectVertex(1)
     for (let i = 0; i < 20; i++) w().moveSelected(0, 1)
     expect(w().current()!.vertices[1].p[0]).toBe(8)
   })
 
-  it('builds a face from three picks, ignores duplicates, and reindexes on delete', () => {
-    w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0]); w().addVertex([0, 0, 1]); w().addVertex([2, 0, 2])
-    w().setTool('face')
-    w().pickForFace(1); w().pickForFace(2); w().pickForFace(3)
-    expect(w().current()!.faces).toEqual([[1, 2, 3]])
-    w().pickForFace(3); w().pickForFace(1); w().pickForFace(2)
-    expect(w().current()!.faces).toHaveLength(1)
-    w().pickForFace(0); w().pickForFace(1); w().pickForFace(2)
-    expect(w().current()!.faces).toHaveLength(2)
-    // Delete vertex 0: the face using it goes, the other shifts down.
-    w().setTool('select'); w().selectVertex(0); w().deleteSelected()
-    expect(w().current()!.vertices).toHaveLength(3)
-    expect(w().current()!.faces).toEqual([[0, 1, 2]])
+  it('stamps a shape, and the first faces switch LINES to SOLID once', () => {
+    w().placeStamp([0, 0, 0])
+    const s = w().current()!
+    expect(s.vertices).toHaveLength(8)
+    expect(s.faces).toHaveLength(12)
+    expect(s.mode).toBe('solid')
+    expect(w().notice).toMatch(/SOLID/)
+    // Back to LINES on purpose: the next stamp respects it.
+    w().setMode('lines')
+    w().placeStamp([3, 0, 0])
+    expect(w().current()!.mode).toBe('lines')
+    expect(w().current()!.vertices).toHaveLength(16)
+  })
+
+  it('a ring has no faces and leaves the mode alone', () => {
+    w().setStampKind('ring')
+    w().placeStamp([0, 0, 0])
+    expect(w().current()!.faces).toHaveLength(0)
+    expect(w().current()!.mode).toBe('lines')
+    expect(w().notice).toBeNull()
+  })
+
+  it('moves, colours and deletes every vertex on the selected point together', () => {
+    w().placeStamp([0, 0, 0])
+    w().setColor([1, 0, 0])
+    w().placeStamp([1, 0, 0])
+    const s = w().current()!
+    const shared = s.vertices.map((v, i) => (v.p.join() === '1,0,0' ? i : -1)).filter((i) => i >= 0)
+    expect(shared).toHaveLength(2)
+    w().selectVertex(shared[0])
+    // Off to a free point: landing on the blocks' top corners would join those too.
+    w().moveSelected(2, -1)
+    for (const i of shared) expect(w().current()!.vertices[i].p).toEqual([1, 0, -1])
+    w().colorSelected([0, 1, 0])
+    for (const i of shared) expect(w().current()!.vertices[i].c).toEqual([0, 1, 0])
+    const facesBefore = w().current()!.faces.length
+    w().deleteSelected()
+    const after = w().current()!
+    expect(after.vertices).toHaveLength(14)
+    expect(after.faces.length).toBeLessThan(facesBefore)
+    for (const f of after.faces) for (const i of f) expect(i).toBeLessThan(14)
     expect(w().selected).toBeNull()
+  })
+
+  it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
+    w().setTool('add')
+    w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])
+    w().setTool('face')
+    w().pickForFace(0); w().pickForFace(1); w().pickForFace(2); w().pickForFace(3)
+    expect(w().facePick).toEqual([0, 1, 2, 3])
+    w().pickForFace(0)
+    expect(w().current()!.faces).toHaveLength(2)
+    expect(w().current()!.mode).toBe('solid')
+    expect(w().facePick).toEqual([])
+    // The same loop again adds nothing.
+    w().pickForFace(0); w().pickForFace(1); w().pickForFace(2); w().pickForFace(3); w().fill()
+    expect(w().current()!.faces).toHaveLength(2)
+    // A second pick of a corner unpicks it; CANCEL drops the rest.
+    w().pickForFace(0); w().pickForFace(1); w().pickForFace(2); w().pickForFace(1)
+    expect(w().facePick).toEqual([0, 2])
+    w().clearFacePick()
+    expect(w().facePick).toEqual([])
+  })
+
+  it('refuses a fill that is not a polygon and keeps the picks', () => {
+    w().setTool('add')
+    w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0]); w().addVertex([2, 0, 0])
+    w().setTool('face')
+    w().pickForFace(0); w().pickForFace(1); w().pickForFace(2)
+    w().fill()
+    expect(w().current()!.faces).toHaveLength(0)
+    expect(w().facePick).toHaveLength(3)
+    expect(w().notice).toMatch(/corners/)
+  })
+
+  it('undoes and redoes every edit, and switching shards forgets the history', () => {
+    w().placeStamp([0, 0, 0])
+    w().colorAll([1, 0, 0])
+    w().setUnit(3)
+    expect(w().current()!.unit).toBe(3)
+    w().undo()
+    expect(w().current()!.unit).toBe(0)
+    expect(w().current()!.vertices[0].c).toEqual([1, 0, 0])
+    w().undo()
+    expect(w().current()!.vertices[0].c).toEqual([0, 0.9, 1])
+    w().undo()
+    expect(w().current()!.vertices).toHaveLength(0)
+    expect(w().current()!.mode).toBe('lines')
+    w().undo()
+    expect(w().current()!.vertices).toHaveLength(0)
+    w().redo(); w().redo(); w().redo()
+    expect(w().current()!.unit).toBe(3)
+    expect(w().current()!.vertices).toHaveLength(8)
+    w().redo()
+    expect(w().current()!.unit).toBe(3)
+    w().undo()
+    w().placeStamp([2, 0, 2])
+    w().redo()
+    expect(w().current()!.unit).toBe(0)
+    const other = w().create('u')
+    expect(w().past).toEqual([])
+    w().select(other); w().undo()
+    expect(w().current()!.id).toBe(other)
   })
 
   it('colours the selection or everything', () => {
@@ -73,5 +169,35 @@ describe('workshop', () => {
     w().remove(copy)
     expect(w().shards.map((s) => s.id)).toEqual([src])
     expect(w().currentId).toBe(src)
+  })
+
+  it('exports wire form and imports it as a new shard; garbage is refused', () => {
+    w().setStampKind('pyramid'); w().placeStamp([0, 0, 0]); w().setUnit(5)
+    const text = w().exportCurrent()!
+    const before = w().currentId
+    const id = w().importText(text)!
+    expect(id).not.toBe(before)
+    expect(w().currentId).toBe(id)
+    const s = w().current()!
+    expect(s.vertices).toHaveLength(5)
+    expect(s.faces).toHaveLength(6)
+    expect(s.unit).toBe(5)
+    expect(s.mode).toBe('solid')
+    expect(w().importText('not json')).toBeNull()
+    expect(w().importText('{"v":1,"type":"note"}')).toBeNull()
+    expect(w().shards).toHaveLength(2)
+    // A found shard copies in as a model, renamed if the name is taken.
+    const found = w().importShard(s)
+    expect(found).not.toBe(id)
+    expect(w().shards).toHaveLength(3)
+    expect(w().shards.find((x) => x.id === found)!.name).toBe(`${s.name} copy`)
+  })
+
+  it('stamps that cannot fit leave a notice and the shard alone', () => {
+    w().setStampSize(4)
+    for (let i = 0; i < 70; i++) w().placeStamp([(i % 5) * 3 - 6, 0, (Math.floor(i / 5) % 5) * 3 - 6])
+    const n = w().current()!.vertices.length
+    expect(n).toBeLessThanOrEqual(512)
+    expect(w().notice).toMatch(/No room/)
   })
 })

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -5,13 +5,13 @@
  * and a deployed shard stays here too, so it can be deployed again somewhere
  * else or edited into a new one. The editing model is small and exact: stamp
  * a shape, place a vertex, select a point and nudge it a unit along an axis,
- * colour it, tap corners into a face. It fits a thumb.
+ * color it, tap corners into a face. It fits a thumb.
  *
  * Two rules about points. A vertex you ADD lands on an empty point or selects
  * the one already there, so hand placing never stacks vertices by accident. A
  * stamp brings its own vertices even onto occupied points (stamps.ts says
  * why), so from then on "a point" can be several vertices, and SELECT, the
- * nudge pad, the colour and DELETE act on every vertex at the selected point
+ * nudge pad, the color and DELETE act on every vertex at the selected point
  * together. What you see is one dot, and it behaves like one dot.
  *
  * Every change to the current shard goes through `edit`, which is also where
@@ -65,11 +65,11 @@ export interface WorkshopState {
   facePick: number[]
   /** The face tapped in FACE mode, an index into the shard's faces, so DELETE can take it. */
   selectedFace: number | null
-  /** Swatches to hand: newest first, every colour the picker ever settled on, then the defaults. */
+  /** Swatches to hand: newest first, every color the picker ever settled on, then the defaults. */
   palette: string[]
   /** The Y the add and stamp tools place on: the grid plane moves up and down. */
   level: number
-  /** The colour new vertices get, and the colour input shows. */
+  /** The color new vertices get, and the color input shows. */
   color: [number, number, number]
   stampKind: StampKind
   stampSize: number
@@ -105,7 +105,7 @@ export interface WorkshopState {
   selectVertex: (index: number | null) => void
   selectFace: (index: number | null) => void
   deleteSelectedFace: () => void
-  /** Put a colour at the front of the palette (moving it there if it is already in). */
+  /** Put a color at the front of the palette (moving it there if it is already in). */
   rememberColor: (hex: string) => void
   forgetColor: (hex: string) => void
   moveSelected: (axis: 0 | 1 | 2, delta: number) => void

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -3,16 +3,32 @@
  *
  * Everything here is local: shards persist in localStorage until deployed,
  * and a deployed shard stays here too, so it can be deployed again somewhere
- * else or edited into a new one. The editing model is deliberately small:
- * select a vertex, nudge it a unit along an axis, colour it, join three into
- * a face. It fits a thumb, and it is exact.
+ * else or edited into a new one. The editing model is small and exact: stamp
+ * a shape, place a vertex, select a point and nudge it a unit along an axis,
+ * colour it, tap corners into a face. It fits a thumb.
+ *
+ * Two rules about points. A vertex you ADD lands on an empty point or selects
+ * the one already there, so hand placing never stacks vertices by accident. A
+ * stamp brings its own vertices even onto occupied points (stamps.ts says
+ * why), so from then on "a point" can be several vertices, and SELECT, the
+ * nudge pad, the colour and DELETE act on every vertex at the selected point
+ * together. What you see is one dot, and it behaves like one dot.
+ *
+ * Every change to the current shard goes through `edit`, which is also where
+ * undo lives: the shard as it was is pushed onto a stack, redo holds what
+ * undo popped, and switching shards clears both. Renaming is not an edit.
  */
 
 import { create } from 'zustand'
 import {
   GRID_HALF,
+  MAX_FACES,
+  MAX_VERTICES,
   clampColor,
+  fromPayload,
   newShard,
+  pointKey,
+  toPayload,
   uuid,
   validFace,
   validPoint,
@@ -20,10 +36,16 @@ import {
   type ShardModel,
   type ShardVertex,
 } from '../lib/shards'
+import { MAX_SIZE, MIN_SIZE, stamp, type Facing, type StampKind } from '../lib/stamps'
+import { triangulate } from '../lib/triangulate'
 
-export type Tool = 'add' | 'select' | 'face'
+export type Tool = 'stamp' | 'add' | 'select' | 'face'
 
 const STORAGE = 'onosendai:shards'
+/** Undo depth per shard. */
+const HISTORY = 64
+
+type P3 = [number, number, number]
 
 export interface WorkshopState {
   shards: ShardModel[]
@@ -31,18 +53,27 @@ export interface WorkshopState {
   /** The workshop overlay is up. */
   open: boolean
   tool: Tool
-  /** Selected vertex index, for moving, colouring and deleting. */
+  /** Selected vertex index; every vertex on the same point moves with it. */
   selected: number | null
-  /** Vertices picked so far for the next face. */
+  /** Corners picked so far for the next face, in order. */
   facePick: number[]
-  /** The Y the add tool places on: the grid plane moves up and down. */
+  /** The Y the add and stamp tools place on: the grid plane moves up and down. */
   level: number
   /** The colour new vertices get, and the colour input shows. */
   color: [number, number, number]
+  stampKind: StampKind
+  stampSize: number
+  stampFacing: Facing
+  /** The grid point under the pointer, where a tap would land; null off the grid. */
+  aim: P3 | null
+  /** The current shard as it was before each edit, oldest first. */
+  past: ShardModel[]
+  /** What undo took away, for redo. */
+  future: ShardModel[]
+  /** One line about the last action, shown on the bench until the next edit. */
+  notice: string | null
 
   openWorkshop: (id?: string) => void
-  /** Add a deep copy of a model from elsewhere (a found shard) to your Stash; returns its new id. */
-  importShard: (model: ShardModel) => string
   closeWorkshop: () => void
   create: (name?: string) => string
   select: (id: string | null) => void
@@ -54,7 +85,12 @@ export interface WorkshopState {
   setTool: (tool: Tool) => void
   setLevel: (level: number) => void
   setColor: (c: [number, number, number]) => void
-  addVertex: (p: [number, number, number]) => void
+  setStampKind: (kind: StampKind) => void
+  setStampSize: (size: number) => void
+  turnStamp: () => void
+  setAim: (p: P3 | null) => void
+  placeStamp: (at: P3) => void
+  addVertex: (p: P3) => void
   selectVertex: (index: number | null) => void
   moveSelected: (axis: 0 | 1 | 2, delta: number) => void
   colorSelected: (c: [number, number, number]) => void
@@ -62,9 +98,18 @@ export interface WorkshopState {
   deleteSelected: () => void
   pickForFace: (index: number) => void
   clearFacePick: () => void
-  removeLastFace: () => void
+  /** Make faces from the picked corners, in order. */
+  fill: () => void
   removeFace: (index: number) => void
   clearShard: () => void
+  undo: () => void
+  redo: () => void
+  /** The current shard in wire form, for the clipboard. */
+  exportCurrent: () => string | null
+  /** A shard from wire form (the clipboard); the new shard's id, or null if it is not one. */
+  importText: (text: string) => string | null
+  /** Add a deep copy of a model from elsewhere (a found shard) to your Stash; returns its new id. */
+  importShard: (model: ShardModel) => string
   current: () => ShardModel | null
 }
 
@@ -81,47 +126,73 @@ function save(shards: ShardModel[]): void {
   try { localStorage.setItem(STORAGE, JSON.stringify(shards)) } catch { /* quota or private mode */ }
 }
 
+/** Every vertex on the same point as vertex `index`, itself included. */
+function group(s: ShardModel, index: number): number[] {
+  const v = s.vertices[index]
+  if (!v) return []
+  const key = pointKey(v.p)
+  const out: number[] = []
+  s.vertices.forEach((o, i) => { if (pointKey(o.p) === key) out.push(i) })
+  return out
+}
+
+const faceKey = (f: [number, number, number]): string => [...f].sort((a, b) => a - b).join(',')
+
 export const useWorkshop = create<WorkshopState>((set, get) => {
-  /** Apply an edit to the current shard, stamp it, persist. */
-  const edit = (fn: (s: ShardModel) => ShardModel | null): void => {
-    const { shards, currentId } = get()
+  /** Apply an edit to the current shard, remember what it was, stamp it, persist. */
+  const edit = (fn: (s: ShardModel) => ShardModel | null, notice: string | null = null): boolean => {
+    const { shards, currentId, past } = get()
     const i = shards.findIndex((s) => s.id === currentId)
-    if (i < 0) return
+    if (i < 0) return false
     const next = fn(shards[i])
-    if (!next) return
+    if (!next) return false
     const list = shards.slice()
     list[i] = { ...next, updatedAt: Date.now() }
-    set({ shards: list })
+    set({ shards: list, past: [...past.slice(-(HISTORY - 1)), shards[i]], future: [], notice })
     save(list)
+    return true
   }
+
+  /** Faces show only in SOLID: a shard's first faces switch it there. */
+  const solidIfFirstFaces = (before: ShardModel, after: ShardModel): { mode: ShardMode; notice: string | null } =>
+    before.faces.length === 0 && after.faces.length > 0 && before.mode !== 'solid'
+      ? { mode: 'solid', notice: 'Switched to SOLID so the faces show. POINTS and LINES are one tap away.' }
+      : { mode: after.mode, notice: null }
 
   return {
     shards: load(),
     currentId: null,
     open: false,
-    tool: 'add',
+    tool: 'stamp',
     selected: null,
     facePick: [],
     level: 0,
     color: [0, 0.9, 1],
+    stampKind: 'block',
+    stampSize: 2,
+    stampFacing: 0,
+    aim: null,
+    past: [],
+    future: [],
+    notice: null,
 
     openWorkshop: (id) => {
       const { shards } = get()
       const currentId = id ?? get().currentId ?? shards[0]?.id ?? get().create()
-      set({ open: true, currentId, selected: null, facePick: [], tool: 'add' })
+      set({ open: true, currentId, selected: null, facePick: [], tool: 'stamp', aim: null, past: [], future: [], notice: null })
     },
 
-    closeWorkshop: () => set({ open: false, selected: null, facePick: [] }),
+    closeWorkshop: () => set({ open: false, selected: null, facePick: [], aim: null }),
 
     create: (name) => {
       const s = newShard(name ?? `Shard ${get().shards.length + 1}`)
       const list = [...get().shards, s]
-      set({ shards: list, currentId: s.id, selected: null, facePick: [] })
+      set({ shards: list, currentId: s.id, selected: null, facePick: [], past: [], future: [], notice: null })
       save(list)
       return s.id
     },
 
-    select: (id) => set({ currentId: id, selected: null, facePick: [] }),
+    select: (id) => set({ currentId: id, selected: null, facePick: [], past: [], future: [], notice: null }),
 
     rename: (id, name) => {
       const list = get().shards.map((s) => (s.id === id ? { ...s, name: name.slice(0, 64), updatedAt: Date.now() } : s))
@@ -131,42 +202,53 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     duplicate: (id) => {
       const src = get().shards.find((s) => s.id === id)
       if (!src) return id
-      const copy: ShardModel = { ...src, id: uuid(), name: `${src.name} copy`, vertices: src.vertices.map((v) => ({ p: [...v.p] as ShardVertex['p'], c: [...v.c] as ShardVertex['c'] })), faces: src.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
+      const copy: ShardModel = { ...src, id: uuid(), name: `${src.name} copy`, vertices: src.vertices.map((v) => ({ p: [...v.p] as P3, c: [...v.c] as ShardVertex['c'] })), faces: src.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
       const list = [...get().shards, copy]
-      set({ shards: list, currentId: copy.id, selected: null, facePick: [] }); save(list)
-      return copy.id
-    },
-
-    importShard: (model) => {
-      const taken = new Set(get().shards.map((s) => s.name))
-      const name = taken.has(model.name) ? `${model.name} copy` : model.name
-      const copy: ShardModel = { ...model, id: uuid(), name, vertices: model.vertices.map((v) => ({ p: [...v.p] as ShardVertex['p'], c: [...v.c] as ShardVertex['c'] })), faces: model.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
-      const list = [...get().shards, copy]
-      set({ shards: list }); save(list)
+      set({ shards: list, currentId: copy.id, selected: null, facePick: [], past: [], future: [], notice: null }); save(list)
       return copy.id
     },
 
     remove: (id) => {
       const list = get().shards.filter((s) => s.id !== id)
       const currentId = get().currentId === id ? (list[0]?.id ?? null) : get().currentId
-      set({ shards: list, currentId, selected: null, facePick: [] }); save(list)
+      set({ shards: list, currentId, selected: null, facePick: [], past: [], future: [], notice: null }); save(list)
     },
 
     setMode: (mode) => edit((s) => ({ ...s, mode })),
     setUnit: (unit) => edit((s) => ({ ...s, unit: Math.max(0, Math.min(84, Math.round(unit))) })),
-    setTool: (tool) => set({ tool, facePick: [] }),
+    setTool: (tool) => set({ tool, facePick: [], aim: null }),
     setLevel: (level) => set({ level: Math.max(-GRID_HALF, Math.min(GRID_HALF, Math.round(level))) }),
     setColor: (c) => set({ color: clampColor(c) }),
+    setStampKind: (stampKind) => set({ stampKind }),
+    setStampSize: (size) => set({ stampSize: Math.max(MIN_SIZE, Math.min(MAX_SIZE, Math.round(size))) }),
+    turnStamp: () => set({ stampFacing: ((get().stampFacing + 1) % 4) as Facing }),
+
+    setAim: (p) => {
+      const a = get().aim
+      if (a === p || (a && p && a[0] === p[0] && a[1] === p[1] && a[2] === p[2])) return
+      set({ aim: p })
+    },
+
+    placeStamp: (at) => {
+      const { stampKind, stampSize, stampFacing, color } = get()
+      const s = get().current()
+      if (!s || !validPoint(at)) return
+      const res = stamp(s, stampKind, stampSize, stampFacing, at, color)
+      if (!res) { set({ notice: `No room: a shard holds up to ${MAX_VERTICES} vertices and ${MAX_FACES} faces.` }); return }
+      const { mode, notice } = solidIfFirstFaces(s, res.shard)
+      edit(() => ({ ...res.shard, mode }), notice)
+      set({ selected: null, facePick: [] })
+    },
 
     addVertex: (p) => {
       if (!validPoint(p)) return
       let added = -1
       edit((s) => {
-        // One vertex per point: adding where one already is selects it instead.
-        const existing = s.vertices.findIndex((v) => v.p[0] === p[0] && v.p[1] === p[1] && v.p[2] === p[2])
+        // One vertex per point by hand: adding where one already is selects it instead.
+        const existing = s.vertices.findIndex((v) => pointKey(v.p) === pointKey(p))
         if (existing >= 0) { added = existing; return null }
         added = s.vertices.length
-        return { ...s, vertices: [...s.vertices, { p: [...p] as ShardVertex['p'], c: [...get().color] as ShardVertex['c'] }] }
+        return { ...s, vertices: [...s.vertices, { p: [...p] as P3, c: [...get().color] as ShardVertex['c'] }] }
       })
       if (added >= 0) set({ selected: added })
     },
@@ -179,13 +261,11 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       edit((s) => {
         const v = s.vertices[selected]
         if (!v) return null
-        const p = [...v.p] as ShardVertex['p']
+        const p = [...v.p] as P3
         p[axis] += delta
         if (!validPoint(p)) return null
-        // Never two vertices on one point.
-        if (s.vertices.some((o, i) => i !== selected && o.p[0] === p[0] && o.p[1] === p[1] && o.p[2] === p[2])) return null
         const vertices = s.vertices.slice()
-        vertices[selected] = { ...v, p }
+        for (const i of group(s, selected)) vertices[i] = { ...vertices[i], p: [...p] as P3 }
         return { ...s, vertices }
       })
     },
@@ -195,9 +275,9 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       set({ color: clampColor(c) })
       if (selected === null) return
       edit((s) => {
+        if (!s.vertices[selected]) return null
         const vertices = s.vertices.slice()
-        if (!vertices[selected]) return null
-        vertices[selected] = { ...vertices[selected], c: clampColor(c) }
+        for (const i of group(s, selected)) vertices[i] = { ...vertices[i], c: clampColor(c) }
         return { ...s, vertices }
       })
     },
@@ -212,38 +292,99 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       if (selected === null) return
       edit((s) => {
         if (!s.vertices[selected]) return null
-        // Faces that used it go; faces above it shift down one.
+        // Every vertex on the point goes; faces that used any of them go; the rest renumber.
+        const gone = new Set(group(s, selected))
+        const remap = new Map<number, number>()
+        s.vertices.forEach((_, i) => { if (!gone.has(i)) remap.set(i, remap.size) })
         const faces = s.faces
-          .filter((f) => !f.includes(selected))
-          .map((f) => f.map((i) => (i > selected ? i - 1 : i)) as [number, number, number])
-        return { ...s, vertices: s.vertices.filter((_, i) => i !== selected), faces }
+          .filter((f) => !f.some((i) => gone.has(i)))
+          .map((f) => f.map((i) => remap.get(i) as number) as [number, number, number])
+        return { ...s, vertices: s.vertices.filter((_, i) => !gone.has(i)), faces }
       })
       set({ selected: null, facePick: [] })
     },
 
     pickForFace: (index) => {
+      const s = get().current()
       const { facePick } = get()
-      if (facePick.includes(index)) { set({ facePick: facePick.filter((i) => i !== index) }); return }
-      const pick = [...facePick, index]
-      if (pick.length < 3) { set({ facePick: pick }); return }
-      const face = pick as [number, number, number]
-      edit((s) => {
-        if (!validFace(face, s.vertices.length)) return null
-        // The same three vertices in any order is the same face.
-        const key = [...face].sort().join(',')
-        if (s.faces.some((f) => [...f].sort().join(',') === key)) return null
-        return { ...s, faces: [...s.faces, face] }
-      })
-      set({ facePick: [] })
+      if (!s || !s.vertices[index]) return
+      // Picks are points, not vertices: any vertex on a picked point counts as that pick.
+      const key = pointKey(s.vertices[index].p)
+      const at = facePick.findIndex((i) => pointKey(s.vertices[i].p) === key)
+      // Tapping the first corner again closes the loop.
+      if (at === 0 && facePick.length >= 3) { get().fill(); return }
+      if (at >= 0) { set({ facePick: facePick.filter((_, i) => i !== at) }); return }
+      set({ facePick: [...facePick, index] })
     },
 
     clearFacePick: () => set({ facePick: [] }),
 
-    removeLastFace: () => edit((s) => (s.faces.length ? { ...s, faces: s.faces.slice(0, -1) } : null)),
+    fill: () => {
+      const s = get().current()
+      const { facePick } = get()
+      if (!s || facePick.length < 3) return
+      const tris = triangulate(facePick.map((i) => s.vertices[i].p))
+      if (!tris) { set({ notice: 'Those corners do not make a face. Pick them in order around its edge.' }); return }
+      edit((cur) => {
+        const have = new Set(cur.faces.map(faceKey))
+        const faces = tris
+          .map((t) => [facePick[t[0]], facePick[t[1]], facePick[t[2]]] as [number, number, number])
+          .filter((f) => validFace(f, cur.vertices.length) && !have.has(faceKey(f)))
+        if (!faces.length) return null
+        const next = { ...cur, faces: [...cur.faces, ...faces] }
+        return { ...next, mode: solidIfFirstFaces(cur, next).mode }
+      }, solidIfFirstFaces(s, { ...s, faces: [[0, 0, 0]] }).notice)
+      set({ facePick: [] })
+    },
 
     removeFace: (index) => edit((s) => (s.faces[index] ? { ...s, faces: s.faces.filter((_, i) => i !== index) } : null)),
 
     clearShard: () => { edit((s) => ({ ...s, vertices: [], faces: [] })); set({ selected: null, facePick: [] }) },
+
+    undo: () => {
+      const { past, shards, currentId } = get()
+      const i = shards.findIndex((s) => s.id === currentId)
+      if (i < 0 || !past.length) return
+      const list = shards.slice()
+      list[i] = past[past.length - 1]
+      set({ shards: list, past: past.slice(0, -1), future: [...get().future, shards[i]], selected: null, facePick: [], notice: null })
+      save(list)
+    },
+
+    redo: () => {
+      const { future, shards, currentId } = get()
+      const i = shards.findIndex((s) => s.id === currentId)
+      if (i < 0 || !future.length) return
+      const list = shards.slice()
+      list[i] = future[future.length - 1]
+      set({ shards: list, future: future.slice(0, -1), past: [...get().past, shards[i]], selected: null, facePick: [], notice: null })
+      save(list)
+    },
+
+    exportCurrent: () => {
+      const s = get().current()
+      return s ? JSON.stringify(toPayload(s)) : null
+    },
+
+    importText: (text) => {
+      let raw: unknown
+      try { raw = JSON.parse(text) } catch { return null }
+      const s = fromPayload(raw, uuid())
+      if (!s) return null
+      const list = [...get().shards, s]
+      set({ shards: list, currentId: s.id, selected: null, facePick: [], past: [], future: [], notice: null })
+      save(list)
+      return s.id
+    },
+
+    importShard: (model) => {
+      const taken = new Set(get().shards.map((s) => s.name))
+      const name = taken.has(model.name) ? `${model.name} copy` : model.name
+      const copy: ShardModel = { ...model, id: uuid(), name, vertices: model.vertices.map((v) => ({ p: [...v.p] as ShardVertex['p'], c: [...v.c] as ShardVertex['c'] })), faces: model.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
+      const list = [...get().shards, copy]
+      set({ shards: list }); save(list)
+      return copy.id
+    },
 
     current: () => get().shards.find((s) => s.id === get().currentId) ?? null,
   }

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -42,8 +42,14 @@ import { triangulate } from '../lib/triangulate'
 export type Tool = 'stamp' | 'add' | 'select' | 'face'
 
 const STORAGE = 'onosendai:shards'
+const PALETTE_STORAGE = 'onosendai:palette'
 /** Undo depth per shard. */
 const HISTORY = 64
+/** The swatches every workshop starts with. */
+export const DEFAULT_PALETTE = ['#00e5ff', '#ff2323', '#52e39f', '#ffb020', '#c07dff', '#f7931a', '#ffffff', '#2f81f7']
+/** Swatches the palette keeps before the oldest falls off the end. */
+const PALETTE_MAX = 24
+const HEX = /^#[0-9a-f]{6}$/
 
 type P3 = [number, number, number]
 
@@ -57,6 +63,10 @@ export interface WorkshopState {
   selected: number | null
   /** Corners picked so far for the next face, in order. */
   facePick: number[]
+  /** The face tapped in FACE mode, an index into the shard's faces, so DELETE can take it. */
+  selectedFace: number | null
+  /** Swatches to hand: newest first, every colour the picker ever settled on, then the defaults. */
+  palette: string[]
   /** The Y the add and stamp tools place on: the grid plane moves up and down. */
   level: number
   /** The colour new vertices get, and the colour input shows. */
@@ -91,7 +101,13 @@ export interface WorkshopState {
   setAim: (p: P3 | null) => void
   placeStamp: (at: P3) => void
   addVertex: (p: P3) => void
+  /** Also drops any selected face: a point and a face are never selected together. */
   selectVertex: (index: number | null) => void
+  selectFace: (index: number | null) => void
+  deleteSelectedFace: () => void
+  /** Put a colour at the front of the palette (moving it there if it is already in). */
+  rememberColor: (hex: string) => void
+  forgetColor: (hex: string) => void
   moveSelected: (axis: 0 | 1 | 2, delta: number) => void
   colorSelected: (c: [number, number, number]) => void
   colorAll: (c: [number, number, number]) => void
@@ -124,6 +140,18 @@ function load(): ShardModel[] {
 
 function save(shards: ShardModel[]): void {
   try { localStorage.setItem(STORAGE, JSON.stringify(shards)) } catch { /* quota or private mode */ }
+}
+
+function loadPalette(): string[] {
+  try {
+    const raw = localStorage.getItem(PALETTE_STORAGE)
+    const list: unknown = raw ? JSON.parse(raw) : null
+    return Array.isArray(list) && list.every((h) => typeof h === 'string' && HEX.test(h)) ? list : DEFAULT_PALETTE
+  } catch { return DEFAULT_PALETTE }
+}
+
+function savePalette(palette: string[]): void {
+  try { localStorage.setItem(PALETTE_STORAGE, JSON.stringify(palette)) } catch { /* quota or private mode */ }
 }
 
 /** Every vertex on the same point as vertex `index`, itself included. */
@@ -166,6 +194,8 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     tool: 'stamp',
     selected: null,
     facePick: [],
+    selectedFace: null,
+    palette: loadPalette(),
     level: 0,
     color: [0, 0.9, 1],
     stampKind: 'block',
@@ -179,20 +209,20 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     openWorkshop: (id) => {
       const { shards } = get()
       const currentId = id ?? get().currentId ?? shards[0]?.id ?? get().create()
-      set({ open: true, currentId, selected: null, facePick: [], tool: 'stamp', aim: null, past: [], future: [], notice: null })
+      set({ open: true, currentId, selected: null, selectedFace: null, facePick: [], tool: 'stamp', aim: null, past: [], future: [], notice: null })
     },
 
-    closeWorkshop: () => set({ open: false, selected: null, facePick: [], aim: null }),
+    closeWorkshop: () => set({ open: false, selected: null, selectedFace: null, facePick: [], aim: null }),
 
     create: (name) => {
       const s = newShard(name ?? `Shard ${get().shards.length + 1}`)
       const list = [...get().shards, s]
-      set({ shards: list, currentId: s.id, selected: null, facePick: [], past: [], future: [], notice: null })
+      set({ shards: list, currentId: s.id, selected: null, selectedFace: null, facePick: [], past: [], future: [], notice: null })
       save(list)
       return s.id
     },
 
-    select: (id) => set({ currentId: id, selected: null, facePick: [], past: [], future: [], notice: null }),
+    select: (id) => set({ currentId: id, selected: null, selectedFace: null, facePick: [], past: [], future: [], notice: null }),
 
     rename: (id, name) => {
       const list = get().shards.map((s) => (s.id === id ? { ...s, name: name.slice(0, 64), updatedAt: Date.now() } : s))
@@ -204,19 +234,19 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       if (!src) return id
       const copy: ShardModel = { ...src, id: uuid(), name: `${src.name} copy`, vertices: src.vertices.map((v) => ({ p: [...v.p] as P3, c: [...v.c] as ShardVertex['c'] })), faces: src.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
       const list = [...get().shards, copy]
-      set({ shards: list, currentId: copy.id, selected: null, facePick: [], past: [], future: [], notice: null }); save(list)
+      set({ shards: list, currentId: copy.id, selected: null, selectedFace: null, facePick: [], past: [], future: [], notice: null }); save(list)
       return copy.id
     },
 
     remove: (id) => {
       const list = get().shards.filter((s) => s.id !== id)
       const currentId = get().currentId === id ? (list[0]?.id ?? null) : get().currentId
-      set({ shards: list, currentId, selected: null, facePick: [], past: [], future: [], notice: null }); save(list)
+      set({ shards: list, currentId, selected: null, selectedFace: null, facePick: [], past: [], future: [], notice: null }); save(list)
     },
 
     setMode: (mode) => edit((s) => ({ ...s, mode })),
     setUnit: (unit) => edit((s) => ({ ...s, unit: Math.max(0, Math.min(84, Math.round(unit))) })),
-    setTool: (tool) => set({ tool, facePick: [], aim: null }),
+    setTool: (tool) => set({ tool, facePick: [], selectedFace: null, aim: null }),
     setLevel: (level) => set({ level: Math.max(-GRID_HALF, Math.min(GRID_HALF, Math.round(level))) }),
     setColor: (c) => set({ color: clampColor(c) }),
     setStampKind: (stampKind) => set({ stampKind }),
@@ -237,7 +267,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       if (!res) { set({ notice: `No room: a shard holds up to ${MAX_VERTICES} vertices and ${MAX_FACES} faces.` }); return }
       const { mode, notice } = solidIfFirstFaces(s, res.shard)
       edit(() => ({ ...res.shard, mode }), notice)
-      set({ selected: null, facePick: [] })
+      set({ selected: null, selectedFace: null, facePick: [] })
     },
 
     addVertex: (p) => {
@@ -253,7 +283,28 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       if (added >= 0) set({ selected: added })
     },
 
-    selectVertex: (index) => set({ selected: index }),
+    selectVertex: (index) => set({ selected: index, selectedFace: null }),
+
+    selectFace: (index) => set({ selectedFace: index, selected: index === null ? get().selected : null }),
+
+    deleteSelectedFace: () => {
+      const { selectedFace } = get()
+      if (selectedFace === null) return
+      get().removeFace(selectedFace)
+      set({ selectedFace: null })
+    },
+
+    rememberColor: (hex) => {
+      const h = hex.toLowerCase()
+      if (!HEX.test(h)) return
+      const palette = [h, ...get().palette.filter((x) => x !== h)].slice(0, PALETTE_MAX)
+      set({ palette }); savePalette(palette)
+    },
+
+    forgetColor: (hex) => {
+      const palette = get().palette.filter((x) => x !== hex.toLowerCase())
+      set({ palette }); savePalette(palette)
+    },
 
     moveSelected: (axis, delta) => {
       const { selected } = get()
@@ -301,7 +352,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
           .map((f) => f.map((i) => remap.get(i) as number) as [number, number, number])
         return { ...s, vertices: s.vertices.filter((_, i) => !gone.has(i)), faces }
       })
-      set({ selected: null, facePick: [] })
+      set({ selected: null, selectedFace: null, facePick: [] })
     },
 
     pickForFace: (index) => {
@@ -313,8 +364,8 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       const at = facePick.findIndex((i) => pointKey(s.vertices[i].p) === key)
       // Tapping the first corner again closes the loop.
       if (at === 0 && facePick.length >= 3) { get().fill(); return }
-      if (at >= 0) { set({ facePick: facePick.filter((_, i) => i !== at) }); return }
-      set({ facePick: [...facePick, index] })
+      if (at >= 0) { set({ facePick: facePick.filter((_, i) => i !== at), selectedFace: null }); return }
+      set({ facePick: [...facePick, index], selectedFace: null })
     },
 
     clearFacePick: () => set({ facePick: [] }),
@@ -339,7 +390,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
 
     removeFace: (index) => edit((s) => (s.faces[index] ? { ...s, faces: s.faces.filter((_, i) => i !== index) } : null)),
 
-    clearShard: () => { edit((s) => ({ ...s, vertices: [], faces: [] })); set({ selected: null, facePick: [] }) },
+    clearShard: () => { edit((s) => ({ ...s, vertices: [], faces: [] })); set({ selected: null, selectedFace: null, facePick: [] }) },
 
     undo: () => {
       const { past, shards, currentId } = get()
@@ -347,7 +398,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       if (i < 0 || !past.length) return
       const list = shards.slice()
       list[i] = past[past.length - 1]
-      set({ shards: list, past: past.slice(0, -1), future: [...get().future, shards[i]], selected: null, facePick: [], notice: null })
+      set({ shards: list, past: past.slice(0, -1), future: [...get().future, shards[i]], selected: null, selectedFace: null, facePick: [], notice: null })
       save(list)
     },
 
@@ -357,7 +408,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       if (i < 0 || !future.length) return
       const list = shards.slice()
       list[i] = future[future.length - 1]
-      set({ shards: list, future: future.slice(0, -1), past: [...get().past, shards[i]], selected: null, facePick: [], notice: null })
+      set({ shards: list, future: future.slice(0, -1), past: [...get().past, shards[i]], selected: null, selectedFace: null, facePick: [], notice: null })
       save(list)
     },
 
@@ -372,7 +423,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       const s = fromPayload(raw, uuid())
       if (!s) return null
       const list = [...get().shards, s]
-      set({ shards: list, currentId: s.id, selected: null, facePick: [], past: [], future: [], notice: null })
+      set({ shards: list, currentId: s.id, selected: null, selectedFace: null, facePick: [], past: [], future: [], notice: null })
       save(list)
       return s.id
     },

--- a/src/styles.css
+++ b/src/styles.css
@@ -2188,6 +2188,13 @@ kbd {
   cursor: default;
 }
 
+/* A tool is an icon and a word. */
+.workshop__tool {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
 .workshop__mode.is-on,
 .workshop__tool.is-on {
   color: #05070d;
@@ -2368,27 +2375,78 @@ kbd {
   border-color: rgba(255, 59, 107, 0.4);
 }
 
+/* The picker: a dashed swatch with a pipette on it, so it reads as "any
+ * colour" beside the fixed ones. */
+.workshop__picker {
+  position: relative;
+  display: inline-flex;
+}
+
 .workshop__color {
   width: 38px;
   height: 30px;
   padding: 0;
-  border: 1px solid rgba(0, 229, 255, 0.25);
+  border: 1px dashed rgba(255, 255, 255, 0.6);
   border-radius: 5px;
   background: transparent;
   cursor: pointer;
 }
 
+.workshop__picker-icon {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  pointer-events: none;
+  color: #fff;
+  filter: drop-shadow(0 0 2px #000) drop-shadow(0 0 1px #000);
+}
+
 .workshop__swatches {
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
 }
 
+/* A swatch is tapped to use and held to delete, so the long press must not
+ * select text, raise a callout or scroll. */
 .workshop__swatch {
   width: 22px;
   height: 22px;
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.2);
   cursor: pointer;
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* The swatch in use. */
+.workshop__swatch.is-on {
+  outline: 2px solid var(--fg);
+  outline-offset: 1px;
+}
+
+.workshop__swatch--sample {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
+/* Between LEVEL and UNIT, which read as one control without it. */
+.workshop__sep {
+  width: 1px;
+  height: 18px;
+  margin: 0 8px;
+  background: rgba(0, 229, 255, 0.25);
+}
+
+/* What the unit exponent means, so changing it visibly changes something. */
+.workshop__unit-size {
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  color: var(--dim);
 }
 
 .workshop__gap {

--- a/src/styles.css
+++ b/src/styles.css
@@ -588,7 +588,7 @@ body {
    * Nothing behind it but the point field, so every glyph carries its own
    * lighting: a tight dark halo for contrast against whatever it lands on, then
    * a wider bloom in currentColor, which means each row and the wall glow their
-   * own colour without this rule having to know the palette.
+   * own color without this rule having to know the palette.
    */
   text-shadow: 0 0 3px var(--bg), 0 0 4px currentColor, 0 0 12px currentColor;
 }
@@ -626,7 +626,7 @@ body {
 
 /*
  * One hue for the whole readout, so the eye reads brightness rather than
- * colour: where you stand is low key, where you are pointing is live, and the
+ * color: where you stand is low key, where you are pointing is live, and the
  * difference between them sits in between. The only warm thing on the block is
  * the wall, which is the one thing that costs money.
  */
@@ -648,7 +648,7 @@ body {
 
 /* The three things the XOR row has to keep apart: shared prefix, wall, and
  * divergence that fell outside the window. Everything else is diverged
- * territory and stays the row's own colour. */
+ * territory and stays the row's own color. */
 .bits__matched {
   color: #2c5670;
 }
@@ -727,7 +727,7 @@ body {
   text-shadow: none;
 }
 
-/* In history the block turns amber, the same colour the cursor goes when it is
+/* In history the block turns amber, the same color the cursor goes when it is
  * somewhere the avatar is not: you are looking at a place you are not at. */
 .explorer__body.is-history {
   border-color: rgba(255, 176, 32, 0.45);
@@ -1268,7 +1268,7 @@ kbd {
   border-color: var(--fg);
 }
 
-/* Lit in the target's own colour, set inline, so the row and the marker on
+/* Lit in the target's own color, set inline, so the row and the marker on
  * the scene agree about which one this is. */
 .targets__toggle.is-on {
   background: rgba(200, 245, 255, 0.06);
@@ -2376,7 +2376,7 @@ kbd {
 }
 
 /* The picker: a dashed swatch with a pipette on it, so it reads as "any
- * colour" beside the fixed ones. */
+ * color" beside the fixed ones. */
 .workshop__picker {
   position: relative;
   display: inline-flex;
@@ -3513,7 +3513,7 @@ kbd {
 }
 
 /* A circle that stays legible over any terrain: its own ring in the target's
- * colour and a dark halo. */
+ * color and a dark halo. */
 .target__body .pfp {
   border: 1px solid currentColor;
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.85);
@@ -3763,7 +3763,7 @@ kbd {
 }
 
 /* The line scrubber: ChainExplorer's rail, retinted so a glance says which
- * one-dimensional thing you are walking. Kind colours follow the scene's
+ * one-dimensional thing you are walking. Kind colors follow the scene's
  * assignments: ideaspace purple for ports, Earth blue for landfalls. */
 .linescrub .explorer__walked {
   background: #f7931a;
@@ -3776,7 +3776,7 @@ kbd {
 }
 
 .linescrub .explorer__body {
-  /* The border stays the chain explorer's colour on purpose: the two
+  /* The border stays the chain explorer's color on purpose: the two
      expanded rails are the same instrument pointed at different lines.
      The meta row's content changes length between PORT and LANDFALL stops;
      a fixed body width keeps the rail from resizing under the pointer. */
@@ -4218,7 +4218,7 @@ kbd {
   border: 1px solid rgba(0, 229, 255, 0.14);
 }
 
-/* A plain focus view (a hidden thing, a loot item): the same bar in the accent colour */
+/* A plain focus view (a hidden thing, a loot item): the same bar in the accent color */
 .hyperbar--focus {
   border-color: rgba(0, 229, 255, 0.5);
   box-shadow: 0 0 14px rgba(0, 229, 255, 0.16);
@@ -4253,7 +4253,7 @@ kbd {
   height: 0;
 }
 
-/* KEY FOUND: the ceremony's chip, breathing in the accent colour */
+/* KEY FOUND: the ceremony's chip, breathing in the accent color */
 .hyperbar--found {
   border-color: rgba(0, 229, 255, 0.6);
   animation: found-breathe 1.6s ease-in-out infinite;
@@ -4289,7 +4289,7 @@ kbd {
 }
 /* ---------- Cloud compute (HOSAKA) ----------
  *
- * Paid movement has its own colour, a warm gold, so a cloud state never reads
+ * Paid movement has its own color, a warm gold, so a cloud state never reads
  * as the amber of local computing or the violet of a local sidestep. The
  * invoice card carries it too, over the modal's default destructive red. */
 :root {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2391,6 +2391,118 @@ kbd {
   cursor: pointer;
 }
 
+.workshop__gap {
+  flex: 1 0 4px;
+}
+
+.workshop__shapes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+}
+
+.workshop__value--wide {
+  min-width: 70px;
+  text-align: left;
+}
+
+.workshop__mini--wide {
+  width: auto;
+  padding: 0 8px;
+}
+
+.workshop__list-row {
+  display: flex;
+  gap: 4px;
+}
+
+.workshop__list-row .workshop__new {
+  flex: 1;
+  width: auto;
+}
+
+.workshop__paste {
+  margin-top: 8px;
+}
+
+.workshop__paste-box {
+  display: block;
+  width: 100%;
+  min-height: 84px;
+  margin-bottom: 4px;
+  padding: 6px 8px;
+  box-sizing: border-box;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--fg);
+  background: rgba(0, 229, 255, 0.05);
+  border: 1px solid rgba(0, 229, 255, 0.22);
+  border-radius: 5px;
+  resize: vertical;
+}
+
+.workshop__paste-box:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.workshop__notice {
+  margin-top: 3px;
+  color: var(--accent);
+}
+
+/* The first-visit card: three steps, then never again. */
+.workshop__intro {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
+  width: min(300px, calc(100vw - 24px));
+  padding: 12px 14px 10px;
+  border-radius: 8px;
+  background: rgba(6, 14, 22, 0.94);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.workshop__intro-title {
+  margin: 0 0 6px;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+}
+
+.workshop__intro-steps {
+  margin: 0 0 8px;
+  padding-left: 18px;
+  color: var(--fg);
+}
+
+.workshop__intro-steps li {
+  margin-bottom: 4px;
+}
+
+.workshop__intro-steps b {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.workshop__intro-ok {
+  color: var(--accent);
+}
+
+/* The EXPLAIN pill ends the tool row; its well, when open, takes a full row. */
+.workshop__tools .explain {
+  display: contents;
+}
+
+.workshop__tools .explain__well {
+  flex: 1 1 100%;
+  margin-top: 2px;
+}
+
 @media (max-width: 600px) {
   .workshop__help { display: none; }
   .workshop__label { min-width: 0; }
@@ -2415,6 +2527,11 @@ kbd {
   .workshop__list-btn { flex: 0 0 auto; }
   .workshop__deploy { flex: 1; }
   .workshop__close { flex: 0 0 auto; margin-left: 0; }
+
+  /* The tray's contextual row only shows the current tool's controls, so the
+   * bench keeps most of the screen; the explanation opens over a full row. */
+  .workshop__tools { gap: 5px; padding: 6px 8px 8px; }
+  .workshop__intro { top: 8px; right: 8px; left: 8px; width: auto; }
 }
 
 /* ---------- Relays panel ---------- */

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -4,7 +4,8 @@
  * A grid at the current level, the shard drawn live in its mode, a handle on
  * every point, and a ghost of what the next tap would make. Taps do the work:
  * on the grid, STAMP lands a shape and ADD a vertex at the snapped point; on
- * a handle, SELECT picks it and FACE collects it. Dragging orbits. R3F
+ * a handle, SELECT picks it and FACE collects it; on a face, FACE selects it
+ * so DELETE can take it. Dragging orbits. R3F
  * reports how far the pointer travelled between down and up, which is what
  * separates a tap from an orbit, so a thumb that wobbles still taps.
  *
@@ -17,10 +18,10 @@
 import { Canvas, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
-import { BufferGeometry, Float32BufferAttribute, Line, LineBasicMaterial, Vector3 } from 'three'
+import { BufferGeometry, DoubleSide, Float32BufferAttribute, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
 import { GRID_HALF, centroid, pointKey, rgbToHex } from '../lib/shards'
-import { preview } from '../lib/stamps'
+import { landing, preview } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
 import { useWorkshop } from '../store/useWorkshop'
 
@@ -90,10 +91,9 @@ function Ghost(): JSX.Element | null {
   const size = useWorkshop((s) => s.stampSize)
   const facing = useWorkshop((s) => s.stampFacing)
   const color = useWorkshop((s) => s.color)
-  const shard = useMemo(
-    () => (aim && tool === 'stamp' ? preview(kind, size, facing, aim, color) : null),
-    [aim, tool, kind, size, facing, color],
-  )
+  // Built once per shape and colour; the aim only moves it. Built per cell, the
+  // ghost cost a fresh geometry every time the pointer crossed a grid line.
+  const model = useMemo(() => (tool === 'stamp' ? preview(kind, size, facing, color) : null), [tool, kind, size, facing, color])
   if (!aim) return null
   if (tool === 'add') {
     return (
@@ -103,7 +103,12 @@ function Ghost(): JSX.Element | null {
       </mesh>
     )
   }
-  return shard ? <ShardMesh shard={shard} ghost /> : null
+  if (!model) return null
+  return (
+    <group position={landing(kind, size, facing, aim)}>
+      <ShardMesh shard={model} ghost />
+    </group>
+  )
 }
 
 /**
@@ -175,7 +180,35 @@ function PickLoop(): JSX.Element | null {
     l.frustumCulled = false
     return l
   }, [shard, facePick])
+  useEffect(() => () => { line?.geometry.dispose(); line?.material.dispose() }, [line])
   return line ? <primitive object={line} /> : null
+}
+
+/** The face tapped in FACE mode, lit in the selection colour so DELETE FACE has a visible target. */
+function FaceHighlight(): JSX.Element | null {
+  const shard = useWorkshop((s) => s.current())
+  const face = useWorkshop((s) => s.selectedFace)
+  const lit = useMemo(() => {
+    const f = face === null ? undefined : shard?.faces[face]
+    if (!shard || !f) return null
+    const pts = f.map((i) => shard.vertices[i].p)
+    // Four points: the mesh draws the first three as its one triangle, the line closes the loop.
+    const g = new BufferGeometry()
+    g.setAttribute('position', new Float32BufferAttribute([...pts, pts[0]].flat(), 3))
+    const edge = new Line(g, new LineBasicMaterial({ color: WARN, toneMapped: false }))
+    edge.frustumCulled = false
+    return { g, edge }
+  }, [shard, face])
+  useEffect(() => () => { lit?.g.dispose(); lit?.edge.material.dispose() }, [lit])
+  if (!lit) return null
+  return (
+    <>
+      <mesh geometry={lit.g} frustumCulled={false}>
+        <meshBasicMaterial color={WARN} transparent opacity={0.5} side={DoubleSide} depthWrite={false} polygonOffset polygonOffsetFactor={-4} toneMapped={false} />
+      </mesh>
+      <primitive object={lit.edge} />
+    </>
+  )
 }
 
 /**
@@ -222,9 +255,9 @@ function Keys(): null {
         KeyR: [1, 1], KeyF: [1, -1],
       }
       if (nudge[e.code]) { e.preventDefault(); w.moveSelected(...nudge[e.code]); return }
-      if (e.code === 'Delete' || e.code === 'Backspace') { e.preventDefault(); w.deleteSelected(); return }
+      if (e.code === 'Delete' || e.code === 'Backspace') { e.preventDefault(); if (w.selectedFace !== null) w.deleteSelectedFace(); else w.deleteSelected(); return }
       if (e.code === 'Enter') { if (w.facePick.length >= 3) { e.preventDefault(); w.fill() } return }
-      if (e.code === 'Escape') { e.preventDefault(); if (w.selected !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
+      if (e.code === 'Escape') { e.preventDefault(); if (w.selected !== null || w.selectedFace !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
       if (e.code === 'Digit1') w.setTool('stamp')
       if (e.code === 'Digit2') w.setTool('add')
       if (e.code === 'Digit3') w.setTool('select')
@@ -241,8 +274,17 @@ function Keys(): null {
 
 export function Bench(): JSX.Element {
   const shard = useWorkshop((s) => s.current())
+  const tool = useWorkshop((s) => s.tool)
   const first = useRef(true)
   useEffect(() => { first.current = false }, [])
+
+  // A tap on a drawn face in FACE mode selects it. Corners still win: their hit
+  // spheres stand proud of the face, so the raycast meets them first.
+  const onFace = (e: ThreeEvent<MouseEvent>): void => {
+    if (e.delta > TAP_SLOP || e.faceIndex === undefined) return
+    e.stopPropagation()
+    useWorkshop.getState().selectFace(e.faceIndex)
+  }
 
   return (
     <Canvas
@@ -257,7 +299,7 @@ export function Bench(): JSX.Element {
       onPointerMissed={(e) => {
         if ((e as PointerEvent).button !== 0) return
         const w = useWorkshop.getState()
-        if (w.selected !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() }
+        if (w.selected !== null || w.selectedFace !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() }
       }}
     >
       <ambientLight intensity={1} />
@@ -267,9 +309,10 @@ export function Bench(): JSX.Element {
       {/* Axes, in the compass's colours, so X is red here and out there. */}
       <axesHelper args={[GRID_HALF + 1]} />
       <Grid />
-      {shard && <ShardMesh shard={shard} />}
+      {shard && <ShardMesh shard={shard} onFaceClick={tool === 'face' ? onFace : undefined} />}
       <Ghost />
       <PickLoop />
+      <FaceHighlight />
       <Handles />
     </Canvas>
   )

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -1,28 +1,43 @@
 /**
  * Bench.tsx — the workshop's 3D view.
  *
- * A grid at the current level, the shard drawn live in its mode, and a handle
- * on every vertex. Taps do the work: on the grid, the add tool places a vertex
- * at the snapped point; on a handle, select picks it or the face tool collects
- * it. Dragging orbits. R3F reports how far the pointer travelled between down
- * and up, which is what separates the two, so a thumb that wobbles still taps.
+ * A grid at the current level, the shard drawn live in its mode, a handle on
+ * every point, and a ghost of what the next tap would make. Taps do the work:
+ * on the grid, STAMP lands a shape and ADD a vertex at the snapped point; on
+ * a handle, SELECT picks it and FACE collects it. Dragging orbits. R3F
+ * reports how far the pointer travelled between down and up, which is what
+ * separates a tap from an orbit, so a thumb that wobbles still taps.
+ *
+ * The ghost is the aim. A mouse hovers it into place; a finger presses and
+ * slides it; either way you see where the thing will land before it lands,
+ * which on a grid seen in perspective is the difference between placing and
+ * guessing.
  */
 
 import { Canvas, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
-import { Vector3 } from 'three'
+import { BufferGeometry, Float32BufferAttribute, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
-import { GRID_HALF, centroid } from '../lib/shards'
+import { GRID_HALF, centroid, pointKey, rgbToHex } from '../lib/shards'
+import { preview } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
 import { useWorkshop } from '../store/useWorkshop'
 
 /** A press that travels further than this is an orbit, not a tap. */
 const TAP_SLOP = 8
 
+type P3 = [number, number, number]
+
+/** The grid point a pointer over the plane means, at the level the store says. */
+function snap(p: Vector3, level: number): P3 {
+  return [Math.round(p.x), level, Math.round(p.z)]
+}
+
 function Grid(): JSX.Element {
   const level = useWorkshop((s) => s.level)
   const tool = useWorkshop((s) => s.tool)
+  const places = tool === 'add' || tool === 'stamp'
 
   const onClick = (e: ThreeEvent<MouseEvent>): void => {
     if (e.delta > TAP_SLOP) return
@@ -31,8 +46,19 @@ function Grid(): JSX.Element {
     // changed a moment ago must apply to this tap even if the bench has not
     // re-rendered yet.
     const w = useWorkshop.getState()
-    const p = e.point
-    w.addVertex([Math.round(p.x), w.level, Math.round(p.z)])
+    const at = snap(e.point, w.level)
+    if (w.tool === 'stamp') w.placeStamp(at)
+    else w.addVertex(at)
+  }
+
+  const onMove = (e: ThreeEvent<PointerEvent>): void => {
+    const w = useWorkshop.getState()
+    w.setAim(snap(e.point, w.level))
+  }
+
+  // A finger lifts and the ghost goes with it; a mouse keeps hovering.
+  const onUp = (e: ThreeEvent<PointerEvent>): void => {
+    if (e.pointerType !== 'mouse') useWorkshop.getState().setAim(null)
   }
 
   return (
@@ -40,14 +66,14 @@ function Grid(): JSX.Element {
       {/* The visible lattice. One cell per unit, so what you tap is what you get. */}
       <gridHelper args={[GRID_HALF * 2, GRID_HALF * 2, ACCENT, '#1d3547']} />
       {/*
-        The surface taps land on, in ADD mode only. In select and face mode it
-        carries no handler at all, so the raycaster ignores it: a raised grid
-        plane must not sit in front of the vertex handles and swallow the taps
-        meant for them, and an empty-space tap should reach onPointerMissed to
-        deselect rather than being caught here.
+        The surface taps land on, in the placing tools only. In select and face
+        mode it carries no handler at all, so the raycaster ignores it: a raised
+        grid plane must not sit in front of the vertex handles and swallow the
+        taps meant for them, and an empty-space tap should reach onPointerMissed
+        to deselect rather than being caught here.
       */}
-      {tool === 'add' && (
-        <mesh rotation={[-Math.PI / 2, 0, 0]} onClick={onClick}>
+      {places && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} onClick={onClick} onPointerMove={onMove} onPointerUp={onUp} onPointerLeave={() => useWorkshop.getState().setAim(null)}>
           <planeGeometry args={[GRID_HALF * 2 + 1, GRID_HALF * 2 + 1]} />
           <meshBasicMaterial transparent opacity={0} depthWrite={false} />
         </mesh>
@@ -56,38 +82,73 @@ function Grid(): JSX.Element {
   )
 }
 
+/** What the next tap would make, drawn faint where it would land. */
+function Ghost(): JSX.Element | null {
+  const aim = useWorkshop((s) => s.aim)
+  const tool = useWorkshop((s) => s.tool)
+  const kind = useWorkshop((s) => s.stampKind)
+  const size = useWorkshop((s) => s.stampSize)
+  const facing = useWorkshop((s) => s.stampFacing)
+  const color = useWorkshop((s) => s.color)
+  const shard = useMemo(
+    () => (aim && tool === 'stamp' ? preview(kind, size, facing, aim, color) : null),
+    [aim, tool, kind, size, facing, color],
+  )
+  if (!aim) return null
+  if (tool === 'add') {
+    return (
+      <mesh position={aim}>
+        <sphereGeometry args={[0.2, 12, 12]} />
+        <meshBasicMaterial color={rgbToHex(color)} transparent opacity={0.5} toneMapped={false} depthWrite={false} />
+      </mesh>
+    )
+  }
+  return shard ? <ShardMesh shard={shard} ghost /> : null
+}
+
+/**
+ * One handle per point. Several vertices can share a point once stamps have
+ * landed on each other; they read and act as one, so they draw as one.
+ */
 function Handles(): JSX.Element | null {
   const shard = useWorkshop((s) => s.current())
   const selected = useWorkshop((s) => s.selected)
   const facePick = useWorkshop((s) => s.facePick)
   const tool = useWorkshop((s) => s.tool)
+  const groups = useMemo(() => {
+    const m = new Map<string, number[]>()
+    shard?.vertices.forEach((v, i) => { const k = pointKey(v.p); m.set(k, [...(m.get(k) ?? []), i]) })
+    return [...m.values()]
+  }, [shard?.vertices])
   if (!shard) return null
 
-  const onClick = (index: number) => (e: ThreeEvent<MouseEvent>): void => {
+  const onClick = (first: number, isSel: boolean) => (e: ThreeEvent<MouseEvent>): void => {
     if (e.delta > TAP_SLOP) return
     e.stopPropagation()
     const w = useWorkshop.getState()
-    if (tool === 'face') w.pickForFace(index)
-    else w.selectVertex(w.selected === index ? null : index)
+    if (tool === 'face') w.pickForFace(first)
+    else w.selectVertex(isSel ? null : first)
   }
 
   return (
     <>
-      {shard.vertices.map((v, i) => {
-        const picked = facePick.indexOf(i)
-        const isSel = selected === i
+      {groups.map((g) => {
+        const first = g[0]
+        const v = shard.vertices[first]
+        const isSel = selected !== null && g.includes(selected)
+        const picked = facePick.some((i) => g.includes(i))
         return (
-          <group key={i} position={v.p}>
+          <group key={first} position={v.p}>
             {/* A generous invisible hit target; the visible handle is small. */}
-            <mesh onClick={onClick(i)}>
+            <mesh onClick={onClick(first, isSel)}>
               <sphereGeometry args={[0.42, 10, 10]} />
               <meshBasicMaterial transparent opacity={0} depthWrite={false} />
             </mesh>
             <mesh>
-              <sphereGeometry args={[isSel || picked >= 0 ? 0.2 : 0.12, 12, 12]} />
-              <meshBasicMaterial color={isSel ? WARN : picked >= 0 ? ACCENT : `rgb(${v.c.map((x) => Math.round(x * 255)).join(',')})`} toneMapped={false} />
+              <sphereGeometry args={[isSel || picked ? 0.2 : 0.12, 12, 12]} />
+              <meshBasicMaterial color={isSel ? WARN : picked ? ACCENT : rgbToHex(v.c)} toneMapped={false} />
             </mesh>
-            {picked >= 0 && (
+            {picked && (
               <mesh>
                 <ringGeometry args={[0.3, 0.36, 24]} />
                 <meshBasicMaterial color={ACCENT} toneMapped={false} side={2} />
@@ -98,6 +159,23 @@ function Handles(): JSX.Element | null {
       })}
     </>
   )
+}
+
+/** The face being picked, as a line through its corners so far, closing once it could. */
+function PickLoop(): JSX.Element | null {
+  const shard = useWorkshop((s) => s.current())
+  const facePick = useWorkshop((s) => s.facePick)
+  const line = useMemo(() => {
+    if (!shard || facePick.length < 2) return null
+    const pts = facePick.map((i) => shard.vertices[i]?.p).filter((p): p is P3 => !!p)
+    if (pts.length >= 3) pts.push(pts[0])
+    const g = new BufferGeometry()
+    g.setAttribute('position', new Float32BufferAttribute(pts.flat(), 3))
+    const l = new Line(g, new LineBasicMaterial({ color: ACCENT, transparent: true, opacity: 0.6, toneMapped: false }))
+    l.frustumCulled = false
+    return l
+  }, [shard, facePick])
+  return line ? <primitive object={line} /> : null
 }
 
 /**
@@ -125,14 +203,19 @@ function Aim(): null {
   return null
 }
 
-/** Keyboard on the bench: nudge, delete, tools. */
+/** Keyboard on the bench: undo, tools, nudge, fill, delete, level, turn. */
 function Keys(): null {
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
-      if (e.metaKey || e.ctrlKey || e.altKey) return
       const tag = (e.target as HTMLElement | null)?.tagName
       if (tag === 'INPUT' || tag === 'TEXTAREA') return
       const w = useWorkshop.getState()
+      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+        if (e.code === 'KeyZ') { e.preventDefault(); if (e.shiftKey) w.redo(); else w.undo() }
+        if (e.code === 'KeyY') { e.preventDefault(); w.redo() }
+        return
+      }
+      if (e.altKey) return
       const nudge: Record<string, [0 | 1 | 2, number]> = {
         ArrowRight: [0, 1], ArrowLeft: [0, -1], KeyD: [0, 1], KeyA: [0, -1],
         ArrowUp: [2, -1], ArrowDown: [2, 1], KeyW: [2, -1], KeyS: [2, 1],
@@ -140,10 +223,13 @@ function Keys(): null {
       }
       if (nudge[e.code]) { e.preventDefault(); w.moveSelected(...nudge[e.code]); return }
       if (e.code === 'Delete' || e.code === 'Backspace') { e.preventDefault(); w.deleteSelected(); return }
+      if (e.code === 'Enter') { if (w.facePick.length >= 3) { e.preventDefault(); w.fill() } return }
       if (e.code === 'Escape') { e.preventDefault(); if (w.selected !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
-      if (e.code === 'Digit1') w.setTool('add')
-      if (e.code === 'Digit2') w.setTool('select')
-      if (e.code === 'Digit3') w.setTool('face')
+      if (e.code === 'Digit1') w.setTool('stamp')
+      if (e.code === 'Digit2') w.setTool('add')
+      if (e.code === 'Digit3') w.setTool('select')
+      if (e.code === 'Digit4') w.setTool('face')
+      if (e.code === 'KeyQ') w.turnStamp()
       if (e.code === 'BracketRight') w.setLevel(w.level + 1)
       if (e.code === 'BracketLeft') w.setLevel(w.level - 1)
     }
@@ -164,10 +250,10 @@ export function Bench(): JSX.Element {
       dpr={[1, 2]}
       gl={{ antialias: true }}
       style={{ background: BG }}
-      // A click that hits nothing deselects and drops a half-built face. In ADD
-      // mode the grid plane catches the click first, so this fires only on true
-      // empty space; in select and face mode there is no plane, so a tap off any
-      // handle lands here.
+      // A click that hits nothing deselects and drops a half-built face. In the
+      // placing tools the grid plane catches the click first, so this fires only
+      // on true empty space; in select and face mode there is no plane, so a tap
+      // off any handle lands here.
       onPointerMissed={(e) => {
         if ((e as PointerEvent).button !== 0) return
         const w = useWorkshop.getState()
@@ -182,6 +268,8 @@ export function Bench(): JSX.Element {
       <axesHelper args={[GRID_HALF + 1]} />
       <Grid />
       {shard && <ShardMesh shard={shard} />}
+      <Ghost />
+      <PickLoop />
       <Handles />
     </Canvas>
   )

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -91,7 +91,7 @@ function Ghost(): JSX.Element | null {
   const size = useWorkshop((s) => s.stampSize)
   const facing = useWorkshop((s) => s.stampFacing)
   const color = useWorkshop((s) => s.color)
-  // Built once per shape and colour; the aim only moves it. Built per cell, the
+  // Built once per shape and color; the aim only moves it. Built per cell, the
   // ghost cost a fresh geometry every time the pointer crossed a grid line.
   const model = useMemo(() => (tool === 'stamp' ? preview(kind, size, facing, color) : null), [tool, kind, size, facing, color])
   if (!aim) return null
@@ -184,7 +184,7 @@ function PickLoop(): JSX.Element | null {
   return line ? <primitive object={line} /> : null
 }
 
-/** The face tapped in FACE mode, lit in the selection colour so DELETE FACE has a visible target. */
+/** The face tapped in FACE mode, lit in the selection color so DELETE FACE has a visible target. */
 function FaceHighlight(): JSX.Element | null {
   const shard = useWorkshop((s) => s.current())
   const face = useWorkshop((s) => s.selectedFace)
@@ -306,7 +306,7 @@ export function Bench(): JSX.Element {
       <OrbitControls makeDefault enablePan={false} minDistance={3} maxDistance={60} dampingFactor={0.12} />
       <Aim />
       <Keys />
-      {/* Axes, in the compass's colours, so X is red here and out there. */}
+      {/* Axes, in the compass's colors, so X is red here and out there. */}
       <axesHelper args={[GRID_HALF + 1]} />
       <Grid />
       {shard && <ShardMesh shard={shard} onFaceClick={tool === 'face' ? onFace : undefined} />}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -18,8 +18,10 @@
  * keeps most of its screen for the bench.
  */
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { MousePointer2, Pipette, Plus, Stamp, Triangle, type LucideIcon } from 'lucide-react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
+import { ConfirmModal } from '../hud/ConfirmModal'
 import { Explanation } from '../hud/Explanation'
 import { GRID_HALF, MODES, hexToRgb, rgbToHex, toPayload, type ShardMode } from '../lib/shards'
 import { formatCellSize } from '../lib/scale'
@@ -28,15 +30,19 @@ import { useWorkshop, type Tool } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { Bench } from './Bench'
 
-const PALETTE = ['#00e5ff', '#ff2323', '#52e39f', '#ffb020', '#c07dff', '#f7931a', '#ffffff', '#2f81f7']
-
 const TOOLS: Tool[] = ['stamp', 'add', 'select', 'face']
+const TOOL_ICON: Record<Tool, LucideIcon> = { stamp: Stamp, add: Plus, select: MousePointer2, face: Triangle }
+
+/** A press this long on a swatch asks to delete it rather than using it. */
+const LONG_PRESS_MS = 550
+/** The picker fires on every step through the wheel; the palette gets the colour you stop on. */
+const SETTLE_MS = 500
 
 const TOOL_HELP: Record<Tool, string> = {
   stamp: 'Tap the grid to place the shape where the ghost shows. Q turns it.',
   add: 'Tap the grid to place a vertex at the current level.',
   select: 'Tap a point, then nudge it with the pad, colour it, or delete it.',
-  face: 'Tap the corners of a face in order, then tap the first again, or FILL.',
+  face: 'Tap corners in order, then the first again or FILL. Tap a face to select it; DELETE FACE removes it.',
 }
 
 /** Shown once, the first time the workshop opens on this device. */
@@ -59,6 +65,29 @@ function Intro(): JSX.Element | null {
   )
 }
 
+/** A swatch: tap to use it, hold to be asked whether to delete it. */
+function Swatch({ hex, on, onUse, onHold }: { hex: string; on: boolean; onUse: () => void; onHold: () => void }): JSX.Element {
+  const timer = useRef<number>()
+  const held = useRef(false)
+  const stop = (): void => { window.clearTimeout(timer.current); timer.current = undefined }
+  useEffect(() => stop, [])
+  return (
+    <button
+      className={`workshop__swatch ${on ? 'is-on' : ''}`}
+      style={{ background: hex }}
+      aria-label={`Colour ${hex}`}
+      aria-pressed={on}
+      title={`${hex} (hold to delete)`}
+      onPointerDown={() => { held.current = false; stop(); timer.current = window.setTimeout(() => { held.current = true; onHold() }, LONG_PRESS_MS) }}
+      onPointerUp={stop}
+      onPointerCancel={stop}
+      onPointerLeave={stop}
+      onClick={() => { if (!held.current) onUse() }}
+      {...noCallout}
+    />
+  )
+}
+
 export function Workshop(): JSX.Element | null {
   const open = useWorkshop((s) => s.open)
   const shard = useWorkshop((s) => s.current())
@@ -66,6 +95,8 @@ export function Workshop(): JSX.Element | null {
   const tool = useWorkshop((s) => s.tool)
   const selected = useWorkshop((s) => s.selected)
   const facePick = useWorkshop((s) => s.facePick)
+  const selectedFace = useWorkshop((s) => s.selectedFace)
+  const palette = useWorkshop((s) => s.palette)
   const level = useWorkshop((s) => s.level)
   const color = useWorkshop((s) => s.color)
   const stampKind = useWorkshop((s) => s.stampKind)
@@ -77,6 +108,10 @@ export function Workshop(): JSX.Element | null {
   const [listOpen, setListOpen] = useState(false)
   const [pasteOpen, setPasteOpen] = useState(false)
   const [pasteText, setPasteText] = useState('')
+  const [deleteColor, setDeleteColor] = useState<string | null>(null)
+  const settle = useRef<number>()
+  const picked = useRef(false)
+  useEffect(() => () => window.clearTimeout(settle.current), [])
   const bind = useRepeatable()
 
   if (!open) return null
@@ -85,6 +120,22 @@ export function Workshop(): JSX.Element | null {
   const nudge = (axis: 0 | 1 | 2, d: number) => () => w().moveSelected(axis, d)
   const canNudge = selected !== null
   const say = (notice: string): void => useWorkshop.setState({ notice })
+
+  // The picker paints live and, once the wheel has settled, puts the colour at
+  // the front of the palette; leaving the picker settles it at once.
+  const hex = rgbToHex(color)
+  const pick = (value: string): void => {
+    w().colorSelected(hexToRgb(value))
+    picked.current = true
+    window.clearTimeout(settle.current)
+    settle.current = window.setTimeout(() => { picked.current = false; w().rememberColor(value) }, SETTLE_MS)
+  }
+  const settled = (value: string): void => {
+    if (!picked.current) return
+    window.clearTimeout(settle.current)
+    picked.current = false
+    w().rememberColor(value)
+  }
 
   const copy = (id: string): void => {
     const s = w().shards.find((x) => x.id === id)
@@ -184,6 +235,7 @@ export function Workshop(): JSX.Element | null {
             {selected !== null && shard.vertices[selected] && (
               <> · selected ({shard.vertices[selected].p.join(', ')})</>
             )}
+            {selectedFace !== null && <> · face {selectedFace + 1} selected</>}
             {tool === 'face' && facePick.length > 0 && <> · {facePick.length} corner{facePick.length === 1 ? '' : 's'}</>}
             {shard.mode !== 'solid' && shard.faces.length > 0 && <> · faces draw in SOLID</>}
             {notice && <div className="workshop__notice">{notice}</div>}
@@ -193,11 +245,14 @@ export function Workshop(): JSX.Element | null {
 
       <div className="workshop__tools">
         <div className="workshop__row" role="group" aria-label="Tool">
-          {TOOLS.map((t, i) => (
-            <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => w().setTool(t)} title={`${t} (${i + 1})`}>
-              {t.toUpperCase()}
-            </button>
-          ))}
+          {TOOLS.map((t, i) => {
+            const Icon = TOOL_ICON[t]
+            return (
+              <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => w().setTool(t)} title={`${t} (${i + 1})`}>
+                <Icon size={12} strokeWidth={2.25} aria-hidden />{t.toUpperCase()}
+              </button>
+            )
+          })}
           <span className="workshop__gap" />
           <button className="workshop__btn" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)">UNDO</button>
           <button className="workshop__btn" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)">REDO</button>
@@ -206,7 +261,9 @@ export function Workshop(): JSX.Element | null {
             A shard is coloured points on a grid of whole units, drawn SOLID (faces, colours blending
             across them), POINTS (every point a light) or LINES (one line through the points in the
             order they were made). STAMP places a whole shape; ADD one point; SELECT a point to move,
-            colour or delete it; FACE picks corners and FILL joins them. Stamps keep their own corners
+            colour or delete it; FACE picks corners and FILL joins them, and a tap on a face selects it
+            for DELETE FACE. The palette keeps every colour the picker settles on; hold a swatch to
+            delete it. Stamps keep their own corners
             even where they touch, so a red block against a blue one keeps a crisp edge. UNIT says how
             big one grid unit is in the world, from a picometre to the width of a sector; DEPLOY shows
             the shard at true size before you place it. Keys: 1 2 3 4 tools, Q turns a stamp, WASD /
@@ -253,7 +310,16 @@ export function Workshop(): JSX.Element | null {
           </div>
         )}
 
-        {tool === 'face' && (
+        {tool === 'face' && selectedFace !== null && (
+          <div className="workshop__row">
+            <span className="workshop__label">FACE</span>
+            <span className="workshop__value workshop__value--wide">face {selectedFace + 1} of {shard?.faces.length ?? 0}</span>
+            <button className="workshop__btn workshop__btn--danger" onClick={() => w().deleteSelectedFace()} title="Remove this face (Del)">DELETE FACE</button>
+            <button className="workshop__btn" onClick={() => w().selectFace(null)} title="Keep it (Esc)">CANCEL</button>
+          </div>
+        )}
+
+        {tool === 'face' && selectedFace === null && (
           <div className="workshop__row">
             <span className="workshop__label">FACE</span>
             <span className="workshop__value workshop__value--wide">{facePick.length} corner{facePick.length === 1 ? '' : 's'}</span>
@@ -268,32 +334,52 @@ export function Workshop(): JSX.Element | null {
           <span className="workshop__value">{level}</span>
           <button className="workshop__btn" {...bind(() => w().setLevel(w().level + 1))} disabled={level >= GRID_HALF} aria-label="Level up">+</button>
 
-          <span className="workshop__label workshop__label--gap">UNIT 2^</span>
-          <button className="workshop__btn" {...bind(() => w().setUnit((shard?.unit ?? 0) - 1))} disabled={!shard || shard.unit <= 0} aria-label="Smaller unit">−</button>
+          <span className="workshop__sep" aria-hidden />
+          <span className="workshop__label">UNIT 2^</span>
+          {/* Read the unit from the store, not the render: held, the button repeats, and the closure's shard is the one from before the first step. */}
+          <button className="workshop__btn" {...bind(() => w().setUnit((w().current()?.unit ?? 0) - 1))} disabled={!shard || shard.unit <= 0} aria-label="Smaller unit">−</button>
           <span className="workshop__value">{shard?.unit ?? 0}</span>
-          <button className="workshop__btn" {...bind(() => w().setUnit((shard?.unit ?? 0) + 1))} disabled={!shard || shard.unit >= 84} aria-label="Larger unit">+</button>
+          <button className="workshop__btn" {...bind(() => w().setUnit((w().current()?.unit ?? 0) + 1))} disabled={!shard || shard.unit >= 84} aria-label="Larger unit">+</button>
+          <span className="workshop__unit-size" title="What one grid unit is in the world. DEPLOY shows the shard at this size.">= {formatCellSize(shard?.unit ?? 0)}</span>
           <span className="workshop__gap" />
           <button className="workshop__btn workshop__btn--danger" disabled={!shard || shard.vertices.length === 0} onClick={() => { if (window.confirm('Clear every vertex and face of this shard? (UNDO brings it back.)')) w().clearShard() }}>CLEAR</button>
         </div>
 
         <div className="workshop__row">
           <span className="workshop__label">COLOUR</span>
-          <input
-            type="color"
-            className="workshop__color"
-            value={rgbToHex(color)}
-            onChange={(e) => w().colorSelected(hexToRgb(e.target.value))}
-            aria-label="Vertex colour"
-            {...noCallout}
-          />
+          <span className="workshop__picker" title="Pick any colour; it joins the palette">
+            <input
+              type="color"
+              className="workshop__color"
+              value={hex}
+              list="workshop-palette"
+              onChange={(e) => pick(e.target.value)}
+              onBlur={(e) => settled(e.target.value)}
+              aria-label="Pick a colour"
+              {...noCallout}
+            />
+            <Pipette className="workshop__picker-icon" size={13} strokeWidth={2.25} aria-hidden />
+            {/* Browsers that honour it (Chrome, desktop and Android) offer these inside the picker as starting points. */}
+            <datalist id="workshop-palette">{palette.map((h) => <option key={h} value={h} />)}</datalist>
+          </span>
           <div className="workshop__swatches">
-            {PALETTE.map((hex) => (
-              <button key={hex} className="workshop__swatch" style={{ background: hex }} aria-label={`Colour ${hex}`} onClick={() => w().colorSelected(hexToRgb(hex))} />
+            {palette.map((h) => (
+              <Swatch key={h} hex={h} on={h === hex} onUse={() => w().colorSelected(hexToRgb(h))} onHold={() => setDeleteColor(h)} />
             ))}
           </div>
           <button className="workshop__btn" disabled={!shard || shard.vertices.length === 0} onClick={() => w().colorAll(w().color)} title="Apply the colour to every vertex">ALL</button>
         </div>
       </div>
+
+      {deleteColor !== null && (
+        <ConfirmModal
+          title="Delete colour from palette?"
+          body={<><span className="workshop__swatch workshop__swatch--sample" style={{ background: deleteColor }} aria-hidden />{deleteColor} leaves the palette. Vertices already painted with it keep it.</>}
+          confirmLabel="DELETE"
+          onConfirm={() => { w().forgetColor(deleteColor); setDeleteColor(null) }}
+          onCancel={() => setDeleteColor(null)}
+        />
+      )}
     </div>
   )
 }

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -5,14 +5,14 @@
  * order a first visit meets them: STAMP lands a whole shape where you tap
  * (a block, a wedge, a pyramid, a column, a ring, a star, an arrow), sized in
  * whole units and turned a quarter at a time; ADD places one vertex; SELECT
- * picks a point so the pad can nudge it a unit along X, Y or Z, colour it or
+ * picks a point so the pad can nudge it a unit along X, Y or Z, color it or
  * delete it; FACE collects corners and FILL joins them into a face, any
- * number of corners, notches and all. Colour applies to the selection or to
+ * number of corners, notches and all. Color applies to the selection or to
  * everything. The mode, solid, points or lines, is part of the shard and
  * previews live. Every edit undoes.
  *
  * v1's modeller wanted a mouse: drag handles for every axis, bars to drag for
- * every colour channel. This wants a thumb. Every action is a tap or a button,
+ * every color channel. This wants a thumb. Every action is a tap or a button,
  * every position an integer, and the keyboard is a shortcut, not a requirement.
  * The tray shows the row the current tool needs and nothing else, so a phone
  * keeps most of its screen for the bench.
@@ -35,13 +35,13 @@ const TOOL_ICON: Record<Tool, LucideIcon> = { stamp: Stamp, add: Plus, select: M
 
 /** A press this long on a swatch asks to delete it rather than using it. */
 const LONG_PRESS_MS = 550
-/** The picker fires on every step through the wheel; the palette gets the colour you stop on. */
+/** The picker fires on every step through the wheel; the palette gets the color you stop on. */
 const SETTLE_MS = 500
 
 const TOOL_HELP: Record<Tool, string> = {
   stamp: 'Tap the grid to place the shape where the ghost shows. Q turns it.',
   add: 'Tap the grid to place a vertex at the current level.',
-  select: 'Tap a point, then nudge it with the pad, colour it, or delete it.',
+  select: 'Tap a point, then nudge it with the pad, color it, or delete it.',
   face: 'Tap corners in order, then the first again or FILL. Tap a face to select it; DELETE FACE removes it.',
 }
 
@@ -75,7 +75,7 @@ function Swatch({ hex, on, onUse, onHold }: { hex: string; on: boolean; onUse: (
     <button
       className={`workshop__swatch ${on ? 'is-on' : ''}`}
       style={{ background: hex }}
-      aria-label={`Colour ${hex}`}
+      aria-label={`Color ${hex}`}
       aria-pressed={on}
       title={`${hex} (hold to delete)`}
       onPointerDown={() => { held.current = false; stop(); timer.current = window.setTimeout(() => { held.current = true; onHold() }, LONG_PRESS_MS) }}
@@ -121,7 +121,7 @@ export function Workshop(): JSX.Element | null {
   const canNudge = selected !== null
   const say = (notice: string): void => useWorkshop.setState({ notice })
 
-  // The picker paints live and, once the wheel has settled, puts the colour at
+  // The picker paints live and, once the wheel has settled, puts the color at
   // the front of the palette; leaving the picker settles it at once.
   const hex = rgbToHex(color)
   const pick = (value: string): void => {
@@ -258,11 +258,11 @@ export function Workshop(): JSX.Element | null {
           <button className="workshop__btn" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)">REDO</button>
           <span className="workshop__help">{TOOL_HELP[tool]}</span>
           <Explanation>
-            A shard is coloured points on a grid of whole units, drawn SOLID (faces, colours blending
+            A shard is colored points on a grid of whole units, drawn SOLID (faces, colors blending
             across them), POINTS (every point a light) or LINES (one line through the points in the
             order they were made). STAMP places a whole shape; ADD one point; SELECT a point to move,
-            colour or delete it; FACE picks corners and FILL joins them, and a tap on a face selects it
-            for DELETE FACE. The palette keeps every colour the picker settles on; hold a swatch to
+            color or delete it; FACE picks corners and FILL joins them, and a tap on a face selects it
+            for DELETE FACE. The palette keeps every color the picker settles on; hold a swatch to
             delete it. Stamps keep their own corners
             even where they touch, so a red block against a blue one keeps a crisp edge. UNIT says how
             big one grid unit is in the world, from a picometre to the width of a sector; DEPLOY shows
@@ -346,8 +346,8 @@ export function Workshop(): JSX.Element | null {
         </div>
 
         <div className="workshop__row">
-          <span className="workshop__label">COLOUR</span>
-          <span className="workshop__picker" title="Pick any colour; it joins the palette">
+          <span className="workshop__label">COLOR</span>
+          <span className="workshop__picker" title="Pick any color; it joins the palette">
             <input
               type="color"
               className="workshop__color"
@@ -355,7 +355,7 @@ export function Workshop(): JSX.Element | null {
               list="workshop-palette"
               onChange={(e) => pick(e.target.value)}
               onBlur={(e) => settled(e.target.value)}
-              aria-label="Pick a colour"
+              aria-label="Pick a color"
               {...noCallout}
             />
             <Pipette className="workshop__picker-icon" size={13} strokeWidth={2.25} aria-hidden />
@@ -367,13 +367,13 @@ export function Workshop(): JSX.Element | null {
               <Swatch key={h} hex={h} on={h === hex} onUse={() => w().colorSelected(hexToRgb(h))} onHold={() => setDeleteColor(h)} />
             ))}
           </div>
-          <button className="workshop__btn" disabled={!shard || shard.vertices.length === 0} onClick={() => w().colorAll(w().color)} title="Apply the colour to every vertex">ALL</button>
+          <button className="workshop__btn" disabled={!shard || shard.vertices.length === 0} onClick={() => w().colorAll(w().color)} title="Apply the color to every vertex">ALL</button>
         </div>
       </div>
 
       {deleteColor !== null && (
         <ConfirmModal
-          title="Delete colour from palette?"
+          title="Delete color from palette?"
           body={<><span className="workshop__swatch workshop__swatch--sample" style={{ background: deleteColor }} aria-hidden />{deleteColor} leaves the palette. Vertices already painted with it keep it.</>}
           confirmLabel="DELETE"
           onConfirm={() => { w().forgetColor(deleteColor); setDeleteColor(null) }}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -1,31 +1,62 @@
 /**
  * Workshop.tsx — where shards are made.
  *
- * A full-screen bench over the world. The tools are few and exact: ADD
- * places a vertex where you tap the grid, at the current level; SELECT picks
- * one and the pad nudges it a unit along X, Y or Z; FACE joins three taps
- * into a triangle. Colour applies to the selection or to everything. The
- * mode, solid, points or lines, is part of the shard and previews live.
+ * A full-screen bench over the world. The tools are few and exact, in the
+ * order a first visit meets them: STAMP lands a whole shape where you tap
+ * (a block, a wedge, a pyramid, a column, a ring, a star, an arrow), sized in
+ * whole units and turned a quarter at a time; ADD places one vertex; SELECT
+ * picks a point so the pad can nudge it a unit along X, Y or Z, colour it or
+ * delete it; FACE collects corners and FILL joins them into a face, any
+ * number of corners, notches and all. Colour applies to the selection or to
+ * everything. The mode, solid, points or lines, is part of the shard and
+ * previews live. Every edit undoes.
  *
  * v1's modeller wanted a mouse: drag handles for every axis, bars to drag for
  * every colour channel. This wants a thumb. Every action is a tap or a button,
  * every position an integer, and the keyboard is a shortcut, not a requirement.
+ * The tray shows the row the current tool needs and nothing else, so a phone
+ * keeps most of its screen for the bench.
  */
 
 import { useState } from 'react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
-import { GRID_HALF, MODES, hexToRgb, rgbToHex, type ShardMode } from '../lib/shards'
+import { Explanation } from '../hud/Explanation'
+import { GRID_HALF, MODES, hexToRgb, rgbToHex, toPayload, type ShardMode } from '../lib/shards'
 import { formatCellSize } from '../lib/scale'
+import { FACED, FACING_LABEL, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { Bench } from './Bench'
 
 const PALETTE = ['#00e5ff', '#ff2323', '#52e39f', '#ffb020', '#c07dff', '#f7931a', '#ffffff', '#2f81f7']
 
+const TOOLS: Tool[] = ['stamp', 'add', 'select', 'face']
+
 const TOOL_HELP: Record<Tool, string> = {
+  stamp: 'Tap the grid to place the shape where the ghost shows. Q turns it.',
   add: 'Tap the grid to place a vertex at the current level.',
-  select: 'Tap a vertex, then nudge it with the pad, colour it, or delete it.',
-  face: 'Tap three vertices to make a triangle. Faces draw in SOLID mode.',
+  select: 'Tap a point, then nudge it with the pad, colour it, or delete it.',
+  face: 'Tap the corners of a face in order, then tap the first again, or FILL.',
+}
+
+/** Shown once, the first time the workshop opens on this device. */
+const INTRO_KEY = 'onosendai:workshop-intro'
+
+function Intro(): JSX.Element | null {
+  const [show, setShow] = useState<boolean>(() => { try { return !localStorage.getItem(INTRO_KEY) } catch { return false } })
+  if (!show) return null
+  const done = (): void => { try { localStorage.setItem(INTRO_KEY, '1') } catch { /* private mode */ } setShow(false) }
+  return (
+    <div className="workshop__intro" role="note" aria-label="How to make a shard">
+      <h3 className="workshop__intro-title">MAKE A SHARD</h3>
+      <ol className="workshop__intro-steps">
+        <li><b>STAMP</b> a shape: pick one below, tap the grid where the ghost shows.</li>
+        <li><b>Drag</b> to look around. <b>LEVEL</b> raises the grid to stack things.</li>
+        <li><b>DEPLOY</b> hides it in the world at a place you choose.</li>
+      </ol>
+      <button className="workshop__btn workshop__intro-ok" onClick={done}>GOT IT</button>
+    </div>
+  )
 }
 
 export function Workshop(): JSX.Element | null {
@@ -37,7 +68,15 @@ export function Workshop(): JSX.Element | null {
   const facePick = useWorkshop((s) => s.facePick)
   const level = useWorkshop((s) => s.level)
   const color = useWorkshop((s) => s.color)
+  const stampKind = useWorkshop((s) => s.stampKind)
+  const stampSize = useWorkshop((s) => s.stampSize)
+  const stampFacing = useWorkshop((s) => s.stampFacing)
+  const canUndo = useWorkshop((s) => s.past.length > 0)
+  const canRedo = useWorkshop((s) => s.future.length > 0)
+  const notice = useWorkshop((s) => s.notice)
   const [listOpen, setListOpen] = useState(false)
+  const [pasteOpen, setPasteOpen] = useState(false)
+  const [pasteText, setPasteText] = useState('')
   const bind = useRepeatable()
 
   if (!open) return null
@@ -45,6 +84,27 @@ export function Workshop(): JSX.Element | null {
 
   const nudge = (axis: 0 | 1 | 2, d: number) => () => w().moveSelected(axis, d)
   const canNudge = selected !== null
+  const say = (notice: string): void => useWorkshop.setState({ notice })
+
+  const copy = (id: string): void => {
+    const s = w().shards.find((x) => x.id === id)
+    if (!s) return
+    navigator.clipboard?.writeText(JSON.stringify(toPayload(s))).then(() => say(`Copied "${s.name}" to the clipboard. PASTE it here or anywhere.`)).catch(() => say('The clipboard is not available here.'))
+  }
+
+  const importText = (text: string): void => {
+    const id = w().importText(text)
+    if (id) { setPasteOpen(false); setPasteText(''); setListOpen(false); say('Pasted as a new shard.') }
+    else say('That is not a shard.')
+  }
+
+  const paste = async (): Promise<void> => {
+    try {
+      const text = await navigator.clipboard.readText()
+      if (text.trim()) { importText(text); return }
+    } catch { /* no permission or no API: fall through to the box */ }
+    setPasteOpen(true)
+  }
 
   return (
     <div className="workshop" role="dialog" aria-label="Shard workshop">
@@ -79,7 +139,26 @@ export function Workshop(): JSX.Element | null {
 
       {listOpen && (
         <aside className="workshop__list">
-          <button className="workshop__new" onClick={() => { w().create(); setListOpen(false) }}>+ NEW SHARD</button>
+          <div className="workshop__list-row">
+            <button className="workshop__new" onClick={() => { w().create(); setListOpen(false) }}>+ NEW SHARD</button>
+            <button className="workshop__btn" onClick={() => void paste()} title="A shard copied from here or anywhere">PASTE</button>
+          </div>
+          {pasteOpen && (
+            <div className="workshop__paste">
+              <textarea
+                className="workshop__paste-box"
+                value={pasteText}
+                onChange={(e) => setPasteText(e.target.value)}
+                placeholder='Paste a shard here: {"v":1,"type":"shard",...}'
+                aria-label="Shard to import"
+                spellCheck={false}
+              />
+              <div className="workshop__list-row">
+                <button className="workshop__btn" disabled={!pasteText.trim()} onClick={() => importText(pasteText)}>IMPORT</button>
+                <button className="workshop__btn" onClick={() => { setPasteOpen(false); setPasteText('') }}>CANCEL</button>
+              </div>
+            </div>
+          )}
           <ul>
             {shards.map((s) => (
               <li key={s.id} className={s.id === shard?.id ? 'is-current' : ''}>
@@ -88,6 +167,7 @@ export function Workshop(): JSX.Element | null {
                   <span className="workshop__pick-meta">{s.vertices.length} v · {s.faces.length} f · {s.mode}</span>
                 </button>
                 <button className="workshop__mini" title="Duplicate" onClick={() => w().duplicate(s.id)}>⧉</button>
+                <button className="workshop__mini workshop__mini--wide" title="Copy to the clipboard" onClick={() => copy(s.id)}>COPY</button>
                 <button className="workshop__mini workshop__mini--danger" title="Delete" onClick={() => { if (window.confirm(`Delete "${s.name}"? This cannot be undone.`)) w().remove(s.id) }}>✕</button>
               </li>
             ))}
@@ -97,26 +177,90 @@ export function Workshop(): JSX.Element | null {
 
       <div className="workshop__bench">
         <Bench />
+        <Intro />
         {shard && (
           <div className="workshop__stats">
             {shard.vertices.length} vertices · {shard.faces.length} faces · unit 2^{shard.unit} = {formatCellSize(shard.unit)}
             {selected !== null && shard.vertices[selected] && (
-              <> · selected #{selected} at ({shard.vertices[selected].p.join(', ')})</>
+              <> · selected ({shard.vertices[selected].p.join(', ')})</>
             )}
-            {tool === 'face' && facePick.length > 0 && <> · face {facePick.length}/3</>}
+            {tool === 'face' && facePick.length > 0 && <> · {facePick.length} corner{facePick.length === 1 ? '' : 's'}</>}
+            {shard.mode !== 'solid' && shard.faces.length > 0 && <> · faces draw in SOLID</>}
+            {notice && <div className="workshop__notice">{notice}</div>}
           </div>
         )}
       </div>
 
       <div className="workshop__tools">
         <div className="workshop__row" role="group" aria-label="Tool">
-          {(['add', 'select', 'face'] as Tool[]).map((t, i) => (
+          {TOOLS.map((t, i) => (
             <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => w().setTool(t)} title={`${t} (${i + 1})`}>
               {t.toUpperCase()}
             </button>
           ))}
+          <span className="workshop__gap" />
+          <button className="workshop__btn" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)">UNDO</button>
+          <button className="workshop__btn" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)">REDO</button>
           <span className="workshop__help">{TOOL_HELP[tool]}</span>
+          <Explanation>
+            A shard is coloured points on a grid of whole units, drawn SOLID (faces, colours blending
+            across them), POINTS (every point a light) or LINES (one line through the points in the
+            order they were made). STAMP places a whole shape; ADD one point; SELECT a point to move,
+            colour or delete it; FACE picks corners and FILL joins them. Stamps keep their own corners
+            even where they touch, so a red block against a blue one keeps a crisp edge. UNIT says how
+            big one grid unit is in the world, from a picometre to the width of a sector; DEPLOY shows
+            the shard at true size before you place it. Keys: 1 2 3 4 tools, Q turns a stamp, WASD /
+            RF or arrows nudge, Del deletes, Enter fills, [ ] change the level, Ctrl+Z undoes, Esc
+            deselects then closes.
+          </Explanation>
         </div>
+
+        {tool === 'stamp' && (
+          <div className="workshop__row" role="group" aria-label="Shape">
+            <span className="workshop__label">SHAPE</span>
+            <div className="workshop__shapes">
+              {STAMPS.map((k: StampKind) => (
+                <button key={k} className={`workshop__tool ${stampKind === k ? 'is-on' : ''}`} aria-pressed={stampKind === k} onClick={() => w().setStampKind(k)} title={STAMP_HELP[k]}>
+                  {k.toUpperCase()}
+                </button>
+              ))}
+            </div>
+            <span className="workshop__label workshop__label--gap">SIZE</span>
+            <button className="workshop__btn" {...bind(() => w().setStampSize(w().stampSize - 1))} disabled={stampSize <= MIN_SIZE} aria-label="Smaller">−</button>
+            <span className="workshop__value">{stampSize}</span>
+            <button className="workshop__btn" {...bind(() => w().setStampSize(w().stampSize + 1))} disabled={stampSize >= MAX_SIZE} aria-label="Larger">+</button>
+            {FACED[stampKind] && (
+              <>
+                <span className="workshop__label workshop__label--gap">FACING</span>
+                <button className="workshop__btn" onClick={() => w().turnStamp()} title="Turn a quarter (Q)">{FACING_LABEL[stampFacing]} ↻</button>
+              </>
+            )}
+          </div>
+        )}
+
+        {tool === 'select' && (
+          <div className="workshop__row">
+            <span className="workshop__label">NUDGE</span>
+            <div className="workshop__pad" role="group" aria-label="Move selected point">
+              <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, -1))} title="−X (A)">−X</button>
+              <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, 1))} title="+X (D)">+X</button>
+              <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, -1))} title="−Y (F)">−Y</button>
+              <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, 1))} title="+Y (R)">+Y</button>
+              <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, -1))} title="−Z (W)">−Z</button>
+              <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, 1))} title="+Z (S)">+Z</button>
+            </div>
+            <button className="workshop__btn workshop__btn--danger" disabled={!canNudge} onClick={() => w().deleteSelected()} title="Delete point (Del)">DELETE</button>
+          </div>
+        )}
+
+        {tool === 'face' && (
+          <div className="workshop__row">
+            <span className="workshop__label">FACE</span>
+            <span className="workshop__value workshop__value--wide">{facePick.length} corner{facePick.length === 1 ? '' : 's'}</span>
+            <button className="workshop__btn" disabled={facePick.length < 3} onClick={() => w().fill()} title="Join the corners into a face (Enter)">FILL</button>
+            <button className="workshop__btn" disabled={facePick.length === 0} onClick={() => w().clearFacePick()} title="Drop the picks (Esc)">CANCEL</button>
+          </div>
+        )}
 
         <div className="workshop__row">
           <span className="workshop__label">LEVEL Y</span>
@@ -128,19 +272,8 @@ export function Workshop(): JSX.Element | null {
           <button className="workshop__btn" {...bind(() => w().setUnit((shard?.unit ?? 0) - 1))} disabled={!shard || shard.unit <= 0} aria-label="Smaller unit">−</button>
           <span className="workshop__value">{shard?.unit ?? 0}</span>
           <button className="workshop__btn" {...bind(() => w().setUnit((shard?.unit ?? 0) + 1))} disabled={!shard || shard.unit >= 84} aria-label="Larger unit">+</button>
-        </div>
-
-        <div className="workshop__row">
-          <span className="workshop__label">NUDGE</span>
-          <div className="workshop__pad" role="group" aria-label="Move selected vertex">
-            <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, -1))} title="−X (A)">−X</button>
-            <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, 1))} title="+X (D)">+X</button>
-            <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, -1))} title="−Y (F)">−Y</button>
-            <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, 1))} title="+Y (R)">+Y</button>
-            <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, -1))} title="−Z (W)">−Z</button>
-            <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, 1))} title="+Z (S)">+Z</button>
-          </div>
-          <button className="workshop__btn workshop__btn--danger" disabled={!canNudge} onClick={() => w().deleteSelected()} title="Delete vertex (Del)">DELETE</button>
+          <span className="workshop__gap" />
+          <button className="workshop__btn workshop__btn--danger" disabled={!shard || shard.vertices.length === 0} onClick={() => { if (window.confirm('Clear every vertex and face of this shard? (UNDO brings it back.)')) w().clearShard() }}>CLEAR</button>
         </div>
 
         <div className="workshop__row">
@@ -159,13 +292,6 @@ export function Workshop(): JSX.Element | null {
             ))}
           </div>
           <button className="workshop__btn" disabled={!shard || shard.vertices.length === 0} onClick={() => w().colorAll(w().color)} title="Apply the colour to every vertex">ALL</button>
-        </div>
-
-        <div className="workshop__row">
-          <span className="workshop__label">FACES</span>
-          <span className="workshop__value">{shard?.faces.length ?? 0}</span>
-          <button className="workshop__btn" disabled={!shard || shard.faces.length === 0} onClick={() => w().removeLastFace()}>UNDO LAST</button>
-          <button className="workshop__btn workshop__btn--danger" disabled={!shard || shard.vertices.length === 0} onClick={() => { if (window.confirm('Clear every vertex and face of this shard?')) w().clearShard() }}>CLEAR</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Why

The workshop was a precision vertex placer with a strong point of view (integer grid, tap-first, a thumb not a mouse) and one wall for a first-timer: to make anything SOLID you had to think in triangles. A closed cube by hand was 36 disciplined taps with no undo. People who have never opened a 3D editor have used Minecraft, pixel art and Lego, and the shard format is closer to those than to a mesh editor, so the first tool they meet now makes a shape.

Nothing about the wire form changes: stamps compile to plain vertices and triangles in the `v: 1` payload, and the world learns nothing new.

## What

**STAMP** (new first tool). Tap the grid and a whole shape lands there: BLOCK, WEDGE, PYRAMID, COLUMN, RING, STAR or ARROW, SIZE 1 to 4 whole units, the asymmetric ones turned a quarter at a time with FACING (Q). A ghost of the shape follows the pointer on the grid; on a phone a finger presses and slides it. You see where it lands before it does, which on a grid seen in perspective is the difference between placing and guessing. A stamp that would poke out of the grid is pushed back inside.

**Hard edges.** A stamp keeps its own vertices even where the shard already has one on that point, so a red block against a blue one keeps a crisp seam instead of blending across it (colours live on vertices). Where two stamps meet face to face, the two triangles facing each other are dropped rather than paid for, which is why every box splits each face on the same diagonal: the cull matches triangles corner for corner. From then on a point can hold several vertices, and SELECT, the nudge pad, the colour and DELETE act on every vertex at that point together. One dot that behaves like one dot. ADD by hand still never stacks: tapping an occupied point selects it.

**FILL.** FACE collects any number of corners in order; FILL, Enter, or tapping the first corner again joins them into a face, notches and all, by ear clipping in the loop's own plane (`triangulate.ts`). A line traces the picks as you go. A loop that is not a polygon is refused with a notice and the picks kept.

**Undo and redo.** Every edit to the current shard, 64 deep, Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y and buttons. Switching shards clears the history; renaming is not an edit.

**A new shard starts in LINES**, so the first tap glows and the second draws a line. The first faces (a stamp with faces, or a FILL) switch it to SOLID with a notice saying so; after that the mode is yours. A ring has no faces and leaves the mode alone.

**COPY and PASTE** in the shard list carry a shard through the clipboard in its wire form, with a paste box where the clipboard API is not available. This is also how a design survives a cleared localStorage.

**EXPLAIN** in the workshop, like every other panel, and a three-step card the first time it opens on a device. The tray shows only the row the current tool needs (shapes, the nudge pad, or FILL), so a phone keeps the same bench area it had.

Keys: 1 2 3 4 tools, Q turns a stamp, Enter fills; the rest as before.

## Decisions taken with arkinox

- Hard edges: yes (duplicate-position vertices from stamps; point groups in the editor).
- v1 shape maker before any assistant.
- The stamp library lives in this repo (`src/lib/stamps.ts`).
- New shards default to LINES.
- Grid half-width, budgets (512 / 1024) and the payload version are unchanged.

## Tests

- `triangulate.test.ts`: a triangle, a square, a concave L, either winding, a vertical plane, a flat mid-edge corner dropped without a sliver, collinear and too-few refused, a ten-corner star.
- `stamps.test.ts`: every kind at every size is integer and inside the grid with valid faces; budgets per shape; loops close for LINES; centred on the tap and standing on the level; pushed inside at the edge; FACING turns the faced shapes and not the others; colour and validity after stamping; the wall between touching blocks is culled on both sides (side by side and stacked, not diagonal); seams stay crisp; budget refusal; preview mode.
- `useWorkshop.test.ts`: LINES and STAMP on a new shard; hand ADD never stacks; nudging may land on another vertex; stamp flips LINES to SOLID once and respects a later LINES; ring leaves the mode; point groups move, colour and delete together with faces renumbered; FILL closes on the first pick or by FILL, unpicks, refuses a non-polygon; undo/redo through stamp, colour and unit, cleared on switching; export/import round trip, garbage refused, and the found-shard copy from #48 kept.
- Driven in a real browser (desktop and phone viewports): the hover ghost aims at the cell under the pointer, a real mouse click and a real touch tap each land a block and flip the mode with the notice, undo reverts. 457 tests, typecheck and build green.

## Not in this slice (next, in the memo's order)

Whole-shard operations (CENTRE, MIRROR, MOVE ALL, multi-select), scale you can see on the bench (the ladder words and a human-height reference), the phone tray as a bottom sheet, and the assistant (runtime and pricing still to be discussed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHNpe8aEcogEWkX6bHAaWX
