### PR TITLE
Fleet cubes: glide to the one you click, name each, fade them in

### DIFF
--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -262,7 +262,6 @@ function Rig(): JSX.Element {
   // the previous focus effect saw, so the next one can tell a move within
   // the same view from a change of subject.
   const glideLeft = useRef(0)
-  const flyFrom = useRef<{ anchor: Position; plane: number; scaleExp: number; owned: boolean } | null>(null)
 
   // Re-framed on an axis snap and on a respawn. A respawn moves the render
   // origin home in one step, and the per-frame shift below would faithfully
@@ -273,9 +272,6 @@ function Rig(): JSX.Element {
     const c = controls.current
     if (!c) return
     const s = useCyberspace.getState()
-    const owned = useHyperspace.getState().viewOwned
-    const prev = flyFrom.current
-    flyFrom.current = { anchor: s.anchor, plane: s.anchorPlane, scaleExp: s.scaleExp, owned }
     const before = prevDeps.current
     prevDeps.current = { view, genesisId, focusPubkey, focusPoint, exploreIndex }
     // A chain step: only the explored index changed. Keep the orbit. Near
@@ -286,7 +282,7 @@ function Rig(): JSX.Element {
     const stepOnly = before !== null && before.view === view && before.genesisId === genesisId &&
       before.focusPubkey === focusPubkey && before.focusPoint === focusPoint && before.exploreIndex !== exploreIndex
     const trace = (branch: string, extra: Record<string, unknown> = {}): void => {
-      if (import.meta.env.DEV) (window as unknown as { __rigLast?: unknown }).__rigLast = { branch, stepOnly, before, exploreIndex, prevPlane: prev?.plane, plane: s.anchorPlane, prevScale: prev?.scaleExp, scale: s.scaleExp, ...extra }
+      if (import.meta.env.DEV) (window as unknown as { __rigLast?: unknown }).__rigLast = { branch, stepOnly, before, exploreIndex, seenPlane: seen?.plane, plane: s.anchorPlane, seenScale: seen?.scaleExp, scale: s.scaleExp, ...extra }
     }
     const same = (a: { anchor: Position; plane: number; scaleExp: number }): boolean =>
       a.anchor.x === s.anchor.x && a.anchor.y === s.anchor.y && a.anchor.z === s.anchor.z && a.plane === s.anchorPlane && a.scaleExp === s.scaleExp
@@ -323,22 +319,43 @@ function Rig(): JSX.Element {
       c.update()
       return
     }
-    // Same plane, same zoom, both frames owned by hyperspace: skip the
-    // re-frame. The per-frame origin shift below carries the camera into the
-    // new frame still looking at the old stop, and the stretched follow
-    // eases it onto the new one, which is the fly.
-    if (owned && prev !== null && prev.owned && prev.plane === s.anchorPlane &&
-        prev.scaleExp === s.scaleExp && s.focus !== null) {
+    // A change of focus at the same zoom: a stop clicked from another, RETURN
+    // to the avatar, a shard picked from the panel. Keep the orbit, exactly as
+    // a chain step does: near enough, the per-frame origin shift below
+    // carries the camera into the new frame still looking at the old point
+    // and the stretched follow eases it onto the new one, which is the fly;
+    // too far, cut to the new point with the same offset the camera had from
+    // the old. This used to demand that hyperspace owned the view on both
+    // sides of the change and that the zoom had not moved since the LAST
+    // focus, so a stop clicked after any wheel zoom re-framed straight on
+    // at the default distance instead: the scene jumped and the click read
+    // as having gone nowhere. `seen` is frame-accurate, so a zoom in between
+    // no longer disqualifies the fly; only a zoom in the same change does.
+    const focusOnly = before !== null && before.view === view && before.genesisId === genesisId &&
+      before.exploreIndex === exploreIndex && (before.focusPubkey !== focusPubkey || before.focusPoint !== focusPoint)
+    if (focusOnly && seen !== null && seen.scaleExp === s.scaleExp) {
       const cells = Math.max(
-        Math.abs(cellDelta(s.anchor.x, prev.anchor.x, s.scaleExp)),
-        Math.abs(cellDelta(s.anchor.y, prev.anchor.y, s.scaleExp)),
-        Math.abs(cellDelta(s.anchor.z, prev.anchor.z, s.scaleExp)),
+        Math.abs(cellDelta(s.anchor.x, seen.anchor.x, s.scaleExp)),
+        Math.abs(cellDelta(s.anchor.y, seen.anchor.y, s.scaleExp)),
+        Math.abs(cellDelta(s.anchor.z, seen.anchor.z, s.scaleExp)),
       )
-      if (cells > 0 && cells < GLIDE_MAX_CELLS) {
+      trace(cells === 0 ? 'focus-none' : cells < GLIDE_MAX_CELLS ? 'focus-glide' : 'focus-cut', { cells })
+      if (cells === 0) return
+      if (cells < GLIDE_MAX_CELLS) {
         glideLeft.current = GLIDE_SECONDS
         locked.current = true
         return
       }
+      const offset = c.object.position.clone().sub(c.target)
+      const [x, y, z] = s.cursorOffset()
+      glideLeft.current = 0
+      smooth.current.set(x, y, z)
+      c.target.copy(smooth.current)
+      c.object.position.copy(smooth.current).add(offset)
+      locked.current = true
+      prevOrigin.current = null
+      c.update()
+      return
     }
     trace('reframe')
     glideLeft.current = 0

--- a/src/scene/StopCubes.tsx
+++ b/src/scene/StopCubes.tsx
@@ -8,10 +8,10 @@
  * you have flown to never vanishes into a subpixel while still reading as a
  * small landmark rather than a billboard.
  */
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { markSceneTapHandled } from '../hooks/useCanvasTap'
 import { useFrame } from '@react-three/fiber'
-import { Group } from 'three'
+import { Group, Mesh, type MeshBasicMaterial } from 'three'
 import { xyzToCoord } from 'cyberspace-core'
 import { GRID_RADIUS, markerCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
@@ -30,6 +30,12 @@ const DEST_COLOR = '#ffff00'
 const MAX_CUBES = 24
 /** A cube never renders smaller than this many cells (visibility floor). */
 const MIN_CELLS = 0.15
+/** How long a fleet cube takes to fade in, in seconds. They used to pop:
+ * the anti-clump filter releases them as you zoom, and a cube appearing
+ * from nothing read as an event rather than a neighbour coming into view. */
+const FADE_SECONDS = 0.3
+/** The fleet's resting opacity. */
+const FLEET_OPACITY = 0.75
 const REACH = GRID_RADIUS * 8
 
 export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
@@ -96,14 +102,46 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
   }, [indexVersion, anchor, anchorPlane, scaleExp, axes, scrubHeight, destination])
 
   const spin = useRef<Group>(null)
-  useFrame((_, dt) => {
+  const fleet = useRef<Group>(null)
+  // When each fleet cube first appeared, by height, for the fade-in. Kept
+  // outside React state: it changes every frame while a cube fades and
+  // nothing but the material needs to know.
+  const born = useRef(new Map<number, number>())
+  useFrame(({ clock }, dt) => {
     const g = spin.current
-    if (!g) return
-    for (const child of g.children) {
-      child.rotation.y += dt * 0.9
-      child.rotation.x += dt * 0.45
+    if (g) {
+      for (const child of g.children) {
+        child.rotation.y += dt * 0.9
+        child.rotation.x += dt * 0.45
+      }
     }
+    const f = fleet.current
+    if (!f) return
+    const now = clock.elapsedTime
+    const present = new Set<number>()
+    for (const child of f.children) {
+      if (!(child instanceof Mesh)) continue
+      const height = child.userData.height as number
+      present.add(height)
+      let t0 = born.current.get(height)
+      if (t0 === undefined) { t0 = now; born.current.set(height, now) }
+      const k = Math.min(1, (now - t0) / FADE_SECONDS)
+      ;(child.material as MeshBasicMaterial).opacity = FLEET_OPACITY * k
+    }
+    for (const height of born.current.keys()) if (!present.has(height)) born.current.delete(height)
   })
+  // The labels follow the cubes in after the fade rather than popping ahead
+  // of them: one state update per batch, not one per frame.
+  const fleetKey = cubes
+    .filter(({ stop }) => stop.height !== destination && stop.height !== scrubHeight)
+    .map(({ stop }) => stop.height)
+    .join(',')
+  const [labelled, setLabelled] = useState('')
+  useEffect(() => {
+    const t = window.setTimeout(() => setLabelled(fleetKey), FADE_SECONDS * 1000)
+    return () => window.clearTimeout(t)
+  }, [fleetKey])
+  const labelledSet = useMemo(() => new Set(labelled.split(',').filter(Boolean).map(Number)), [labelled])
 
   if (cubes.length === 0) return null
   const side = Math.max(2 ** -scaleExp, MIN_CELLS)
@@ -113,26 +151,46 @@ export function StopCubes({ axes }: { axes: ViewAxes }): JSX.Element | null {
 
   return (
     <>
-      {cubes.map(({ stop, centre }) =>
-        stop.height === destination || stop.height === scrubHeight ? null : (
-          <mesh
-            key={stop.height}
-            position={centre}
-            // A cube is an exact target in a way the point cloud is not:
-            // the raycast hits its faces, so a click selects THIS stop and
-            // never a neighbour within some threshold of the ray.
-            onClick={(e) => {
-              if (e.delta > 8) return
-              e.stopPropagation()
-              markSceneTapHandled()
-              selectStopInScene(stop.height)
-            }}
-          >
-            <boxGeometry args={[inertSide, inertSide, inertSide]} />
-            <meshBasicMaterial color={CUBE_COLOR} transparent opacity={0.75} />
-          </mesh>
-        ),
-      )}
+      <group ref={fleet}>
+        {cubes.map(({ stop, centre }) =>
+          stop.height === destination || stop.height === scrubHeight ? null : (
+            <mesh
+              key={stop.height}
+              position={centre}
+              userData={{ height: stop.height }}
+              // A cube is an exact target in a way the point cloud is not:
+              // the raycast hits its faces, so a click selects THIS stop and
+              // never a neighbour within some threshold of the ray.
+              onClick={(e) => {
+                if (e.delta > 8) return
+                e.stopPropagation()
+                markSceneTapHandled()
+                selectStopInScene(stop.height)
+              }}
+            >
+              <boxGeometry args={[inertSide, inertSide, inertSide]} />
+              <meshBasicMaterial color={CUBE_COLOR} transparent opacity={0} />
+            </mesh>
+          ),
+        )}
+      </group>
+      {/* Each fleet cube says which block it is: the number the Hyperspace
+          panel's nearest list shows, so cubes and list read against each
+          other. Unlabelled, a clump of orange cubes around the selection
+          was a mystery. */}
+      {cubes
+        .filter(({ stop }) => stop.height !== destination && stop.height !== scrubHeight && labelledSet.has(stop.height))
+        .map(({ stop, centre }) => (
+          <WorldLabel
+            key={`f${stop.height}`}
+            text={String(stop.height)}
+            color={CUBE_COLOR}
+            at={[centre[0], centre[1] + inertSide * 0.5 + 0.22, centre[2]]}
+            align="center"
+            px={9}
+            opacity={0.8}
+          />
+        ))}
       <group ref={spin}>
         {/* The scrubbed block earns the selected look too (yellow, spinning,
             no burst): stepping the line one block at a time on Earth needs


### PR DESCRIPTION
arkinox's third CYBERSPACE view note, the three parts agreed.

**What the fleet is.** The orange cubes around a selected port are its nearest neighbours on the line, up to 24, thinned so none sits against another: the same blocks the Hyperspace panel's nearest list names.

**The click.** It did select the block, but the rig re-framed straight on at the default distance and re-anchored the world in one frame, so the scene jumped and the click read as having gone nowhere. The rig demanded that hyperspace owned the view on both sides of the change and that the zoom had not moved since the *last* focus change, which any wheel zoom in between broke. A change of focus at the same zoom now keeps the orbit exactly as a chain step does (#47): near, glide; too far, cut with the same offset; the frame-accurate `seen` is the reference, so a zoom in between no longer disqualifies the fly. The same rule serves RETURN and a shard picked from the panel. The straight-on re-frame remains for a change of view or of zoom in the same update.

**Labels and fade.** Each fleet cube carries its block height, and they fade in over 0.3 s instead of popping when the anti-clump filter releases them; the labels follow once the fade is done. The selected block keeps the bright yellow spin.

Verified headlessly: twelve fleet cubes on screen at 2^76 after a zoom; a click on one sets the destination, takes the glide branch, and the camera eases onto it over the glide time; 24 height labels on the scene. 433 tests, type check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc