### PR TITLE
Proof worker: stop turning the region root into a decimal string

### DIFF
--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -211,7 +211,7 @@ describe('cloudProofResponse', () => {
     }
     const msg = cloudProofResponse(7, base, job('completed', { result, cost_msats: 1234 }), 5000)
     expect(msg).toEqual({
-      type: 'done', id: 7, mode: 'hop', elapsedMs: 5000, proofHash: 'aa'.repeat(32), regionN: null, terrainK: 11,
+      type: 'done', id: 7, mode: 'hop', elapsedMs: 5000, proofHash: 'aa'.repeat(32), terrainK: 11,
       lca: { x: 13, y: 0, z: 0 }, totalOps: 0, source: 'cloud', jobId: 'job-1', costMsats: 1234, lookupId: 'cc'.repeat(32),
     })
   })
@@ -229,7 +229,6 @@ describe('cloudProofResponse', () => {
     if (msg.type !== 'done') return
     expect(msg.mode).toBe('sidestep')
     expect(msg.proofHash).toBe(p.proofHash)
-    expect(msg.regionN).toBe(p.regionM.toString())
     expect(msg.lca).toEqual({ x: 13, y: 0, z: 0 })
     expect(msg.sidestep).toEqual({
       merkleRoots: [bytesToHex(p.merkleX), bytesToHex(p.merkleY), bytesToHex(p.merkleZ)],

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -434,7 +434,6 @@ export function cloudProofResponse(id: number, record: PendingCloudJob, job: Hos
       elapsedMs,
       proofHash: r.hop_n.public_proof,
       // The region integer never left the cloud; its lookup id did.
-      regionN: null,
       terrainK: r.K,
       lca,
       totalOps: 0,
@@ -451,7 +450,6 @@ export function cloudProofResponse(id: number, record: PendingCloudJob, job: Hos
     mode: 'sidestep',
     elapsedMs,
     proofHash: r.proof_hash,
-    regionN: /^[0-9a-f]+$/.test(r.region_m_hex ?? '') ? BigInt('0x' + r.region_m_hex).toString() : null,
     terrainK: r.terrain_k,
     lca,
     totalOps: 0,

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -388,7 +388,7 @@ describe('cloud routes', () => {
     expect(S().plan?.step.source).toBe('local')
 
     // The local hop lands (the worker's answer, fed by hand); the cloud sidestep follows and lands.
-    await S().applyProofMessage({ type: 'done', id: req1.id, mode: 'hop', elapsedMs: 5, proofHash: 'dd'.repeat(32), regionN: '1', terrainK: 3, lca: { x: 12, y: 0, z: 0 }, totalOps: 4 })
+    await S().applyProofMessage({ type: 'done', id: req1.id, mode: 'hop', elapsedMs: 5, proofHash: 'dd'.repeat(32), terrainK: 3, lca: { x: 12, y: 0, z: 0 }, totalOps: 4 })
     await vi.waitFor(() => { expect(S().position.x).toBe(landing) }, { timeout: 5000 })
     expect(fake.submitSidestep).toHaveBeenCalledWith({ ...from, x: edge, plane: s0.headPlane }, { ...from, x: landing, plane: s0.headPlane }, expect.any(String))
     const ev = S().events[S().events.length - 1]
@@ -403,7 +403,7 @@ describe('cloud routes', () => {
     await vi.waitFor(() => { expect(vi.mocked(postProof)).toHaveBeenCalledTimes(2) })
     const req2 = vi.mocked(postProof).mock.calls[1][0]
     expect(req2).toMatchObject({ mode: 'hop', to: cursor })
-    await S().applyProofMessage({ type: 'done', id: req2.id, mode: 'hop', elapsedMs: 5, proofHash: 'ee'.repeat(32), regionN: '1', terrainK: 3, lca: { x: 1, y: 0, z: 0 }, totalOps: 4 })
+    await S().applyProofMessage({ type: 'done', id: req2.id, mode: 'hop', elapsedMs: 5, proofHash: 'ee'.repeat(32), terrainK: 3, lca: { x: 1, y: 0, z: 0 }, totalOps: 4 })
     expect(S().plan).toBeNull()
     expect(S().position).toEqual(cursor)
     expect(S().events).toHaveLength(before + 3)

--- a/src/store/explore.test.ts
+++ b/src/store/explore.test.ts
@@ -15,7 +15,7 @@ async function land(dx: bigint): Promise<void> {
   useCyberspace.setState({ pendingTarget: { ...s.position, x: s.position.x + dx } })
   await s.applyProofMessage({
     type: 'done', id: 0, mode: 'hop', elapsedMs: 1, proofHash: 'ab'.repeat(32),
-    regionN: '1', terrainK: 8, lca: { x: 1, y: 0, z: 0 }, totalOps: 1,
+    terrainK: 8, lca: { x: 1, y: 0, z: 0 }, totalOps: 1,
   })
 }
 

--- a/src/store/movePlan.test.ts
+++ b/src/store/movePlan.test.ts
@@ -34,7 +34,7 @@ function done(req: (typeof posted)[number]) {
   const sidestep = req.mode === 'sidestep'
     ? { merkleRoots: ['aa'.repeat(32), 'bb'.repeat(32), 'cc'.repeat(32)] as [string, string, string], inclusionProofs: ['', '', ''] as [string, string, string], lcaHeights: [1, 0, 0] as [number, number, number] }
     : undefined
-  return { type: 'done' as const, id: req.id, mode: req.mode as 'hop' | 'sidestep', elapsedMs: 5, proofHash: 'dd'.repeat(32), regionN: '1', terrainK: 3, lca: { x: 1, y: 0, z: 0 }, totalOps: 4, sidestep }
+  return { type: 'done' as const, id: req.id, mode: req.mode as 'hop' | 'sidestep', elapsedMs: 5, proofHash: 'dd'.repeat(32), terrainK: 3, lca: { x: 1, y: 0, z: 0 }, totalOps: 4, sidestep }
 }
 
 async function land(): Promise<void> {

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -156,7 +156,6 @@ export interface ProofState {
   progress: number
   elapsedMs: number
   proofHash: string | null
-  regionN: string | null
   terrainK: number | null
   lca: { x: number; y: number; z: number } | null
   /** Cantor pairings for hops; SHA-256 evaluations for sidesteps. */
@@ -176,7 +175,6 @@ const IDLE_PROOF: ProofState = {
   progress: 0,
   elapsedMs: 0,
   proofHash: null,
-  regionN: null,
   terrainK: null,
   lca: null,
   totalOps: null,
@@ -1620,7 +1618,6 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         progress: 1,
         elapsedMs: msg.elapsedMs,
         proofHash: msg.proofHash,
-        regionN: msg.regionN,
         terrainK: msg.terrainK,
         lca: msg.lca,
         totalOps: msg.totalOps,

--- a/src/workers/proof.worker.ts
+++ b/src/workers/proof.worker.ts
@@ -48,8 +48,6 @@ export type ProofResponse =
       mode: ProofMode
       elapsedMs: number
       proofHash: string
-      /** The spatial region integer, decimal; null for a cloud hop, whose region never left the cloud. */
-      regionN: string | null
       terrainK: number
       lca: { x: number; y: number; z: number }
       /** Cantor pairings for hops; SHA-256 evaluations for sidesteps; 0 for a cloud proof. */
@@ -108,7 +106,6 @@ self.onmessage = (event: MessageEvent<ProofRequest>) => {
         mode,
         elapsedMs: performance.now() - started,
         proofHash: proof.proofHash,
-        regionN: proof.regionM.toString(),
         terrainK: proof.terrainK,
         lca: { x: proof.lcaHeights[0], y: proof.lcaHeights[1], z: proof.lcaHeights[2] },
         totalOps: estimate.totalHashes,
@@ -165,7 +162,6 @@ self.onmessage = (event: MessageEvent<ProofRequest>) => {
       mode,
       elapsedMs: performance.now() - started,
       proofHash: proof.proofHash,
-      regionN: proof.regionN.toString(),
       terrainK: proof.terrainK,
       lca: { x: estimate.lcaX, y: estimate.lcaY, z: estimate.lcaZ },
       totalOps: estimate.totalOps,


### PR DESCRIPTION
Found while hunting the memory growth arkinox saw during a HOSAKA offload.

After every local hop the proof worker called `toString()` on the region Cantor root and posted it to the main thread, where the store kept it as `proof.regionN` and nothing ever read it (no panel, no template, no derivation; the region's identity anything uses is the lookup id, which stays). At h17 that root is 44.5 million bits and its decimal form 13.4 million characters. The conversion is the entire gap between the proof reporting 100% and the step landing, and the string then travels through structured clone and sits in state until the next proof replaces it.

Measured headlessly (renderer RSS, one local hop each, this machine):

| | v2 | this PR |
|---|---|---|
| h17: proof 100% to step landed | 5.2 s stall, 9.4 s total | no stall, 4.2 s total |
| h17: renderer peak | 900 MB | 605 MB |
| h19 (two-step walk): total | 20.5 s | 11.3 s |
| h19: renderer peak | 1272 MB | 995 MB |
| string kept in state | 13.4 M chars at h17 | none |

The field is removed from the worker message, the cloud done message and the proof slice; fixtures updated. 434 tests, type check clean.

What the same investigation did *not* find: an eight-minute stalled cloud wait keeps the main heap flat at about 190 MB with DOM nodes, listeners and worker count steady; the hop verifier never touches the big Cantor values; local sidesteps stream in O(h) memory (62 MB at h20 in node). Details in the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc