### PR TITLE
Scene: dispose the geometries that rebuilds replace

### DIFF
--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -82,6 +82,10 @@ function setSegments(legs: LineSegments, geometry: BufferGeometry, pairs: Readon
     arr[i * 6] = a[0]; arr[i * 6 + 1] = a[1]; arr[i * 6 + 2] = a[2]
     arr[i * 6 + 3] = b[0]; arr[i * 6 + 4] = b[1]; arr[i * 6 + 5] = b[2]
   })
+  // Replacing an attribute leaves the old one's GL buffer allocated until the
+  // geometry is disposed; dispose first (the object stays usable and uploads
+  // the new buffer on the next frame), or every cursor move leaked one.
+  geometry.dispose()
   geometry.setAttribute('position', new Float32BufferAttribute(arr, 3))
   geometry.computeBoundingSphere()
   legs.computeLineDistances()
@@ -120,6 +124,7 @@ function makeDashedLine(geometry: BufferGeometry): Line {
 }
 
 function setSegment(line: Line, geometry: BufferGeometry, a: number[], b: number[], color: string): void {
+  geometry.dispose()
   geometry.setAttribute('position', new Float32BufferAttribute([...a, ...b], 3))
   geometry.attributes.position.needsUpdate = true
   // Dash rendering needs per-vertex distances recomputed on every reshape.

--- a/src/scene/PathTrail.tsx
+++ b/src/scene/PathTrail.tsx
@@ -7,7 +7,7 @@
  * just standing somewhere along it, and the faint part is where it goes next.
  */
 
-import { useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { BufferGeometry, Float32BufferAttribute } from 'three'
 import { useCyberspace } from '../store/useCyberspace'
@@ -62,6 +62,8 @@ export function PathTrail({ axes, scaleExp }: Props): JSX.Element | null {
     }
     return { walked: make(walked), ahead: make(ahead) }
   }, [positionHistory, axes, scaleExp, anchor, split])
+  // Rebuilt on every hop and re-anchor; the old pair's GL buffers go with it.
+  useEffect(() => () => { geometry?.walked?.dispose(); geometry?.ahead?.dispose() }, [geometry])
 
   // The newest segment ends on the avatar, which is drawn trailing behind its
   // committed cell for a moment after a commit. Left alone, the trail would

--- a/src/scene/Rooms.tsx
+++ b/src/scene/Rooms.tsx
@@ -24,7 +24,7 @@
  * be drawn.
  */
 
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { BufferGeometry, Float32BufferAttribute } from 'three'
 import { formatOps, stepFor, type AxisDirection, type ViewAxes } from '../lib/space'
 import { subtreeCantorOps } from 'cyberspace-core'
@@ -203,6 +203,10 @@ export function Rooms({ axes }: Props): JSX.Element {
       }
     })
   }, [position, scaleExp, axes])
+  // A rebuilt lattice replaces the geometry prop; nothing disposes the old
+  // one, and a BufferGeometry's GL buffers live until dispose() or context
+  // loss. Every anchor change and zoom leaked three of them.
+  useEffect(() => () => { for (const l of levels) l.geometry.dispose() }, [levels])
 
   return (
     <group>

--- a/src/scene/SectorBox.tsx
+++ b/src/scene/SectorBox.tsx
@@ -17,7 +17,7 @@
  * reason the room nest stops drawing boxes larger than the window.
  */
 
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { BoxGeometry, EdgesGeometry } from 'three'
 import { sectorTag, xyzToSectorId, SECTOR_BITS_DEFAULT } from 'cyberspace-core'
 import { GRID_RADIUS, cellDelta, type ViewAxes } from '../lib/space'
@@ -66,6 +66,8 @@ export function SectorBox({ axes }: Props): JSX.Element | null {
     () => (box ? new EdgesGeometry(new BoxGeometry(box.size, box.size, box.size)) : null),
     [box],
   )
+  // The previous cage's GL buffers, freed when a new one replaces it.
+  useEffect(() => () => geometry?.dispose(), [geometry])
 
   if (!box || !geometry) return null
 


### PR DESCRIPTION
From the memory hunt. Rooms, the sector cage and the path trail build a fresh `BufferGeometry` on every anchor change or zoom and hand it to a persistent element; React Three Fiber disposes on unmount, not on a replaced prop, and a geometry's GL buffers live until `dispose()` or context loss. The cursor's legs swapped their position attribute the same way on every cursor move. Each one now disposes what it replaces; the cursor disposes its geometry before the swap, which frees the buffers and re-uploads on the next frame.

Honest about size: measured headlessly, 400 cursor moves grew the GPU process by 7 MB before this change. Small per event, unbounded over a long session, and the class of bug is worth closing. It is not the 12 GB.

Type check, 434 tests and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc