### PR TITLE
Comments on hidden items: NIP-22, sealed to the place as FF-1 derived-key events

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ vertices, colours blending along it), chosen per shard and previewed live.
 localStorage. Keys on the bench: WASD / RF or arrows nudge, Del deletes,
 1 2 3 pick tools, [ ] change the level, Esc deselects then closes.
 
+**Comments.** A found shard or message, and each of your own deployments,
+carries a comment section: NIP-22 `kind:1111` events whose root scope is the
+bag by address (`A`, `K`, `P`) and whose parent is the inner item (`e`, `k`,
+`p`), replies parenting the comment they answer, every one tagged
+`["client", "ONOSENDAI"]`. The author is p-tagged, so any nostr client tells
+them. The words are sealed to the place like the item they answer: per FF-1
+(a derived-key event) the public `.content` is the placeholder "This comment
+is hidden at an undisclosed location in cyberspace. Happy hunting:
+https://onosendai.tech" and the text sits in
+`["encrypted", "aes-256-gcm", <ciphertext>, "cyberspace:region"]` under the
+bag's region key, with no `d` tag. Other clients show the invitation; this
+one derives the key from where the bag is, as it did to open the bag, and
+shows the words. A comment the key does not open shows the placeholder,
+dimmed.
+
 **Hidden content is a bag of signed events.** A hidden thing is a full signed
 nostr event — a shard (`kind:3330`, geometry in the content) or a message
 (`kind:1`, text). All the things one author hides in one region-and-height live

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -1,0 +1,66 @@
+/**
+ * useComments: the comments on one hidden item, and posting one.
+ *
+ * Fetched once per subject from the app's relays (every comment on the
+ * bag, threaded to this item), posted by signing a kind 1111 with the
+ * active signer and publishing it to the same relays. A posted comment is
+ * shown at once; a failed publish says so and keeps the text.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { commentTemplate, commentsFilter, itemParent, threadComments, type Comment, type CommentParent, type CommentSubject } from '../lib/comments'
+import type { NostrEvent } from '../lib/events'
+import { publish, query } from '../lib/relay'
+import { useCyberspace } from '../store/useCyberspace'
+
+export interface CommentsState {
+  comments: Comment[]
+  loading: boolean
+  error: string | null
+  posting: boolean
+  /** Post a comment on the item, or a reply to one of its comments. Resolves true when a relay accepted it. */
+  post: (text: string, parent?: CommentParent) => Promise<boolean>
+  refresh: () => void
+}
+
+export function useComments(subject: CommentSubject | null): CommentsState {
+  const [events, setEvents] = useState<NostrEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [posting, setPosting] = useState(false)
+  const [tick, setTick] = useState(0)
+  const key = subject ? `${subject.author}:${subject.lookupId}:${subject.itemId}` : null
+
+  useEffect(() => {
+    if (!subject) return
+    let alive = true
+    setLoading(true); setError(null); setEvents([])
+    query(commentsFilter(subject))
+      .then((found) => { if (alive) setEvents(found) })
+      .catch((err: unknown) => { if (alive) setError(err instanceof Error ? err.message : String(err)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, tick])
+
+  const post = useCallback(async (text: string, parent?: CommentParent): Promise<boolean> => {
+    if (!subject) return false
+    setPosting(true); setError(null)
+    try {
+      const template = commentTemplate(subject, parent ?? itemParent(subject), text, Math.floor(Date.now() / 1000))
+      const event = await useCyberspace.getState().signEvent(template)
+      const result = await publish(event)
+      if (!result.ok) { setError(`Not published: ${result.reason}`); return false }
+      setEvents((prev) => [...prev, event])
+      return true
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      return false
+    } finally {
+      setPosting(false)
+    }
+  }, [subject])
+
+  const comments = subject ? threadComments(events, subject) : []
+  return { comments, loading, error, posting, post, refresh: () => setTick((t) => t + 1) }
+}

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -2,16 +2,19 @@
  * useComments: the comments on one hidden item, and posting one.
  *
  * Fetched once per subject from the app's relays (every comment on the
- * bag, threaded to this item), posted by signing a kind 1111 with the
+ * bag, threaded to this item), opened with the bag's region key, which this
+ * client derives from where the bag is, exactly as it did to open the bag.
+ * Posted by sealing the words under that key, signing the kind 1111 with the
  * active signer and publishing it to the same relays. A posted comment is
  * shown at once; a failed publish says so and keeps the text.
  */
 
-import { useCallback, useEffect, useState } from 'react'
-import { commentTemplate, commentsFilter, itemParent, threadComments, type Comment, type CommentParent, type CommentSubject } from '../lib/comments'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { MAX_COMMENT_LENGTH, commentsFilter, itemParent, openComments, sealedComment, threadComments, type Comment, type CommentParent, type CommentSubject } from '../lib/comments'
 import type { NostrEvent } from '../lib/events'
 import { publish, query } from '../lib/relay'
-import { useCyberspace } from '../store/useCyberspace'
+import { regionKeyAt } from '../lib/shardCrypto'
+import { MAX_COMPUTE_HEIGHT, useCyberspace } from '../store/useCyberspace'
 
 export interface CommentsState {
   comments: Comment[]
@@ -25,18 +28,22 @@ export interface CommentsState {
 
 export function useComments(subject: CommentSubject | null): CommentsState {
   const [events, setEvents] = useState<NostrEvent[]>([])
+  const [opened, setOpened] = useState<Map<string, string>>(new Map())
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [posting, setPosting] = useState(false)
   const [tick, setTick] = useState(0)
   const key = subject ? `${subject.author}:${subject.lookupId}:${subject.itemId}` : null
+  // The region key is a function of the bag (its place and height), so it is derived once per subject.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const regionKey = useMemo(() => (subject ? regionKeyAt(subject.at, subject.height, MAX_COMPUTE_HEIGHT).key : null), [key])
 
   useEffect(() => {
-    if (!subject) return
+    if (!subject || !regionKey) return
     let alive = true
-    setLoading(true); setError(null); setEvents([])
+    setLoading(true); setError(null); setEvents([]); setOpened(new Map())
     query(commentsFilter(subject))
-      .then((found) => { if (alive) setEvents(found) })
+      .then(async (found) => { const words = await openComments(found, regionKey); if (alive) { setEvents(found); setOpened(words) } })
       .catch((err: unknown) => { if (alive) setError(err instanceof Error ? err.message : String(err)) })
       .finally(() => { if (alive) setLoading(false) })
     return () => { alive = false }
@@ -44,14 +51,16 @@ export function useComments(subject: CommentSubject | null): CommentsState {
   }, [key, tick])
 
   const post = useCallback(async (text: string, parent?: CommentParent): Promise<boolean> => {
-    if (!subject) return false
+    if (!subject || !regionKey) return false
     setPosting(true); setError(null)
     try {
-      const template = commentTemplate(subject, parent ?? itemParent(subject), text, Math.floor(Date.now() / 1000))
+      const body = text.trim().slice(0, MAX_COMMENT_LENGTH)
+      const template = await sealedComment(subject, parent ?? itemParent(subject), body, Math.floor(Date.now() / 1000), regionKey)
       const event = await useCyberspace.getState().signEvent(template)
       const result = await publish(event)
       if (!result.ok) { setError(`Not published: ${result.reason}`); return false }
       setEvents((prev) => [...prev, event])
+      setOpened((prev) => new Map(prev).set(event.id, body))
       return true
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -59,8 +68,8 @@ export function useComments(subject: CommentSubject | null): CommentsState {
     } finally {
       setPosting(false)
     }
-  }, [subject])
+  }, [subject, regionKey])
 
-  const comments = subject ? threadComments(events, subject) : []
+  const comments = subject ? threadComments(events, subject, opened) : []
   return { comments, loading, error, posting, post, refresh: () => setTick((t) => t + 1) }
 }

--- a/src/hud/Comments.tsx
+++ b/src/hud/Comments.tsx
@@ -1,0 +1,100 @@
+/**
+ * Comments.tsx: the comment section under a hidden shard or message.
+ *
+ * NIP-22 comments, threaded: each answers the item or another comment, and
+ * the person answered is `p`-tagged, so their client tells them. The list
+ * and a composer; REPLY opens a composer under a comment. The item is
+ * hidden, the comments are not, and the composer says so.
+ */
+
+import { useState } from 'react'
+import { nip19 } from 'nostr-tools'
+import { MAX_COMMENT_LENGTH, commentParent, countComments, type Comment, type CommentParent, type CommentSubject } from '../lib/comments'
+import { formatAgo, formatStamp } from '../lib/time'
+import { useComments } from '../hooks/useComments'
+import { useProfile } from '../hooks/useProfile'
+import { profileLabel } from '../store/useProfiles'
+import { useCyberspace } from '../store/useCyberspace'
+import { ProfilePic } from './ProfileBadge'
+
+function Composer({ placeholder, busy, onPost, onCancel }: { placeholder: string; busy: boolean; onPost: (text: string) => Promise<boolean>; onCancel?: () => void }): JSX.Element {
+  const [text, setText] = useState('')
+  const send = async (): Promise<void> => { if (await onPost(text)) { setText(''); onCancel?.() } }
+  return (
+    <div className="comments__form">
+      <textarea
+        className="comments__input"
+        value={text}
+        maxLength={MAX_COMMENT_LENGTH}
+        placeholder={placeholder}
+        rows={2}
+        disabled={busy}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void send() }}
+      />
+      <div className="comments__row">
+        {onCancel && <button className="secret__act" onClick={onCancel} disabled={busy}>CANCEL</button>}
+        <button className="secret__act comments__post" onClick={() => void send()} disabled={busy || !text.trim()}>{busy ? 'POSTING…' : 'POST'}</button>
+      </div>
+    </div>
+  )
+}
+
+function Author({ pubkey, mine }: { pubkey: string; mine: boolean }): JSX.Element {
+  const profile = useProfile(pubkey)
+  let npub = pubkey
+  try { npub = nip19.npubEncode(pubkey) } catch { /* shown as hex */ }
+  return (
+    <span className="comment__author">
+      <ProfilePic pubkey={pubkey} size={18} />
+      <span className="comment__name">{profileLabel(profile, npub)}{mine ? ' (you)' : ''}</span>
+    </span>
+  )
+}
+
+function CommentRow({ c, me, depth, posting, onPost }: { c: Comment; me: string; depth: number; posting: boolean; onPost: (text: string, parent: CommentParent) => Promise<boolean> }): JSX.Element {
+  const [replying, setReplying] = useState(false)
+  return (
+    <li className="comment" style={{ marginLeft: Math.min(depth, 4) * 14 }}>
+      <div className="comment__head">
+        <Author pubkey={c.pubkey} mine={c.pubkey === me} />
+        <span className="comment__when" title={formatStamp(c.createdAt)}>{formatAgo(c.createdAt)}</span>
+      </div>
+      <p className="comment__text">{c.text}</p>
+      {!replying && <button className="comment__reply" onClick={() => setReplying(true)}>REPLY</button>}
+      {replying && <Composer placeholder="Your reply" busy={posting} onPost={(t) => onPost(t, commentParent(c))} onCancel={() => setReplying(false)} />}
+      {c.replies.length > 0 && (
+        <ul className="comments__list">
+          {c.replies.map((r) => <CommentRow key={r.id} c={r} me={me} depth={depth + 1} posting={posting} onPost={onPost} />)}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+export function Comments({ subject }: { subject: CommentSubject }): JSX.Element {
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const signerKind = useCyberspace((s) => s.signerKind)
+  const { comments, loading, error, posting, post, refresh } = useComments(subject)
+  const n = countComments(comments)
+  return (
+    <section className="comments" aria-label="Comments">
+      <div className="comments__head">
+        <span className="secret__label">Comments{n > 0 ? ` (${n})` : ''}</span>
+        <button className="comment__reply" onClick={refresh} disabled={loading}>{loading ? 'LOADING…' : 'REFRESH'}</button>
+      </div>
+      {comments.length === 0 && !loading && <p className="comments__empty">No comments yet.</p>}
+      {comments.length > 0 && (
+        <ul className="comments__list">
+          {comments.map((c) => <CommentRow key={c.id} c={c} me={me} depth={0} posting={posting} onPost={post} />)}
+        </ul>
+      )}
+      <Composer placeholder={subject.author === me ? 'Add a note under your own' : 'Say something to the author'} busy={posting} onPost={(t) => post(t)} />
+      {error && <p className="comments__error">{error}</p>}
+      <p className="comments__note">
+        Comments are public, unlike what they answer. The author is tagged and gets told by their own client.
+        {signerKind !== 'local' ? ' Your signer will be asked to sign it.' : ''}
+      </p>
+    </section>
+  )
+}

--- a/src/hud/Comments.tsx
+++ b/src/hud/Comments.tsx
@@ -3,8 +3,10 @@
  *
  * NIP-22 comments, threaded: each answers the item or another comment, and
  * the person answered is `p`-tagged, so their client tells them. The list
- * and a composer; REPLY opens a composer under a comment. The item is
- * hidden, the comments are not, and the composer says so.
+ * and a composer; REPLY opens a composer under a comment. The words are
+ * sealed to the place like the item (FF-1 derived-key events under the bag's
+ * region key): here they read as words, elsewhere as an invitation to come
+ * and find them. A comment this client could not open shows the placeholder.
  */
 
 import { useState } from 'react'
@@ -60,7 +62,7 @@ function CommentRow({ c, me, depth, posting, onPost }: { c: Comment; me: string;
         <Author pubkey={c.pubkey} mine={c.pubkey === me} />
         <span className="comment__when" title={formatStamp(c.createdAt)}>{formatAgo(c.createdAt)}</span>
       </div>
-      <p className="comment__text">{c.text}</p>
+      <p className={`comment__text ${c.sealed ? 'comment__text--sealed' : ''}`}>{c.text}</p>
       {!replying && <button className="comment__reply" onClick={() => setReplying(true)}>REPLY</button>}
       {replying && <Composer placeholder="Your reply" busy={posting} onPost={(t) => onPost(t, commentParent(c))} onCancel={() => setReplying(false)} />}
       {c.replies.length > 0 && (
@@ -92,7 +94,8 @@ export function Comments({ subject }: { subject: CommentSubject }): JSX.Element 
       <Composer placeholder={subject.author === me ? 'Add a note under your own' : 'Say something to the author'} busy={posting} onPost={(t) => post(t)} />
       {error && <p className="comments__error">{error}</p>}
       <p className="comments__note">
-        Comments are public, unlike what they answer. The author is tagged and gets told by their own client.
+        Comments are sealed to this place, like what they answer: other clients show only that a comment is
+        hiding somewhere in cyberspace. The author is tagged and gets told by their own client.
         {signerKind !== 'local' ? ' Your signer will be asked to sign it.' : ''}
       </p>
     </section>

--- a/src/hud/DeploymentDetail.tsx
+++ b/src/hud/DeploymentDetail.tsx
@@ -16,6 +16,7 @@ import { formatCellSize } from '../lib/scale'
 import { messagePreview } from '../lib/hidden'
 import { shortHex } from '../lib/time'
 import { ConfirmModal } from './ConfirmModal'
+import { Comments } from './Comments'
 import { useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
 
@@ -34,6 +35,7 @@ function Field({ label, value, full }: { label: string; value: string; full?: st
 
 export function DeploymentDetail(): JSX.Element | null {
   const inspecting = useShards((s) => s.inspecting)
+  const me = useCyberspace((s) => s.identity.pubkey)
   const dep = useShards((s) => s.mine.find((d) => d.eventId === s.inspecting) ?? null)
   const [confirm, setConfirm] = useState(false)
   const [test, setTest] = useState<'idle' | 'testing' | 'found' | 'missing'>('idle')
@@ -86,6 +88,8 @@ export function DeploymentDetail(): JSX.Element | null {
           {test === 'missing' && '✗ NOT FOUND — TAP TO RETRY'}
         </button>
       )}
+
+      <Comments subject={{ author: me, lookupId: dep.lookupId, itemId: dep.eventId, type: dep.type }} />
 
       <button className="detail__delete" onClick={() => setConfirm(true)}>DELETE FROM CYBERSPACE</button>
 

--- a/src/hud/DeploymentDetail.tsx
+++ b/src/hud/DeploymentDetail.tsx
@@ -18,7 +18,7 @@ import { shortHex } from '../lib/time'
 import { ConfirmModal } from './ConfirmModal'
 import { Comments } from './Comments'
 import { useCyberspace } from '../store/useCyberspace'
-import { useShards } from '../store/useShards'
+import { positionOf, useShards } from '../store/useShards'
 
 function Field({ label, value, full }: { label: string; value: string; full?: string }): JSX.Element {
   const [copied, setCopied] = useState(false)
@@ -89,7 +89,7 @@ export function DeploymentDetail(): JSX.Element | null {
         </button>
       )}
 
-      <Comments subject={{ author: me, lookupId: dep.lookupId, itemId: dep.eventId, type: dep.type }} />
+      <Comments subject={{ author: me, lookupId: dep.lookupId, itemId: dep.eventId, type: dep.type, at: positionOf(dep), height: dep.height }} />
 
       <button className="detail__delete" onClick={() => setConfirm(true)}>DELETE FROM CYBERSPACE</button>
 

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -95,7 +95,7 @@ export function SecretModal(): JSX.Element | null {
         </dl>
 
         {item.author && item.lookupId && (
-          <Comments subject={{ author: item.author, lookupId: item.lookupId, itemId: item.key, type: item.type }} />
+          <Comments subject={{ author: item.author, lookupId: item.lookupId, itemId: item.key, type: item.type, at: item.at, height: item.height }} />
         )}
 
         <div className="secret__actions">

--- a/src/hud/SecretModal.tsx
+++ b/src/hud/SecretModal.tsx
@@ -17,6 +17,7 @@ import { regionLabel } from '../lib/loot'
 import { formatAgo, formatStamp, shortHex } from '../lib/time'
 import { spectate } from '../lib/spectator'
 import { ProfilePic } from './ProfileBadge'
+import { Comments } from './Comments'
 import { useProfile } from '../hooks/useProfile'
 import { profileLabel } from '../store/useProfiles'
 import { useCyberspace } from '../store/useCyberspace'
@@ -92,6 +93,10 @@ export function SecretModal(): JSX.Element | null {
           <div><dt>Region</dt><dd>{regionLabel(item.height)}</dd></div>
           <div><dt>Plane</dt><dd>{item.plane === 0 ? 'dataspace' : 'ideaspace'}</dd></div>
         </dl>
+
+        {item.author && item.lookupId && (
+          <Comments subject={{ author: item.author, lookupId: item.lookupId, itemId: item.key, type: item.type }} />
+        )}
 
         <div className="secret__actions">
           <button className="secret__act" onClick={goTo}>GO TO IT</button>

--- a/src/lib/comments.test.ts
+++ b/src/lib/comments.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { HIDDEN_KIND, MESSAGE_KIND, SHARD_KIND } from './hidden'
+import type { NostrEvent } from './events'
+import {
+  COMMENT_KIND,
+  bagAddress,
+  commentParent,
+  commentTemplate,
+  commentsFilter,
+  countComments,
+  itemParent,
+  parseComment,
+  threadComments,
+  type CommentSubject,
+} from './comments'
+
+const AUTHOR = 'aa'.repeat(32)
+const OTHER = 'bb'.repeat(32)
+const subject: CommentSubject = { author: AUTHOR, lookupId: 'cd'.repeat(32), itemId: '11'.repeat(32), type: 'message' }
+
+function ev(id: string, pubkey: string, createdAt: number, content: string, parent: { id: string; kind: number; pubkey: string }, root = bagAddress(subject)): NostrEvent {
+  return { id, pubkey, created_at: createdAt, kind: COMMENT_KIND, content, sig: '', tags: [['A', root], ['K', String(HIDDEN_KIND)], ['P', AUTHOR], ['e', parent.id, '', parent.pubkey], ['k', String(parent.kind)], ['p', parent.pubkey]] }
+}
+
+describe('NIP-22 comment on a hidden item', () => {
+  it('scopes the root to the bag by address, the parent to the inner item, and names the client', () => {
+    const t = commentTemplate(subject, itemParent(subject), '  nice one  ', 1000)
+    expect(t.kind).toBe(1111)
+    expect(t.content).toBe('nice one')
+    expect(t.tags).toEqual([
+      ['A', `${HIDDEN_KIND}:${AUTHOR}:${subject.lookupId}`],
+      ['K', String(HIDDEN_KIND)],
+      ['P', AUTHOR],
+      ['e', subject.itemId, '', AUTHOR],
+      ['k', String(MESSAGE_KIND)],
+      ['p', AUTHOR],
+      ['client', 'ONOSENDAI'],
+    ])
+    expect(itemParent({ ...subject, type: 'shard' }).kind).toBe(SHARD_KIND)
+  })
+  it('a reply answers the comment, and its author is the one notified', () => {
+    const t = commentTemplate(subject, commentParent({ id: '22'.repeat(32), pubkey: OTHER }), 'agreed', 1001)
+    expect(t.tags.find((x) => x[0] === 'e')).toEqual(['e', '22'.repeat(32), '', OTHER])
+    expect(t.tags.find((x) => x[0] === 'k')).toEqual(['k', '1111'])
+    expect(t.tags.find((x) => x[0] === 'p')).toEqual(['p', OTHER])
+    expect(t.tags.find((x) => x[0] === 'P')).toEqual(['P', AUTHOR])
+  })
+  it('refuses an empty comment and finds comments by the bag address', () => {
+    expect(() => commentTemplate(subject, itemParent(subject), '   ', 1)).toThrow()
+    expect(commentsFilter(subject)).toEqual({ kinds: [1111], '#A': [bagAddress(subject)], limit: 500 })
+  })
+  it('threads: top-level under the item, replies under their comment, other items and orphans left out', () => {
+    const item = itemParent(subject)
+    const a = ev('a1', OTHER, 10, 'first', item)
+    const b = ev('b2', AUTHOR, 20, 'second', item)
+    const r1 = ev('r1', AUTHOR, 30, 'reply to first', { id: 'a1', kind: COMMENT_KIND, pubkey: OTHER })
+    const r2 = ev('r2', OTHER, 40, 'reply to reply', { id: 'r1', kind: COMMENT_KIND, pubkey: AUTHOR })
+    const otherItem = ev('o1', OTHER, 15, 'on another item', { id: '99'.repeat(32), kind: MESSAGE_KIND, pubkey: AUTHOR })
+    const orphan = ev('x1', OTHER, 50, 'reply to nothing here', { id: 'zz', kind: COMMENT_KIND, pubkey: OTHER })
+    const otherBag = ev('y1', OTHER, 5, 'other bag', item, `${HIDDEN_KIND}:${OTHER}:deadbeef`)
+    const thread = threadComments([r2, orphan, b, otherItem, a, r1, otherBag, a], subject)
+    expect(thread.map((c) => c.id)).toEqual(['a1', 'b2'])
+    expect(thread[0].replies.map((c) => c.id)).toEqual(['r1'])
+    expect(thread[0].replies[0].replies.map((c) => c.id)).toEqual(['r2'])
+    expect(countComments(thread)).toBe(4)
+    expect(parseComment({ ...a, kind: 1 })).toBeNull()
+  })
+})

--- a/src/lib/comments.test.ts
+++ b/src/lib/comments.test.ts
@@ -1,33 +1,57 @@
+/**
+ * comments.test.ts - a comment is a NIP-22 kind 1111 scoped to the bag and
+ * parented to the item, and an FF-1 derived-key event: placeholder content,
+ * the words sealed under the bag's region key, no d tag. The right key opens
+ * it, the wrong key leaves the placeholder, plaintext comments still thread.
+ */
+
 import { describe, expect, it } from 'vitest'
 import { HIDDEN_KIND, MESSAGE_KIND, SHARD_KIND } from './hidden'
 import type { NostrEvent } from './events'
 import {
   COMMENT_KIND,
+  ENCRYPTED_SCHEME,
+  KEY_DERIVATION,
+  PLACEHOLDER,
   bagAddress,
   commentParent,
   commentTemplate,
   commentsFilter,
   countComments,
   itemParent,
+  openComments,
   parseComment,
+  sealedComment,
   threadComments,
   type CommentSubject,
 } from './comments'
 
 const AUTHOR = 'aa'.repeat(32)
 const OTHER = 'bb'.repeat(32)
-const subject: CommentSubject = { author: AUTHOR, lookupId: 'cd'.repeat(32), itemId: '11'.repeat(32), type: 'message' }
+const subject: CommentSubject = { author: AUTHOR, lookupId: 'cd'.repeat(32), itemId: '11'.repeat(32), type: 'message', at: { x: 0n, y: 0n, z: 0n }, height: 0 }
+const KEY = new Uint8Array(32).map((_, i) => i * 7 + 1)
+const WRONG = new Uint8Array(32).map((_, i) => 255 - i)
 
-function ev(id: string, pubkey: string, createdAt: number, content: string, parent: { id: string; kind: number; pubkey: string }, root = bagAddress(subject)): NostrEvent {
-  return { id, pubkey, created_at: createdAt, kind: COMMENT_KIND, content, sig: '', tags: [['A', root], ['K', String(HIDDEN_KIND)], ['P', AUTHOR], ['e', parent.id, '', parent.pubkey], ['k', String(parent.kind)], ['p', parent.pubkey]] }
+function ev(id: string, pubkey: string, createdAt: number, content: string, parent: { id: string; kind: number; pubkey: string }, root = bagAddress(subject), extra: string[][] = []): NostrEvent {
+  return { id, pubkey, created_at: createdAt, kind: COMMENT_KIND, content, sig: '', tags: [['A', root], ['K', String(HIDDEN_KIND)], ['P', AUTHOR], ['e', parent.id, '', parent.pubkey], ['k', String(parent.kind)], ['p', parent.pubkey], ...extra] }
 }
 
-describe('NIP-22 comment on a hidden item', () => {
-  it('scopes the root to the bag by address, the parent to the inner item, and names the client', () => {
-    const t = commentTemplate(subject, itemParent(subject), '  nice one  ', 1000)
+/** A sealed comment as the relay would hand it back. */
+async function sealed(id: string, pubkey: string, createdAt: number, text: string, parent: { id: string; kind: number; pubkey: string }, key = KEY): Promise<NostrEvent> {
+  const t = await sealedComment(subject, parent, text, createdAt, key)
+  return { ...t, id, pubkey, sig: '' } as NostrEvent
+}
+
+describe('NIP-22 comment on a hidden item, sealed per FF-1', () => {
+  it('scopes the root to the bag, the parent to the item, names the client, and seals the words with no d tag', async () => {
+    const t = await sealedComment(subject, itemParent(subject), '  nice one  ', 1000, KEY)
     expect(t.kind).toBe(1111)
-    expect(t.content).toBe('nice one')
-    expect(t.tags).toEqual([
+    expect(t.content).toBe(PLACEHOLDER)
+    const enc = t.tags.find((x) => x[0] === 'encrypted')!
+    expect(enc[1]).toBe(ENCRYPTED_SCHEME)
+    expect(enc[2].length).toBeGreaterThan(20)
+    expect(enc[3]).toBe(KEY_DERIVATION)
+    expect(t.tags.filter((x) => x[0] !== 'encrypted')).toEqual([
       ['A', `${HIDDEN_KIND}:${AUTHOR}:${subject.lookupId}`],
       ['K', String(HIDDEN_KIND)],
       ['P', AUTHOR],
@@ -36,33 +60,60 @@ describe('NIP-22 comment on a hidden item', () => {
       ['p', AUTHOR],
       ['client', 'ONOSENDAI'],
     ])
+    expect(t.tags.some((x) => x[0] === 'd')).toBe(false)
     expect(itemParent({ ...subject, type: 'shard' }).kind).toBe(SHARD_KIND)
   })
+
   it('a reply answers the comment, and its author is the one notified', () => {
-    const t = commentTemplate(subject, commentParent({ id: '22'.repeat(32), pubkey: OTHER }), 'agreed', 1001)
+    const t = commentTemplate(subject, commentParent({ id: '22'.repeat(32), pubkey: OTHER }), 'ciphertext', 1001)
     expect(t.tags.find((x) => x[0] === 'e')).toEqual(['e', '22'.repeat(32), '', OTHER])
     expect(t.tags.find((x) => x[0] === 'k')).toEqual(['k', '1111'])
     expect(t.tags.find((x) => x[0] === 'p')).toEqual(['p', OTHER])
     expect(t.tags.find((x) => x[0] === 'P')).toEqual(['P', AUTHOR])
   })
-  it('refuses an empty comment and finds comments by the bag address', () => {
-    expect(() => commentTemplate(subject, itemParent(subject), '   ', 1)).toThrow()
+
+  it('refuses an empty comment and finds comments by the bag address', async () => {
+    await expect(sealedComment(subject, itemParent(subject), '   ', 1000, KEY)).rejects.toThrow()
+    expect(() => commentTemplate(subject, itemParent(subject), '', 1000)).toThrow()
     expect(commentsFilter(subject)).toEqual({ kinds: [1111], '#A': [bagAddress(subject)], limit: 500 })
   })
-  it('threads: top-level under the item, replies under their comment, other items and orphans left out', () => {
-    const item = itemParent(subject)
-    const a = ev('a1', OTHER, 10, 'first', item)
-    const b = ev('b2', AUTHOR, 20, 'second', item)
-    const r1 = ev('r1', AUTHOR, 30, 'reply to first', { id: 'a1', kind: COMMENT_KIND, pubkey: OTHER })
-    const r2 = ev('r2', OTHER, 40, 'reply to reply', { id: 'r1', kind: COMMENT_KIND, pubkey: AUTHOR })
-    const otherItem = ev('o1', OTHER, 15, 'on another item', { id: '99'.repeat(32), kind: MESSAGE_KIND, pubkey: AUTHOR })
-    const orphan = ev('x1', OTHER, 50, 'reply to nothing here', { id: 'zz', kind: COMMENT_KIND, pubkey: OTHER })
-    const otherBag = ev('y1', OTHER, 5, 'other bag', item, `${HIDDEN_KIND}:${OTHER}:deadbeef`)
-    const thread = threadComments([r2, orphan, b, otherItem, a, r1, otherBag, a], subject)
+
+  it('the right key opens the words, the wrong key leaves the placeholder, and a plaintext comment reads as written', async () => {
+    const a = await sealed('a1', OTHER, 10, 'found it under the arch', itemParent(subject))
+    const b = ev('b2', OTHER, 11, 'old plaintext comment', itemParent(subject))
+    expect(parseComment(a)!.ciphertext).not.toBeNull()
+    expect(parseComment(a)!.preview).toBe(PLACEHOLDER)
+    expect(parseComment(b)!.ciphertext).toBeNull()
+
+    const opened = await openComments([a, b], KEY)
+    expect(opened.get('a1')).toBe('found it under the arch')
+    expect(opened.has('b2')).toBe(false)
+    const thread = threadComments([a, b], subject, opened)
+    expect(thread.map((c) => [c.text, c.sealed])).toEqual([['found it under the arch', false], ['old plaintext comment', false]])
+
+    const wrong = await openComments([a], WRONG)
+    expect(wrong.size).toBe(0)
+    const still = threadComments([a], subject, wrong)
+    expect(still[0].text).toBe(PLACEHOLDER)
+    expect(still[0].sealed).toBe(true)
+    // No key at all: the same placeholder.
+    expect(threadComments([a], subject)[0].sealed).toBe(true)
+  })
+
+  it('threads: top-level under the item, replies under their comment, other items and orphans left out', async () => {
+    const other = ev('x9', OTHER, 5, 'on another item', { id: '33'.repeat(32), kind: MESSAGE_KIND, pubkey: AUTHOR })
+    const a1 = await sealed('a1', OTHER, 10, 'first', itemParent(subject))
+    const b2 = await sealed('b2', AUTHOR, 12, 'second', itemParent(subject))
+    const r1 = await sealed('r1', AUTHOR, 11, 'reply to first', { id: 'a1', kind: COMMENT_KIND, pubkey: OTHER })
+    const r2 = await sealed('r2', OTHER, 13, 'reply to the reply', { id: 'r1', kind: COMMENT_KIND, pubkey: AUTHOR })
+    const orphan = await sealed('o1', OTHER, 14, 'answers a comment we never saw', { id: 'zz'.repeat(32), kind: COMMENT_KIND, pubkey: OTHER })
+    const elsewhere = ev('e1', OTHER, 15, 'another bag', itemParent(subject), `${HIDDEN_KIND}:${OTHER}:${'ef'.repeat(32)}`)
+    const events = [other, r2, orphan, b2, a1, r1, elsewhere, a1]
+    const thread = threadComments(events, subject, await openComments(events, KEY))
     expect(thread.map((c) => c.id)).toEqual(['a1', 'b2'])
     expect(thread[0].replies.map((c) => c.id)).toEqual(['r1'])
     expect(thread[0].replies[0].replies.map((c) => c.id)).toEqual(['r2'])
+    expect(thread[0].replies[0].replies[0].text).toBe('reply to the reply')
     expect(countComments(thread)).toBe(4)
-    expect(parseComment({ ...a, kind: 1 })).toBeNull()
   })
 })

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -12,17 +12,30 @@
  * the notification; only a client that has opened the bag can put the
  * comment under the exact item.
  *
- * Comments are plaintext and public, even though the item they answer is
- * hidden. The composer says so.
+ * The words are sealed to the place, like the item they answer. A comment is
+ * an FF-1 derived-key event: its `.content` is a public placeholder that any
+ * NIP-22 client shows in the author's notifications, and the text lives in
+ * an `encrypted` tag under the bag's region key (aes-256-gcm, the same bytes
+ * FF-1 specifies), so whoever has reached the place, or opened the bag, reads
+ * it and nobody else does. Element [3] of the tag names the derivation,
+ * `cyberspace:region`, because there is no key service: every reader derives
+ * the key from the location. No `d` tag, as FF-1 requires of derived events.
  */
 
 import { HIDDEN_KIND, MESSAGE_KIND, SHARD_KIND, type HiddenType } from './hidden'
 import type { EventTemplate, NostrEvent } from './events'
+import { decryptForRegion, encryptForRegion } from './shardCrypto'
+import type { Position } from './space'
 
 export const COMMENT_KIND = 1111
 export const MAX_COMMENT_LENGTH = 2000
 /** NIP-89 client attribution: the app that wrote the comment. */
 export const CLIENT_TAG: [string, string] = ['client', 'ONOSENDAI']
+/** What every other client shows: an invitation, not the words. */
+export const PLACEHOLDER = 'This comment is hidden at an undisclosed location in cyberspace. Happy hunting: https://onosendai.tech'
+/** FF-1 `encrypted` tag: the scheme (the reference one) and, in place of a key service, the derivation. */
+export const ENCRYPTED_SCHEME = 'aes-256-gcm'
+export const KEY_DERIVATION = 'cyberspace:region'
 
 /** The thing being commented on: one item, inside one bag. */
 export interface CommentSubject {
@@ -33,6 +46,9 @@ export interface CommentSubject {
   /** The inner item's event id. */
   itemId: string
   type: HiddenType
+  /** Where the bag is hidden and the height it is encrypted to: what the region key derives from. */
+  at: Position
+  height: number
 }
 
 /** What a comment answers: the item, or another comment. */
@@ -46,7 +62,10 @@ export interface Comment {
   id: string
   pubkey: string
   createdAt: number
+  /** The words when opened, else the placeholder. */
   text: string
+  /** Still sealed: the key did not open it (or no key was at hand). */
+  sealed: boolean
   parentId: string
   replies: Comment[]
 }
@@ -69,14 +88,17 @@ export function commentParent(c: Pick<Comment, 'id' | 'pubkey'>): CommentParent 
   return { id: c.id, kind: COMMENT_KIND, pubkey: c.pubkey }
 }
 
-/** The kind 1111 template, per NIP-22: uppercase tags for the root scope, lowercase for the parent. */
-export function commentTemplate(subject: CommentSubject, parent: CommentParent, text: string, createdAt: number): EventTemplate {
-  const body = text.trim().slice(0, MAX_COMMENT_LENGTH)
-  if (!body) throw new Error('a comment needs some text')
+/**
+ * The kind 1111 template, per NIP-22 (uppercase tags for the root scope,
+ * lowercase for the parent) and FF-1 (placeholder content, the words in the
+ * `encrypted` tag). `ciphertext` is what `sealedComment` produced.
+ */
+export function commentTemplate(subject: Pick<CommentSubject, 'author' | 'lookupId'>, parent: CommentParent, ciphertext: string, createdAt: number): EventTemplate {
+  if (!ciphertext) throw new Error('a comment needs some text')
   return {
     kind: COMMENT_KIND,
     created_at: createdAt,
-    content: body,
+    content: PLACEHOLDER,
     tags: [
       ['A', bagAddress(subject)],
       ['K', String(HIDDEN_KIND)],
@@ -85,8 +107,16 @@ export function commentTemplate(subject: CommentSubject, parent: CommentParent, 
       ['k', String(parent.kind)],
       ['p', parent.pubkey],
       [...CLIENT_TAG],
+      ['encrypted', ENCRYPTED_SCHEME, ciphertext, KEY_DERIVATION],
     ],
   }
+}
+
+/** The words sealed under the bag's region key, as a ready template. */
+export async function sealedComment(subject: Pick<CommentSubject, 'author' | 'lookupId'>, parent: CommentParent, text: string, createdAt: number, key: Uint8Array): Promise<EventTemplate> {
+  const body = text.trim().slice(0, MAX_COMMENT_LENGTH)
+  if (!body) throw new Error('a comment needs some text')
+  return commentTemplate(subject, parent, await encryptForRegion(key, body), createdAt)
 }
 
 /** The relay filter that finds every comment on a bag, whichever item they answer. */
@@ -98,7 +128,10 @@ interface Parsed {
   id: string
   pubkey: string
   createdAt: number
-  text: string
+  /** The public content: the placeholder on a sealed comment, the words on a plaintext one. */
+  preview: string
+  /** The sealed words, when the comment carries them in our scheme. */
+  ciphertext: string | null
   rootAddress: string
   parentId: string
   parentKind: number
@@ -115,9 +148,23 @@ export function parseComment(ev: NostrEvent): Parsed | null {
   const parent = firstTag(ev, 'e')?.[1]
   const parentKind = Number(firstTag(ev, 'k')?.[1])
   if (!root || !parent || !Number.isFinite(parentKind)) return null
-  const text = ev.content.trim()
-  if (!text) return null
-  return { id: ev.id, pubkey: ev.pubkey, createdAt: ev.created_at, text: text.slice(0, MAX_COMMENT_LENGTH), rootAddress: root, parentId: parent, parentKind }
+  const enc = firstTag(ev, 'encrypted')
+  const ciphertext = enc && enc[1] === ENCRYPTED_SCHEME && enc[2] ? enc[2] : null
+  const preview = ev.content.trim().slice(0, MAX_COMMENT_LENGTH)
+  if (!ciphertext && !preview) return null
+  return { id: ev.id, pubkey: ev.pubkey, createdAt: ev.created_at, preview, ciphertext, rootAddress: root, parentId: parent, parentKind }
+}
+
+/** The words of every sealed comment the key opens, by event id. A wrong key opens nothing and says nothing. */
+export async function openComments(events: NostrEvent[], key: Uint8Array): Promise<Map<string, string>> {
+  const out = new Map<string, string>()
+  await Promise.all(events.map(async (ev) => {
+    const c = parseComment(ev)
+    if (!c?.ciphertext) return
+    const text = (await decryptForRegion(key, c.ciphertext))?.trim()
+    if (text) out.set(c.id, text.slice(0, MAX_COMMENT_LENGTH))
+  }))
+  return out
 }
 
 /**
@@ -126,13 +173,15 @@ export function parseComment(ev: NostrEvent): Parsed | null {
  * Comments on other items in the same bag, and replies whose parent is not
  * here, are left out.
  */
-export function threadComments(events: NostrEvent[], subject: CommentSubject): Comment[] {
+export function threadComments(events: NostrEvent[], subject: Pick<CommentSubject, 'author' | 'lookupId' | 'itemId'>, opened: ReadonlyMap<string, string> = new Map()): Comment[] {
   const address = bagAddress(subject)
   const byId = new Map<string, Comment & { parentKind: number }>()
   for (const ev of events) {
     const c = parseComment(ev)
     if (!c || c.rootAddress !== address || byId.has(c.id)) continue
-    byId.set(c.id, { id: c.id, pubkey: c.pubkey, createdAt: c.createdAt, text: c.text, parentId: c.parentId, parentKind: c.parentKind, replies: [] })
+    const words = opened.get(c.id)
+    const sealed = c.ciphertext !== null && words === undefined
+    byId.set(c.id, { id: c.id, pubkey: c.pubkey, createdAt: c.createdAt, text: words ?? (sealed ? PLACEHOLDER : c.preview), sealed, parentId: c.parentId, parentKind: c.parentKind, replies: [] })
   }
   const roots: Comment[] = []
   const ordered = [...byId.values()].sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -1,0 +1,152 @@
+/**
+ * comments.ts: NIP-22 comments (kind 1111) on a hidden item.
+ *
+ * A hidden shard or message is an inner event sealed inside a bag, the
+ * addressable kind 33330 envelope, and the bag is the only one of the two a
+ * relay has ever seen. So a comment's ROOT scope is the bag, by address
+ * (`A` = 33330:<author>:<lookup id>, `K` 33330, `P` the author), and its
+ * PARENT is the item itself: the inner event's id, its kind (3330 for a
+ * shard, 1 for a message) and its author, which is the bag's author. A
+ * reply's parent is the comment it answers. Anyone reading NIP-22 sees a
+ * comment on the bag and a `p` tag naming the author, which is what makes
+ * the notification; only a client that has opened the bag can put the
+ * comment under the exact item.
+ *
+ * Comments are plaintext and public, even though the item they answer is
+ * hidden. The composer says so.
+ */
+
+import { HIDDEN_KIND, MESSAGE_KIND, SHARD_KIND, type HiddenType } from './hidden'
+import type { EventTemplate, NostrEvent } from './events'
+
+export const COMMENT_KIND = 1111
+export const MAX_COMMENT_LENGTH = 2000
+/** NIP-89 client attribution: the app that wrote the comment. */
+export const CLIENT_TAG: [string, string] = ['client', 'ONOSENDAI']
+
+/** The thing being commented on: one item, inside one bag. */
+export interface CommentSubject {
+  /** The bag's author, who also signed the inner item. */
+  author: string
+  /** The bag's `d` tag. */
+  lookupId: string
+  /** The inner item's event id. */
+  itemId: string
+  type: HiddenType
+}
+
+/** What a comment answers: the item, or another comment. */
+export interface CommentParent {
+  id: string
+  kind: number
+  pubkey: string
+}
+
+export interface Comment {
+  id: string
+  pubkey: string
+  createdAt: number
+  text: string
+  parentId: string
+  replies: Comment[]
+}
+
+export function bagAddress(subject: Pick<CommentSubject, 'author' | 'lookupId'>): string {
+  return `${HIDDEN_KIND}:${subject.author}:${subject.lookupId}`
+}
+
+export function itemKind(type: HiddenType): number {
+  return type === 'shard' ? SHARD_KIND : MESSAGE_KIND
+}
+
+/** The item as a parent: a top-level comment answers the item. */
+export function itemParent(subject: CommentSubject): CommentParent {
+  return { id: subject.itemId, kind: itemKind(subject.type), pubkey: subject.author }
+}
+
+/** A comment as a parent: a reply answers the comment. */
+export function commentParent(c: Pick<Comment, 'id' | 'pubkey'>): CommentParent {
+  return { id: c.id, kind: COMMENT_KIND, pubkey: c.pubkey }
+}
+
+/** The kind 1111 template, per NIP-22: uppercase tags for the root scope, lowercase for the parent. */
+export function commentTemplate(subject: CommentSubject, parent: CommentParent, text: string, createdAt: number): EventTemplate {
+  const body = text.trim().slice(0, MAX_COMMENT_LENGTH)
+  if (!body) throw new Error('a comment needs some text')
+  return {
+    kind: COMMENT_KIND,
+    created_at: createdAt,
+    content: body,
+    tags: [
+      ['A', bagAddress(subject)],
+      ['K', String(HIDDEN_KIND)],
+      ['P', subject.author],
+      ['e', parent.id, '', parent.pubkey],
+      ['k', String(parent.kind)],
+      ['p', parent.pubkey],
+      [...CLIENT_TAG],
+    ],
+  }
+}
+
+/** The relay filter that finds every comment on a bag, whichever item they answer. */
+export function commentsFilter(subject: Pick<CommentSubject, 'author' | 'lookupId'>): { kinds: number[]; '#A': string[]; limit: number } {
+  return { kinds: [COMMENT_KIND], '#A': [bagAddress(subject)], limit: 500 }
+}
+
+interface Parsed {
+  id: string
+  pubkey: string
+  createdAt: number
+  text: string
+  rootAddress: string
+  parentId: string
+  parentKind: number
+}
+
+function firstTag(ev: NostrEvent, name: string): string[] | undefined {
+  return ev.tags.find((t) => t[0] === name)
+}
+
+/** A kind 1111 event as a comment, or null when it is not one we can place. */
+export function parseComment(ev: NostrEvent): Parsed | null {
+  if (ev.kind !== COMMENT_KIND) return null
+  const root = firstTag(ev, 'A')?.[1]
+  const parent = firstTag(ev, 'e')?.[1]
+  const parentKind = Number(firstTag(ev, 'k')?.[1])
+  if (!root || !parent || !Number.isFinite(parentKind)) return null
+  const text = ev.content.trim()
+  if (!text) return null
+  return { id: ev.id, pubkey: ev.pubkey, createdAt: ev.created_at, text: text.slice(0, MAX_COMMENT_LENGTH), rootAddress: root, parentId: parent, parentKind }
+}
+
+/**
+ * The comments on ONE item, threaded: top-level comments answer the item,
+ * replies hang under the comment they answer, oldest first at every level.
+ * Comments on other items in the same bag, and replies whose parent is not
+ * here, are left out.
+ */
+export function threadComments(events: NostrEvent[], subject: CommentSubject): Comment[] {
+  const address = bagAddress(subject)
+  const byId = new Map<string, Comment & { parentKind: number }>()
+  for (const ev of events) {
+    const c = parseComment(ev)
+    if (!c || c.rootAddress !== address || byId.has(c.id)) continue
+    byId.set(c.id, { id: c.id, pubkey: c.pubkey, createdAt: c.createdAt, text: c.text, parentId: c.parentId, parentKind: c.parentKind, replies: [] })
+  }
+  const roots: Comment[] = []
+  const ordered = [...byId.values()].sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+  for (const c of ordered) {
+    if (c.parentKind !== COMMENT_KIND && c.parentId === subject.itemId) roots.push(c)
+    else if (c.parentKind === COMMENT_KIND) byId.get(c.parentId)?.replies.push(c)
+  }
+  const placed = new Set<string>()
+  const visit = (c: Comment): void => { placed.add(c.id); for (const r of c.replies) visit(r) }
+  for (const r of roots) visit(r)
+  for (const c of ordered) c.replies = c.replies.filter((r) => placed.has(r.id))
+  return roots
+}
+
+export function countComments(list: Comment[]): number {
+  return list.reduce((n, c) => n + 1 + countComments(c.replies), 0)
+}

--- a/src/lib/hidden.ts
+++ b/src/lib/hidden.ts
@@ -51,6 +51,8 @@ export interface Hidden {
   eventId: string
   /** The envelope (bag) currently holding it; changes when the bag is rewritten. */
   bagId: string
+  /** The bag's `d` tag (spec §8.6 lookup id): with the author it is the bag's address. */
+  lookupId: string
   /** The author, from the inner (and envelope) pubkey. */
   author: string
   at: Position
@@ -139,6 +141,7 @@ function fromInner(inner: NostrEvent, outer: NostrEvent): Hidden | null {
   const base = {
     eventId: inner.id,
     bagId: outer.id,
+    lookupId: tag(outer, 'd') ?? '',
     author: outer.pubkey,
     at: { x, y, z },
     plane,

--- a/src/store/useCeremony.ts
+++ b/src/store/useCeremony.ts
@@ -82,7 +82,7 @@ export const useCeremony = create<CeremonyState>((set, get) => ({
     const cell = 1n << BigInt(scaleExp)
     const plane: Plane = anchorPlane
     const now = Math.floor(Date.now() / 1000)
-    const base = { bagId: `preview-bag-${now}`, author: PREVIEW_AUTHOR, plane, height: 5, createdAt: now }
+    const base = { bagId: `preview-bag-${now}`, lookupId: '', author: PREVIEW_AUTHOR, plane, height: 5, createdAt: now }
     const shard: Hidden = {
       ...base,
       eventId: `preview-shard-${now}`,

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -67,6 +67,8 @@ export interface WorldItem {
   shard?: ShardModel
   text?: string
   createdAt?: number
+  /** The bag's lookup id, for anything addressed to the bag (comments). */
+  lookupId?: string
 }
 
 /** What a deploy is placing, before it lands. */
@@ -345,11 +347,11 @@ export const useShards = create<ShardsState>((set, get) => {
       const me = useCyberspace.getState().identity.pubkey
       for (const d of get().mine) {
         seen.add(d.eventId)
-        out.push({ key: d.eventId, type: d.type, at: positionOf(d), plane: d.plane, height: d.height, mine: true, author: me, shard: d.shard, text: d.text, createdAt: d.createdAt })
+        out.push({ key: d.eventId, type: d.type, at: positionOf(d), plane: d.plane, height: d.height, mine: true, author: me, shard: d.shard, text: d.text, createdAt: d.createdAt, lookupId: d.lookupId })
       }
       for (const h of Object.values(get().discovered)) {
         if (seen.has(h.eventId)) continue
-        out.push({ key: h.eventId, type: h.type, at: h.at, plane: h.plane, height: h.height, mine: false, author: h.author, shard: h.shard, text: h.text, createdAt: h.createdAt })
+        out.push({ key: h.eventId, type: h.type, at: h.at, plane: h.plane, height: h.height, mine: false, author: h.author, shard: h.shard, text: h.text, createdAt: h.createdAt, lookupId: h.lookupId })
       }
       return out
     },

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -142,7 +142,7 @@ function saveDeleted(deleted: Record<string, true>): void {
   try { localStorage.setItem(DELETED_KEY, JSON.stringify(Object.keys(deleted))) } catch { /* quota or private mode */ }
 }
 
-function positionOf(d: { at: { x: string; y: string; z: string } }): Position {
+export function positionOf(d: { at: { x: string; y: string; z: string } }): Position {
   return { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -4450,3 +4450,46 @@ kbd {
     opacity: 0.7;
   }
 }
+
+/* ---------- Comments (NIP-22) under a hidden shard or message ---------- */
+.comments {
+  margin: 12px 0 4px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(0, 229, 255, 0.12);
+}
+.comments__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px; }
+.comments__list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.comment { display: grid; gap: 3px; }
+.comment__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.comment__author { display: inline-flex; align-items: center; gap: 6px; min-width: 0; }
+.comment__name { font-size: 11px; letter-spacing: 0.05em; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.comment__when { font-size: 9px; letter-spacing: 0.1em; color: var(--dim); white-space: nowrap; }
+.comment__text { margin: 0; font-size: 12px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; }
+.comment__reply {
+  justify-self: start;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--accent);
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  cursor: pointer;
+}
+.comment__reply:disabled { opacity: 0.5; cursor: default; }
+.comments__form { display: grid; gap: 6px; margin-top: 8px; }
+.comments__input {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 1px solid rgba(0, 229, 255, 0.25);
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--fg);
+  font: inherit;
+  font-size: 12px;
+}
+.comments__row { display: flex; justify-content: flex-end; gap: 6px; }
+.comments__empty, .comments__note { margin: 4px 0 0; font-size: 10px; letter-spacing: 0.05em; color: var(--dim); line-height: 1.4; }
+.comments__error { margin: 4px 0 0; font-size: 10px; color: #ff6b6b; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4465,6 +4465,8 @@ kbd {
 .comment__name { font-size: 11px; letter-spacing: 0.05em; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .comment__when { font-size: 9px; letter-spacing: 0.1em; color: var(--dim); white-space: nowrap; }
 .comment__text { margin: 0; font-size: 12px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; }
+/* A comment this client could not open: the placeholder, dimmed. */
+.comment__text--sealed { color: var(--dim); font-style: italic; }
 .comment__reply {
   justify-self: start;
   padding: 0;


### PR DESCRIPTION
A comment section under the shard and message detail modals (found items in SecretModal, your own in DeploymentDetail).

**Shape.** NIP-22 kind 1111: root scope is the bag by address (`A` = `33330:<author>:<lookupId>`, `K`, `P`), parent is the inner item (`e`, `k` 3330 or 1, `p` the author), replies parent the comment they answer, `["client","ONOSENDAI"]` on every one. The author is p-tagged, so any nostr client notifies them.

**Sealed to the place.** Per FF-1 (fanfares/kb-private #7 adds the clause), a comment is a derived-key event: `.content` is the public placeholder "This comment is hidden at an undisclosed location in cyberspace. Happy hunting: https://onosendai.tech", and the words sit in `["encrypted", "aes-256-gcm", <ciphertext>, "cyberspace:region"]` under the bag's region key, no `d` tag. Amethyst or Damus show the invitation; ONOSENDAI derives the key from where the bag is (as it did to open the bag) and shows the words. A comment the key does not open shows the placeholder, dimmed. The same convention Fanfares uses for comments sealed with a purchase's unlock key.

**Tests** cover the tag shape, sealing and opening with the right key, the placeholder with the wrong key or none, plaintext comments threading as before, and the threading rules. 448 tests, tsc and `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz