### PR TITLE
Cloud: a claim poll can no longer hang (signing timeout, poll watchdog, CHECK PAYMENT un-sticks)

### DIFF
--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -317,6 +317,8 @@ export interface CloudStageDetail {
 export interface CloudDriverHooks {
   /** Each answer from the node about the job's own invoice. */
   onDepositPoll?: (dep: HosakaDeposit) => void
+  /** A claim poll failed; the wait continues. */
+  onDepositPollError?: (err: unknown) => void
   /** The record changed (a stage or a new invoice): persist and show it. */
   onRecord: (record: PendingCloudJob) => void
   /** A stage began, with what the HUD needs for it. */
@@ -358,6 +360,7 @@ export async function driveCloudJob(
         intervalMs: hooks.claimIntervalMs,
         waker,
         onPoll: hooks.onDepositPoll,
+        onPollError: hooks.onDepositPollError,
       })
       if (dep.status !== 'settled') throw new CloudFlowError('invoice_expired', 'The invoice expired unpaid. Commit again for a fresh quote.')
       record = { ...record, stage: 'paid' }

--- a/src/lib/hosaka.test.ts
+++ b/src/lib/hosaka.test.ts
@@ -21,6 +21,7 @@ import {
   jsonWithBigints,
   type HosakaDeposit,
   type HosakaJob,
+  SIGN_TIMEOUT_MS,
 } from './hosaka'
 
 const sk = generateSecretKey()
@@ -225,7 +226,7 @@ describe('polling', () => {
     const done = c.waitForDeposit('d1', { onPollError: (e) => errors.push(e) })
     await vi.advanceTimersByTimeAsync(0)
     expect(calls).toHaveLength(0)
-    await vi.advanceTimersByTimeAsync(19_999)
+    await vi.advanceTimersByTimeAsync(SIGN_TIMEOUT_MS - 1)
     expect(errors).toHaveLength(0)
     await vi.advanceTimersByTimeAsync(1)
     expect(errors).toHaveLength(1)

--- a/src/lib/hosaka.test.ts
+++ b/src/lib/hosaka.test.ts
@@ -216,6 +216,41 @@ describe('polling', () => {
     expect((await done).status).toBe('expired')
   })
 
+  it('a signer that never answers does not hang the claim poll: the poll times out, is reported, and the next one goes out', async () => {
+    let hang = true
+    const flaky = (template: Parameters<typeof sign>[0]): ReturnType<typeof sign> => (hang ? new Promise(() => { /* the bunker never answers */ }) : sign(template))
+    const { fetch, calls } = scripted({ 'POST /api/v1/deposit/d1/claim': () => ({ body: { ...pending, status: 'settled', settled_msats: 1000 } }) })
+    const c = createHosaka({ apiUrl: API, sign: flaky, fetch })
+    const errors: unknown[] = []
+    const done = c.waitForDeposit('d1', { onPollError: (e) => errors.push(e) })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls).toHaveLength(0)
+    await vi.advanceTimersByTimeAsync(19_999)
+    expect(errors).toHaveLength(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(errors).toHaveLength(1)
+    expect((errors[0] as HosakaError).code).toBe('sign_timeout')
+    hang = false
+    await vi.advanceTimersByTimeAsync(CLAIM_INTERVAL_MS)
+    expect(calls).toHaveLength(1)
+    expect((await done).status).toBe('settled')
+  })
+
+  it('a failed poll is reported and the wait goes on', async () => {
+    let n = 0
+    const { fetch, calls } = scripted({
+      'POST /api/v1/deposit/d1/claim': () => (++n === 1 ? { status: 503, body: { detail: { error: 'payments_unavailable' } } } : { body: { ...pending, status: 'settled', settled_msats: 1000 } }),
+    })
+    const c = createHosaka({ apiUrl: API, sign, fetch })
+    const errors: unknown[] = []
+    const done = c.waitForDeposit('d1', { onPollError: (e) => errors.push(e) })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(errors).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(CLAIM_INTERVAL_MS)
+    expect(calls).toHaveLength(2)
+    expect((await done).status).toBe('settled')
+  })
+
   it('an abort stops a claim poll with code aborted', async () => {
     const { fetch } = scripted({ 'POST /api/v1/deposit/d1/claim': () => ({ body: pending }) })
     const c = createHosaka({ apiUrl: API, sign, fetch })

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -32,6 +32,16 @@ export function defaultHosakaUrl(): string {
 
 /** One request outstanding longer than this is a dead connection, not a slow one. */
 const REQUEST_TIMEOUT_MS = 20_000
+/**
+ * How long a signer gets to sign one request. An extension or a bunker
+ * answers over a channel the phone can drop while the tab is in the wallet
+ * app; a request that never comes back must not hang the claim poll, which
+ * is what left an invoice unrecognised after payment (the spinner stuck,
+ * no further polls) until a reload claimed it.
+ */
+const SIGN_TIMEOUT_MS = 20_000
+/** A poll that has not settled by then is abandoned and the next one goes out. */
+const POLL_HANG_MS = SIGN_TIMEOUT_MS + REQUEST_TIMEOUT_MS + 5_000
 /** Contract: claim polls every 3 to 5 s. */
 export const CLAIM_INTERVAL_MS = 4_000
 /** Contract: job polls every 5 to 15 s; this ramps from the first to the second. */
@@ -279,7 +289,8 @@ export interface WaitForDepositOptions {
   intervalMs?: number
   waker?: Waker
   /** Every answer from the node, settled or not, so a manual check can show it landed. */
-  onPoll?: (dep: HosakaDeposit) => void
+  onPoll?: (dep: HosakaDeposit) => void  /** A poll that failed (timed out, 5xx, dropped socket); the wait goes on, the UI can stop spinning. */
+  onPollError?: (err: unknown) => void
 }
 
 export interface WaitForJobOptions {
@@ -335,13 +346,36 @@ export function createHosaka(opts: HosakaClientOptions): HosakaClient {
    * sent twice; the nonce tag makes two requests signed in the same second
    * distinct events, which nostr-tools' template alone would not.
    */
-  const authorization = (url: string, method: string): Promise<string> =>
-    nip98.getToken(
+  const authorization = async (url: string, method: string): Promise<string> => {
+    const token = nip98.getToken(
       url,
       method,
       (template) => opts.sign({ ...template, tags: [...template.tags, ['nonce', randomNonce()]] }),
       true,
     )
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const late = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new HosakaError(0, 'sign_timeout', 'the signer did not answer in time')), SIGN_TIMEOUT_MS)
+    })
+    try {
+      return await Promise.race([token, late])
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  /** The promise, or a poll_timeout once POLL_HANG_MS has passed without it settling. */
+  const guarded = async <T>(work: Promise<T>): Promise<T> => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const late = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new HosakaError(0, 'poll_timeout', 'HOSAKA did not answer in time')), POLL_HANG_MS)
+    })
+    try {
+      return await Promise.race([work, late])
+    } finally {
+      clearTimeout(timer)
+    }
+  }
 
   const request = async <T>(path: string, init: RequestInit): Promise<T> => {
     const url = apiUrl + path
@@ -417,12 +451,13 @@ export function createHosaka(opts: HosakaClientOptions): HosakaClient {
       for (;;) {
         if (o.signal?.aborted) throw abortError()
         try {
-          last = await claimDeposit(depositId, o.signal)
+          last = await guarded(claimDeposit(depositId, o.signal))
           failures = 0
           o.onPoll?.(last)
           if (last.status === 'settled' || last.status === 'expired') return last
         } catch (err) {
           if (err instanceof HosakaError && err.code === 'aborted') throw err
+          o.onPollError?.(err)
           // The node blinking (503 payments_unavailable) or a dropped socket
           // is not the payer's problem; keep asking for a while.
           if (!(err instanceof HosakaError && err.transient) || ++failures >= POLL_FAILURE_LIMIT + 2) throw err
@@ -444,7 +479,7 @@ export function createHosaka(opts: HosakaClientOptions): HosakaClient {
       for (;;) {
         if (o.signal?.aborted) throw abortError()
         try {
-          const job = await getJob(jobId, pollToken, o.signal)
+          const job = await guarded(getJob(jobId, pollToken, o.signal))
           failures = 0
           o.onPoll?.(job)
           if (job.status === 'completed' || job.status === 'failed') return job

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -39,9 +39,9 @@ const REQUEST_TIMEOUT_MS = 20_000
  * is what left an invoice unrecognised after payment (the spinner stuck,
  * no further polls) until a reload claimed it.
  */
-const SIGN_TIMEOUT_MS = 20_000
+export const SIGN_TIMEOUT_MS = 45_000 // outlasts the store's own patience, one rebuild of the signer, and a second try
 /** A poll that has not settled by then is abandoned and the next one goes out. */
-const POLL_HANG_MS = SIGN_TIMEOUT_MS + REQUEST_TIMEOUT_MS + 5_000
+export const POLL_HANG_MS = SIGN_TIMEOUT_MS + REQUEST_TIMEOUT_MS + 5_000
 /** Contract: claim polls every 3 to 5 s. */
 export const CLAIM_INTERVAL_MS = 4_000
 /** Contract: job polls every 5 to 15 s; this ramps from the first to the second. */

--- a/src/lib/signWithin.test.ts
+++ b/src/lib/signWithin.test.ts
@@ -1,0 +1,30 @@
+/**
+ * signWithin.test.ts - a remote signer that never answers fails within its
+ * patience instead of hanging what awaited it; a prompt one is untouched.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SIGN_PATIENCE_MS, SignerTimeout, signWithin } from './signWithin'
+
+const template = { kind: 1, created_at: 1, tags: [], content: '' }
+
+describe('signWithin', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('passes a prompt signature through', async () => {
+    const signed = { ...template, id: 'x', pubkey: 'p', sig: 's' }
+    await expect(signWithin({ signEvent: async () => signed as never }, template)).resolves.toBe(signed)
+  })
+
+  it('gives up on a signer that never answers, after its patience', async () => {
+    const never = { signEvent: () => new Promise<never>(() => { /* the bunker is gone */ }) }
+    const p = signWithin(never, template)
+    const settled = vi.fn()
+    p.then(settled, settled)
+    await vi.advanceTimersByTimeAsync(SIGN_PATIENCE_MS - 1)
+    expect(settled).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(p).rejects.toBeInstanceOf(SignerTimeout)
+  })
+})

--- a/src/lib/signWithin.ts
+++ b/src/lib/signWithin.ts
@@ -1,0 +1,33 @@
+/**
+ * signWithin.ts: a signature, or a timeout. On its own so that the store and
+ * the signers can both import it without a cycle (signers.ts reaches the relay
+ * pool, which reaches the store, which reaches the signers).
+ */
+
+import type { EventTemplate, NostrEvent } from './events'
+
+/**
+ * How long a remote signer (extension, bunker) gets to sign one event. A
+ * phone drops the signer's channel while the tab sits in a wallet app; a
+ * signature that will never come must fail, not hang whatever awaited it.
+ */
+export const SIGN_PATIENCE_MS = 15_000
+
+export class SignerTimeout extends Error {
+  constructor() {
+    super('the signer did not answer in time')
+    this.name = 'SignerTimeout'
+  }
+}
+
+/** The signature, or a SignerTimeout once SIGN_PATIENCE_MS has passed. */
+export async function signWithin(signer: { signEvent: (template: EventTemplate) => Promise<NostrEvent> }, template: EventTemplate, ms: number = SIGN_PATIENCE_MS): Promise<NostrEvent> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const late = new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new SignerTimeout()), ms) })
+  try {
+    return await Promise.race([signer.signEvent(template), late])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+

--- a/src/lib/signers.ts
+++ b/src/lib/signers.ts
@@ -19,6 +19,7 @@ import { getPool } from './relay'
 import type { EventTemplate, NostrEvent } from './events'
 
 export type SignerKind = 'local' | 'nip07' | 'nip46'
+export { SIGN_PATIENCE_MS, SignerTimeout, signWithin } from './signWithin'
 
 export interface Signer {
   kind: SignerKind
@@ -116,6 +117,13 @@ export async function nip46Signer(bunkerUri: string, clientSecretKey?: Uint8Arra
     clientSecretKey: clientSk,
     signEvent: (template) => bunker.signEvent(template) as unknown as Promise<NostrEvent>,
     close: () => bunker.close(),
+    // The bunker listens for answers on a relay subscription that dies with
+    // the socket, and a phone kills sockets while the tab is away. A fresh
+    // signer over a fresh connection, same client key, same pubkey.
+    reconnect: async () => {
+      try { await bunker.close() } catch { /* already gone */ }
+      return nip46Signer(bunkerUri, clientSk)
+    },
   }
 }
 

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -33,6 +33,8 @@ import {
   saveSignerPref,
   type Signer,
   type SignerKind,
+  SignerTimeout,
+  signWithin,
 } from '../lib/signers'
 import {
   coordToXyz,
@@ -721,8 +723,23 @@ function pickInitialSigner(): Signer {
   return localSigner(loadOrGenerateKey())
 }
 
-function signEvent(template: EventTemplate): Promise<NostrEvent> {
-  return currentSigner.signEvent(template)
+/**
+ * A local key signs at once. A remote signer gets SIGN_PATIENCE_MS; if it does
+ * not answer, its channel is presumed dead (the phone was in a wallet app)
+ * and it is rebuilt once and asked again. A payment poll used to await this
+ * forever, which left a paid invoice unrecognised until a reload.
+ */
+async function signEvent(template: EventTemplate): Promise<NostrEvent> {
+  const signer = currentSigner
+  if (signer.kind === 'local') return signer.signEvent(template)
+  try {
+    return await signWithin(signer, template)
+  } catch (err) {
+    if (!(err instanceof SignerTimeout) || !signer.reconnect) throw err
+    const fresh = await signer.reconnect()
+    if (currentSigner === signer) currentSigner = fresh
+    return await signWithin(fresh, template)
+  }
 }
 
 const pubkeyHex = currentSigner.pubkey

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -1037,6 +1037,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
           intervalMs: claimIntervalFor(currentSigner.kind),
           waker,
           onPoll: (d) => { if (id === requestId) set({ cloud: { ...get().cloud, checking: false, lastCheck: { at: Date.now(), status: d.status } } }) },
+          onPollError: () => { if (id === requestId) set({ cloud: { ...get().cloud, checking: false } }) },
         })
         if (typeof settled.balance_msats === 'number') get().noteBalance(settled.balance_msats)
         if (id !== requestId) return
@@ -1144,6 +1145,10 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         },
         onDepositPoll: (d) => {
           if (id === requestId) set({ cloud: { ...get().cloud, checking: false, lastCheck: { at: Date.now(), status: d.status } } })
+        },
+        // A failed poll must not leave CHECK PAYMENT spinning: the wait goes on and the button is live again.
+        onDepositPollError: () => {
+          if (id === requestId) set({ cloud: { ...get().cloud, checking: false } })
         },
         onStage: (stage, d) => {
           if (id !== requestId) return


### PR DESCRIPTION
**Incident:** a 9 sat invoice paid from a wallet app on a phone was never recognised. The API log shows the deposit created, one claim poll, then nothing. CHECK PAYMENT spun and could not be pressed. A reload claimed it at once (the #67 startup claim), so the money was never at risk.

**Cause:** each claim poll signs a NIP-98 request before the fetch timeout is armed, and the signature itself had no timeout. An extension or bunker answers over a channel the phone drops while the tab is in the wallet app; that signature never came, the claim never returned, and the loop, which awaits each claim before sleeping, was dead until a reload.

**Fix:**
- Signing gets a 20 s timeout and fails as a transient `sign_timeout`.
- Every claim poll and job poll is raced against a 45 s watchdog and abandoned as `poll_timeout`, so the next poll always goes out.
- A failed poll reports through `onPollError`; the store clears `checking`, so CHECK PAYMENT stops spinning and can be pressed.

Tests: a signer that never answers times out at 20 s, is reported, and the next poll goes out and settles; a 503 is reported and the wait continues. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz

**Second commit:** the store's own signing now has 15 s of patience for a remote signer; on a timeout a bunker is rebuilt over a fresh connection (same client key, same pubkey) and asked once more, so a phone that dropped the bunker's relay channel while in the wallet app recovers instead of failing every retry. HOSAKA's outer signing guard is 45 s to outlast one rebuild.