### PR TITLE
Cloud quote: one wait for the whole route, the steps' seconds added up

### DIFF
--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -36,6 +36,7 @@ import {
   sinceLabel,
   type PendingCloudJob,
   wirePosition,
+  formatWait,
 } from './cloud'
 import { HosakaError, type HosakaClient, type HosakaDeposit, type HosakaJob, type HosakaLimits } from './hosaka'
 
@@ -55,6 +56,17 @@ describe('routeCommit', () => {
     [18, 12, 'auto', { ...LIMITS, max_hop_height: 12 }, 'cloud-sidestep'],
   ] as const)('h%d, ceiling %d, mode %s -> %s', (maxHeight, ceiling, mode, limits, route) => {
     expect(routeCommit({ maxHeight, ceiling, mode, limits })).toBe(route)
+  })
+})
+
+describe('formatWait', () => {
+  it('reads coarse, the way the server words one step', () => {
+    expect(formatWait(3)).toBe('under 10 sec')
+    expect(formatWait(30)).toBe('about 30 sec')
+    expect(formatWait(31)).toBe('about 40 sec')
+    expect(formatWait(60)).toBe('about 1 min')
+    expect(formatWait(61)).toBe('about 2 min')
+    expect(formatWait(5400)).toBe('about 1.5 hr')
   })
 })
 

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -245,6 +245,17 @@ export function routeCommit(i: RouteInput): CloudRoute {
 }
 
 /** Whole sats, rounded up: the only unit a person is asked to pay in. */
+/**
+ * A wait a person can plan around, coarse on purpose, and the same words the
+ * server uses for one step, so a route's summed estimate reads like a quote.
+ */
+export function formatWait(seconds: number): string {
+  if (seconds < 10) return 'under 10 sec'
+  if (seconds < 60) return `about ${Math.ceil(seconds / 10) * 10} sec`
+  if (seconds < 3600) return `about ${Math.ceil(seconds / 60)} min`
+  return `about ${(seconds / 3600).toFixed(1)} hr`
+}
+
 export function satsOf(msats: number): number {
   return Math.ceil(msats / 1000)
 }

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -77,6 +77,8 @@ export interface HosakaQuote {
   K: number
   tier: string | null
   est_time: string | null
+  /** The wait in seconds, so a route's steps can be added up; older servers omit it. */
+  est_seconds?: number | null
   hint: string | null
 }
 

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -82,7 +82,7 @@ function sidestepResult(from: Position, to: Position, plane: 0 | 1, prev: string
   }
 }
 
-const quote = (action: 'hop' | 'sidestep', cost = 1000) => ({ action, cost_msats: cost, within_cap: true, cap: 25, max_height: 13, per_axis_heights: { x: 13, y: 0, z: 0 }, K: 7, tier: 'trivial', est_time: '<5 sec', hint: null })
+const quote = (action: 'hop' | 'sidestep', cost = 1000) => ({ action, cost_msats: cost, within_cap: true, cap: 25, max_height: 13, per_axis_heights: { x: 13, y: 0, z: 0 }, K: 7, tier: 'trivial', est_time: 'about 30 sec', est_seconds: 30, hint: null })
 const funded = (id = 'job-1'): HosakaJob => ({ id, status: 'computing', cost_msats: 1000, poll_token: `tok-${id}`, result: null, error: null, payment_required: false, balance_debited: true })
 const deposit = (id: string, status: HosakaDeposit['status'] = 'pending'): HosakaDeposit => ({
   deposit_id: id, status, amount_msats: 1000, bolt11: `lnbc-${id}`, payment_hash: 'h', created_at: 1, expires_at: Math.floor(Date.now() / 1000) + 3600, settled_at: null, settled_msats: null, preimage: null,

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -114,7 +114,9 @@ import {
   clearCloudDeposit,
   loadBalance,
   saveBalance,
-  type KnownBalance, formatWait } from '../lib/cloud'
+  type KnownBalance,
+  formatWait,
+} from '../lib/cloud'
 import { nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -114,8 +114,7 @@ import {
   clearCloudDeposit,
   loadBalance,
   saveBalance,
-  type KnownBalance,
-} from '../lib/cloud'
+  type KnownBalance, formatWait } from '../lib/cloud'
 import { nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
@@ -248,7 +247,9 @@ export interface CloudQuote {
   to: Position
   costMsats: number
   tier: string | null
+  /** The whole route's wait: the steps' seconds added up when the server gives them. */
   estTime: string | null
+  estSeconds: number | null
   maxHeight: number
   K: number
   /** A whole route's quote: the sum over its cloud steps, paid with one deposit. */
@@ -957,6 +958,9 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     let total = 0
     let tallest = 0
     let estTime: string | null = null
+    // The steps run one after another, so their waits add, like their prices.
+    let seconds = 0
+    let secondsKnown = true
     try {
       for (const step of steps) {
         const q = await client.quote(step.kind, hosakaCoord(step.from, plane), hosakaCoord(step.to, plane))
@@ -966,6 +970,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
           return
         }
         total += q.cost_msats
+        if (typeof q.est_seconds === 'number') seconds += q.est_seconds
+        else secondsKnown = false
         if (q.max_height > tallest) { tallest = q.max_height; estTime = q.est_time }
       }
     } catch (err) {
@@ -979,7 +985,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       to: plan.target,
       costMsats: total,
       tier: null,
-      estTime,
+      estTime: secondsKnown && steps.length > 0 ? formatWait(seconds) : estTime,
+      estSeconds: secondsKnown && steps.length > 0 ? seconds : null,
       maxHeight: tallest,
       K: 0,
       route: { steps: plan.summary.steps, cloudSteps: steps.length },


### PR DESCRIPTION
HOSAKA's quotes now carry `est_seconds` beside `est_time` (hosaka-api pricing PR). The client adds the seconds of every cloud step of a route, as it already adds their prices, and shows one wait in the words the server uses for a step: "under 10 sec", "about 30 sec", "about 4 min", "about 1.5 hr". A server without the field still gets the tallest step's string, as before.

Pairs with the HOSAKA pricing change (cost model: Modal plus 2 sats margin, one price per job, cap h27). Works against the current server too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz