### PR TITLE
HUD: explainers, two-column Scale & view, five avatars then VIEW MORE, OFFICIAL links, tap-to-copy position, HOSAKA watermark

### DIFF
--- a/src/hud/AvatarsPanel.tsx
+++ b/src/hud/AvatarsPanel.tsx
@@ -3,13 +3,16 @@
  *
  * Each row is a pubkey and its newest action on the relay. SPECTATE anchors
  * the scene on that avatar's chain head and hands the explorer their history;
- * the field above takes any npub or hex key, for someone who has not moved
- * lately or is not on this relay's feed at all. Your own key is listed when it
- * has published, marked YOU, since spectating yourself is just being here.
+ * the field above takes any npub, nprofile or hex key, for someone who has not
+ * moved lately or is not on this relay's feed at all. Your own key is listed
+ * when it has published, marked YOU, since spectating yourself is just being
+ * here. The panel shows the five newest; VIEW MORE opens the whole list in an
+ * overlay that scrolls, so the menu column stays short.
  */
 
 import { useEffect, useState } from 'react'
-import { useRecentAvatars } from '../hooks/useRecentAvatars'
+import { createPortal } from 'react-dom'
+import { useRecentAvatars, type RecentAvatars } from '../hooks/useRecentAvatars'
 import { parsePubkey } from '../lib/chains'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { spectate } from '../lib/spectator'
@@ -19,11 +22,15 @@ import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
 import { Explanation } from './Explanation'
 
+/** Rows the panel shows before VIEW MORE takes over. */
+const SHOWN = 5
+
 export function AvatarsPanel(): JSX.Element {
   const { avatars, status } = useRecentAvatars()
   const me = useCyberspace((s) => s.identity.pubkey)
   const targets = useCyberspace((s) => s.targets)
   const [input, setInput] = useState('')
+  const [more, setMore] = useState(false)
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {
     const t = window.setInterval(() => setNow(Date.now() / 1000), 10_000)
@@ -34,7 +41,34 @@ export function AvatarsPanel(): JSX.Element {
 
   const go = (pubkey: string): void => {
     setInput('')
+    setMore(false)
     void spectate(pubkey)
+  }
+
+  const row = (a: RecentAvatars['avatars'][number]): JSX.Element => {
+    const you = a.pubkey === me
+    const on = !!targets[a.pubkey]
+    return (
+      <li key={a.pubkey} className="avatars__row">
+        <ProfileBadge pubkey={a.pubkey} />
+        <span className={`avatars__type avatars__type--${a.type}`}>{a.type.toUpperCase()}</span>
+        <span className="avatars__when" title={formatStamp(a.createdAt)}>{formatAgo(a.createdAt, now)}</span>
+        {you ? (
+          <span className="avatars__you">YOU</span>
+        ) : (
+          <span className="avatars__acts">
+            <button
+              className={`targets__toggle targets__toggle--mini ${on ? 'is-on' : ''}`}
+              style={on ? { color: targetColor(a.pubkey), borderColor: targetColor(a.pubkey) } : undefined}
+              aria-pressed={on}
+              title={on ? 'Stop targeting' : 'Target'}
+              onClick={() => useCyberspace.getState().toggleTarget(a.pubkey)}
+            >◎</button>
+            <button className="avatars__spectate" onClick={() => go(a.pubkey)}>SPECTATE</button>
+          </span>
+        )}
+      </li>
+    )
   }
 
   return (
@@ -52,7 +86,7 @@ export function AvatarsPanel(): JSX.Element {
           className="avatars__input"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="npub or hex pubkey"
+          placeholder="npub, nprofile or hex pubkey"
           spellCheck={false}
           autoComplete="off"
           aria-label="Pubkey to spectate"
@@ -63,41 +97,37 @@ export function AvatarsPanel(): JSX.Element {
       {status === 'error' && <p className="notice">Could not reach {CYBERSPACE_RELAY.replace('wss://', '')}.</p>}
 
       <ul className="avatars__list">
-        {avatars.map((a) => {
-          const you = a.pubkey === me
-          const on = !!targets[a.pubkey]
-          return (
-            <li key={a.pubkey} className="avatars__row">
-              <ProfileBadge pubkey={a.pubkey} />
-              <span className={`avatars__type avatars__type--${a.type}`}>{a.type.toUpperCase()}</span>
-              <span className="avatars__when" title={formatStamp(a.createdAt)}>{formatAgo(a.createdAt, now)}</span>
-              {you ? (
-                <span className="avatars__you">YOU</span>
-              ) : (
-                <span className="avatars__acts">
-                  <button
-                    className={`targets__toggle targets__toggle--mini ${on ? 'is-on' : ''}`}
-                    style={on ? { color: targetColor(a.pubkey), borderColor: targetColor(a.pubkey) } : undefined}
-                    aria-pressed={on}
-                    title={on ? 'Stop targeting' : 'Target'}
-                    onClick={() => useCyberspace.getState().toggleTarget(a.pubkey)}
-                  >◎</button>
-                  <button className="avatars__spectate" onClick={() => go(a.pubkey)}>SPECTATE</button>
-                </span>
-              )}
-            </li>
-          )
-        })}
+        {avatars.slice(0, SHOWN).map(row)}
         {status === 'ready' && avatars.length === 0 && (
           <li className="avatars__empty">No v2 actions on the relay yet.</li>
         )}
       </ul>
+      {avatars.length > SHOWN && (
+        <button className="avatars__more" onClick={() => setMore(true)}>VIEW MORE ({avatars.length - SHOWN})</button>
+      )}
 
       <Explanation>
-        Newest kind:3333 action per pubkey on {CYBERSPACE_RELAY.replace('wss://', '')}.
-        Spectating anchors the scene on their chain head and gives the chain
-        explorer their history; the controls stand down until you end it.
+        Identities publish action proofs to move through cyberspace. You can
+        spectate or target other identities to track where they go. Recent
+        activity is listed above.
       </Explanation>
+
+      {/* Through a portal: the panel's backdrop-filter makes it a stacking context, under the panels below it. */}
+      {more && createPortal(
+        <div className="modal" role="dialog" aria-modal="true" aria-label="All avatars" onPointerDown={() => setMore(false)}>
+          <div className="modal__card modal__card--list" onPointerDown={(e) => e.stopPropagation()}>
+            <header className="panel__head">
+              <h2>Avatars</h2>
+              <span className="tag">{avatars.length} SEEN</span>
+            </header>
+            <ul className="avatars__list avatars__list--all">{avatars.map(row)}</ul>
+            <div className="modal__row">
+              <button className="modal__cancel" onClick={() => setMore(false)}>CLOSE</button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
     </section>
   )
 }

--- a/src/hud/ChainPanel.tsx
+++ b/src/hud/ChainPanel.tsx
@@ -13,7 +13,6 @@
 import { formatMs, formatOps } from '../lib/space'
 import { useCyberspace } from '../store/useCyberspace'
 import { CYBERSPACE_RELAY } from '../lib/relay'
-import { useRelays } from '../store/useRelays'
 import { Explanation } from './Explanation'
 
 export function ChainPanel(): JSX.Element {
@@ -25,7 +24,6 @@ export function ChainPanel(): JSX.Element {
   const published = useCyberspace((s) => s.published)
   const publishError = useCyberspace((s) => s.publishError)
   const live = useCyberspace((s) => s.live)
-  const relayCount = useRelays((s) => s.relays.length)
   const actions = chain.hops + chain.sidesteps
 
   const statuses = events.map((e) => published[e.id])
@@ -93,10 +91,11 @@ export function ChainPanel(): JSX.Element {
       {publishError && <p className="notice">{CYBERSPACE_RELAY}: {publishError}</p>}
 
       <Explanation>
-        Every committed action is a signed kind:3333 event naming the one
-        before it (spec section 8). {live
-          ? `Live publishes each one to your ${relayCount === 1 ? CYBERSPACE_RELAY.replace('wss://', '') : `${relayCount} relays`} as it lands.`
-          : 'Local keeps them on this device; switching to Live publishes the whole chain in order.'}
+        To alter your position in cyberspace, you must compute the cantor root for
+        the region containing your origin and destination, and publish a root proof
+        naming the proof that came before it. This forms a personal "hash chain" for
+        your identity that mathematically proves a valid history of your actions
+        without relying on a central authority to enforce movement rules.
       </Explanation>
     </section>
   )

--- a/src/hud/ChainPanel.tsx
+++ b/src/hud/ChainPanel.tsx
@@ -24,7 +24,7 @@ export function ChainPanel(): JSX.Element {
   const published = useCyberspace((s) => s.published)
   const publishError = useCyberspace((s) => s.publishError)
   const live = useCyberspace((s) => s.live)
-  const actions = chain.hops + chain.sidesteps
+  const exploreIndex = useCyberspace((s) => s.exploreIndex)
 
   const statuses = events.map((e) => published[e.id])
   const sent = statuses.filter((st) => st === 'ok').length
@@ -40,9 +40,16 @@ export function ChainPanel(): JSX.Element {
     <section className="panel">
       <header className="panel__head">
         <h2>Proof chain</h2>
-        <span className="tag">
-          {actions} ACTION{actions === 1 ? '' : 'S'}
-        </span>
+        {/* The whole chain, spawn included, not this session's proofs; a tap
+            opens the chain explorer at the head, a second tap puts it away. */}
+        <button
+          className="tag tag--tap"
+          onClick={() => useCyberspace.getState().explore(exploreIndex === null ? Math.max(0, events.length - 1) : null)}
+          aria-pressed={exploreIndex !== null}
+          title="Open the chain explorer"
+        >
+          {events.length} ACTION{events.length === 1 ? '' : 'S'}
+        </button>
       </header>
 
       <dl className="stats">
@@ -84,7 +91,7 @@ export function ChainPanel(): JSX.Element {
         <code>{genesisId}</code>
       </div>
       <div className="hash">
-        <span className="hash__label">chain head{actions === 0 ? ' (spawn)' : ''}</span>
+        <span className="hash__label">chain head{events.length <= 1 ? ' (spawn)' : ''}</span>
         <code>{prevEventId}</code>
       </div>
 

--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -81,9 +81,7 @@ export function CloudPanel(): JSX.Element {
   return (
     <section className={`panel panel--cloud ${active ? 'is-active' : ''}`}>
       <header className="panel__head">
-        {/* The HOSAKA mark, small, so this panel is not one more panel: it is
-            the one whose work happens on someone else's machine. */}
-        <h2><img className="panel__mark" src="/hosaka-mark.png" alt="" aria-hidden="true" width={308} height={334} decoding="async" />Cloud compute</h2>
+        <h2>Cloud compute</h2>
         <span className={`tag tag--cloud ${cloud.status === 'error' ? 'tag--danger' : active ? 'tag--live' : ''}`}>{tag}</span>
       </header>
 
@@ -238,16 +236,23 @@ export function CloudPanel(): JSX.Element {
       )}
 
       <Explanation>
-        Beyond this machine's ceiling, Space asks HOSAKA for a quote instead of
-        stalling: a cloud hop lands at the cursor and returns the region key, a
-        cloud sidestep crosses a wall taller than the cloud's hop cap. AUTO
-        submits without asking up to the budget and asks above it; ASK always
-        asks; OFF keeps every proof local. You pay a Lightning invoice from
-        any wallet (this app has none); a job that fails is refunded to your
-        HOSAKA balance. HOSAKA learns the coordinates of each cloud move and
-        holds the region key of every region it computes for you. Every result
-        is verified here before it is signed.
+        <p>
+          Actions may require hardware resources beyond your machine's capacity.
+          Cloud services can compute actions on your behalf and return the data
+          for assembly into a valid proof. ONOSENDAI's own compute provider is
+          HOSAKA, but you can switch it to any provider.
+        </p>
+        <p>
+          HOSAKA quotes prices in satoshis paid via lightning, and holds a balance
+          for your identity to order compute jobs against. HOSAKA necessarily
+          learns the cantor root of every region it computes for you.
+        </p>
       </Explanation>
+
+      {/* The HOSAKA mark as a watermark, the pulse mark's size, so this panel is
+          not one more panel: it is the one whose work happens on someone else's
+          machine. */}
+      <img className="cloud__watermark" src="/hosaka-mark.png" alt="" aria-hidden="true" width={308} height={334} decoding="async" />
     </section>
   )
 }

--- a/src/hud/ConfirmModal.tsx
+++ b/src/hud/ConfirmModal.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
 interface Props {
   /** Something to show above the title, such as the HOSAKA banner. */
@@ -27,7 +28,10 @@ interface Props {
 }
 
 export function ConfirmModal({ banner, title, body, figure, busy = false, confirmLabel, danger = true, cardClassName, cancelLabel = 'CANCEL', onConfirm, onCancel }: Props): JSX.Element {
-  return (
+  // Through a portal: every .panel has a backdrop-filter, which makes it a
+  // stacking context, so a fixed modal rendered inside one panel would be
+  // painted under the panels that follow it in the column.
+  return createPortal(
     <div className="modal" role="dialog" aria-modal="true" aria-label={title} onPointerDown={onCancel}>
       <div className={`modal__card ${cardClassName ?? ''}`} onPointerDown={(e) => e.stopPropagation()}>
         {banner}
@@ -41,6 +45,7 @@ export function ConfirmModal({ banner, title, body, figure, busy = false, confir
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -184,12 +184,12 @@ function ScalePanel(): JSX.Element {
               <dd>{formatCellSizeLong(scaleExp)}</dd>
             </div>
             <div>
-              <dt>Screen right</dt>
-              <dd>{signed(axes.right.axis, axes.right.dir)}</dd>
-            </div>
-            <div>
               <dt>Screen up</dt>
               <dd>{signed(axes.up.axis, axes.up.dir)}</dd>
+            </div>
+            <div>
+              <dt>Screen right</dt>
+              <dd>{signed(axes.right.axis, axes.right.dir)}</dd>
             </div>
             <div>
               <dt>Looking along</dt>

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -214,6 +214,7 @@ const OFFICIAL: Array<{ href: string; name: string; what: string }> = [
   { href: 'https://github.com/arkin0x/cyberspace', name: 'Cyberspace v2 Specification', what: 'the core protocol documentation' },
   { href: 'https://straylight.cafe', name: 'straylight.cafe', what: 'cyberspace enthusiast community hub' },
   { href: 'https://cyberspace.international', name: 'cyberspace.international', what: 'education, proliferation, adoption of cyberspace' },
+  { href: 'https://github.com/arkin0x/ONOSENDAI/tree/v2', name: 'ONOSENDAI v2 Codebase', what: 'this client, on GitHub' },
 ]
 
 function LinksPanel(): JSX.Element {

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -5,6 +5,7 @@
 
 import { useState } from 'react'
 import { formatBig, formatStep } from '../lib/space'
+import { formatCellSizeLong } from '../lib/scale'
 import { useCyberspace } from '../store/useCyberspace'
 import { shortHex } from '../lib/time'
 import { ProfilePic } from './ProfileBadge'
@@ -50,6 +51,21 @@ const SIGNER_LABEL: Record<string, string> = {
   nip46: 'BUNKER',
 }
 
+/** How long a tapped readout says COPIED before its label returns. */
+const COPIED_MS = 1200
+
+/** Tap to copy: which key was copied last, and the copier. The clipboard gets the raw text. */
+function useCopied(): [string | null, (key: string, text: string) => void] {
+  const [copied, setCopied] = useState<string | null>(null)
+  const copy = (key: string, text: string): void => {
+    navigator.clipboard?.writeText(text).then(
+      () => { setCopied(key); window.setTimeout(() => setCopied((c) => (c === key ? null : c)), COPIED_MS) },
+      () => { /* no clipboard here: the value stays selectable */ },
+    )
+  }
+  return [copied, copy]
+}
+
 function IdentityPanel(): JSX.Element {
   const identity = useCyberspace((s) => s.identity)
   const signerKind = useCyberspace((s) => s.signerKind)
@@ -77,12 +93,10 @@ function IdentityPanel(): JSX.Element {
       </div>
 
       <Explanation>
-        Spawned at this key's coordinate: the 256-bit pubkey decodes directly
-        to x / y / z / plane (spec section 8.3). Persisted locally so
-        refreshing keeps your identity and position.
-        {live
-          ? ' LIVE: every action is signed and published to cyberspace.nostr1.com as it completes.'
-          : ' LOCAL: actions are signed but stay on this device. Going live publishes the whole chain.'}
+        Your spawn location is equal to your public key. Use the generated key or
+        sign in with your nostr keypair. LIVE indicates your proofs are being
+        published so other identities can see your movements. LOCAL means proofs
+        are stored on this device until you switch to LIVE.
       </Explanation>
 
       {loginOpen && <LoginModal onClose={() => setLoginOpen(false)} />}
@@ -95,6 +109,16 @@ function PositionPanel(): JSX.Element {
   const plane = useCyberspace((s) => s.plane)
   const coordHex = useCyberspace((s) => s.coordHex())
   const sector = useCyberspace((s) => s.sector())
+  const [copied, copy] = useCopied()
+
+  // Every figure copies on a tap, raw: the grouping commas are for reading,
+  // not for pasting into a filter or a script.
+  const readout = (key: string, label: string, shown: string, raw: string): JSX.Element => (
+    <div key={key}>
+      <dt className={copied === key ? 'is-copied' : ''}>{copied === key ? 'Copied' : label}</dt>
+      <dd><button className="copy" onClick={() => copy(key, raw)} title="Tap to copy">{shown}</button></dd>
+    </div>
+  )
 
   return (
     <section className="panel">
@@ -106,28 +130,16 @@ function PositionPanel(): JSX.Element {
       </header>
 
       <dl className="stats stats--axes">
-        <div>
-          <dt>X</dt>
-          <dd>{formatBig(position.x)}</dd>
-        </div>
-        <div>
-          <dt>Y</dt>
-          <dd>{formatBig(position.y)}</dd>
-        </div>
-        <div>
-          <dt>Z</dt>
-          <dd>{formatBig(position.z)}</dd>
-        </div>
-        <div>
-          <dt>Sector</dt>
-          <dd>{sector}</dd>
-        </div>
+        {readout('x', 'X', formatBig(position.x), position.x.toString())}
+        {readout('y', 'Y', formatBig(position.y), position.y.toString())}
+        {readout('z', 'Z', formatBig(position.z), position.z.toString())}
+        {readout('sector', 'Sector', sector, sector)}
       </dl>
 
-      <div className="hash">
-        <span className="hash__label">coord</span>
+      <button className="hash copy" onClick={() => copy('coord', coordHex)} title="Tap to copy">
+        <span className={`hash__label ${copied === 'coord' ? 'is-copied' : ''}`}>{copied === 'coord' ? 'copied' : 'coord'}</span>
         <code>{coordHex}</code>
-      </div>
+      </button>
     </section>
   )
 }
@@ -143,55 +155,79 @@ function ScalePanel(): JSX.Element {
         <span className="scale-exp">2^{scaleExp}</span>
       </header>
 
-      <dl className="stats">
-        <div>
-          <dt>Step</dt>
-          <dd>{formatStep(scaleExp)}</dd>
+      {/* Two columns: the axis key and the view facts on the left, the whole
+          scale range on the right, so the ladder's height is not empty space
+          beside three lines of text. */}
+      <div className="scale__cols">
+        <div className="scale__facts">
+          <div className="axis-legend">
+            <div className="axis-legend-item">
+              <span className="axis-dot axis-dot--x"></span>
+              <span className="axis-name">X axis</span>
+            </div>
+            <div className="axis-legend-item">
+              <span className="axis-dot axis-dot--y"></span>
+              <span className="axis-name">Y axis</span>
+            </div>
+            <div className="axis-legend-item">
+              <span className="axis-dot axis-dot--z"></span>
+              <span className="axis-name">Z axis (forward)</span>
+            </div>
+          </div>
+          <dl className="stats stats--stack">
+            <div>
+              <dt>Step</dt>
+              <dd>{formatStep(scaleExp)}</dd>
+            </div>
+            <div>
+              <dt>Cursor</dt>
+              <dd>{formatCellSizeLong(scaleExp)}</dd>
+            </div>
+            <div>
+              <dt>Screen right</dt>
+              <dd>{signed(axes.right.axis, axes.right.dir)}</dd>
+            </div>
+            <div>
+              <dt>Screen up</dt>
+              <dd>{signed(axes.up.axis, axes.up.dir)}</dd>
+            </div>
+            <div>
+              <dt>Looking along</dt>
+              <dd>{signed(axes.out.axis, -axes.out.dir)}</dd>
+            </div>
+          </dl>
         </div>
-        <div>
-          <dt>Screen right</dt>
-          <dd>{signed(axes.right.axis, axes.right.dir)}</dd>
-        </div>
-        <div>
-          <dt>Screen up</dt>
-          <dd>{signed(axes.up.axis, axes.up.dir)}</dd>
-        </div>
-      </dl>
-
-      <ScaleLadder />
-
-      <div className="axis-legend">
-        <div className="axis-legend-item">
-          <span className="axis-dot axis-dot--x"></span>
-          <span className="axis-name">X axis</span>
-        </div>
-        <div className="axis-legend-item">
-          <span className="axis-dot axis-dot--y"></span>
-          <span className="axis-name">Y axis</span>
-        </div>
-        <div className="axis-legend-item">
-          <span className="axis-dot axis-dot--z"></span>
-          <span className="axis-name">Z axis (forward)</span>
-        </div>
+        <ScaleLadder />
       </div>
 
       <Explanation>
-        Looking along {signed(axes.out.axis, -axes.out.dir)}. R and F travel the
-        axis into and out of the screen.
+        2^0 is the atomic-scale view of cyberspace; things don't get any smaller.
+        Your view can scale up exponentially until 2^85, which is the full size of
+        cyberspace (along each axis). The cursor represents a cubic meter at 2^33.
+        Earth is visible around 2^50.
       </Explanation>
     </section>
   )
 }
 
+const OFFICIAL: Array<{ href: string; name: string; what: string }> = [
+  { href: 'https://github.com/arkin0x/cyberspace', name: 'Cyberspace v2 Specification', what: 'the core protocol documentation' },
+  { href: 'https://straylight.cafe', name: 'straylight.cafe', what: 'cyberspace enthusiast community hub' },
+  { href: 'https://cyberspace.international', name: 'cyberspace.international', what: 'education, proliferation, adoption of cyberspace' },
+]
+
 function LinksPanel(): JSX.Element {
   return (
     <section className="panel panel--links">
-      <a href="https://straylight.cafe" target="_blank" rel="noopener noreferrer">
-        straylight.cafe
-      </a>
-      <a href="https://cyberspace.international" target="_blank" rel="noopener noreferrer">
-        cyberspace.international
-      </a>
+      <header className="panel__head">
+        <h2>Official</h2>
+      </header>
+      {OFFICIAL.map((l) => (
+        <p key={l.href} className="links__row">
+          <a href={l.href} target="_blank" rel="noopener noreferrer">{l.name}</a>
+          <span className="links__what"> - {l.what}</span>
+        </p>
+      ))}
     </section>
   )
 }

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -239,7 +239,7 @@ export function HyperspacePanel(): JSX.Element {
       </header>
 
       <div className="hyper__group">
-        <span className="legend__label hyper__kicker hyper__kicker--nearest">Station</span>
+        <span className="legend__label hyper__kicker hyper__kicker--nearest">Nearest station</span>
         {nearest ? (
           <>
             <dl className="stats">
@@ -282,7 +282,7 @@ export function HyperspacePanel(): JSX.Element {
       <div className="hyper__group">
         <span className="legend__label hyper__kicker hyper__kicker--destination">Destination</span>
         {destination === null ? (
-          <p className="legend__note">None set. Open the line scrubber (H) and pick a stop.</p>
+          <p className="legend__note">None set. Open the Hyperspace overlay (H) to see any block or tap one in the HUD.</p>
         ) : (
           <>
             <dl className="stats">
@@ -358,9 +358,7 @@ export function HyperspacePanel(): JSX.Element {
       {transit === null && progress === null && (
         !ready ? (
           <p className="hyper__why">BOARD UNLOCKS WHEN THE LINE FINISHES SYNCING</p>
-        ) : destination === null ? (
-          <p className="hyper__why">BOARD NEEDS A DESTINATION BLOCK: PICK ONE ON THE LINE (H)</p>
-        ) : !atHead ? (
+        ) : destination === null ? null : !atHead ? (
           <p className="hyper__why">BOARD STARTS FROM YOUR AVATAR: RETURN TO IT FIRST</p>
         ) : null
       )}

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -35,7 +35,7 @@ function formatDuration(ms: number): string {
   return `${(h / 24).toFixed(1)} d`
 }
 import { useCyberspace } from '../store/useCyberspace'
-import { markViewedStop, ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
+import { exitHyperspaceView, markViewedStop, ownHyperspaceView, getStopByHeight, getStopIndex, stopCount, useHyperspace } from '../store/useHyperspace'
 import { Explanation } from './Explanation'
 
 /**
@@ -235,7 +235,15 @@ export function HyperspacePanel(): JSX.Element {
     <section className="panel">
       <header className="panel__head">
         <h2>Hyperspace</h2>
-        <span className={`tag ${sync.status === 'error' ? 'tag--danger' : ''}`}>{tag}</span>
+        {ready ? (
+          <button
+            className="tag tag--tap"
+            title="Open the Hyperspace overlay (H)"
+            onClick={() => { const hs = useHyperspace.getState(); if (hs.scrubHeight === null) hs.setScrubHeight(hs.tipHeight ?? 0); else exitHyperspaceView() }}
+          >{tag}</button>
+        ) : (
+          <span className={`tag ${sync.status === 'error' ? 'tag--danger' : ''}`}>{tag}</span>
+        )}
       </header>
 
       <div className="hyper__group">

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -40,12 +40,12 @@ import { Explanation } from './Explanation'
 
 /**
  * Where a stop sits, for the camera. The float64-approximate coordinate is
- * within a metre of the exact one, invisible at any spectate scale; only the
+ * within a meter of the exact one, invisible at any spectate scale; only the
  * signed hyperjump needs the exact coordinate.
  */
 export function stopPosition(stop: Stop): Position {
   // Exact, not approx: the float64 landfall shortcut is good to about a
-  // nanometre, which is TENS OF GIBSONS, so at human zooms an approx marker
+  // nanometer, which is TENS OF GIBSONS, so at human zooms an approx marker
   // renders visibly beside the avatar standing exactly on the stop. The
   // decimal derivation is lazy and cached per stop, and everything that
   // calls this touches a handful of stops, not the field.
@@ -268,7 +268,7 @@ export function HyperspacePanel(): JSX.Element {
                 stopPosition(nearest.stop),
                 stopPlane(nearest.stop),
                 `STATION · BLOCK ${nearest.stop.height}`,
-                // 2^34: one render cell is 2 metres, the spec's h34 human
+                // 2^34: one render cell is 2 meters, the spec's h34 human
                 // scale, so the stop reads as a place you could stand at.
                 34,
               ) }}

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -372,15 +372,16 @@ export function HyperspacePanel(): JSX.Element {
       {rideError && <p className="notice">{rideError}</p>}
 
       <Explanation>
-        Your STATION is your nearest block, ties to the lowest height:
-        distance is the size of the smallest aligned cube holding you both,
-        so far from the line several blocks are equally near and every
-        verifier must resolve to the same one. VIEW STATION flies the camera
-        there; the viewing bar's RETURN or Escape brings it home at your
-        previous zoom. Boarding marks your chain; the ride proves fresh work
-        for every block passed and sets you down exactly at the block.
-        Leaving is an ordinary hop, so the last mile from any block is
-        normal movement.
+        Each block in the bitcoin blockchain is a railway station in cyberspace.
+        Identities can enter their nearest block for free, produce a nominally
+        easy proof to move between stations, and exit at the exact coordinate of
+        their desired station. This is called hyperspace. Blocks ending with a
+        binary 0 are mapped to Earth, and blocks ending with a binary 1 are
+        mapped to the rest of cyberspace. Without hyperspace, no identity would
+        be capable of traveling any significant distance. Bitcoin's blockchain
+        is used for stations because nobody can control where the next station
+        (block) will appear. The hyperspace railway grows consistently and
+        unpredictably and autonomously without the possibility of manipulation.
       </Explanation>
     </section>
   )

--- a/src/hud/Legend.tsx
+++ b/src/hud/Legend.tsx
@@ -3,15 +3,12 @@
  */
 
 import { boundaryColor, terrainColor } from '../lib/palette'
-import { useCyberspace } from '../store/useCyberspace'
 import { Explanation } from './Explanation'
 
 const TERRAIN_SAMPLES = [0, 4, 6, 8, 10, 12, 14, 16]
 const HEIGHT_SAMPLES = [5, 20, 40, 60, 80]
 
 export function Legend(): JSX.Element {
-  const scaleExp = useCyberspace((s) => s.scaleExp)
-
   return (
     <section className="panel panel--legend">
       <header className="panel__head">
@@ -37,7 +34,7 @@ export function Legend(): JSX.Element {
       </div>
 
       <div className="legend__row">
-        <span className="legend__label">Crossing cost (grid + flash)</span>
+        <span className="legend__label">Cube grid - region cost</span>
         <div className="swatches">
           {HEIGHT_SAMPLES.map((height) => (
             <span
@@ -55,12 +52,14 @@ export function Legend(): JSX.Element {
       </div>
 
       <Explanation>
-        The subtree lattice takes its colour from the height of its own walls, so
-        the grid climbs this ramp as you zoom out. Committing flashes the region
-        the proof covered, striking white and settling into the same ramp at the
-        height you paid. Height is the power-of-two boundary you cross, not how
-        far you travel. The cyan box is the move you are lining up. Current
-        scale: {scaleExp}.
+        Cyberspace is not flat. A terrain function required for movement proofs
+        imposes hills and valleys on the geography of cyberspace, represented by
+        the colorful point cloud surrounding your avatar. The terrain K value is
+        the difficulty to move to each point. The cubic grids represent the
+        power-of-2 regions you are currently within. Leaving a region is when the
+        cost of movement jumps the most; depending on the alignment of the region,
+        the cost may be impossibly high, requiring either cloud compute or a trip
+        through hyperspace.
       </Explanation>
     </section>
   )

--- a/src/hud/Legend.tsx
+++ b/src/hud/Legend.tsx
@@ -8,6 +8,54 @@ import { Explanation } from './Explanation'
 const TERRAIN_SAMPLES = [0, 4, 6, 8, 10, 12, 14, 16]
 const HEIGHT_SAMPLES = [5, 20, 40, 60, 80]
 
+/** A faceted ball in outline, the avatar's wireframe seen small. */
+const ball = (stroke: string): JSX.Element => (
+  <svg viewBox="0 0 20 20" aria-hidden="true">
+    <g fill="none" stroke={stroke} strokeWidth="1.2" strokeLinejoin="round">
+      <polygon points="10,1.5 17.5,5.75 17.5,14.25 10,18.5 2.5,14.25 2.5,5.75" />
+      <path d="M10 1.5 L10 18.5 M2.5 5.75 L17.5 14.25 M17.5 5.75 L2.5 14.25" />
+    </g>
+  </svg>
+)
+
+/** The things drawn in the world that are not terrain: what each glyph is. */
+const KEYS: Array<{ what: string; glyph: JSX.Element }> = [
+  { what: 'Red dodecahedron: your avatar', glyph: ball('#ff2323') },
+  { what: "White dodecahedron: another identity's avatar", glyph: ball('#ffffff') },
+  {
+    what: 'Yellow rotating cube: hyperjump station',
+    glyph: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <g fill="rgba(247, 147, 26, 0.18)" stroke="#f7931a" strokeWidth="1.2" strokeLinejoin="round">
+          <path d="M10 2 L17 6 L17 14 L10 18 L3 14 L3 6 Z" />
+          <path fill="none" d="M3 6 L10 10 L17 6 M10 10 L10 18" />
+        </g>
+      </svg>
+    ),
+  },
+  {
+    what: 'Purple ring: the Black Sun, the fixed bearing at +Z',
+    glyph: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <circle cx="10" cy="10" r="6.5" fill="rgba(146, 88, 209, 0.22)" stroke="#9258d1" strokeWidth="2.2" />
+      </svg>
+    ),
+  },
+  {
+    what: 'Spawn point mesh: spawn point',
+    glyph: (
+      <svg viewBox="0 0 20 20" aria-hidden="true">
+        <g fill="none" strokeWidth="1.2" strokeLinejoin="round">
+          <polygon stroke="#ff7a90" points="10,1.5 17.5,5.75 17.5,14.25 10,18.5 2.5,14.25 2.5,5.75" />
+          <rect stroke="#ff7a90" x="8" y="8" width="4" height="4" />
+          <path stroke="#ff2323" d="M10 8 L10 4.5 M8.2 11.2 L5.2 13.2 M11.8 11.2 L14.8 13.2" />
+          <path stroke="#c07dff" d="M8.2 8.8 L5.2 6.8 M11.8 8.8 L14.8 6.8 M10 12 L10 15.5" />
+        </g>
+      </svg>
+    ),
+  },
+]
+
 export function Legend(): JSX.Element {
   return (
     <section className="panel panel--legend">
@@ -16,7 +64,7 @@ export function Legend(): JSX.Element {
       </header>
 
       <div className="legend__row">
-        <span className="legend__label">Terrain K (cell fill)</span>
+        <span className="legend__label">Terrain K</span>
         <div className="swatches">
           {TERRAIN_SAMPLES.map((k) => (
             <span
@@ -50,6 +98,15 @@ export function Legend(): JSX.Element {
           <em>high</em>
         </span>
       </div>
+
+      <ul className="legend__keys">
+        {KEYS.map((k) => (
+          <li key={k.what} className="legend__key">
+            <span className="legend__glyph">{k.glyph}</span>
+            <span>{k.what}</span>
+          </li>
+        ))}
+      </ul>
 
       <Explanation>
         Cyberspace is not flat. A terrain function required for movement proofs

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -79,9 +79,11 @@ export function LootPanel(): JSX.Element {
       </ul>
 
       <Explanation>
-        Every kind:33330 bag on {relayName}. The size is the region each bag is
-        encrypted to, not its distance from you: where that region is stays hidden
-        until its hider adds a hint. Tap a bag for its record.
+        Identities can encrypt messages, 3D objects (shards), or other data by
+        location. These encrypted bundles are called "bags" and might have clues
+        as to where they can be found. The size is the area wherein the bag can be
+        found; larger is more work to decrypt but easier to find, smaller is less
+        work to decrypt but harder to find.
       </Explanation>
     </section>
   )

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -7,12 +7,15 @@
  * the panel answers the question a newcomer asks first, whether there is
  * anything out there at all. Tapping a bag opens its record (LootDetail). A bag
  * your scan has already opened is marked FOUND; your own bags are marked YOURS.
+ * The panel shows the four newest; VIEW MORE opens the whole list in an overlay
+ * that scrolls, so the menu column stays short.
  */
 
 import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useLoot } from '../hooks/useLoot'
 import { messagePreview } from '../lib/hidden'
-import { formatBytes, regionLabel } from '../lib/loot'
+import { formatBytes, regionLabel, type LootItem } from '../lib/loot'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { formatAgo, formatStamp } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
@@ -21,8 +24,12 @@ import { useShards } from '../store/useShards'
 import { ProfileBadge } from './ProfileBadge'
 import { Explanation } from './Explanation'
 
+/** Rows the panel shows before VIEW MORE takes over. */
+const SHOWN = 4
+
 export function LootPanel(): JSX.Element {
   const { items, status } = useLoot()
+  const [more, setMore] = useState(false)
   const me = useCyberspace((s) => s.identity.pubkey)
   const discovered = useShards((s) => s.discovered)
   // What each found bag holds, oldest item first, as glyphs: ◇ a shard, ✎ a message.
@@ -46,6 +53,22 @@ export function LootPanel(): JSX.Element {
   }, [])
   const relayName = CYBERSPACE_RELAY.replace('wss://', '')
 
+  const open = (it: LootItem): void => { setMore(false); useLootView.getState().select(it) }
+  const row = (it: LootItem): JSX.Element => (
+    <li key={it.key} className="loot__row">
+      <button className="loot__open" onClick={() => open(it)} title="Open this bag's record">
+        <div className="loot__top">
+          <ProfileBadge pubkey={it.author} />
+          {it.author === me && <span className="avatars__you">YOURS</span>}
+          {found.has(it.bagId) && <span className="tag tag--live loot__kinds" title={`Found: ${kinds.get(it.bagId)?.length ?? 0} items`}>{kinds.get(it.bagId)}</span>}
+          <span className="avatars__when" title={formatStamp(it.createdAt)}>{formatAgo(it.createdAt, now)}</span>
+        </div>
+        <div className="loot__meta">{regionLabel(it.height)} · {formatBytes(it.bytes)}</div>
+        {it.riddle && <div className="loot__riddle" title={it.riddle}>“{messagePreview(it.riddle, 90)}”</div>}
+      </button>
+    </li>
+  )
+
   return (
     <section className="panel panel--loot">
       <header className="panel__head">
@@ -59,24 +82,14 @@ export function LootPanel(): JSX.Element {
       {status === 'error' && <p className="notice">Could not reach {relayName}.</p>}
 
       <ul className="avatars__list loot__list">
-        {items.map((it) => (
-          <li key={it.key} className="loot__row">
-            <button className="loot__open" onClick={() => useLootView.getState().select(it)} title="Open this bag's record">
-              <div className="loot__top">
-                <ProfileBadge pubkey={it.author} />
-                {it.author === me && <span className="avatars__you">YOURS</span>}
-                {found.has(it.bagId) && <span className="tag tag--live loot__kinds" title={`Found: ${kinds.get(it.bagId)?.length ?? 0} items`}>{kinds.get(it.bagId)}</span>}
-                <span className="avatars__when" title={formatStamp(it.createdAt)}>{formatAgo(it.createdAt, now)}</span>
-              </div>
-              <div className="loot__meta">{regionLabel(it.height)} · {formatBytes(it.bytes)}</div>
-              {it.riddle && <div className="loot__riddle" title={it.riddle}>“{messagePreview(it.riddle, 90)}”</div>}
-            </button>
-          </li>
-        ))}
+        {items.slice(0, SHOWN).map(row)}
         {status === 'ready' && items.length === 0 && (
           <li className="avatars__empty">Nothing hidden on the relay yet.</li>
         )}
       </ul>
+      {items.length > SHOWN && (
+        <button className="avatars__more" onClick={() => setMore(true)}>VIEW MORE ({items.length - SHOWN})</button>
+      )}
 
       <Explanation>
         Identities can encrypt messages, 3D objects (shards), or other data by
@@ -85,6 +98,23 @@ export function LootPanel(): JSX.Element {
         found; larger is more work to decrypt but easier to find, smaller is less
         work to decrypt but harder to find.
       </Explanation>
+
+      {/* Through a portal: the panel's backdrop-filter makes it a stacking context, under the panels below it. */}
+      {more && createPortal(
+        <div className="modal" role="dialog" aria-modal="true" aria-label="All loot" onPointerDown={() => setMore(false)}>
+          <div className="modal__card modal__card--list" onPointerDown={(e) => e.stopPropagation()}>
+            <header className="panel__head">
+              <h2>Loot</h2>
+              <span className="tag">{items.length} HIDDEN</span>
+            </header>
+            <ul className="avatars__list avatars__list--all loot__list">{items.map(row)}</ul>
+            <div className="modal__row">
+              <button className="modal__cancel" onClick={() => setMore(false)}>CLOSE</button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
     </section>
   )
 }

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -120,7 +120,7 @@ export function ProofPanel(): JSX.Element {
               <dd>{routeLabel(preview.route)}</dd>
             </div>
             <div>
-              <dt>Tallest wall</dt>
+              <dt>Highest boundary</dt>
               <dd>2^{preview.route.tallestWall}</dd>
             </div>
             <div>
@@ -201,7 +201,7 @@ export function ProofPanel(): JSX.Element {
         </>
       )}
 
-      <p className="legend__note">{`THIS MACHINE: HOP <= 2^${hopCeil} · SIDESTEP <= 2^${sidestepCeil}`}</p>
+      <p className="legend__note">{`THIS MACHINE BENCHMARK: HOP <= 2^${hopCeil} · SIDESTEP <= 2^${sidestepCeil}`}</p>
     </section>
   )
 }

--- a/src/hud/ScaleLadder.tsx
+++ b/src/hud/ScaleLadder.tsx
@@ -9,7 +9,7 @@
  *
  * So the range is drawn once with its landmarks fixed on it and the current zoom
  * riding it. The landmarks are not decoration; each is a consequence of the
- * spec's one anchor, Cantor height 34 = 2 metres (§9.2), which makes a gibson
+ * spec's one anchor, Cantor height 34 = 2 meters (§9.2), which makes a gibson
  * 2^-33 m. Everything else follows by arithmetic, including the one that
  * surprises people: a sector is 2^30 gibsons, which is 12.5 cm.
  */
@@ -29,7 +29,7 @@ const LANDMARKS: Array<{ h: number; name: string }> = [
   { h: 0, name: 'gibson' },
   { h: 30, name: 'sector' },
   { h: 34, name: 'human' },
-  { h: 43, name: 'kilometre' },
+  { h: 43, name: 'kilometer' },
   { h: 56.6, name: 'Earth' },
   { h: MAX_SCALE_EXP + 1, name: 'axis' },
 ]
@@ -49,9 +49,11 @@ export function ScaleLadder(): JSX.Element {
             <span className="ladder__tick-name">{l.name}</span>
           </span>
         ))}
+        {/* The reading sits left of the rail, the landmarks right of it, so
+            neither ever covers the other. */}
         <span className="ladder__here" style={{ bottom: `${pct(scaleExp)}%` }}>
-          <span className="ladder__here-dot" />
           <span className="ladder__here-text">{formatCellSize(scaleExp)}</span>
+          <span className="ladder__here-dot" />
         </span>
       </div>
     </div>

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -129,11 +129,8 @@ export function ShardsPanel(): JSX.Element {
       )}
 
       <Explanation>
-        Encrypt by location: a shard is coloured vertices (SOLID / POINTS / LINES);
-        a message is text. Both are hidden at a location and found only by someone
-        who computes its region key (spec section 7). Tap a deployment to fly to it and prove it
-        with TEST DISCOVERY. The tag counts what you have hidden; what your scans
-        have found is on the Loot panel.
+        Build 3D objects (shards), messages, and encrypt them at a location in
+        cyberspace for others to find.
       </Explanation>
 
       {target && (

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { nip19 } from 'nostr-tools'
 import { latestByPubkey, parsePubkey, V2_ACTIONS } from '../lib/chains'
-import { fetchContacts, GENERAL_RELAYS, type Contact } from '../lib/contacts'
+import { fetchContacts, type Contact } from '../lib/contacts'
 import { query } from '../lib/relay'
 import { spectate } from '../lib/spectator'
 import { targetColor } from '../lib/targets'
@@ -127,7 +127,7 @@ export function TargetsPanel(): JSX.Element {
 
       <form className="avatars__find" onSubmit={(e) => { e.preventDefault(); if (typed) { useCyberspace.getState().addTarget(typed); setInput('') } }}>
         <input className="avatars__input" value={input} onChange={(e) => setInput(e.target.value)}
-          placeholder="npub or hex pubkey" spellCheck={false} autoComplete="off" aria-label="Pubkey to target" />
+          placeholder="npub, nprofile or hex pubkey" spellCheck={false} autoComplete="off" aria-label="Pubkey to target" />
         <button className="avatars__go" type="submit" disabled={!typed}>TARGET</button>
       </form>
 
@@ -153,7 +153,7 @@ export function TargetsPanel(): JSX.Element {
         <span className="legend__label">Follows of</span>
         <form className="avatars__find" onSubmit={(e) => { e.preventDefault(); void loadContacts() }}>
           <input className="avatars__input" value={who} onChange={(e) => setWho(e.target.value)}
-            placeholder="npub or hex pubkey" spellCheck={false} autoComplete="off" aria-label="Whose follows to list" />
+            placeholder="npub, nprofile or hex pubkey" spellCheck={false} autoComplete="off" aria-label="Whose follows to list" />
           <button className="avatars__go" type="submit" disabled={!whoHex || contactsState === 'loading'}>
             {contactsState === 'loading' ? 'LOADING' : 'LOAD'}
           </button>
@@ -181,11 +181,7 @@ export function TargetsPanel(): JSX.Element {
       </div>
 
       <Explanation>
-        A target is pointed at from anywhere, like Earth: reticle in frame,
-        chevron on the edge, distance either way, and the avatar itself once
-        you are near. Positions are chain heads on the relay, kept live; a key
-        with no chain is pointed at its spawn coordinate. Follows come from
-        kind 3 on {GENERAL_RELAYS.map((r) => r.replace('wss://', '')).join(', ')}.
+        Target an identity to mark their location on your HUD.
       </Explanation>
     </section>
   )

--- a/src/lib/chains.test.ts
+++ b/src/lib/chains.test.ts
@@ -39,11 +39,15 @@ describe('mergeEvents', () => {
 })
 
 describe('parsePubkey', () => {
-  it('accepts hex and npub, rejects the rest', () => {
+  it('accepts hex, npub and nprofile, rejects the rest', () => {
     expect(parsePubkey(pa)).toBe(pa)
     expect(parsePubkey(pa.toUpperCase())).toBe(pa)
     expect(parsePubkey(`  ${nip19.npubEncode(pa)} `)).toBe(pa)
+    expect(parsePubkey(nip19.nprofileEncode({ pubkey: pa, relays: ['wss://relay.example'] }))).toBe(pa)
+    expect(parsePubkey(nip19.nprofileEncode({ pubkey: pa }).toUpperCase())).toBe(pa)
     expect(parsePubkey('npub1notakey')).toBeNull()
+    expect(parsePubkey('nprofile1notakey')).toBeNull()
+    expect(parsePubkey(nip19.noteEncode(pa))).toBeNull()
     expect(parsePubkey('xyz')).toBeNull()
   })
 })

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -71,14 +71,16 @@ export function watchAuthor(pubkey: string, since: number, onEvent: (ev: NostrEv
   return subscribe({ kinds: [KIND], authors: [pubkey], '#A': V2_ACTIONS, since }, onEvent)
 }
 
-/** Accepts an npub or 64-char hex; returns hex, or null when it is neither. */
+/** Accepts an npub, an nprofile (its relay hints dropped) or 64-char hex; returns hex, or null when it is none of them. */
 export function parsePubkey(input: string): string | null {
   const v = input.trim()
   if (/^[0-9a-f]{64}$/i.test(v)) return v.toLowerCase()
-  if (!/^npub1/i.test(v)) return null
+  if (!/^(npub|nprofile)1/i.test(v)) return null
   try {
     const decoded = nip19.decode(v.toLowerCase())
-    return decoded.type === 'npub' ? decoded.data : null
+    if (decoded.type === 'npub') return decoded.data
+    if (decoded.type === 'nprofile') return decoded.data.pubkey
+    return null
   } catch {
     return null
   }

--- a/src/lib/contacts.ts
+++ b/src/lib/contacts.ts
@@ -10,7 +10,7 @@ import { queryAny, CYBERSPACE_RELAY } from './relay'
 import type { NostrEvent } from './events'
 
 /** Where kind 3 is most likely to be found. */
-export const GENERAL_RELAYS = ['wss://purplepag.es', 'wss://relay.damus.io', 'wss://nos.lol']
+export const GENERAL_RELAYS = ['wss://relay.primal.net', 'wss://relay.damus.io', 'wss://nos.lol']
 
 export interface Contact {
   pubkey: string

--- a/src/lib/contacts.ts
+++ b/src/lib/contacts.ts
@@ -6,7 +6,7 @@
  * separate from the fetch so it can be tested without a socket.
  */
 
-import { queryAny, CYBERSPACE_RELAY } from './relay'
+import { queryAny, relaySet } from './relay'
 import type { NostrEvent } from './events'
 
 /** Where kind 3 is most likely to be found. */
@@ -32,7 +32,8 @@ export function parseContacts(ev: NostrEvent): Contact[] {
 
 /** The newest kind 3 for a pubkey across the general relays and ours. */
 export async function fetchContacts(pubkey: string): Promise<Contact[]> {
-  const events = await queryAny([...GENERAL_RELAYS, CYBERSPACE_RELAY], { kinds: [3], authors: [pubkey] })
+  // The general relays and every configured one: the cyberspace relay and any you added.
+  const events = await queryAny([...new Set([...GENERAL_RELAYS, ...relaySet()])], { kinds: [3], authors: [pubkey] })
   const newest = events.sort((a, b) => b.created_at - a.created_at)[0]
   return newest ? parseContacts(newest) : []
 }

--- a/src/lib/earthSurface.test.ts
+++ b/src/lib/earthSurface.test.ts
@@ -49,7 +49,7 @@ describe('latLonToCsMetres', () => {
 })
 
 describe('originCsMetres', () => {
-  it('is exact at the mapping centre and metre-true nearby', () => {
+  it('is exact at the mapping centre and meter-true nearby', () => {
     const at = originCsMetres({ x: CENTRE, y: CENTRE, z: CENTRE })
     expect(at).toEqual({ x: 0, y: 0, z: 0 })
     const oneKm = originCsMetres({ x: CENTRE + BigInt(1000 * GIBSONS_PER_M), y: CENTRE, z: CENTRE })
@@ -84,7 +84,7 @@ describe('graticuleStep', () => {
 })
 
 describe('surfaceDetailOpacity', () => {
-  it('is full at human scale, gone below metre scale', () => {
+  it('is full at human scale, gone below meter scale', () => {
     expect(surfaceDetailOpacity(49)).toBe(1)
     expect(surfaceDetailOpacity(34)).toBe(1)
     expect(surfaceDetailOpacity(33)).toBeCloseTo(2 / 3, 5)

--- a/src/lib/earthSurface.ts
+++ b/src/lib/earthSurface.ts
@@ -10,9 +10,9 @@
  * The way out is the render convention the whole scene already lives by:
  * never hand a large absolute to the GPU. Surface vertices are produced as
  * DELTAS from the render origin, computed in float64 METRES. Both the vertex
- * and the origin carry about a nanometre of representation error at
+ * and the origin carry about a nanometer of representation error at
  * Earth-radius magnitudes (float64 ulp, tens of gibsons), so their
- * difference does too, and a few nanometres is invisible at every scale the
+ * difference does too, and a few nanometers is invisible at every scale the
  * surface draws at. No Decimal derivation is needed anywhere in the render
  * path; the consensus-critical decimal profile stays in landfall.ts where
  * verifiers need it.
@@ -28,7 +28,7 @@ export const WGS84_F = 1 / 298.257223563
 export const WGS84_B_M = WGS84_A_M * (1 - WGS84_F)
 const E2 = WGS84_F * (2 - WGS84_F)
 
-/** §9.7: 1 metre = 2^33 gibsons (Cantor height 34 is 2 metres). */
+/** §9.7: 1 meter = 2^33 gibsons (Cantor height 34 is 2 meters). */
 export const GIBSONS_PER_M = 2 ** 33
 
 /** §9.7: the WGS84 mapping is centred on the half-axis point. */
@@ -37,7 +37,7 @@ const CENTRE = 1n << 84n
 /** Mean radius in km, the same summary Earth.tsx has always drawn. */
 export const EARTH_RADIUS_KM = 6371
 
-/** Cyberspace axis values in metres from the mapping centre (float64). */
+/** Cyberspace axis values in meters from the mapping centre (float64). */
 export interface CsMetres {
   x: number
   y: number
@@ -46,7 +46,7 @@ export interface CsMetres {
 
 /**
  * Geodetic latitude/longitude (degrees) and height above the ellipsoid
- * (metres) to cyberspace axis metres. Standard geodetic-to-ECEF, then the
+ * (meters) to cyberspace axis meters. Standard geodetic-to-ECEF, then the
  * §9.4 permutation: X_cs = X_ecef, Y_cs = Z_ecef, Z_cs = Y_ecef.
  */
 export function latLonToCsMetres(latDeg: number, lonDeg: number, altM = 0): CsMetres {
@@ -62,7 +62,7 @@ export function latLonToCsMetres(latDeg: number, lonDeg: number, altM = 0): CsMe
 }
 
 /**
- * The render origin's axis values in metres from the mapping centre. The
+ * The render origin's axis values in meters from the mapping centre. The
  * bigint subtraction happens first, so the Number conversion sees a value
  * of Earth-radius magnitude (or the origin's true offset), never 2^84.
  */
@@ -75,7 +75,7 @@ export function originCsMetres(origin: Position): CsMetres {
 }
 
 /**
- * A surface point as a render-space vertex: metre deltas from the origin,
+ * A surface point as a render-space vertex: meter deltas from the origin,
  * to cells at this scale, through the screen axis mapping, with the
  * continuous family's -0.5 shift (the one pointCentre and the globe's own
  * centre apply), so the surface stays glued to the landfall shell and the
@@ -121,7 +121,7 @@ export function graticuleStep(windowDeg: number, minLines = 6): number {
 /**
  * How strongly surface detail (the graticule patch, and later the
  * coastlines) is drawn at this scale. Full strength down to 2^34, the
- * spec's human scale, then fading out through metre scale: below that the
+ * spec's human scale, then fading out through meter scale: below that the
  * shore and the grid of places stop being what the view is about, and the
  * fade is the scale itself teaching that. Zero at and below 2^31.
  */

--- a/src/lib/hyperspace/landfall.test.ts
+++ b/src/lib/hyperspace/landfall.test.ts
@@ -30,7 +30,7 @@ describe('landfall derivation (DECK-0001 v3 §1.2)', () => {
     }
   })
 
-  it('float64 approximation agrees with the exact derivation to within a few metres', () => {
+  it('float64 approximation agrees with the exact derivation to within a few meters', () => {
     for (const [, hash] of VECTORS) {
       const exact = landfallCoord(hash)
       const approx = landfallCoordApprox(hash)

--- a/src/lib/hyperspace/landfall.ts
+++ b/src/lib/hyperspace/landfall.ts
@@ -8,7 +8,7 @@
  * mapping (precision 96, ROUND_HALF_EVEN, the exact PI_STR, Taylor sin/cos),
  * with every operation performed in the order the DECK lists.
  *
- * `landfallCoordApprox` is a float64 shortcut good to about a nanometre
+ * `landfallCoordApprox` is a float64 shortcut good to about a nanometer
  * (float64 ulp at Earth-radius magnitudes, i.e. tens of gibsons), for
  * indexing and rendering hundreds of thousands of stops quickly. Anything a
  * verifier compares against MUST use the exact `landfallCoord`.
@@ -156,7 +156,7 @@ const B_F = A_F * (1 - F_F)
 const CENTER_F = 2 ** 84
 
 /**
- * Float64 landfall approximation, about a metre of error (2^33 G), for the
+ * Float64 landfall approximation, about a meter of error (2^33 G), for the
  * index and the renderer. Never use for anything a verifier will check.
  */
 export function landfallXyzApprox(blockHashHex: string): { x: bigint; y: bigint; z: bigint } {
@@ -179,7 +179,7 @@ export function landfallCoordApprox(blockHashHex: string): bigint {
   return xyzToCoord(x, y, z, PLANE_DATASPACE)
 }
 
-/** Float64 inverse for labels: dataspace axis values to WGS84 lat/lon/alt (metres). */
+/** Float64 inverse for labels: dataspace axis values to WGS84 lat/lon/alt (meters). */
 export function axesToLatLon(x: bigint, y: bigint, z: bigint): { lat: number; lon: number; altM: number } {
   const xm = Number(x - AXIS_CENTER) / G_PER_M
   const ym = Number(y - AXIS_CENTER) / G_PER_M

--- a/src/lib/hyperspace/station.ts
+++ b/src/lib/hyperspace/station.ts
@@ -17,7 +17,7 @@
  * is done on byte arrays for the same reason.
  *
  * Landfalls enter the index with float64-approximate coordinates (about a
- * nanometre of error, which is still tens of gibsons). That cannot change
+ * nanometer of error, which is still tens of gibsons). That cannot change
  * a distance decided at h47 and above,
  * but to be safe against ties the finalists are re-derived exactly before
  * the winner is chosen.

--- a/src/lib/hyperspace/stops.ts
+++ b/src/lib/hyperspace/stops.ts
@@ -9,7 +9,7 @@
  *
  * Legacy anchors (published before v3) carry C = merkle root for every block
  * and no M tag. For a plane-0 legacy anchor the landfall coordinate must be
- * derived from H; we derive the float64 approximation eagerly (about a metre
+ * derived from H; we derive the float64 approximation eagerly (about a meter
  * of error, fine for the index and the renderer) and the exact decimal
  * coordinate lazily, only when a verifier-visible value is needed.
  */

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -158,9 +158,30 @@ export function query(filter: Filter): Promise<NostrEvent[]> {
   return collect(relaySet(), filter)
 }
 
-/** Query an explicit set, for the few things that live elsewhere (contact lists). */
-export function queryAny(relays: string[], filter: Filter, maxWait?: number): Promise<NostrEvent[]> {
-  return collect(relays, filter, maxWait)
+/** How long a general relay that refused a connection is left alone. */
+const DEAD_MS = 5 * 60_000
+const deadUntil = new Map<string, number>()
+
+/**
+ * The relays in `relays` that will take a connection now. One that refuses is
+ * skipped for DEAD_MS: every profile and contact lookup used to knock on it
+ * again, and a relay that is down turned each lookup into a failed socket in
+ * the console and a 3 s wait for nothing.
+ */
+async function reachable(relays: string[]): Promise<string[]> {
+  const now = Date.now()
+  const out: string[] = []
+  await Promise.all(relays.map(async (url) => {
+    if ((deadUntil.get(url) ?? 0) > now) return
+    try { await getPool().ensureRelay(url); out.push(url) } catch { deadUntil.set(url, now + DEAD_MS) }
+  }))
+  return out
+}
+
+/** Query an explicit set, for the few things that live elsewhere (profiles, contact lists). */
+export async function queryAny(relays: string[], filter: Filter, maxWait?: number): Promise<NostrEvent[]> {
+  const up = await reachable(relays)
+  return up.length ? collect(up, filter, maxWait) : []
 }
 
 /** A live subscription across the configured relays; the returned function closes it. */

--- a/src/lib/scale.test.ts
+++ b/src/lib/scale.test.ts
@@ -10,10 +10,10 @@ import { formatStep } from './space'
 describe('cell size', () => {
   it('spells the unit out for the readout and abbreviates it for the ladder', () => {
     expect(formatCellSize(0)).toBe('116 pm')
-    expect(formatCellSizeLong(0)).toBe('116 picometres')
-    expect(formatCellSizeLong(33)).toBe('1 metre')
-    expect(formatCellSizeLong(34)).toBe('2 metres')
-    expect(formatCellSizeLong(43)).toBe('1.02 kilometres')
+    expect(formatCellSizeLong(0)).toBe('116 picometers')
+    expect(formatCellSizeLong(33)).toBe('1 meter')
+    expect(formatCellSizeLong(34)).toBe('2 meters')
+    expect(formatCellSizeLong(43)).toBe('1.02 kilometers')
     expect(formatCellSizeLong(84)).toMatch(/astronomical units$/)
   })
 })

--- a/src/lib/scale.test.ts
+++ b/src/lib/scale.test.ts
@@ -1,0 +1,27 @@
+/**
+ * scale.test.ts - a cell's size reads in the unit it is best read in, short
+ * for the ladder and spelled out for the readout; the step reads in gibsons.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatCellSize, formatCellSizeLong } from './scale'
+import { formatStep } from './space'
+
+describe('cell size', () => {
+  it('spells the unit out for the readout and abbreviates it for the ladder', () => {
+    expect(formatCellSize(0)).toBe('116 pm')
+    expect(formatCellSizeLong(0)).toBe('116 picometres')
+    expect(formatCellSizeLong(33)).toBe('1 metre')
+    expect(formatCellSizeLong(34)).toBe('2 metres')
+    expect(formatCellSizeLong(43)).toBe('1.02 kilometres')
+    expect(formatCellSizeLong(84)).toMatch(/astronomical units$/)
+  })
+})
+
+describe('step', () => {
+  it('reads in gibsons, singular at 2^0', () => {
+    expect(formatStep(0)).toBe('1 gibson')
+    expect(formatStep(10)).toBe('1,024 gibsons')
+    expect(formatStep(40)).toBe('2^40 gibsons')
+  })
+})

--- a/src/lib/scale.ts
+++ b/src/lib/scale.ts
@@ -8,17 +8,26 @@
 /** Gibson size in metres: 2^-33. */
 const GIBSON_METERS = 2 ** -33
 
-const UNITS: Array<{ threshold: number; symbol: string; scale: number }> = [
-  { threshold: 1e-9, symbol: 'pm', scale: 1e12 },
-  { threshold: 1e-6, symbol: 'nm', scale: 1e9 },
-  { threshold: 1e-3, symbol: '\u03bcm', scale: 1e6 },
-  { threshold: 1e-2, symbol: 'mm', scale: 1e3 },
-  { threshold: 1e-1, symbol: 'cm', scale: 1e2 },
-  { threshold: 1e3, symbol: 'm', scale: 1 },
-  { threshold: 1e6, symbol: 'km', scale: 1e-3 },
-  { threshold: 1e9, symbol: 'Mm', scale: 1e-6 },
-  { threshold: 1.496e11, symbol: 'AU', scale: 1 / 1.496e11 },
+const UNITS: Array<{ threshold: number; symbol: string; name: string; scale: number }> = [
+  { threshold: 1e-9, symbol: 'pm', name: 'picometres', scale: 1e12 },
+  { threshold: 1e-6, symbol: 'nm', name: 'nanometres', scale: 1e9 },
+  { threshold: 1e-3, symbol: '\u03bcm', name: 'micrometres', scale: 1e6 },
+  { threshold: 1e-2, symbol: 'mm', name: 'millimetres', scale: 1e3 },
+  { threshold: 1e-1, symbol: 'cm', name: 'centimetres', scale: 1e2 },
+  { threshold: 1e3, symbol: 'm', name: 'metres', scale: 1 },
+  { threshold: 1e6, symbol: 'km', name: 'kilometres', scale: 1e-3 },
+  { threshold: 1e9, symbol: 'Mm', name: 'megametres', scale: 1e-6 },
+  { threshold: 1.496e11, symbol: 'AU', name: 'astronomical units', scale: 1 / 1.496e11 },
 ]
+
+/** The unit a length in metres is best read in, and the figure in it to three significant digits. */
+function inUnit(meters: number): { figure: number; unit: (typeof UNITS)[number] } {
+  for (let i = 0; i < UNITS.length; i++) {
+    const u = UNITS[i]
+    if (meters < u.threshold || i === UNITS.length - 1) return { figure: parseFloat((meters * u.scale).toPrecision(3)), unit: u }
+  }
+  return { figure: meters, unit: UNITS[5] }
+}
 
 /**
  * A gibson count as a human distance.
@@ -42,12 +51,12 @@ export function formatDistance(gibsons: bigint): string {
 
 /** One cell at this scale, as a short human string like "1.91 \u03bcm". */
 export function formatCellSize(scaleExp: number): string {
-  const meters = 2 ** scaleExp * GIBSON_METERS
-  for (let i = 0; i < UNITS.length; i++) {
-    const u = UNITS[i]
-    if (meters < u.threshold || i === UNITS.length - 1) {
-      return `${parseFloat((meters * u.scale).toPrecision(3))} ${u.symbol}`
-    }
-  }
-  return `${meters} m`
+  const { figure, unit } = inUnit(2 ** scaleExp * GIBSON_METERS)
+  return `${figure} ${unit.symbol}`
+}
+
+/** The same, with the unit spelled out: "1.91 micrometres", "1 metre", "2 astronomical units". */
+export function formatCellSizeLong(scaleExp: number): string {
+  const { figure, unit } = inUnit(2 ** scaleExp * GIBSON_METERS)
+  return `${figure} ${figure === 1 ? unit.name.replace(/s$/, '') : unit.name}`
 }

--- a/src/lib/scale.ts
+++ b/src/lib/scale.ts
@@ -1,26 +1,26 @@
 /**
  * scale.ts — the physical size of one cell at a given scale.
  *
- * The spec puts 2^33 gibsons in a metre (§9.2, §9.7), so a gibson is about
+ * The spec puts 2^33 gibsons in a meter (§9.2, §9.7), so a gibson is about
  * 1.16e-10 m, roughly a hydrogen atom.
  */
 
-/** Gibson size in metres: 2^-33. */
+/** Gibson size in meters: 2^-33. */
 const GIBSON_METERS = 2 ** -33
 
 const UNITS: Array<{ threshold: number; symbol: string; name: string; scale: number }> = [
-  { threshold: 1e-9, symbol: 'pm', name: 'picometres', scale: 1e12 },
-  { threshold: 1e-6, symbol: 'nm', name: 'nanometres', scale: 1e9 },
-  { threshold: 1e-3, symbol: '\u03bcm', name: 'micrometres', scale: 1e6 },
-  { threshold: 1e-2, symbol: 'mm', name: 'millimetres', scale: 1e3 },
-  { threshold: 1e-1, symbol: 'cm', name: 'centimetres', scale: 1e2 },
-  { threshold: 1e3, symbol: 'm', name: 'metres', scale: 1 },
-  { threshold: 1e6, symbol: 'km', name: 'kilometres', scale: 1e-3 },
-  { threshold: 1e9, symbol: 'Mm', name: 'megametres', scale: 1e-6 },
+  { threshold: 1e-9, symbol: 'pm', name: 'picometers', scale: 1e12 },
+  { threshold: 1e-6, symbol: 'nm', name: 'nanometers', scale: 1e9 },
+  { threshold: 1e-3, symbol: '\u03bcm', name: 'micrometers', scale: 1e6 },
+  { threshold: 1e-2, symbol: 'mm', name: 'millimeters', scale: 1e3 },
+  { threshold: 1e-1, symbol: 'cm', name: 'centimeters', scale: 1e2 },
+  { threshold: 1e3, symbol: 'm', name: 'meters', scale: 1 },
+  { threshold: 1e6, symbol: 'km', name: 'kilometers', scale: 1e-3 },
+  { threshold: 1e9, symbol: 'Mm', name: 'megameters', scale: 1e-6 },
   { threshold: 1.496e11, symbol: 'AU', name: 'astronomical units', scale: 1 / 1.496e11 },
 ]
 
-/** The unit a length in metres is best read in, and the figure in it to three significant digits. */
+/** The unit a length in meters is best read in, and the figure in it to three significant digits. */
 function inUnit(meters: number): { figure: number; unit: (typeof UNITS)[number] } {
   for (let i = 0; i < UNITS.length; i++) {
     const u = UNITS[i]
@@ -34,19 +34,19 @@ function inUnit(meters: number): { figure: number; unit: (typeof UNITS)[number] 
  *
  * Takes a bigint because these are real cyberspace distances: a landmark can be
  * 10^25 gibsons away, which is past what a double holds exactly. The division to
- * metres happens in fixed point for that reason, and only then becomes a float.
+ * meters happens in fixed point for that reason, and only then becomes a float.
  */
 export function formatDistance(gibsons: bigint): string {
   if (gibsons === 0n) return '0'
-  // 2^33 gibsons per metre, so this is exact rather than a rounding.
-  const metres = Number((gibsons * 1_000_000n) >> 33n) / 1_000_000
+  // 2^33 gibsons per meter, so this is exact rather than a rounding.
+  const meters = Number((gibsons * 1_000_000n) >> 33n) / 1_000_000
   for (let i = 0; i < UNITS.length; i++) {
     const u = UNITS[i]
-    if (metres < u.threshold || i === UNITS.length - 1) {
-      return `${parseFloat((metres * u.scale).toPrecision(3))} ${u.symbol}`
+    if (meters < u.threshold || i === UNITS.length - 1) {
+      return `${parseFloat((meters * u.scale).toPrecision(3))} ${u.symbol}`
     }
   }
-  return `${metres} m`
+  return `${meters} m`
 }
 
 /** One cell at this scale, as a short human string like "1.91 \u03bcm". */
@@ -55,7 +55,7 @@ export function formatCellSize(scaleExp: number): string {
   return `${figure} ${unit.symbol}`
 }
 
-/** The same, with the unit spelled out: "1.91 micrometres", "1 metre", "2 astronomical units". */
+/** The same, with the unit spelled out: "1.91 micrometers", "1 meter", "2 astronomical units". */
 export function formatCellSizeLong(scaleExp: number): string {
   const { figure, unit } = inUnit(2 ** scaleExp * GIBSON_METERS)
   return `${figure} ${figure === 1 ? unit.name.replace(/s$/, '') : unit.name}`

--- a/src/lib/space.ts
+++ b/src/lib/space.ts
@@ -451,12 +451,12 @@ export function formatBig(v: bigint): string {
 }
 
 /**
- * Compact scale label, e.g. "1 G", "1.02 KG", "2^40 G".
+ * The step at a scale, in gibsons: "1 gibson", "1,024 gibsons", "2^40 gibsons".
  */
 export function formatStep(scaleExp: number): string {
-  if (scaleExp === 0) return '1 G'
-  if (scaleExp < 20) return `${formatBig(stepFor(scaleExp))} G`
-  return `2^${scaleExp} G`
+  if (scaleExp === 0) return '1 gibson'
+  if (scaleExp < 20) return `${formatBig(stepFor(scaleExp))} gibsons`
+  return `2^${scaleExp} gibsons`
 }
 
 /**

--- a/src/lib/space.ts
+++ b/src/lib/space.ts
@@ -127,7 +127,7 @@ export function cellCentre(
  * cellCentre floor-snaps to the aligned cell, which is right for everything
  * that lives on the movement grid but puts a marker up to a whole cell
  * toward negative on every axis. At planetary zoom that half-cell average
- * bias is hundreds of kilometres: the landfall cloud sat visibly sunk into
+ * bias is hundreds of kilometers: the landfall cloud sat visibly sunk into
  * the +X+Y+Z octant of the globe and floated off the -X-Y-Z one. Markers
  * keep their sub-cell position instead, the same continuous math the Earth
  * sphere's own centre uses, so the shell hugs the wireframe exactly.
@@ -152,7 +152,7 @@ export function pointCentre(
 
 /**
  * Above this scale a stop marker is part of a distribution and renders as a
- * continuous point (pointCentre); at or below it (cells of about a metre
+ * continuous point (pointCentre); at or below it (cells of about a meter
  * and finer) a stop is a place an avatar stands, so its marker snaps to its
  * cell exactly the way the avatar does. Without the snap, a marker at a
  * coordinate is drawn on the corner FACE of its cell cube, which at gibson

--- a/src/scene/Earth.tsx
+++ b/src/scene/Earth.tsx
@@ -4,7 +4,7 @@
  * Dataspace (plane 0) maps WGS84 onto the axes, and §9.7 fixes both the scale
  * and the placement exactly:
  *
- *   units_per_km = 1000 * 2^33      (from Cantor height 34 = 2 metres)
+ *   units_per_km = 1000 * 2^33      (from Cantor height 34 = 2 meters)
  *   u = km * units_per_km + 2^84
  *
  * So the planet's centre is the half-axis point on all three axes, and its
@@ -97,7 +97,7 @@ export function Earth({ axes }: Props): JSX.Element | null {
   // decoration that reoriented with the view. These rings are geographic,
   // poles where §9.4 puts them, so the lines MEAN latitude and longitude
   // and the equator and prime meridian can be named. Vertices are float64
-  // metre deltas from the render origin on the true ellipsoid
+  // meter deltas from the render origin on the true ellipsoid
   // (earthSurface.ts), absolute in render space, so they live outside the
   // centred group below.
   const graticule = useMemo(() => {

--- a/src/scene/EarthPatch.tsx
+++ b/src/scene/EarthPatch.tsx
@@ -6,7 +6,7 @@
  * nothing, and the planet you were standing on vanished. This fills that
  * dead band. From 2^49 down to human scale the surface is a graticule
  * PATCH: the piece of the true WGS84 ellipsoid within reach of the anchor,
- * with vertices computed as float64 metre deltas from the render origin
+ * with vertices computed as float64 meter deltas from the render origin
  * (earthSurface.ts), so precision holds at every zoom with no Decimal
  * anywhere in the render path.
  *
@@ -17,7 +17,7 @@
  * globe could never reach.
  *
  * Below human scale (2^34) the patch fades, gone at 2^31: a graticule is a
- * map of places, and metre scale is where the view stops being about
+ * map of places, and meter scale is where the view stops being about
  * places. The fade is deliberate teaching, zooming past the shoreline is
  * supposed to feel like leaving geography for the microscopic.
  *
@@ -182,7 +182,7 @@ export function EarthPatch({ axes }: { axes: ViewAxes }): JSX.Element | null {
     // opaque: a refined triangle's middle sits up to 15.6 km below the
     // surface its corners are on, and a ground plane any higher than that
     // would bury the interior of every large continent while leaving its
-    // coast drawn. Depth is all this plane does, so a few more kilometres of
+    // coast drawn. Depth is all this plane does, so a few more kilometers of
     // it costs nothing to look at.
     const ground: number[] = []
     const idx: number[] = []

--- a/src/scene/RidePath.tsx
+++ b/src/scene/RidePath.tsx
@@ -81,7 +81,7 @@ export function RidePath({ axes }: { axes: ViewAxes }): JSX.Element | null {
       // hash), but a mid-ride index rebuild can be briefly behind: reuse the
       // previous vertex rather than stitching in the origin.
       // Approx on purpose: the trail is thousands of stops at cube zoom,
-      // where the float shortcut's nanometre error is invisible, and the
+      // where the float shortcut's nanometer error is invisible, and the
       // exact decimal derivation would cost seconds across the tail.
       const c = stop ? pointCentre(approxPosition(stop.coordApprox), origin, scaleExp, axes) : last
       last = c

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -20,7 +20,7 @@
  * gone.
  */
 
-import { Canvas } from '@react-three/fiber'
+import { Canvas, useThree } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
 import { useEffect, useMemo, useRef } from 'react'
@@ -460,6 +460,27 @@ function Rig(): JSX.Element {
   )
 }
 
+/**
+ * One console line every 30 s: what the renderer holds and what the heap
+ * weighs. A tab was seen at 10 GB after fifteen idle minutes and no probe here
+ * reproduces it; this puts the numbers where the person who sees it can read
+ * them. `localStorage.setItem('onosendai:memlog', '0')` silences it.
+ */
+function MemoryLog(): null {
+  const gl = useThree((s) => s.gl)
+  useEffect(() => {
+    try { if (localStorage.getItem('onosendai:memlog') === '0') return } catch { /* private mode: log anyway */ }
+    const tick = (): void => {
+      const m = gl.info.memory
+      const heap = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory?.usedJSHeapSize
+      console.info(`[mem] geometries=${m.geometries} textures=${m.textures} programs=${gl.info.programs?.length ?? 0}${heap ? ` heap=${Math.round(heap / 1048576)}MB` : ''}`)
+    }
+    const t = window.setInterval(tick, 30_000)
+    return () => window.clearInterval(t)
+  }, [gl])
+  return null
+}
+
 export function Scene(): JSX.Element {
   return (
     <Canvas
@@ -471,6 +492,7 @@ export function Scene(): JSX.Element {
       style={{ background: BG }}
       frameloop="always"
     >
+      <MemoryLog />
       {/* Fog to pure black: the only distance cue in an otherwise empty field. */}
       <fog attach="fog" args={[0x000000, GRID_RADIUS * 0.9, GRID_RADIUS * 4]} />
       <ambientLight intensity={0.8} />

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -283,9 +283,9 @@ export function StopField({ axes }: Props): JSX.Element | null {
     const w = rows.length
 
     const origin = alignedOrigin(anchor, scaleExp)
-    // At occupancy zooms (cells of about a metre and finer) the handful of
+    // At occupancy zooms (cells of about a meter and finer) the handful of
     // stops in range render from their EXACT coordinates, snapped to their
-    // cells like the avatar: the float shortcut's nanometre error is tens
+    // cells like the avatar: the float shortcut's nanometer error is tens
     // of gibsons, which at these zooms put the dot for the block you are
     // standing on visibly beside you. The coverage cull guarantees the
     // exact decimal derivations stay countable on one hand here.

--- a/src/store/useProfiles.ts
+++ b/src/store/useProfiles.ts
@@ -5,7 +5,8 @@
  * nip05. Components ask for one by pubkey; this batches the misses into a
  * single relay query, caches what comes back, and keeps it in localStorage so
  * a reload does not refetch the world. Profiles live on the general relays
- * (purplepag.es aggregates them), so it asks those alongside ours.
+ * (primal, damus, nos.lol), so it asks those alongside every configured one:
+ * the cyberspace relay and any you added.
  *
  * The whole cache is one reactive record: a component that reads get(pubkey)
  * re-renders when that profile arrives, without every row holding a
@@ -13,7 +14,7 @@
  */
 
 import { create } from 'zustand'
-import { queryAny } from '../lib/relay'
+import { queryAny, relaySet } from '../lib/relay'
 import { GENERAL_RELAYS } from '../lib/contacts'
 import type { NostrEvent } from '../lib/events'
 
@@ -100,7 +101,7 @@ export const useProfiles = create<ProfilesState>((set, get) => {
       const authors = want.slice(i, i + CHUNK)
       let events: NostrEvent[] = []
       try {
-        events = await queryAny(GENERAL_RELAYS, { kinds: [0], authors }, PROFILE_WAIT_MS)
+        events = await queryAny([...new Set([...GENERAL_RELAYS, ...relaySet()])], { kinds: [0], authors }, PROFILE_WAIT_MS)
       } catch { /* relays down */ }
 
       const newest = new Map<string, Profile>()

--- a/src/styles.css
+++ b/src/styles.css
@@ -3137,7 +3137,7 @@ kbd {
 .ladder__rail {
   position: relative;
   height: 132px;
-  margin-left: 6px;
+  margin-left: 64px; /* room for the reading, which hangs left of the rail */
   border-left: 1px solid var(--border, #1d3547);
 }
 
@@ -3165,8 +3165,11 @@ kbd {
   opacity: 0.75;
 }
 
-/* The marker rides above the ticks: it is the one thing here that moves. */
+/* The marker rides above the ticks, on the other side of the rail: it is the
+ * one thing here that moves, and it must never cover a landmark's name. */
 .ladder__here {
+  left: auto;
+  right: 100%;
   z-index: 1;
 }
 
@@ -3176,7 +3179,7 @@ kbd {
   border-radius: 2px;
   background: var(--accent, #00e5ff);
   box-shadow: 0 0 8px rgba(0, 229, 255, 0.7);
-  margin-left: -6px;
+  margin-right: -7px; /* straddles the rail */
 }
 
 .ladder__here-text {

--- a/src/styles.css
+++ b/src/styles.css
@@ -889,6 +889,35 @@ body {
   color: var(--dim);
 }
 
+/* The non-terrain things drawn in the world, one glyph and one line each. */
+.legend__keys {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.legend__key {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10px;
+  color: var(--fg);
+}
+
+.legend__glyph {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+}
+
+.legend__glyph svg {
+  width: 100%;
+  height: 100%;
+}
+
 .legend__note {
   margin: 8px 0 0;
   font-size: 10px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -225,6 +225,23 @@ body {
   color: var(--ok);
 }
 
+/* A tag that opens something when tapped: the same pill, a hand cursor, and
+ * the accent on hover so it reads as a control. */
+.tag--tap {
+  font-family: inherit;
+  line-height: inherit;
+  background: none;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.tag--tap:hover,
+.tag--tap:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+
 .tag--local {
   color: var(--dim);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -162,6 +162,41 @@ body {
   overflow-wrap: anywhere;
 }
 
+/* A readout that copies on a tap: looks like the text it wraps, and says so
+ * for a moment through its label. */
+.copy {
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.copy:hover,
+.copy:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.stats dt.is-copied,
+.hash__label.is-copied {
+  color: var(--accent);
+}
+
+/* An explanation in paragraphs. */
+.explain__well p {
+  margin: 0;
+}
+
+.explain__well p + p {
+  margin-top: 6px;
+}
+
 .stats--axes {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -295,24 +330,44 @@ body {
   text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
 }
 
+/* Scale & view in two columns: the key and the view facts beside the ladder,
+ * which is as tall as both of them together. */
+.scale__cols {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0 14px;
+  align-items: start;
+}
+
+.scale__facts {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.stats--stack {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 6px;
+}
+
 .axis-legend {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-  margin-bottom: 0.75rem;
+  gap: 6px;
+  margin-top: 2px;
 }
 
 .axis-legend-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
+  gap: 8px;
+  font-size: 11px;
 }
 
 .axis-dot {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   flex-shrink: 0;
 }
@@ -333,7 +388,7 @@ body {
 }
 
 .axis-name {
-  color: var(--text-primary);
+  color: var(--fg);
 }
 
 .plane--0 {
@@ -1021,6 +1076,46 @@ kbd {
   letter-spacing: 0.14em;
   color: #ff2323;
   padding: 0 9px;
+}
+
+/* The five newest show; the rest wait behind VIEW MORE. */
+.avatars__more {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 6px 0;
+  font-family: inherit;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid rgba(0, 229, 255, 0.25);
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.avatars__more:hover {
+  background: rgba(0, 229, 255, 0.08);
+}
+
+/* The overlay with every avatar: a calm border (the card's own rule, later in
+ * this file, would otherwise keep the confirm red), and the list is what scrolls. */
+.modal__card.modal__card--list {
+  display: flex;
+  flex-direction: column;
+  max-height: min(80vh, 640px);
+  border-color: var(--border);
+}
+
+.modal__card--list .modal__cancel {
+  width: 100%;
+}
+
+.avatars__list--all {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
+  overflow-y: auto;
 }
 
 .avatars__empty {
@@ -2441,6 +2536,20 @@ kbd {
   letter-spacing: 0.05em;
   transition: color 0.15s ease;
   pointer-events: auto;
+}
+
+.panel--links .panel__head {
+  margin-bottom: 1px;
+}
+
+.links__row {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.links__what {
+  color: var(--dim);
 }
 
 .panel--links a:hover {
@@ -4231,11 +4340,26 @@ kbd {
 /* The HOSAKA mark inline in the Cloud compute panel's title. Taller than
    the 10px type so it can be read; the negative vertical margins keep the
    header the height every other panel's is. */
-.panel__mark {
-  width: 16px;
+/* The HOSAKA mark as a watermark in the panel's corner: the pulse mark's
+ * width, steady, so the panel is signed rather than decorated. */
+.panel--cloud {
+  position: relative;
+}
+
+.cloud__watermark {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  width: 56px;
   height: auto;
-  vertical-align: middle;
-  margin: -4px 6px -4px 0;
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+@media (min-width: 1101px) {
+  .cloud__watermark {
+    width: 46px;
+  }
 }
 
 /* ---------- HOSAKA pulse: the mark breathing while a job runs ----------


### PR DESCRIPTION
The batch of small HUD changes from tonight, panel by panel:

- **Cloud compute**: the small mark leaves the title and becomes a bottom-right watermark at the pulse mark's width (56 px, 46 px on desktop), 90%, still. New two-paragraph explainer.
- **Scale & view**: two columns. Left: the X/Y/Z key and the readouts STEP (in gibsons), CURSOR (the cube side, spelled out: "116 picometres"), SCREEN RIGHT, SCREEN UP, LOOKING ALONG. Right: the ladder. New explainer.
- **Identity, Loot, Stash, Avatars, Targets, Proof chain**: explainers replaced with your wording.
- **Avatars**: five newest rows, then VIEW MORE (n) opens a scrolling overlay with every avatar; "N SEEN" stays top right. Pubkey fields here and on Targets accept nprofile.
- **OFFICIAL** (was the links panel): the v2 specification, straylight.cafe, cyberspace.international, each with its one-line description.
- **Position**: X, Y, Z, Sector and coord copy raw on a tap (no commas); the label says Copied for a moment.
- **Movement proof**: "Highest boundary", "THIS MACHINE BENCHMARK:".

Underneath: every `.panel` has a backdrop-filter, so it is a stacking context, and a fixed modal rendered inside a panel was painted under the panels after it (the Stash delete confirm had this bug). ConfirmModal and the new overlay now render through a portal to `document.body`, like LoginModal.

443 tests, tsc and `npm run build` green. Checked in headless Chromium at 390x844 and 1400x900: five rows + overlay open/close, clipboard receives the raw digits and the 64-char coord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz