### PR TITLE
Cloud compute panel: the prepaid HOSAKA balance

### DIFF
--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -10,8 +10,8 @@
  */
 
 import { CheckPaymentButton } from './InvoiceModal'
-import { useState } from 'react'
-import { formatClock, satsLabel, satsOf, type CloudMode } from '../lib/cloud'
+import { useEffect, useState } from 'react'
+import { balanceLabel, formatClock, satsLabel, satsOf, sinceLabel, type CloudMode } from '../lib/cloud'
 import { HOSAKA_DEFAULT_URL } from '../lib/hosaka'
 import { shortHex } from '../lib/time'
 import { useNow } from '../hooks/useNow'
@@ -42,6 +42,9 @@ function hostOf(url: string): string {
   try { return new URL(url).host } catch { return url }
 }
 
+/** A remembered balance older than this is refreshed on its own, local keys only. */
+const BALANCE_STALE_MS = 10 * 60 * 1000
+
 export function CloudPanel(): JSX.Element {
   const prefs = useCyberspace((s) => s.cloudPrefs)
   const cloud = useCyberspace((s) => s.cloud)
@@ -53,6 +56,19 @@ export function CloudPanel(): JSX.Element {
   const job = cloud.job
   // Elapsed and "ago" lines only exist while there is a job to describe.
   const now = useNow(job || cloud.status === 'awaiting_payment' ? 1000 : 0)
+  const pubkey = useCyberspace((s) => s.identity.pubkey)
+  const signerKind = useCyberspace((s) => s.signerKind)
+  const balance = cloud.balance
+  // The remembered balance for this identity, the moment the panel is up;
+  // and with a local key (no signer to ask) a fresh figure when the one we
+  // have is stale, once HOSAKA has answered the caps so it is known to be
+  // reachable.
+  useEffect(() => {
+    const st = useCyberspace.getState()
+    st.ensureBalance()
+    const known = st.cloud.balance
+    if (signerKind === 'local' && st.cloud.limits !== null && st.cloudPrefs.mode !== 'off' && (known === null || Date.now() - known.at > BALANCE_STALE_MS)) void st.refreshBalance()
+  }, [pubkey, signerKind, cloud.limits !== null])
   const tag = prefs.mode === 'off' ? 'OFF' : active || cloud.status === 'error' ? STATUS_LABEL[cloud.status] : prefs.mode.toUpperCase()
 
   const setUrl = (): void => {
@@ -116,7 +132,22 @@ export function CloudPanel(): JSX.Element {
           <dt>Cloud caps</dt>
           <dd>{cloud.limits ? `HOPS 2^${cloud.limits.max_hop_height} · SIDESTEPS 2^${cloud.limits.max_sidestep_height}` : prefs.mode === 'off' ? '—' : 'not fetched'}</dd>
         </div>
+        <div>
+          <dt>Prepaid balance</dt>
+          <dd>
+            {balance ? balanceLabel(balance.msats) : '—'}{' '}
+            <button
+              className="cloud__link"
+              onClick={() => { void useCyberspace.getState().refreshBalance() }}
+              disabled={cloud.balanceChecking}
+              title={signerKind === 'local' ? 'Ask HOSAKA for the balance' : 'Ask HOSAKA for the balance (your signer will be asked to sign the request)'}
+            >
+              {cloud.balanceChecking ? 'CHECKING…' : balance ? `REFRESH · ${sinceLabel(balance.at, now || Date.now())}` : 'CHECK'}
+            </button>
+          </dd>
+        </div>
       </dl>
+      {cloud.balanceError && <p className="legend__note">{cloud.balanceError}</p>}
 
       {editingUrl && (
         <form className="avatars__find cloud__url" onSubmit={(e) => { e.preventDefault(); setUrl() }}>

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computeSidestepProof, bytesToHex } from 'cyberspace-core'
 import {
   CloudFlowError,
+  balanceLabel,
   clearCloudJob,
   cloudProofResponse,
   defaultCloudPrefs,
@@ -20,15 +21,19 @@ import {
   driveCloudJob,
   formatClock,
   jobInProgress,
+  loadBalance,
   loadCloudJob,
   loadCloudPrefs,
   needsApproval,
   positionFromWire,
   retainsRecord,
   routeCommit,
+  satsLabel,
   satsOf,
+  saveBalance,
   saveCloudJob,
   saveCloudPrefs,
+  sinceLabel,
   type PendingCloudJob,
   wirePosition,
 } from './cloud'
@@ -257,5 +262,29 @@ describe('jobInProgress', () => {
   it('is paid, computing or verifying, and no other status', () => {
     for (const st of ['paid', 'computing', 'verifying'] as const) expect(jobInProgress(st)).toBe(true)
     for (const st of ['idle', 'quoting', 'confirm', 'funding', 'awaiting_payment', 'error'] as const) expect(jobInProgress(st)).toBe(false)
+  })
+})
+
+describe('remembered balance', () => {
+  beforeEach(() => { vi.stubGlobal('localStorage', memoryStorage()) })
+  it('sinceLabel picks the coarsest non-zero unit', () => {
+    const t = 1_700_000_000_000
+    expect(sinceLabel(t, t + 30_000)).toBe('just now')
+    expect(sinceLabel(t, t + 4 * 60_000)).toBe('4 min ago')
+    expect(sinceLabel(t, t + 3 * 3_600_000)).toBe('3 h ago')
+    expect(sinceLabel(t, t + 5 * 86_400_000)).toBe('5 d ago')
+  })
+  it('balanceLabel rounds down, satsLabel rounds up', () => {
+    expect(balanceLabel(4200)).toBe('4 sats')
+    expect(balanceLabel(1000)).toBe('1 sat')
+    expect(balanceLabel(-5)).toBe('0 sats')
+    expect(satsLabel(4200)).toBe('5 sats')
+  })
+  it('saveBalance rounds, floors at zero and loads back per pubkey', () => {
+    const rec = saveBalance('pk-a', 1234.6, 42)
+    expect(rec).toEqual({ msats: 1235, at: 42 })
+    expect(loadBalance('pk-a')).toEqual({ msats: 1235, at: 42 })
+    expect(loadBalance('pk-b')).toBeNull()
+    expect(saveBalance('pk-b', -5, 1).msats).toBe(0)
   })
 })

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -249,6 +249,12 @@ export function satsOf(msats: number): number {
   return Math.ceil(msats / 1000)
 }
 
+/** A balance is what you have, so it rounds DOWN: 4200 msats is "4 sats", never 5. */
+export function balanceLabel(msats: number): string {
+  const n = Math.floor(Math.max(0, msats) / 1000)
+  return `${n} sat${n === 1 ? '' : 's'}`
+}
+
 /** "1 sat", "15 sats": the unit agrees with the number everywhere it is shown. */
 export function satsLabel(msats: number): string {
   const n = satsOf(msats)
@@ -550,4 +556,51 @@ export function depositSettled(prev: CloudStatus, next: CloudStatus): boolean {
  * or the result is being verified here. Drives the pulsing mark. */
 export function jobInProgress(status: CloudStatus): boolean {
   return status === 'paid' || status === 'computing' || status === 'verifying'
+}
+
+// ---------------------------------------------------------------------------
+// The prepaid balance, remembered per identity
+// ---------------------------------------------------------------------------
+
+const BALANCE_KEY = 'onosendai:hosakaBalance'
+
+/** The balance HOSAKA last reported for an identity, and when. */
+export interface KnownBalance {
+  msats: number
+  at: number
+}
+
+function balanceTable(): Record<string, KnownBalance> {
+  try {
+    const raw = localStorage.getItem(BALANCE_KEY)
+    const parsed: unknown = raw ? JSON.parse(raw) : {}
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, KnownBalance>) : {}
+  } catch {
+    return {}
+  }
+}
+
+export function loadBalance(pubkey: string): KnownBalance | null {
+  const v = balanceTable()[pubkey]
+  return v && typeof v.msats === 'number' && Number.isFinite(v.msats) && typeof v.at === 'number' ? v : null
+}
+
+/** Remember a balance HOSAKA just reported. Returns the record kept. */
+export function saveBalance(pubkey: string, msats: number, at = Date.now()): KnownBalance {
+  const table = balanceTable()
+  const rec = { msats: Math.max(0, Math.round(msats)), at }
+  table[pubkey] = rec
+  try { localStorage.setItem(BALANCE_KEY, JSON.stringify(table)) } catch { /* storage unavailable: the figure is still in memory */ }
+  return rec
+}
+
+/** How long ago, in the coarsest unit that is not zero: "just now", "4 min ago", "2 h ago", "3 d ago". */
+export function sinceLabel(at: number, now: number): string {
+  const s = Math.max(0, Math.floor((now - at) / 1000))
+  if (s < 60) return 'just now'
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m} min ago`
+  const h = Math.floor(m / 60)
+  if (h < 48) return `${h} h ago`
+  return `${Math.floor(h / 24)} d ago`
 }

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -120,6 +120,8 @@ describe('cloud routes', () => {
     storage.removeItem('onosendai:cloudJob')
     storage.removeItem('onosendai:cloudDeposit')
     storage.removeItem('onosendai:spent')
+    storage.removeItem('onosendai:hosakaBalance')
+    useCyberspace.setState({ cloud: { ...S().cloud, balance: null, balanceChecking: false, balanceError: null } })
     useCyberspace.setState({ spentMsats: 0 })
   })
   afterEach(() => {
@@ -440,5 +442,36 @@ describe('cloud routes', () => {
     expect(fake.quote).toHaveBeenCalledTimes(1)
     expect(S().plan?.summary.cloudSteps).toBe(1)
     S().cancel()
+  })
+
+  // ---- the prepaid balance ----
+
+  it('refreshBalance asks HOSAKA once, keeps the figure, and remembers it per identity', async () => {
+    fake.balance.mockResolvedValue({ pubkey: S().identity.pubkey, balance_msats: 7000, ledger: [] })
+    await S().refreshBalance()
+    expect(fake.balance).toHaveBeenCalledTimes(1)
+    expect(S().cloud.balance?.msats).toBe(7000)
+    expect(S().cloud.balanceChecking).toBe(false)
+    expect(JSON.parse(storage.getItem('onosendai:hosakaBalance') ?? '{}')[S().identity.pubkey].msats).toBe(7000)
+    useCyberspace.setState({ cloud: { ...S().cloud, balance: null } })
+    S().ensureBalance()
+    expect(S().cloud.balance?.msats).toBe(7000)
+  })
+  it('a failed check keeps the last figure and says why', async () => {
+    fake.balance.mockResolvedValue({ pubkey: S().identity.pubkey, balance_msats: 3000, ledger: [] })
+    await S().refreshBalance()
+    fake.balance.mockRejectedValue(new HosakaError(503, 'payments_unavailable', 'no wallet'))
+    await S().refreshBalance()
+    expect(S().cloud.balance?.msats).toBe(3000)
+    expect(S().cloud.balanceError).toMatch(/503|payments_unavailable|wallet/)
+  })
+  it('a funded route notes the balance it read on the way', async () => {
+    lineUpH13()
+    fake.quote.mockResolvedValue(quote('hop'))
+    fake.submitHop.mockResolvedValue(funded())
+    fake.waitForJob.mockResolvedValue(completed(hopResult(S().position, S().cursor, S().plane, S().prevEventId)))
+    await S().commit()
+    await idle()
+    expect(S().cloud.balance?.msats).toBe(5000)
   })
 })

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -112,6 +112,9 @@ import {
   loadCloudDeposit,
   saveCloudDeposit,
   clearCloudDeposit,
+  loadBalance,
+  saveBalance,
+  type KnownBalance,
 } from '../lib/cloud'
 import { nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
@@ -272,6 +275,11 @@ export interface CloudState {
   /** The last cloud proof that landed, for the panel. */
   last: { jobId: string; action: HosakaAction; costMsats: number; lookupId: string | null; at: number } | null
   /** CHECK PAYMENT was pressed and the node has not answered yet. */
+  /** HOSAKA's prepaid balance for this identity as last reported, from a
+   * balance check or from any response that carried one; null until known. */
+  balance: KnownBalance | null
+  balanceChecking: boolean
+  balanceError: string | null
   checking: boolean
   /** The node's last word on the invoice, so a check shows something even when nothing changed. */
   lastCheck: { at: number; status: string } | null
@@ -290,6 +298,9 @@ const IDLE_CLOUD: CloudState = {
   last: null,
   checking: false,
   lastCheck: null,
+  balance: null,
+  balanceChecking: false,
+  balanceError: null,
 }
 
 /**
@@ -497,6 +508,12 @@ export interface CyberspaceState {
    * money is spent and the result can still be claimed while the head holds.
    */
   cancelCloud: () => void
+  /** Remember a balance HOSAKA just reported for this identity. */
+  noteBalance: (msats: number) => void
+  /** Load the remembered balance for this identity, if the slice has none yet. */
+  ensureBalance: () => void
+  /** Ask HOSAKA for the balance (a signed request) and remember the answer. */
+  refreshBalance: () => Promise<void>
   /**
    * Pick up the persisted job (on load, after an identity switch, or from the
    * panel) when its chain head is still ours; drop it when the head moved or
@@ -988,6 +1005,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     try {
       set({ cloud: { ...get().cloud, status: 'funding', message: currentSigner.kind === 'local' ? 'Checking your HOSAKA balance.' : 'Waiting for your signer to approve the HOSAKA balance check.' } })
       const bal = await client.balance(abort.signal)
+      get().noteBalance(bal.balance_msats)
       if (id !== requestId) return
       // Whole sats: a node refuses an invoice for a fraction of one.
       const shortfall = Math.ceil(Math.max(0, totalMsats - bal.balance_msats) / 1000) * 1000
@@ -1005,6 +1023,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
           waker,
           onPoll: (d) => { if (id === requestId) set({ cloud: { ...get().cloud, checking: false, lastCheck: { at: Date.now(), status: d.status } } }) },
         })
+        if (typeof settled.balance_msats === 'number') get().noteBalance(settled.balance_msats)
         if (id !== requestId) return
         if (settled.status !== 'settled') {
           clearCloudDeposit()
@@ -1057,6 +1076,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       job = step.kind === 'hop'
         ? await client.submitHop(v1, v2, prevEventId)
         : await client.submitSidestep(v1, v2, prevEventId)
+      const after = job.new_balance_msats ?? job.current_balance_msats
+      if (typeof after === 'number') get().noteBalance(after)
     } catch (err) {
       if (id !== requestId) return
       routeFail(describeCloudError(err))
@@ -1197,6 +1218,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     set({
       cloud: {
         ...IDLE_CLOUD,
+        balance: get().cloud.balance,
         limits: get().cloud.limits,
         // A route in progress keeps its funded status visible.
         status: get().plan ? 'paid' : 'idle',
@@ -1240,7 +1262,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       spectate: null,
       focus: null,
       transit: null,
-      cloud: { ...IDLE_CLOUD, limits: get().cloud.limits },
+      cloud: { ...IDLE_CLOUD, limits: get().cloud.limits, balance: loadBalance(signer.pubkey) },
     })
     if (local) saveChain(base.events, base.published, base.chain)
     // A pending cloud job of THIS identity, if there is one, picks up where it stopped.
@@ -1682,7 +1704,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       proof: IDLE_PROOF,
       publishError: null,
       spentMsats: loadSpent(fresh.genesisId),
-      cloud: { ...IDLE_CLOUD, limits: get().cloud.limits },
+      cloud: { ...IDLE_CLOUD, limits: get().cloud.limits, balance: get().cloud.balance },
     })
     saveChain(fresh.events, fresh.published, fresh.chain)
   },
@@ -2023,6 +2045,31 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     void fundRoute(cloud.quote.costMsats, requestId)
   },
 
+  noteBalance: (msats) => {
+    set({ cloud: { ...get().cloud, balance: saveBalance(get().identity.pubkey, msats), balanceError: null } })
+  },
+
+  ensureBalance: () => {
+    const { cloud, identity } = get()
+    if (cloud.balance !== null) return
+    const known = loadBalance(identity.pubkey)
+    if (known) set({ cloud: { ...cloud, balance: known } })
+  },
+
+  refreshBalance: async () => {
+    const { cloud, cloudPrefs } = get()
+    if (cloud.balanceChecking) return
+    set({ cloud: { ...cloud, balanceChecking: true, balanceError: null } })
+    try {
+      const bal = await cloudClient(cloudPrefs.apiUrl).balance()
+      get().noteBalance(bal.balance_msats)
+    } catch (err) {
+      set({ cloud: { ...get().cloud, balanceError: describeCloudError(err) } })
+    } finally {
+      set({ cloud: { ...get().cloud, balanceChecking: false } })
+    }
+  },
+
   declineCloud: () => {
     if (get().cloud.status !== 'confirm') return
     requestId++
@@ -2045,6 +2092,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       cloud: {
         ...IDLE_CLOUD,
         limits: cloud.limits,
+        balance: cloud.balance,
         last: cloud.last,
         job: keep ? cloud.job : null,
         message: keep
@@ -2068,6 +2116,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       } else {
         try {
           const claimed = await cloudClient(cloudPrefs.apiUrl).claimDeposit(dep.depositId)
+          if (typeof claimed.balance_msats === 'number') get().noteBalance(claimed.balance_msats)
           if (claimed.status === 'settled') {
             clearCloudDeposit()
             set({ cloud: { ...get().cloud, message: `A ${satsOf(claimed.settled_msats ?? dep.amountMsats)} sat route deposit from an interrupted commit was credited to your HOSAKA balance.` } })


### PR DESCRIPTION
A **Prepaid balance** row in the Cloud compute panel: the balance HOSAKA last reported for this identity, and when.

- Learned for free from every response that already carries one (the balance check a route makes, a settled deposit, a claim, a funded submit), and remembered per identity in localStorage, so the figure is there the moment the panel opens.
- **CHECK / REFRESH** asks HOSAKA outright. That is a signed request, so an extension or bunker user is asked to sign once, and the button's tooltip says so. With a local key the panel refreshes a figure older than ten minutes on its own, once HOSAKA has answered the caps (so it is known to be reachable).
- A failed check keeps the last figure and shows why.
- A balance rounds down (4200 msats is 4 sats), unlike a price, which rounds up.
- The resets that rebuild the cloud slice after a job, a route or a cancel now carry the remembered balance instead of dropping it; an identity switch loads the new identity's.

Verified headlessly with a stubbed balance endpoint: the local-key auto refresh sends a NIP-98 header and fills the row; CHECK fills it from empty; the figure is back right after a reload. Tests for the store (refresh, failure, capture on a funded route) and the helpers. Type check and the full suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc