### PR TITLE
Bunker signing survives the app switch: half-open sockets dropped, request retried, harness included

### DIFF
--- a/scripts/e2e/bunker-payment/README.md
+++ b/scripts/e2e/bunker-payment/README.md
@@ -1,0 +1,27 @@
+# A bunker-signed HOSAKA payment, recognised after the phone's app switch
+
+Reproduces the incident of 2026-09-03: an invoice paid from a wallet app on a
+phone was never recognised, because the tab's relay sockets came back
+half-open (the browser still called them connected) and the bunker signature
+for the next claim poll went into the void.
+
+The pieces: a local relay (`nak serve`), a TCP proxy in front of it that can
+play dead (`halfopen-proxy.mjs`: existing connections stay open and forward
+nothing, new ones work), a NIP-46 remote signer (`fake-bunker.mjs`) talking to
+the relay directly, and a Playwright run of the app (`bunker-payment-e2e.mjs`)
+that logs in through the bunker via the proxy, stubs HOSAKA, commits a move
+the cloud must do, hides the tab, kills the sockets, "pays", returns, and
+measures how long the client takes to notice.
+
+```
+nak serve --port 10547 &
+node scripts/e2e/bunker-payment/halfopen-proxy.mjs 10548 10547 10549 &
+node scripts/e2e/bunker-payment/fake-bunker.mjs ws://127.0.0.1:10547 bunker.log keys.json &
+npx vite --port 5211 --strictPort --host 127.0.0.1 &
+node scripts/e2e/bunker-payment/bunker-payment-e2e.mjs 5211 run keys.json bunker.log
+```
+
+Pass: `recognisedAfterSeconds` is a few seconds and `signRequestsAfterReturn`
+is at least 1. Before the fix the run ended in `FLOW DIED` ("All promises were
+rejected") or hung with the spinner. `PLAYWRIGHT_BROWSERS_PATH` may be needed
+where the browsers live outside the default cache.

--- a/scripts/e2e/bunker-payment/bunker-payment-e2e.mjs
+++ b/scripts/e2e/bunker-payment/bunker-payment-e2e.mjs
@@ -1,0 +1,78 @@
+// End to end: a bunker-signed HOSAKA payment recognised after the phone's app switch.
+// Needs: nak serve on 10547, halfopen-proxy.mjs 10548->10547 (control 10549), fake-bunker.mjs
+// on the relay directly, a dev server. usage: node bunker-payment-e2e.mjs <port> <label> <keys.json> <bunkerlog>
+import fs from 'node:fs'
+import { chromium } from 'playwright'
+import { getPublicKey, generateSecretKey } from 'nostr-tools/pure'
+import { nsecEncode } from 'nostr-tools/nip19'
+import { hexToBytes } from '@noble/hashes/utils'
+
+const PORT = +process.argv[2] || 5211
+const LABEL = process.argv[3] || 'run'
+const keys = JSON.parse(fs.readFileSync(process.argv[4] || 'bunker-keys.json', 'utf8'))
+const BUNKER_LOG = process.argv[5] || 'fake-bunker.log'
+const bunkerPub = getPublicKey(hexToBytes(keys.bunkerSk)), userPub = getPublicKey(hexToBytes(keys.userSk))
+const RELAY_VIA_PROXY = 'ws://127.0.0.1:10548'
+const bunkerUri = `bunker://${bunkerPub}?relay=${encodeURIComponent(RELAY_VIA_PROXY)}`
+const clientSk = generateSecretKey()
+const pref = { kind: 'nip46', pubkey: userPub, bunkerUri, clientNsec: nsecEncode(clientSk) }
+const control = (path) => fetch(`http://127.0.0.1:10549${path}`).then((r) => r.text())
+const bunkerLines = () => fs.existsSync(BUNKER_LOG) ? fs.readFileSync(BUNKER_LOG, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l)) : []
+
+const API = `http://127.0.0.1:${PORT}/hosaka-stub`
+let paid = false, claims = 0, deposits = 0
+const cors = { 'access-control-allow-origin': '*', 'access-control-allow-headers': '*', 'access-control-allow-methods': '*' }
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await ctx.newPage()
+page.on('pageerror', (e) => console.log('pageerror', e.message))
+await page.addInitScript((p) => { try { localStorage.setItem('onosendai:signer', JSON.stringify(p)); localStorage.removeItem('onosendai:cloudDeposit'); localStorage.removeItem('onosendai:cloudJob') } catch {} }, pref)
+const json = (route, body, status = 200) => route.fulfill({ status, contentType: 'application/json', headers: cors, body: JSON.stringify(body) })
+const deposit = () => ({ deposit_id: 'dep-1', status: paid ? 'settled' : 'pending', amount_msats: 10000, bolt11: 'lnbc100n1fake', payment_hash: 'ff'.repeat(32), created_at: Math.floor(Date.now() / 1000), expires_at: Math.floor(Date.now() / 1000) + 3600, settled_at: paid ? Math.floor(Date.now() / 1000) : null, settled_msats: paid ? 10000 : null, balance_msats: paid ? 10000 : 0 })
+await page.route('**/hosaka-stub/**', async (route) => {
+  const req = route.request(); const p = new URL(req.url()).pathname.replace(/^.*\/hosaka-stub/, '')
+  if (req.method() === 'OPTIONS') return route.fulfill({ status: 204, headers: cors })
+  if (p === '/api/v1/limits') return json(route, { max_hop_height: 27, max_sidestep_height: 29, hop_min_msats: 1000, deposit_min_msats: 1000, deposit_max_msats: 5e9, invoice_ttl_seconds: 3600 })
+  if (p === '/api/v1/balance') return json(route, { pubkey: userPub, balance_msats: paid ? 10000 : 0, ledger: [] })
+  if (p === '/api/v1/quote') { const b = JSON.parse(req.postData()); return json(route, { action: b.action, cost_msats: 10000, within_cap: true, cap: 27, max_height: 24, per_axis_heights: { x: 24, y: 0, z: 0 }, K: 7, tier: 'small', est_seconds: 277, est_time: 'about 5 min', hint: null }) }
+  if (p === '/api/v1/deposit' && req.method() === 'POST') { deposits++; return json(route, deposit(), 201) }
+  if (/^\/api\/v1\/deposit\/dep-1\/claim$/.test(p)) { claims++; return json(route, deposit()) }
+  if (p === '/api/v1/deposit/dep-1') return json(route, deposit())
+  if (p === '/api/v1/hop') return json(route, { id: 'job-1', status: 'computing', cost_msats: 10000, poll_token: 'tok', result: null, error: null, payment_required: false, balance_debited: true })
+  if (p.startsWith('/api/v1/jobs/')) return json(route, { id: 'job-1', status: 'computing', cost_msats: 10000, result: { progress_percent: 10 }, error: null })
+  return json(route, { error: 'unstubbed ' + p }, 404)
+})
+
+const T0 = Date.now(); const t = () => ((Date.now() - T0) / 1000).toFixed(1)
+const state = () => page.evaluate(() => { const s = window.__store.getState(); return { signer: s.signerKind, me: s.identity.pubkey.slice(0, 8), loginError: s.loginError, cloud: s.cloud.status, checking: s.cloud.checking, msg: (s.cloud.message || '').slice(0, 70), proof: s.proof.status, pmsg: (s.proof.message || '').slice(0, 70) } })
+await page.goto(`http://127.0.0.1:${PORT}`, { waitUntil: 'load' })
+// Wait for the bunker identity to take over (initSigner connects through the proxy).
+for (let i = 0; i < 40; i++) { const s = await state(); if (s.signer === 'nip46' && s.me === userPub.slice(0, 8)) break; await page.waitForTimeout(500) }
+console.log(t(), 'signer', JSON.stringify(await state()))
+await page.evaluate((api) => { window.__store.setState({ cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: api } }) }, API)
+await page.waitForTimeout(8000) // let calibration and caps settle before committing (#69)
+// An h24 crossing on x: beyond this machine, HOSAKA's job.
+await page.evaluate(() => { const st = window.__store; const s = st.getState(); st.setState({ cursor: { ...s.position, x: s.position.x ^ (1n << 23n) } }); void st.getState().commit() })
+for (let i = 0; i < 60; i++) { const s = await state(); if (s.cloud === 'awaiting_payment') break; await page.waitForTimeout(500) }
+console.log(t(), 'after commit', JSON.stringify(await state()), 'deposits', deposits, 'claims', claims)
+const signsBefore = bunkerLines().filter((l) => l.method === 'sign_event').length
+
+// The app switch: the tab goes hidden, and every socket it holds goes half-open.
+await page.evaluate(() => { Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true }); Object.defineProperty(document, 'hidden', { value: true, configurable: true }); document.dispatchEvent(new Event('visibilitychange')) })
+console.log(t(), 'hidden; proxy ->', await control('/dead'))
+await page.waitForTimeout(12000) // in the wallet
+paid = true
+console.log(t(), 'PAID in the wallet; coming back')
+await page.evaluate(() => { Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true }); Object.defineProperty(document, 'hidden', { value: false, configurable: true }); document.dispatchEvent(new Event('visibilitychange')) })
+const tBack = Date.now()
+let recognised = null
+for (let i = 0; i < 180; i++) {
+  const s = await state()
+  if (s.cloud === 'paid' || s.cloud === 'computing') { recognised = (Date.now() - tBack) / 1000; console.log(t(), 'RECOGNISED after', recognised.toFixed(1), 's', JSON.stringify(s)); break }
+  if (s.cloud === 'error') { console.log(t(), 'FLOW DIED', JSON.stringify(s)); break }
+  if (i % 10 === 9) console.log(t(), 'still waiting', JSON.stringify(s), 'claims', claims, 'signs', bunkerLines().filter((l) => l.method === 'sign_event').length - signsBefore)
+  await page.waitForTimeout(500)
+}
+const signsAfter = bunkerLines().filter((l) => l.method === 'sign_event').length - signsBefore
+console.log(JSON.stringify({ label: LABEL, recognisedAfterSeconds: recognised, claimsTotal: claims, signRequestsAfterReturn: signsAfter, proxy: await control('/status'), final: await state() }))
+await browser.close()

--- a/scripts/e2e/bunker-payment/fake-bunker.mjs
+++ b/scripts/e2e/bunker-payment/fake-bunker.mjs
@@ -1,0 +1,39 @@
+// A NIP-46 remote signer over the local relay: answers connect, get_public_key,
+// sign_event and ping for one user key. Logs every request as JSON lines to
+// the file in argv[3] so a test can see when the client's requests arrive.
+import fs from 'node:fs'
+import { SimplePool, finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools'
+import * as nip44 from 'nostr-tools/nip44'
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils'
+
+const RELAY = process.argv[2] || 'ws://127.0.0.1:10548'
+const LOG = process.argv[3] || 'fake-bunker.log'
+const KEYS = process.argv[4] // optional path to persisted keys
+let bunkerSk, userSk
+if (KEYS && fs.existsSync(KEYS)) { const k = JSON.parse(fs.readFileSync(KEYS, 'utf8')); bunkerSk = hexToBytes(k.bunkerSk); userSk = hexToBytes(k.userSk) }
+else { bunkerSk = generateSecretKey(); userSk = generateSecretKey(); if (KEYS) fs.writeFileSync(KEYS, JSON.stringify({ bunkerSk: bytesToHex(bunkerSk), userSk: bytesToHex(userSk) })) }
+const bunkerPub = getPublicKey(bunkerSk), userPub = getPublicKey(userSk)
+console.log(JSON.stringify({ bunkerPub, userPub, bunkerUri: `bunker://${bunkerPub}?relay=${encodeURIComponent(RELAY)}` }))
+
+const pool = new SimplePool()
+const log = (o) => fs.appendFileSync(LOG, JSON.stringify({ at: new Date().toISOString(), ...o }) + '\n')
+pool.subscribe([RELAY], { kinds: [24133], '#p': [bunkerPub] }, {
+  onevent: async (ev) => {
+    const convKey = nip44.v2.utils.getConversationKey(bunkerSk, ev.pubkey)
+    let req
+    try { req = JSON.parse(nip44.v2.decrypt(ev.content, convKey)) } catch (e) { log({ bad: String(e) }); return }
+    let result = null, error = null
+    try {
+      if (req.method === 'connect') result = 'ack'
+      else if (req.method === 'get_public_key') result = userPub
+      else if (req.method === 'ping') result = 'pong'
+      else if (req.method === 'sign_event') { const t = JSON.parse(req.params[0]); result = JSON.stringify(finalizeEvent(t, userSk)) }
+      else error = `unsupported ${req.method}`
+    } catch (e) { error = String(e) }
+    const kind = req.method === 'sign_event' ? JSON.parse(req.params[0]).kind : undefined
+    log({ method: req.method, id: req.id, kind, from: ev.pubkey.slice(0, 8) })
+    const reply = finalizeEvent({ kind: 24133, created_at: Math.floor(Date.now() / 1000), tags: [['p', ev.pubkey]], content: nip44.v2.encrypt(JSON.stringify({ id: req.id, result, error }), convKey) }, bunkerSk)
+    try { await Promise.any(pool.publish([RELAY], reply)) } catch (e) { log({ publishFailed: String(e) }) }
+  },
+  oneose: () => log({ ready: true }),
+})

--- a/scripts/e2e/bunker-payment/halfopen-proxy.mjs
+++ b/scripts/e2e/bunker-payment/halfopen-proxy.mjs
@@ -1,0 +1,30 @@
+// A TCP proxy in front of the local relay that can play dead: existing connections
+// stay open but forward nothing (a phone's half-open socket after suspend), while
+// new connections work. Control over HTTP on CONTROL_PORT: /dead, /alive, /status.
+import net from 'node:net'
+import http from 'node:http'
+const LISTEN = +process.argv[2] || 10548
+const TARGET = +process.argv[3] || 10547
+const CONTROL_PORT = +process.argv[4] || 10549
+let generation = 0
+let deadGenerations = new Set()
+let opened = 0, forwarded = 0, dropped = 0
+const server = net.createServer((client) => {
+  const gen = generation
+  opened++
+  const upstream = net.connect(TARGET, '127.0.0.1')
+  const alive = () => !deadGenerations.has(gen)
+  client.on('data', (d) => { if (alive()) { forwarded++; upstream.write(d) } else dropped++ })
+  upstream.on('data', (d) => { if (alive()) client.write(d); else dropped++ })
+  const closeBoth = () => { try { client.destroy() } catch {} try { upstream.destroy() } catch {} }
+  client.on('error', closeBoth); upstream.on('error', closeBoth)
+  // A half-open socket must NOT close when the relay side closes: keep the client side up.
+  upstream.on('close', () => { if (alive()) client.end() })
+  client.on('close', () => upstream.destroy())
+})
+server.listen(LISTEN, '127.0.0.1', () => console.log(`proxy ${LISTEN} -> ${TARGET}`))
+http.createServer((req, res) => {
+  if (req.url === '/dead') { deadGenerations.add(generation); generation++; res.end(JSON.stringify({ deadUpTo: generation - 1 })); return }
+  if (req.url === '/alive') { deadGenerations.clear(); res.end('ok'); return }
+  res.end(JSON.stringify({ generation, dead: [...deadGenerations], opened, forwarded, dropped }))
+}).listen(CONTROL_PORT, '127.0.0.1', () => console.log(`control ${CONTROL_PORT}`))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,12 @@ export default function App(): JSX.Element {
   // so the invoice poll's timer is still counting when the tab returns. Ask
   // HOSAKA at once instead of waiting the interval out; harmless otherwise.
   useEffect(() => {
-    const back = (): void => { if (document.visibilityState === 'visible') useCyberspace.getState().checkCloudPayment() }
+    const back = (): void => {
+      if (document.visibilityState !== 'visible') return
+      const s = useCyberspace.getState()
+      s.wakeSigner()
+      s.checkCloudPayment()
+    }
     document.addEventListener('visibilitychange', back)
     window.addEventListener('pageshow', back)
     window.addEventListener('focus', back)

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -359,6 +359,11 @@ export function createHosaka(opts: HosakaClientOptions): HosakaClient {
     })
     try {
       return await Promise.race([token, late])
+    } catch (err) {
+      // Whatever the signer's failure, a poll must not die of it: as a
+      // transient HosakaError the loop asks again.
+      if (err instanceof HosakaError) throw err
+      throw new HosakaError(0, 'sign_failed', err instanceof Error ? err.message : String(err))
     } finally {
       clearTimeout(timer)
     }

--- a/src/lib/signers.ts
+++ b/src/lib/signers.ts
@@ -110,21 +110,26 @@ export async function nip46Signer(bunkerUri: string, clientSecretKey?: Uint8Arra
   const bunker = nip46.BunkerSigner.fromBunker(clientSk, bp, { pool: getPool() as never })
   await bunker.connect()
   const pubkey = await bunker.getPublicKey()
-  return {
+  const signer: Signer = {
     kind: 'nip46',
     pubkey,
     bunkerUri,
     clientSecretKey: clientSk,
     signEvent: (template) => bunker.signEvent(template) as unknown as Promise<NostrEvent>,
     close: () => bunker.close(),
-    // The bunker listens for answers on a relay subscription that dies with
-    // the socket, and a phone kills sockets while the tab is away. A fresh
-    // signer over a fresh connection, same client key, same pubkey.
+    // A phone that suspends the tab leaves its relay sockets half-open: the
+    // browser still calls them connected, so the pool reuses them and a
+    // request goes into the void, to be answered never or to fail with
+    // "All promises were rejected". Closing the bunker's relays in the pool
+    // drops those sockets; the same signer opens fresh ones on its next
+    // request (nostr-tools re-subscribes when its subscription is gone), so
+    // nothing is rebuilt and the bunker sees no new connect handshake.
     reconnect: async () => {
-      try { await bunker.close() } catch { /* already gone */ }
-      return nip46Signer(bunkerUri, clientSk)
+      getPool().close([...bp.relays])
+      return signer
     },
   }
+  return signer
 }
 
 /** What we persist to bring a signer back on reload. */

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -33,7 +33,6 @@ import {
   saveSignerPref,
   type Signer,
   type SignerKind,
-  SignerTimeout,
   signWithin,
 } from '../lib/signers'
 import {
@@ -528,6 +527,8 @@ export interface CyberspaceState {
   discardCloudJob: () => void
   /** Ask HOSAKA about the invoice now rather than at the next poll. */
   checkCloudPayment: () => void
+  /** Back from another app: drop a remote signer's sockets before the next request. */
+  wakeSigner: () => void
   /** The credited-while-away notice was read. */
   dismissCredited: () => void
   setCloudMode: (mode: CloudMode) => void
@@ -735,11 +736,24 @@ async function signEvent(template: EventTemplate): Promise<NostrEvent> {
   try {
     return await signWithin(signer, template)
   } catch (err) {
-    if (!(err instanceof SignerTimeout) || !signer.reconnect) throw err
+    // A timeout, or a publish that gave up ("All promises were rejected"):
+    // either way the signer's sockets are presumed dead. Drop them and ask
+    // once more over fresh ones.
+    if (!signer.reconnect) throw err
     const fresh = await signer.reconnect()
     if (currentSigner === signer) currentSigner = fresh
     return await signWithin(fresh, template)
   }
+}
+
+/**
+ * The tab is back from another app. A remote signer's sockets are presumed
+ * half-open and dropped now, before the first request, so the payment check
+ * that follows goes out over live connections.
+ */
+function wakeSigner(): void {
+  if (currentSigner.kind === 'local') return
+  void currentSigner.reconnect?.().then((fresh) => { if (currentSigner !== fresh && currentSigner.kind !== 'local') currentSigner = fresh })
 }
 
 const pubkeyHex = currentSigner.pubkey
@@ -2225,6 +2239,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   },
 
   dismissCredited: () => { set({ cloud: { ...get().cloud, credited: null } }) },
+
+  wakeSigner: () => wakeSigner(),
 
   checkCloudPayment: () => {
     if (get().cloud.status !== 'awaiting_payment') return


### PR DESCRIPTION
**What you saw after #76:** CHECK made the modal vanish and the panels said "this signer is not open anymore, create a new one". That is nostr-tools refusing a closed bunker: #76's reconnect closed the bunker and rebuilt it over the same dead socket, so the rebuild hung and every later signature hit the closed one.

**The real mechanism, reproduced.** After a phone suspends the tab, its relay sockets come back half-open: the browser still calls them connected, nostr-tools reuses them, and the NIP-46 request for the next claim poll goes into the void, to hang or to fail with "All promises were rejected", which the poll loop treated as fatal. Nothing reaches the bunker, so nothing can notice the payment.

**Fix:**
- A bunker's `reconnect` now closes the bunker's relays in the pool, dropping the half-open sockets. The same signer resubscribes and publishes over fresh ones on its next request (nostr-tools does this itself once its subscription is gone). No rebuild, no new connect handshake to Amber.
- The store retries a signature once over fresh sockets after any failure, and drops the sockets proactively when the tab comes back, before the payment check.
- Any signing failure becomes a transient HOSAKA error, so the poll loop asks again instead of dying.

**Harness** (`scripts/e2e/bunker-payment`, README inside): local relay, a TCP proxy that plays dead (old sockets stay open and forward nothing, new ones work), a fake NIP-46 bunker, and a Playwright run that logs in through the bunker, stubs HOSAKA, commits a cloud move, hides the tab, kills the sockets, pays, returns.

| run | outcome | signing requests reaching the bunker after return |
|---|---|---|
| v2 before this PR | flow died: "All promises were rejected" | 0 |
| this PR | recognised **2.0 s** after return, job computing | 2 |

455 tests and tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz