### PR TITLE
Cloud: caps request keyed by API URL; a long walk without HOSAKA is refused, not started

### DIFF
--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -486,4 +486,43 @@ describe('cloud routes', () => {
     expect(S().cloud.credited).toBeNull()
     expect(storage.getItem('onosendai:cloudDeposit')).toBeNull()
   })
+
+  it('a caps request out for another API URL is not reused: the current URL gets its own (#69)', async () => {
+    const old = deferred<HosakaLimits>()
+    fake.limits.mockReturnValueOnce(old.promise).mockResolvedValueOnce(LIMITS)
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://old' } })
+    const first = S().resumeCloudJob()
+    await vi.waitFor(() => expect(fake.limits).toHaveBeenCalledTimes(1))
+    useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, apiUrl: 'http://fake' } })
+    await S().resumeCloudJob()
+    expect(fake.limits).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => expect(S().cloud.limits).toEqual(LIMITS))
+    old.resolve({ ...LIMITS, max_hop_height: 3 })
+    await first
+    // The answer for the old URL arrived late and was dropped.
+    expect(S().cloud.limits).toEqual(LIMITS)
+  })
+
+  it('with the cloud on but HOSAKA unreachable, a long local walk is refused rather than started (#69)', async () => {
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: null } })
+    fake.limits.mockRejectedValue(new Error('down'))
+    const s = S()
+    // An h24 crossing on x: a dozen walls above this machine's h12, a walk of many steps.
+    useCyberspace.setState({ cursor: { ...s.position, x: s.position.x ^ (1n << 23n) } })
+    await S().commit()
+    expect(S().proof.status).toBe('infeasible')
+    expect(S().proof.message).toMatch(/HOSAKA did not answer/)
+    expect(S().plan).toBeNull()
+    expect(vi.mocked(postProof)).not.toHaveBeenCalled()
+  })
+
+  it('with the cloud on but HOSAKA unreachable, a short walk still goes ahead locally', async () => {
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: null } })
+    fake.limits.mockRejectedValue(new Error('down'))
+    lineUpH13()
+    await S().commit()
+    expect(S().proof.status).not.toBe('infeasible')
+    expect(vi.mocked(postProof)).toHaveBeenCalledTimes(1)
+    S().cancel()
+  })
 })

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -836,7 +836,15 @@ let requestId = 0
 let cloudAbort: AbortController | null = null
 let cloudWaker: Waker | null = null
 let hosaka: { url: string; client: HosakaClient } | null = null
-let limitsInFlight: Promise<HosakaLimits | null> | null = null
+/** The caps request out right now, and the API URL it was sent to. */
+let limitsInFlight: { url: string; promise: Promise<HosakaLimits | null> } | null = null
+/**
+ * With the cloud on but HOSAKA unreachable, a local walk longer than this is
+ * refused rather than started. Without the caps the planner falls back to
+ * hops and sidesteps for every wall, which for a distant cursor is hundreds
+ * of steps and many minutes (#69); a short walk is what it always was.
+ */
+const WALK_WITHOUT_CLOUD_MAX = 8
 
 /** One client per API URL. It signs through `signEvent`, so it follows identity switches. */
 function cloudClient(apiUrl: string): HosakaClient {
@@ -892,9 +900,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   const ensureCloudLimits = (): Promise<HosakaLimits | null> => {
     const cached = get().cloud.limits
     if (cached) return Promise.resolve(cached)
-    if (limitsInFlight) return limitsInFlight
     const url = get().cloudPrefs.apiUrl
-    limitsInFlight = cloudClient(url)
+    // A request out for another URL is not this one: its answer would be
+    // dropped as stale below, and the caller would plan without caps (#69).
+    if (limitsInFlight && limitsInFlight.url === url) return limitsInFlight.promise
+    const promise: Promise<HosakaLimits | null> = cloudClient(url)
       .limits()
       .then((limits) => {
         // The URL may have changed while this was out; a stale answer is dropped.
@@ -902,8 +912,9 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         return limits
       })
       .catch(() => null)
-      .finally(() => { limitsInFlight = null })
-    return limitsInFlight
+      .finally(() => { if (limitsInFlight?.promise === promise) limitsInFlight = null })
+    limitsInFlight = { url, promise }
+    return promise
   }
 
   /** What each primitive can reach right now, here and (when on and known) in the cloud. */
@@ -1407,6 +1418,22 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       set({ proof: { ...IDLE_PROOF, status: 'computing', mode: 'hop', message: 'Asking HOSAKA for its caps.' } })
       await ensureCloudLimits()
       set({ proof: IDLE_PROOF })
+      // Still no caps: HOSAKA did not answer. A long walk in its place is
+      // refused; the person asked for the cloud, and can turn it off to walk.
+      if (get().cloud.limits === null) {
+        const walk = planSummary(position, cursor, cloudCeilings())
+        if (walk.steps > WALK_WITHOUT_CLOUD_MAX) {
+          set({
+            plan: null,
+            proof: {
+              ...IDLE_PROOF,
+              status: 'infeasible',
+              message: `HOSAKA did not answer, and without it this route is a local walk of ${walk.steps} steps (${walk.sidesteps} sidesteps). Try again when it is reachable, or turn the cloud OFF to walk it.`,
+            },
+          })
+          return
+        }
+      }
     }
     const ceilings = cloudCeilings()
     const summary = planSummary(position, cursor, ceilings)


### PR DESCRIPTION
Closes #69.

Two causes behind the 129-step local walk seen when committing seconds after load with cloud AUTO:

- **The caps request was shared across URLs.** `ensureCloudLimits` returned whatever request was in flight, and the answer was then dropped as stale if the API URL had changed meanwhile, so the caller planned with no caps and routed every step locally. The in-flight request is now keyed by URL and reused only for the same one.
- **No caps meant a silent walk.** With the cloud on but HOSAKA unreachable, the planner fell back to hops and sidesteps for every wall, however many. A walk longer than eight steps is now refused with a message naming the length and the two ways out: try again when HOSAKA answers, or turn the cloud OFF to walk on purpose. Short walks go ahead as before.

Tests: an in-flight request for another URL is not reused and its late answer is dropped; the unreachable case refuses a long walk (no proof posted, no plan) and still runs a short one. 446 tests and tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz