### PR TITLE
One named action per commit: COMMIT, HOP TO BOUNDARY, SIDESTEP, OFFLOAD or TOO FAR

### DIFF
--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -12,7 +12,7 @@ import { useCyberspace } from '../store/useCyberspace'
 import { exitHyperspaceView, useHyperspace } from '../store/useHyperspace'
 import { useWorkshop } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
-import { offerNeed, offloadWanted, useOffer } from '../store/useOffer'
+import { nextAction, useOffer } from '../store/useOffer'
 import { moveDirection, type MoveName } from '../lib/moves'
 import type { RotateDirection } from '../lib/space'
 
@@ -90,9 +90,11 @@ export function useKeyboard(): void {
       if (event.code === 'Space') {
         event.preventDefault()
         if (useShards.getState().pending) { void useShards.getState().deploy(); return }
-        // A move this machine cannot do brings up the HOSAKA card first; Space again goes.
-        const need = offerNeed()
-        if (offloadWanted(need, store.cloudPrefs.mode) && need && useOffer.getState().requestedFor !== need.cursorKey) useOffer.getState().request(need.cursorKey)
+        // The next action, as the button names it: HOSAKA's step brings up the
+        // card first (Space again goes); too far does nothing; the rest commit.
+        const next = nextAction()
+        if (next?.action === 'too-far') return
+        if (next?.action === 'offload' && useOffer.getState().requestedFor !== next.cursorKey) useOffer.getState().request(next.cursorKey)
         else store.commit()
         return
       }

--- a/src/hud/HosakaOffer.tsx
+++ b/src/hud/HosakaOffer.tsx
@@ -74,7 +74,7 @@ export function HosakaOffer({ hidden = false }: { hidden?: boolean }): JSX.Eleme
           <div><dt>HOSAKA</dt><dd>{cloudKnown ? `up to 2^${cloud.limits!.max_hop_height} hops, 2^${cloud.limits!.max_sidestep_height} sidesteps` : 'asking for its caps'}</dd></div>
         </dl>
         {verdict.tier === 'impossible' && (
-          <p className="notice">Beyond HOSAKA too: no one computes a wall this tall yet. Line up a nearer cursor.</p>
+          <p className="notice">Beyond HOSAKA too: no one computes a boundary this high yet. Line up a nearer cursor.</p>
         )}
         {verdict.tier === 'cloud' && (
           <p className="legend__note">{`${verdict.cloudSteps} of ${verdict.steps} actions would offload to HOSAKA.`}</p>

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -19,7 +19,7 @@ import { useCyberspace } from '../store/useCyberspace'
 import { moveDirection, type MoveName } from '../lib/moves'
 import { MAX_SCALE_EXP } from '../lib/space'
 import { useShards } from '../store/useShards'
-import { offloadWanted, useOffer, useOfferNeed } from '../store/useOffer'
+import { ACTION_LABEL, useNextAction, useOffer } from '../store/useOffer'
 import { useUiHints } from '../store/useUiHints'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 
@@ -44,11 +44,14 @@ export function TouchControls(): JSX.Element {
 
   const computing = proof.status === 'computing'
   const armed = !(position.x === cursor.x && position.y === cursor.y && position.z === cursor.z)
-  // A move this machine cannot do reads OFFLOAD, in blue: pressing it brings
-  // up the HOSAKA card instead of committing; pressing again goes.
-  const need = useOfferNeed()
-  const cloudMode = useCyberspace((s) => s.cloudPrefs.mode)
-  const offload = armed && !deploying && !computing && offloadWanted(need, cloudMode)
+  // The button names the one action the next commit takes: COMMIT for a hop
+  // to the cursor, HOP TO BOUNDARY or SIDESTEP for a step of the way, OFFLOAD
+  // in blue when the step is HOSAKA's (pressing it brings up the card;
+  // pressing again goes), TOO FAR in red, disabled, when nobody computes it.
+  const next = useNextAction()
+  const action = armed && !deploying && !computing ? next?.action ?? null : null
+  const offload = action === 'offload'
+  const tooFar = action === 'too-far'
 
   const move = (name: MoveName) => () => {
     const s = useCyberspace.getState()
@@ -140,18 +143,18 @@ export function TouchControls(): JSX.Element {
           {computing ? 'STOP' : 'RECALL'}
         </button>
         <button
-          className={`touchops__commit ${deploying ? 'is-armed' : computing ? 'is-busy' : offload ? 'is-offload' : armed ? 'is-armed' : ''}`}
-          disabled={!deploying && !armed && !computing}
-          title={deploying ? 'Place shard here' : offload ? 'This move needs HOSAKA: see the offer (Space)' : 'Commit hop (Space)'}
+          className={`touchops__commit ${deploying ? 'is-armed' : computing ? 'is-busy' : tooFar ? 'is-too-far' : offload ? 'is-offload' : armed ? 'is-armed' : ''}`}
+          disabled={(!deploying && !armed && !computing) || tooFar}
+          title={deploying ? 'Place shard here' : tooFar ? 'Higher than anyone computes: bring the cursor nearer, or ride hyperspace' : offload ? 'This step needs HOSAKA: see the offer (Space)' : action === 'hop-to-boundary' ? 'Hop to the boundary on the way (Space)' : action === 'sidestep' ? 'Sidestep one gibson through the boundary (Space)' : 'Commit hop (Space)'}
           {...noCallout}
           onPointerDown={(e) => {
             e.preventDefault(); e.stopPropagation()
             if (deploying) void useShards.getState().deploy()
-            else if (offload && need && useOffer.getState().requestedFor !== need.cursorKey) useOffer.getState().request(need.cursorKey)
+            else if (offload && next && useOffer.getState().requestedFor !== next.cursorKey) useOffer.getState().request(next.cursorKey)
             else useCyberspace.getState().commit()
           }}
         >
-          {deploying ? 'PLACE' : computing ? `${Math.round(proof.progress * 100)}%` : offload ? 'OFFLOAD' : 'COMMIT'}
+          {deploying ? 'PLACE' : computing ? `${Math.round(proof.progress * 100)}%` : action ? ACTION_LABEL[action] : 'COMMIT'}
         </button>
         {/* Whether a commit leaves the device. Under COMMIT because that is the
             only control whose meaning it changes, and a switch rather than a

--- a/src/lib/movePlan.test.ts
+++ b/src/lib/movePlan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { findLcaHeight } from 'cyberspace-core'
-import { buildMovePlan, isSpecSidestep, isSpecSidestepMove, nextAxisMove, nextStep, planSummary, summarizePlan, wallSource, type PlanStep, type Position } from './movePlan'
+import { buildMovePlan, isSpecSidestep, isSpecSidestepMove, nextAxisMove, nextStep, planSummary, routeFeasible, summarizePlan, wallSource, type PlanStep, type Position } from './movePlan'
 
 const P = (x: bigint, y: bigint = 5n, z: bigint = 5n): Position => ({ x, y, z })
 
@@ -131,30 +131,46 @@ describe('buildMovePlan', () => {
   })
 })
 
-describe('two ceilings: local first, cloud second, infeasible named', () => {
+describe('two ceilings: local first per step, cloud only where no local step exists', () => {
   const c = { hop: 17, sidestep: 24, cloudHop: 25, cloudSidestep: 29 }
-  it('a cursor within the cloud hop cap is one paid hop, no wall', () => {
-    const from = P(1000n)
-    const steps = buildMovePlan(from, P(1000n + (1n << 22n)), c)
-    expect(steps.map((s) => `${s.kind}:${s.source}`)).toEqual(['hop:cloud'])
+  const localStep = (s: PlanStep) => s.source === 'local' && (s.kind === 'hop' ? s.maxHeight <= c.hop : s.maxHeight <= c.sidestep)
+  const cloudStep = (s: PlanStep) => s.source === 'cloud' && (s.kind === 'hop' ? s.maxHeight > c.hop : s.maxHeight > c.sidestep)
+  it('a walk this machine can make is never paid, however long', () => {
+    const steps = buildMovePlan(P(1000n), P(1000n + (1n << 22n)), c)
+    expect(steps.length).toBeGreaterThan(5)
+    expect(steps.every(localStep)).toBe(true)
   })
   it('within the local ceiling nothing is paid', () => {
     expect(buildMovePlan(P(1000n), P(1000n + (1n << 10n)), c).map((s) => s.source)).toEqual(['local'])
   })
-  it('above the cloud hop cap: paid hop to the edge, paid sidestep, hop on', () => {
+  it('at a wall this machine cannot cross HOSAKA hops to the cursor when its cap reaches', () => {
+    // Standing on the leaf touching the h25 wall: the local sidestep is above h24.
+    const steps = buildMovePlan(P((1n << 24n) - 1n), P((1n << 24n) + 5n), c)
+    expect(steps.map((s) => `${s.kind}:${s.source}:h${s.maxHeight}`)).toEqual(['hop:cloud:h25'])
+  })
+  it('above the cloud hop cap HOSAKA sidesteps, and the walk goes on locally', () => {
+    const steps = buildMovePlan(P((1n << 25n) - 1n), P((1n << 25n) + 5n), c)
+    expect(steps.map((s) => `${s.kind}:${s.source}:h${s.maxHeight}`)).toEqual(['sidestep:cloud:h26', 'hop:local:h3'])
+  })
+  it('a far cursor: local walk, paid crossing, local walk, for every wall this machine cannot cross', () => {
     const from = P(5n)
     const to = P((1n << 26n) + 3n)   // wall at h27
     const steps = buildMovePlan(from, to, c)
-    // the edge of the h27 wall is an h26 hop away, above the cloud cap, so the
-    // walk restarts at the cloud level: paid hop, paid sidestep, paid hop, paid sidestep, hop on
-    expect(steps.map((s) => `${s.kind}:${s.source}:h${s.maxHeight}`)).toEqual([
-      'hop:cloud:h25', 'sidestep:cloud:h26', 'hop:cloud:h25', 'sidestep:cloud:h27', 'hop:local:h2',
+    expect(steps.every((s) => localStep(s) || cloudStep(s))).toBe(true)
+    expect(steps.filter((s) => s.source === 'cloud').map((s) => `${s.kind}:h${s.maxHeight}`)).toEqual([
+      'hop:h25', 'sidestep:h26', 'hop:h25', 'sidestep:h27',
     ])
-    expect(planSummary(from, to, c)).toMatchObject({ steps: 5, cloudSteps: 4, infeasibleAt: null })
+    expect(steps[0].source).toBe('local')
+    expect(planSummary(from, to, c)).toMatchObject({ cloudSteps: 4, infeasibleAt: null })
   })
   it('a wall no one sells is named as the first infeasible step', () => {
     const s = planSummary(P(5n), P((1n << 40n) + 3n), c)
     expect(s.infeasibleAt).not.toBeNull()
+  })
+  it('routeFeasible agrees with the walk, in constant time', () => {
+    const cases: Array<[bigint, bigint]> = [[5n, (1n << 40n) + 3n], [5n, (1n << 26n) + 3n], [1000n, 1000n + (1n << 22n)], [(1n << 28n) - 1n, 1n << 28n], [(1n << 29n) - 1n, 1n << 29n]]
+    for (const [a, b] of cases) expect(routeFeasible(P(a), P(b), c)).toBe(planSummary(P(a), P(b), c).infeasibleAt === null)
+    expect(routeFeasible(P(0n), P(1n << 30n), 17)).toBe(true) // a number: sidesteps unbounded
   })
   it('a plain number still means local only', () => {
     expect(buildMovePlan(P(0b0101n), P(0b1011n), 2).map((s) => s.source)).toEqual(['local', 'local', 'local'])

--- a/src/lib/movePlan.ts
+++ b/src/lib/movePlan.ts
@@ -38,11 +38,13 @@ export interface PlanStep {
 
 /**
  * What each primitive can reach, here and in the cloud. Cloud values are 0
- * when the cloud is off or its limits are not known yet. Hops are planned
- * with the taller hop ceiling, so a paid hop replaces a walk whenever HOSAKA
- * reaches the wall; a step is local when this machine can do it and cloud
- * otherwise; a sidestep taller than both sidestep ceilings makes the route
- * infeasible at that step.
+ * when the cloud is off or its limits are not known yet. A step is this
+ * machine's whenever this machine can take it, however long the walk that
+ * makes; HOSAKA takes a step only where no local step exists, which is a
+ * boundary above the local sidestep ceiling. Its step is then planned with
+ * its own caps: a paid hop across the boundary, landing at the cursor when
+ * the cursor is within its hop cap, else a paid sidestep of one gibson. A
+ * boundary above both sidestep ceilings makes the route infeasible there.
  */
 export interface Ceilings {
   hop: number
@@ -62,6 +64,21 @@ function asCeilings(c: number | Ceilings): Ceilings {
 function sourceOf(kind: PlanStepKind, h: number, c: Ceilings): StepSource {
   if (kind === 'hop') return h <= c.hop ? 'local' : h <= c.cloudHop ? 'cloud' : 'infeasible'
   return h <= c.sidestep ? 'local' : h <= c.cloudSidestep ? 'cloud' : 'infeasible'
+}
+
+/**
+ * Whether anyone in `c` can take the whole route, in constant time. The
+ * tallest boundary the route crosses on an axis is the LCA height of that
+ * axis, crossed once; every other boundary on the way is lower. So the route
+ * is feasible exactly when its tallest boundary fits a hop ceiling or a
+ * sidestep ceiling. `planSummary` walks the same route and agrees, but a
+ * long walk costs a step per block boundary and this is asked on every
+ * cursor move.
+ */
+export function routeFeasible(from: Position, to: Position, ceilings: number | Ceilings): boolean {
+  const c = asCeilings(ceilings)
+  const h = Math.max(findLcaHeight(from.x, to.x), findLcaHeight(from.y, to.y), findLcaHeight(from.z, to.z))
+  return h <= Math.max(c.hop, c.cloudHop) || h <= Math.max(c.sidestep, c.cloudSidestep)
 }
 
 export type AxisMove =
@@ -121,10 +138,17 @@ export function nextAxisMove(current: bigint, target: bigint, ceiling: number): 
  * The next step of the route from `cur` to `to`. Hops move every axis that
  * can move at once; a sidestep moves exactly the axes that are standing at
  * their walls (spec 6.9) and holds the others until it is done. Null when
- * `cur` is `to`.
+ * `cur` is `to`. With cloud ceilings the step is this machine's whenever it
+ * has one, and HOSAKA's only at a wall this machine cannot cross.
  */
 export function nextStep(cur: Position, to: Position, ceilings: number | Ceilings): PlanStep | null {
   const c = asCeilings(ceilings)
+  // Local first, per step: the cloud plans a step only when this machine has
+  // none, so a walk this machine can make is never a paid hop.
+  if (c.cloudHop > 0 || c.cloudSidestep > 0) {
+    const mine = nextStep(cur, to, localOnly(c.hop, c.sidestep))
+    if (mine === null || mine.source === 'local') return mine
+  }
   const walk = Math.max(c.hop, c.cloudHop)
   if (walk < 1) throw new Error('ceiling must be at least 1')
   if (cur.x === to.x && cur.y === to.y && cur.z === to.z) return null

--- a/src/lib/offer.test.ts
+++ b/src/lib/offer.test.ts
@@ -10,8 +10,14 @@ describe('offerVerdict', () => {
     expect(offerVerdict(P(1000n), P(1000n), 0, C, true)).toBeNull()
   })
   it('the cloud can, with the counts', () => {
+    // On the leaf touching an h25 wall: above this machine's h24 sidestep, within HOSAKA's h25 hop cap, so one paid hop.
+    const v = offerVerdict(P((1n << 24n) - 1n), P(1n << 24n), 0, C, true)
+    expect(v).toMatchObject({ tier: 'cloud', tallestWall: 25, cloudSteps: 1, steps: 1 })
+  })
+  it('a walk this machine can make counts no cloud step', () => {
     const v = offerVerdict(P(1000n), P(1000n + (1n << 20n)), 0, C, true)
-    expect(v).toMatchObject({ tier: 'cloud', tallestWall: 21, cloudSteps: 1, steps: 1 })
+    expect(v?.cloudSteps).toBe(0)
+    expect(v?.steps).toBeGreaterThan(1)
   })
   it('the cloud could, caps unknown', () => {
     const v = offerVerdict(P(1000n), P(1000n + (1n << 20n)), 0, { ...C, cloudHop: 0, cloudSidestep: 0 }, false)

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -97,11 +97,20 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: 
   return { promise, resolve, reject }
 }
 
-/** The cursor one h13 wall away from the avatar, on x. */
-function lineUpH13(): Position {
+/**
+ * The cursor one h13 wall away from the avatar, on x. By default the avatar
+ * is first stood on the leaf touching that wall: a step is HOSAKA's only
+ * where this machine has none, so the crossing is the very next commit.
+ * `atWall: false` stands it mid-block instead, an h12 hop short of the leaf.
+ * (Earlier tests leave the avatar wherever their route ended, so both stand
+ * it explicitly.)
+ */
+function lineUpH13(atWall = true): Position {
   const s = useCyberspace.getState()
-  const cursor = { ...s.position, x: s.position.x ^ (1n << 12n) }
-  useCyberspace.setState({ cursor })
+  const block = (s.position.x >> 13n) << 13n
+  const position = { ...s.position, x: atWall ? block + 4095n : block + 2053n }
+  const cursor = { ...position, x: position.x ^ (1n << 12n) }
+  useCyberspace.setState({ position, cursor })
   return cursor
 }
 
@@ -134,8 +143,8 @@ describe('cloud routes', () => {
   it('a funded route of one cloud hop lands at the cursor as a signed hop event, verified first', async () => {
     const before = S().events.length
     const head = S().prevEventId
-    const from = S().position
     const to = lineUpH13()
+    const from = S().position
     fake.quote.mockResolvedValue(quote('hop'))
     fake.submitHop.mockResolvedValue(funded())
     fake.waitForJob.mockResolvedValue(completed(hopResult(from, to, S().plane, head)))
@@ -180,8 +189,8 @@ describe('cloud routes', () => {
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, mode: 'ask' } })
     const before = S().events.length
     const head = S().prevEventId
-    const from = S().position
     const to = lineUpH13()
+    const from = S().position
     fake.quote.mockResolvedValue(quote('hop', 2500))
 
     await S().commit()
@@ -212,8 +221,8 @@ describe('cloud routes', () => {
   it('one invoice funds the route: the deposit is on disk before the invoice shows, then the step runs funded', async () => {
     const before = S().events.length
     const head = S().prevEventId
-    const from = S().position
     const to = lineUpH13()
+    const from = S().position
     fake.quote.mockResolvedValue(quote('hop'))
     // 95 msats short of a sat: the invoice is still for whole sats.
     fake.balance.mockResolvedValue({ pubkey: S().identity.pubkey, balance_msats: 95, ledger: [] })
@@ -255,8 +264,8 @@ describe('cloud routes', () => {
   it('refuses to append when the chain head moved while HOSAKA computed', async () => {
     const before = S().events.length
     const head = S().prevEventId
-    const from = S().position
     const to = lineUpH13()
+    const from = S().position
     fake.quote.mockResolvedValue(quote('hop'))
     fake.submitHop.mockResolvedValue(funded())
     const finish = deferred<HosakaJob>()
@@ -281,8 +290,8 @@ describe('cloud routes', () => {
   it('refuses a result that fails verification, and signs nothing', async () => {
     const before = S().events.length
     const head = S().prevEventId
-    const from = S().position
     const to = lineUpH13()
+    const from = S().position
     fake.quote.mockResolvedValue(quote('hop'))
     fake.submitHop.mockResolvedValue(funded())
     const result = hopResult(from, to, S().plane, head)
@@ -298,8 +307,8 @@ describe('cloud routes', () => {
 
   it('X while the route waits for its invoice abandons it; X while a step computes keeps the job for RESUME', async () => {
     const head = S().prevEventId
-    const from = S().position
     const to = lineUpH13()
+    const from = S().position
     fake.quote.mockResolvedValue(quote('hop'))
     fake.balance.mockResolvedValue({ pubkey: S().identity.pubkey, balance_msats: 0, ledger: [] })
     fake.deposit.mockResolvedValue(deposit('d1'))
@@ -370,8 +379,8 @@ describe('cloud routes', () => {
     useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
     useCyberspace.setState({ cloud: { ...S().cloud, limits: { ...LIMITS, max_hop_height: 12 } } })
     const before = S().events.length
+    const cursor = lineUpH13(false)
     const from = S().position
-    const cursor = lineUpH13()
     const edge = wallSource(from.x, cursor.x, 13)
     const landing = cursor.x > from.x ? edge + 1n : edge - 1n
     expect(edge).not.toBe(from.x)                       // this identity spawned away from the wall
@@ -426,8 +435,8 @@ describe('cloud routes', () => {
     // A machine that sidesteps to h24 has a local way across the h13 boundary.
     useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 24 })
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, mode: 'off' } })
+    const cursor = lineUpH13(false)
     const from = S().position
-    const cursor = lineUpH13()
     await S().commit()
     expect(fake.quote).not.toHaveBeenCalled()
     expect(fake.limits).not.toHaveBeenCalled()
@@ -445,6 +454,7 @@ describe('cloud routes', () => {
     // Now a machine with no local way across (sidesteps stop at h12): the move is the cloud's, whose caps are not known yet.
     useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, mode: 'auto' }, cloud: { ...S().cloud, limits: null } })
+    lineUpH13()   // on the leaf touching the wall: the crossing is the next commit
     fake.quote.mockResolvedValue(quote('hop'))
     fake.submitHop.mockResolvedValue(funded('job-5'))
     fake.waitForJob.mockImplementation((_id: string, _tok: string, o: { signal?: AbortSignal }) => new Promise((_, reject) => {

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -6,7 +6,7 @@
  * with two ceilings, the route quote and PAY gate, the single deposit written
  * to disk before its invoice is shown, the verifier (cyberspace-core computes
  * the "cloud" result at h13 so the checks are exact), the refusal when the
- * chain head moved, the local steps of a mixed route, and finishProof signing
+ * chain head moved, one step per commit of a mixed way, and finishProof signing
  * hops and sidesteps exactly as it would local ones. What would fail silently
  * otherwise: a cloud proof appended to a chain whose head moved, a deposit
  * paid but never claimed after a reload, or a cancelled flow landing late.
@@ -110,8 +110,9 @@ const idle = (): Promise<void> => vi.waitFor(() => { expect(S().cloud.status).to
 
 describe('cloud routes', () => {
   beforeEach(() => {
-    // This machine stops at h12, so an h13 move is the cloud's, and the caps are already known.
-    useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 24 })
+    // This machine stops at h12 for hops AND sidesteps, so an h13 move has no local way and is
+    // the cloud's (HOSAKA is used only when needed); the caps are already known.
+    useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
     useCyberspace.setState({ cloud: { ...S().cloud, limits: LIMITS, status: 'idle', job: null, message: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://fake' }, plan: null })
     for (const fn of Object.values(fake)) if (typeof fn === 'function' && 'mockReset' in fn) fn.mockReset()
     fake.limits.mockResolvedValue(LIMITS)
@@ -364,7 +365,7 @@ describe('cloud routes', () => {
     expect(S().cloud.message).toMatch(/1 sat route deposit .* credited/)
   })
 
-  it('beyond the cloud hop cap: a local hop to the wall, a cloud sidestep through it, a local hop on', async () => {
+  it('beyond the cloud hop cap: a local hop to the boundary, a cloud sidestep through it, a local hop on, one commit each', async () => {
     // This machine hashes sidesteps only to h12 here, so the h13 crossing is HOSAKA's.
     useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
     useCyberspace.setState({ cloud: { ...S().cloud, limits: { ...LIMITS, max_hop_height: 12 } } })
@@ -379,18 +380,25 @@ describe('cloud routes', () => {
     fake.waitForJob.mockImplementation(async () => completed(sidestepResult({ ...from, x: edge }, { ...from, x: landing }, S().plane, S().prevEventId), 'job-4'))
 
     await S().commit()
-    // Quoted the sidestep only; funded; the first step is this machine's hop to the wall's edge.
+    // Only the first step of the way is committed, and it is this machine's: the hop to the boundary's edge. Nothing quoted yet.
     const s0 = S()
-    expect(s0.plan?.summary).toMatchObject({ cloudSteps: 1, sidesteps: 1 })
-    expect(fake.quote).toHaveBeenCalledTimes(1)
-    expect(fake.quote).toHaveBeenCalledWith('sidestep', { ...from, x: edge, plane: s0.headPlane }, { ...from, x: landing, plane: s0.headPlane })
+    expect(s0.plan?.summary).toMatchObject({ steps: 1, hops: 1, cloudSteps: 0 })
+    expect(fake.quote).not.toHaveBeenCalled()
     await vi.waitFor(() => { expect(vi.mocked(postProof)).toHaveBeenCalledTimes(1) })
     const req1 = vi.mocked(postProof).mock.calls[0][0]
     expect(req1).toMatchObject({ mode: 'hop', from, to: { ...from, x: edge }, maxComputeHeight: 12 })
     expect(S().plan?.step.source).toBe('local')
 
-    // The local hop lands (the worker's answer, fed by hand); the cloud sidestep follows and lands.
+    // The local hop lands (the worker's answer, fed by hand). That commit is done; the cursor stays.
     await S().applyProofMessage({ type: 'done', id: req1.id, mode: 'hop', elapsedMs: 5, proofHash: 'dd'.repeat(32), terrainK: 3, lca: { x: 12, y: 0, z: 0 }, totalOps: 4 })
+    expect(S().position.x).toBe(edge)
+    expect(S().plan).toBeNull()
+    expect(S().cursor).toEqual(cursor)
+
+    // The next commit is the sidestep through the boundary, HOSAKA's here: quoted, funded, landed.
+    await S().commit()
+    expect(fake.quote).toHaveBeenCalledTimes(1)
+    expect(fake.quote).toHaveBeenCalledWith('sidestep', { ...from, x: edge, plane: s0.headPlane }, { ...from, x: landing, plane: s0.headPlane })
     await vi.waitFor(() => { expect(S().position.x).toBe(landing) }, { timeout: 5000 })
     expect(fake.submitSidestep).toHaveBeenCalledWith({ ...from, x: edge, plane: s0.headPlane }, { ...from, x: landing, plane: s0.headPlane }, expect.any(String))
     const ev = S().events[S().events.length - 1]
@@ -400,8 +408,10 @@ describe('cloud routes', () => {
     expect(ev.tags.find((t) => t[0] === 'mr')?.[1]).toBe([p.merkleX, p.merkleY, p.merkleZ].map(bytesToHex).join(':'))
     expect(ev.tags.find((t) => t[0] === 'mp')?.[1]).toBe([p.inclusionProofs.x.map(bytesToHex).join(''), '', ''].join(':'))
     expect(ev.tags.find((t) => t[0] === 'hx')?.[1]).toBe('13')
+    await vi.waitFor(() => { expect(S().plan).toBeNull() })
 
-    // Then the last local hop on to the cursor, which ends the route.
+    // Then the last commit hops on to the cursor.
+    await S().commit()
     await vi.waitFor(() => { expect(vi.mocked(postProof)).toHaveBeenCalledTimes(2) })
     const req2 = vi.mocked(postProof).mock.calls[1][0]
     expect(req2).toMatchObject({ mode: 'hop', to: cursor })
@@ -413,6 +423,8 @@ describe('cloud routes', () => {
   })
 
   it('with cloud OFF the same move is a local route; with no caps yet the commit fetches them first', async () => {
+    // A machine that sidesteps to h24 has a local way across the h13 boundary.
+    useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 24 })
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, mode: 'off' } })
     const from = S().position
     const cursor = lineUpH13()
@@ -430,6 +442,8 @@ describe('cloud routes', () => {
     expect(S().plan).toBeNull()
     expect(S().proof.status).toBe('idle')
 
+    // Now a machine with no local way across (sidesteps stop at h12): the move is the cloud's, whose caps are not known yet.
+    useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, mode: 'auto' }, cloud: { ...S().cloud, limits: null } })
     fake.quote.mockResolvedValue(quote('hop'))
     fake.submitHop.mockResolvedValue(funded('job-5'))
@@ -503,20 +517,9 @@ describe('cloud routes', () => {
     expect(S().cloud.limits).toEqual(LIMITS)
   })
 
-  it('with the cloud on but HOSAKA unreachable, a long local walk is refused rather than started (#69)', async () => {
-    useCyberspace.setState({ cloud: { ...S().cloud, limits: null } })
-    fake.limits.mockRejectedValue(new Error('down'))
-    const s = S()
-    // An h24 crossing on x: a dozen walls above this machine's h12, a walk of many steps.
-    useCyberspace.setState({ cursor: { ...s.position, x: s.position.x ^ (1n << 23n) } })
-    await S().commit()
-    expect(S().proof.status).toBe('infeasible')
-    expect(S().proof.message).toMatch(/HOSAKA did not answer/)
-    expect(S().plan).toBeNull()
-    expect(vi.mocked(postProof)).not.toHaveBeenCalled()
-  })
-
   it('with the cloud on but HOSAKA unreachable, a short walk still goes ahead locally', async () => {
+    // A machine that sidesteps to h24 has a local way across the h13 boundary.
+    useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 24 })
     useCyberspace.setState({ cloud: { ...S().cloud, limits: null } })
     fake.limits.mockRejectedValue(new Error('down'))
     lineUpH13()

--- a/src/store/movePlan.test.ts
+++ b/src/store/movePlan.test.ts
@@ -1,6 +1,7 @@
 /**
- * movePlan.test.ts - a commit beyond the ceiling runs a route step by step,
- * one signature per step, pausing on a declined signature.
+ * movePlan.test.ts - a commit beyond the ceiling takes exactly one step of the
+ * way there, one signature, pausing on a declined signature; the next commit
+ * takes the next step.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -50,28 +51,33 @@ describe('a commit beyond the ceiling', () => {
     await useCyberspace.getState().respawn()
   })
 
-  it('walks to the wall, sidesteps one gibson, hops on, signing each step', async () => {
+  it('walks to the boundary, sidesteps one gibson, hops on: one step per commit, one signature each', async () => {
     const s = useCyberspace.getState()
     const x0 = (s.position.x >> 4n) << 4n            // block base at h4
     useCyberspace.setState({ position: { ...s.position, x: x0 + 5n }, cursor: { ...s.position, x: x0 + 11n } })
     await useCyberspace.getState().commit()
     let st = useCyberspace.getState()
     expect(st.plan).not.toBeNull()
-    expect(st.plan!.summary).toMatchObject({ hops: 2, sidesteps: 1, tallestWall: 4 })
+    // Only the first step of the way is committed: the hop to the boundary.
+    expect(st.plan!.summary).toMatchObject({ hops: 1, sidesteps: 0 })
     expect(posted).toHaveLength(1)
     expect(posted[0]).toMatchObject({ mode: 'hop', to: { x: x0 + 7n }, maxComputeHeight: 2 })
 
     await land()
     st = useCyberspace.getState()
     expect(st.position.x).toBe(x0 + 7n)
-    expect(st.plan!.done).toBe(1)
-    expect(posted[1]).toMatchObject({ mode: 'sidestep', from: { x: x0 + 7n }, to: { x: x0 + 8n } })
+    expect(st.plan).toBeNull()                          // the one-step route is done
+    expect(st.cursor.x).toBe(x0 + 11n)                  // the cursor stays where it was put
+    expect(posted).toHaveLength(1)                      // nothing runs on its own
 
+    await useCyberspace.getState().commit()             // the next commit is the sidestep
+    expect(posted[1]).toMatchObject({ mode: 'sidestep', from: { x: x0 + 7n }, to: { x: x0 + 8n } })
     await land()
     st = useCyberspace.getState()
     expect(st.position.x).toBe(x0 + 8n)
-    expect(posted[2]).toMatchObject({ mode: 'hop', from: { x: x0 + 8n }, to: { x: x0 + 11n } })
 
+    await useCyberspace.getState().commit()             // and the hop on to the cursor
+    expect(posted[2]).toMatchObject({ mode: 'hop', from: { x: x0 + 8n }, to: { x: x0 + 11n } })
     await land()
     st = useCyberspace.getState()
     expect(st.position.x).toBe(x0 + 11n)
@@ -109,7 +115,9 @@ describe('a commit beyond the ceiling', () => {
     await new Promise((r) => setTimeout(r, 0))
     st = useCyberspace.getState()
     expect(st.position.x).toBe(x0 + 8n)
-    expect(posted).toHaveLength(2)                     // the next step was posted, not the old one again
+    expect(st.plan).toBeNull()                         // that one step was the whole commit
+    expect(posted).toHaveLength(1)                     // the next step waits for the next commit
+    await useCyberspace.getState().commit()
     expect(posted[1]).toMatchObject({ mode: 'hop', to: { x: x0 + 9n } })
   })
 

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -117,7 +117,7 @@ import {
   saveBalance,
   type KnownBalance,
 } from '../lib/cloud'
-import { nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
+import { localOnly, nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
 
@@ -869,13 +869,6 @@ let cloudWaker: Waker | null = null
 let hosaka: { url: string; client: HosakaClient } | null = null
 /** The caps request out right now, and the API URL it was sent to. */
 let limitsInFlight: { url: string; promise: Promise<HosakaLimits | null> } | null = null
-/**
- * With the cloud on but HOSAKA unreachable, a local walk longer than this is
- * refused rather than started. Without the caps the planner falls back to
- * hops and sidesteps for every wall, which for a distant cursor is hundreds
- * of steps and many minutes (#69); a short walk is what it always was.
- */
-const WALK_WITHOUT_CLOUD_MAX = 8
 
 /** One client per API URL. It signs through `signEvent`, so it follows identity switches. */
 function cloudClient(apiUrl: string): HosakaClient {
@@ -1454,24 +1447,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       set({ proof: { ...IDLE_PROOF, status: 'computing', mode: 'hop', message: 'Asking HOSAKA for its caps.' } })
       await ensureCloudLimits()
       set({ proof: IDLE_PROOF })
-      // Still no caps: HOSAKA did not answer. A long walk in its place is
-      // refused; the person asked for the cloud, and can turn it off to walk.
-      if (get().cloud.limits === null) {
-        const walk = planSummary(position, cursor, cloudCeilings())
-        if (walk.steps > WALK_WITHOUT_CLOUD_MAX) {
-          set({
-            plan: null,
-            proof: {
-              ...IDLE_PROOF,
-              status: 'infeasible',
-              message: `HOSAKA did not answer, and without it this route is a local walk of ${walk.steps} steps (${walk.sidesteps} sidesteps). Try again when it is reachable, or turn the cloud OFF to walk it.`,
-            },
-          })
-          return
-        }
-      }
     }
-    const ceilings = cloudCeilings()
+    // Local first, as the button promised: HOSAKA's ceilings enter only when
+    // no local way to the cursor exists (nextActionFor makes the same choice).
+    const machineOnly = localOnly(ceiling, recommendedSidestepHeight())
+    const ceilings = planSummary(position, cursor, machineOnly).infeasibleAt === null ? machineOnly : cloudCeilings()
     const summary = planSummary(position, cursor, ceilings)
     if (summary.infeasibleAt !== null) {
       set({
@@ -1479,19 +1459,28 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         proof: {
           ...IDLE_PROOF,
           status: 'infeasible',
-          message: `Step ${summary.infeasibleAt + 1} of this route needs a wall taller than this machine${ceilings.cloudHop ? ' or HOSAKA' : ''} computes (sidestep cap h${Math.max(ceilings.sidestep, ceilings.cloudSidestep)}). Line up a nearer cursor${ceilings.cloudHop ? '' : ', or turn the cloud on'}.`,
+          message: `Step ${summary.infeasibleAt + 1} of the way there crosses a boundary higher than this machine${ceilings.cloudHop ? ' or HOSAKA' : ''} computes (sidestep cap h${Math.max(ceilings.sidestep, ceilings.cloudSidestep)}). Line up a nearer cursor${ceilings.cloudHop ? '' : ', or turn the cloud on'}.`,
         },
       })
       return
     }
     const step = nextStep(position, cursor, ceilings)
     if (!step) return
-    const funded = summary.cloudSteps === 0
+    // One action per commit. The cursor may sit any distance away; this
+    // commit executes only the first step of the way there, the one the
+    // button named (a hop to the cursor, a hop to the boundary, a sidestep
+    // through it, or HOSAKA's version of either), and lands where that step
+    // lands. The cursor stays, so the next commit names the next step. The
+    // whole path is shown, never run: a route that signs step after step in
+    // the background was harder to follow than to walk.
+    const target = { ...step.to }
+    const one = planSummary(position, target, ceilings)
+    const funded = one.cloudSteps === 0
     set({
       plan: {
-        target: { ...cursor },
+        target,
         ceilings,
-        summary,
+        summary: one,
         done: 0,
         step,
         status: funded ? 'running' : 'funding',

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -117,7 +117,7 @@ import {
   saveBalance,
   type KnownBalance,
 } from '../lib/cloud'
-import { localOnly, nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
+import { nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
 
@@ -1448,24 +1448,24 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       await ensureCloudLimits()
       set({ proof: IDLE_PROOF })
     }
-    // Local first, as the button promised: HOSAKA's ceilings enter only when
-    // no local way to the cursor exists (nextActionFor makes the same choice).
-    const machineOnly = localOnly(ceiling, recommendedSidestepHeight())
-    const ceilings = planSummary(position, cursor, machineOnly).infeasibleAt === null ? machineOnly : cloudCeilings()
-    const summary = planSummary(position, cursor, ceilings)
-    if (summary.infeasibleAt !== null) {
+    // Local first, per step, as the button promised (lib/movePlan.ts): the
+    // step is this machine's whenever it has one; HOSAKA's caps enter only
+    // at a boundary this machine cannot cross (nextActionFor makes the same
+    // choice). Only a step nobody can take is refused here.
+    const ceilings = cloudCeilings()
+    const step = nextStep(position, cursor, ceilings)
+    if (!step) return
+    if (step.source === 'infeasible') {
       set({
         plan: null,
         proof: {
           ...IDLE_PROOF,
           status: 'infeasible',
-          message: `Step ${summary.infeasibleAt + 1} of the way there crosses a boundary higher than this machine${ceilings.cloudHop ? ' or HOSAKA' : ''} computes (sidestep cap h${Math.max(ceilings.sidestep, ceilings.cloudSidestep)}). Line up a nearer cursor${ceilings.cloudHop ? '' : ', or turn the cloud on'}.`,
+          message: `The next step crosses a boundary (h${step.maxHeight}) higher than this machine${ceilings.cloudHop ? ' or HOSAKA' : ''} computes (sidestep cap h${Math.max(ceilings.sidestep, ceilings.cloudSidestep)}). Line up a nearer cursor${ceilings.cloudHop ? '' : ', or turn the cloud on'}.`,
         },
       })
       return
     }
-    const step = nextStep(position, cursor, ceilings)
-    if (!step) return
     // One action per commit. The cursor may sit any distance away; this
     // commit executes only the first step of the way there, the one the
     // button named (a hop to the cursor, a hop to the boundary, a sidestep

--- a/src/store/useOffer.test.ts
+++ b/src/store/useOffer.test.ts
@@ -6,14 +6,16 @@
 import { describe, expect, it } from 'vitest'
 import { offloadWanted, useOffer, type OfferView } from './useOffer'
 
-const need = (tier: OfferView['verdict']['tier']): OfferView => ({ verdict: { tallestWall: 24, tier, cloudSteps: 1, steps: 1 }, cursorKey: 'k', machineCeiling: 17 })
+const need = (tier: OfferView['verdict']['tier'], localFeasible: boolean): OfferView => ({ verdict: { tallestWall: 24, tier, cloudSteps: 1, steps: 1 }, cursorKey: 'k', machineCeiling: 17, localFeasible })
 
 describe('offloadWanted', () => {
-  it('wants OFFLOAD whenever this machine cannot do the move, the impossible case included, unless the cloud is off', () => {
-    expect(offloadWanted(need('cloud'), 'auto')).toBe(true)
-    expect(offloadWanted(need('cloud-unknown'), 'ask')).toBe(true)
-    expect(offloadWanted(need('impossible'), 'auto')).toBe(true)
-    expect(offloadWanted(need('cloud'), 'off')).toBe(false)
+  it('wants OFFLOAD only when no local walk crosses: a wall above the sidestep ceiling, whatever the cloud mode', () => {
+    expect(offloadWanted(need('cloud', false), 'auto')).toBe(true)
+    expect(offloadWanted(need('cloud', false), 'off')).toBe(true)
+    expect(offloadWanted(need('impossible', false), 'auto')).toBe(true)
+    // A wall above the hop ceiling only: the machine hops, sidesteps, hops on. COMMIT.
+    expect(offloadWanted(need('cloud', true), 'auto')).toBe(false)
+    expect(offloadWanted(need('cloud-unknown', true), 'ask')).toBe(false)
     expect(offloadWanted(null, 'auto')).toBe(false)
   })
 })

--- a/src/store/useOffer.test.ts
+++ b/src/store/useOffer.test.ts
@@ -1,22 +1,37 @@
 /**
- * useOffer.test.ts - the HOSAKA card is asked for, per cursor; OFFLOAD is
- * wanted only when the move needs the cloud and the cloud is not off.
+ * useOffer.test.ts - the one action the next commit takes, as the button
+ * names it, and the HOSAKA card being asked for per cursor.
  */
 
 import { describe, expect, it } from 'vitest'
-import { offloadWanted, useOffer, type OfferView } from './useOffer'
+import { nextActionFor, useOffer } from './useOffer'
 
-const need = (tier: OfferView['verdict']['tier'], localFeasible: boolean): OfferView => ({ verdict: { tallestWall: 24, tier, cloudSteps: 1, steps: 1 }, cursorKey: 'k', machineCeiling: 17, localFeasible })
+const at = (x: bigint): { x: bigint; y: bigint; z: bigint } => ({ x, y: 0n, z: 0n })
+const CAPS = { max_hop_height: 27, max_sidestep_height: 29 }
+// A machine that hops to 2^17 and sidesteps to 2^24, as the defaults say.
+const next = (cursorX: bigint, limits: typeof CAPS | null = CAPS) => nextActionFor(at(0n), at(cursorX), 0, 17, 24, limits)
 
-describe('offloadWanted', () => {
-  it('wants OFFLOAD only when no local walk crosses: a wall above the sidestep ceiling, whatever the cloud mode', () => {
-    expect(offloadWanted(need('cloud', false), 'auto')).toBe(true)
-    expect(offloadWanted(need('cloud', false), 'off')).toBe(true)
-    expect(offloadWanted(need('impossible', false), 'auto')).toBe(true)
-    // A wall above the hop ceiling only: the machine hops, sidesteps, hops on. COMMIT.
-    expect(offloadWanted(need('cloud', true), 'auto')).toBe(false)
-    expect(offloadWanted(need('cloud-unknown', true), 'ask')).toBe(false)
-    expect(offloadWanted(null, 'auto')).toBe(false)
+describe('nextActionFor', () => {
+  it('is nothing with the cursor on the avatar', () => {
+    expect(next(0n)).toBeNull()
+  })
+  it('hops to a cursor within the machine ceiling', () => {
+    expect(next(1n << 10n)?.action).toBe('hop')
+  })
+  it('names a step of the way when the cursor is beyond one hop but a local walk exists', () => {
+    const a = next(1n << 22n)
+    expect(a && ['hop-to-boundary', 'sidestep'].includes(a.action)).toBe(true)
+    expect(a?.step).not.toBeNull()
+  })
+  it('is OFFLOAD when the step is HOSAKA\'s, and when HOSAKA has not said what it can', () => {
+    // Across an h26 boundary: above the local sidestep ceiling, within HOSAKA's hop cap.
+    expect(next(1n << 25n)?.action).toBe('offload')
+    expect(next(1n << 25n, null)?.action).toBe('offload')
+  })
+  it('is TOO FAR past every cap', () => {
+    // An h31 boundary: above HOSAKA's sidestep cap too.
+    expect(next(1n << 30n)?.action).toBe('too-far')
+    expect(next(1n << 30n)?.step).toBeNull()
   })
 })
 
@@ -24,11 +39,8 @@ describe('the request', () => {
   it('is per cursor, and NOT NOW clears it', () => {
     useOffer.getState().request('a:b:c:0')
     expect(useOffer.getState().requestedFor).toBe('a:b:c:0')
-    expect(useOffer.getState().dismissedFor).toBeNull()
     useOffer.getState().dismiss('a:b:c:0')
     expect(useOffer.getState().requestedFor).toBeNull()
     expect(useOffer.getState().dismissedFor).toBe('a:b:c:0')
-    useOffer.getState().request('a:b:c:0')
-    expect(useOffer.getState().dismissedFor).toBeNull()
   })
 })

--- a/src/store/useOffer.test.ts
+++ b/src/store/useOffer.test.ts
@@ -23,10 +23,16 @@ describe('nextActionFor', () => {
     expect(a && ['hop-to-boundary', 'sidestep'].includes(a.action)).toBe(true)
     expect(a?.step).not.toBeNull()
   })
-  it('is OFFLOAD when the step is HOSAKA\'s, and when HOSAKA has not said what it can', () => {
-    // Across an h26 boundary: above the local sidestep ceiling, within HOSAKA's hop cap.
-    expect(next(1n << 25n)?.action).toBe('offload')
-    expect(next(1n << 25n, null)?.action).toBe('offload')
+  it('walks toward a boundary only HOSAKA crosses, and is OFFLOAD only on reaching it', () => {
+    // An h26 boundary on the way: above the local sidestep ceiling, within HOSAKA's hop cap.
+    expect(next(1n << 25n)?.action).toBe('hop-to-boundary')
+    expect(next(1n << 25n, null)?.action).toBe('hop-to-boundary')
+    const atWall = (limits: typeof CAPS | null) => nextActionFor(at((1n << 25n) - 1n), at(1n << 25n), 0, 17, 24, limits)
+    expect(atWall(CAPS)?.action).toBe('offload')
+    expect(atWall(CAPS)?.step?.source).toBe('cloud')
+    // HOSAKA has not said what it can: the press asks.
+    expect(atWall(null)?.action).toBe('offload')
+    expect(atWall(null)?.step).toBeNull()
   })
   it('is TOO FAR past every cap', () => {
     // An h31 boundary: above HOSAKA's sidestep cap too.

--- a/src/store/useOffer.test.ts
+++ b/src/store/useOffer.test.ts
@@ -9,11 +9,11 @@ import { offloadWanted, useOffer, type OfferView } from './useOffer'
 const need = (tier: OfferView['verdict']['tier']): OfferView => ({ verdict: { tallestWall: 24, tier, cloudSteps: 1, steps: 1 }, cursorKey: 'k', machineCeiling: 17 })
 
 describe('offloadWanted', () => {
-  it('wants OFFLOAD for a cloud move, or one the caps have not answered for, unless the cloud is off', () => {
+  it('wants OFFLOAD whenever this machine cannot do the move, the impossible case included, unless the cloud is off', () => {
     expect(offloadWanted(need('cloud'), 'auto')).toBe(true)
     expect(offloadWanted(need('cloud-unknown'), 'ask')).toBe(true)
+    expect(offloadWanted(need('impossible'), 'auto')).toBe(true)
     expect(offloadWanted(need('cloud'), 'off')).toBe(false)
-    expect(offloadWanted(need('impossible'), 'auto')).toBe(false)
     expect(offloadWanted(null, 'auto')).toBe(false)
   })
 })

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -13,8 +13,7 @@
 
 import { create } from 'zustand'
 import { useCalibration } from '../lib/calibration'
-import type { CloudMode } from '../lib/cloud'
-import { localOnly, planSummary } from '../lib/movePlan'
+import { localOnly, nextStep, planSummary, type Ceilings, type PlanStep } from '../lib/movePlan'
 import { offerVerdict, type OfferVerdict } from '../lib/offer'
 import type { Position } from '../lib/space'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
@@ -84,16 +83,78 @@ export function useOfferNeed(): OfferView | null {
 }
 
 /**
- * COMMIT reads OFFLOAD only when HOSAKA is actually needed: some wall on the
- * way is taller than this machine's sidestep ceiling, so no local walk
- * crosses it. A wall above the hop ceiling alone is not that: the machine
- * hops to it, sidesteps through, and hops on, in more steps and more time,
- * which the proof panel's preview shows. Whether the cloud is ON, ASK or OFF
- * does not change what is needed, so the mode is not consulted here; the
- * card's own mode control turns it on.
+ * The one action the next commit would take toward the cursor, which is what
+ * the COMMIT button names:
+ *
+ * - `hop`: this machine hops to the cursor.
+ * - `hop-to-boundary`: this machine hops to the leaf touching the boundary
+ *   it cannot hop across; the cursor stays where it is.
+ * - `sidestep`: this machine sidesteps one gibson through that boundary.
+ * - `offload`: the step is HOSAKA's (a hop or a sidestep past this machine),
+ *   or might be, until HOSAKA's caps are known.
+ * - `too-far`: some boundary on the way is higher than anyone computes.
+ *
+ * HOSAKA's caps are used whatever the cloud mode: what the move needs does
+ * not depend on a setting, and the card's mode control turns the cloud on.
  */
-export function offloadWanted(need: OfferView | null, _mode?: CloudMode): boolean {
-  return need !== null && !need.localFeasible
+export type NextAction = 'hop' | 'hop-to-boundary' | 'sidestep' | 'offload' | 'too-far'
+
+export interface NextActionView {
+  action: NextAction
+  /** The step itself, for local actions and HOSAKA's; null when too far. */
+  step: PlanStep | null
+  cursorKey: string
+}
+
+export function nextActionFor(position: Position, cursor: Position, plane: number, hopCeil: number, sidestepCeil: number, limits: { max_hop_height: number; max_sidestep_height: number } | null): NextActionView | null {
+  if (position.x === cursor.x && position.y === cursor.y && position.z === cursor.z) return null
+  const machineCeiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
+  const cursorKey = cursorKeyOf(cursor, plane)
+  // Local first: when this machine can walk there, the next step is its own,
+  // however long the walk (the proof panel shows the length). HOSAKA enters
+  // only when no local way exists, which is when it is actually needed.
+  const local = localOnly(machineCeiling, sidestepCeil)
+  let ceilings: Ceilings = local
+  if (planSummary(position, cursor, local, 20_000).infeasibleAt !== null) {
+    ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0 }
+    if (planSummary(position, cursor, ceilings, 20_000).infeasibleAt !== null) {
+      // Nobody known can: too far. Unless HOSAKA has not said what it can yet.
+      return { action: limits === null ? 'offload' : 'too-far', step: null, cursorKey }
+    }
+  }
+  const step = nextStep(position, cursor, ceilings)
+  if (!step) return null
+  if (step.source === 'cloud') return { action: 'offload', step, cursorKey }
+  if (step.kind === 'sidestep') return { action: 'sidestep', step, cursorKey }
+  const lands = step.to.x === cursor.x && step.to.y === cursor.y && step.to.z === cursor.z
+  return { action: lands ? 'hop' : 'hop-to-boundary', step, cursorKey }
+}
+
+/** The next action, read from the stores. Not a hook: for the keyboard. */
+export function nextAction(): NextActionView | null {
+  const s = useCyberspace.getState()
+  const cal = useCalibration.getState()
+  return nextActionFor(s.position, s.cursor, s.plane, cal.hopHeight, cal.sidestepHeight, s.cloud.limits)
+}
+
+/** The same, for a component. */
+export function useNextAction(): NextActionView | null {
+  const position = useCyberspace((s) => s.position)
+  const cursor = useCyberspace((s) => s.cursor)
+  const plane = useCyberspace((s) => s.plane)
+  const limits = useCyberspace((s) => s.cloud.limits)
+  const hopCeil = useCalibration((s) => s.hopHeight)
+  const sidestepCeil = useCalibration((s) => s.sidestepHeight)
+  return nextActionFor(position, cursor, plane, hopCeil, sidestepCeil, limits)
+}
+
+/** What the COMMIT button says for each next action. */
+export const ACTION_LABEL: Record<NextAction, string> = {
+  hop: 'COMMIT',
+  'hop-to-boundary': 'HOP TO BOUNDARY',
+  sidestep: 'SIDESTEP',
+  offload: 'OFFLOAD',
+  'too-far': 'TOO FAR',
 }
 
 /** The offer to show right now, or null. `hidden` is the caller's veto (a menu, a secret). */

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -13,7 +13,7 @@
 
 import { create } from 'zustand'
 import { useCalibration } from '../lib/calibration'
-import { localOnly, nextStep, planSummary, type Ceilings, type PlanStep } from '../lib/movePlan'
+import { localOnly, nextStep, routeFeasible, type Ceilings, type PlanStep } from '../lib/movePlan'
 import { offerVerdict, type OfferVerdict } from '../lib/offer'
 import type { Position } from '../lib/space'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
@@ -46,7 +46,7 @@ export interface OfferView {
 }
 
 const localFeasibleFor = (position: Position, cursor: Position, hop: number, sidestep: number): boolean =>
-  planSummary(position, cursor, localOnly(hop, sidestep), 20_000).infeasibleAt === null
+  routeFeasible(position, cursor, localOnly(hop, sidestep))
 
 const cursorKeyOf = (c: { x: bigint; y: bigint; z: bigint }, plane: number): string => `${c.x}:${c.y}:${c.z}:${plane}`
 
@@ -110,20 +110,17 @@ export function nextActionFor(position: Position, cursor: Position, plane: numbe
   if (position.x === cursor.x && position.y === cursor.y && position.z === cursor.z) return null
   const machineCeiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
   const cursorKey = cursorKeyOf(cursor, plane)
-  // Local first: when this machine can walk there, the next step is its own,
-  // however long the walk (the proof panel shows the length). HOSAKA enters
-  // only when no local way exists, which is when it is actually needed.
-  const local = localOnly(machineCeiling, sidestepCeil)
-  let ceilings: Ceilings = local
-  if (planSummary(position, cursor, local, 20_000).infeasibleAt !== null) {
-    ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0 }
-    if (planSummary(position, cursor, ceilings, 20_000).infeasibleAt !== null) {
-      // Nobody known can: too far. Unless HOSAKA has not said what it can yet.
-      return { action: limits === null ? 'offload' : 'too-far', step: null, cursorKey }
-    }
-  }
+  // Local first, per step (lib/movePlan.ts): the next step is this machine's
+  // whenever it has one, however long the walk (the proof panel shows the
+  // length). HOSAKA enters only at a boundary this machine cannot cross,
+  // which is when it is actually needed. A cursor no one reaches is TOO FAR
+  // as soon as HOSAKA's caps are known; until they are, the walk goes on and
+  // OFFLOAD at the boundary asks.
+  const ceilings: Ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0 }
+  if (limits !== null && !routeFeasible(position, cursor, ceilings)) return { action: 'too-far', step: null, cursorKey }
   const step = nextStep(position, cursor, ceilings)
   if (!step) return null
+  if (step.source === 'infeasible') return { action: 'offload', step: null, cursorKey }
   if (step.source === 'cloud') return { action: 'offload', step, cursorKey }
   if (step.kind === 'sidestep') return { action: 'sidestep', step, cursorKey }
   const lands = step.to.x === cursor.x && step.to.y === cursor.y && step.to.z === cursor.z

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -72,9 +72,15 @@ export function useOfferNeed(): OfferView | null {
   return verdict ? { verdict, cursorKey: cursorKeyOf(cursor, plane), machineCeiling } : null
 }
 
-/** The move needs HOSAKA (or may, until its caps are known) and the cloud is not OFF: COMMIT reads OFFLOAD. */
+/**
+ * This machine cannot do the move and the cloud is not OFF: COMMIT reads
+ * OFFLOAD. Every tier but "machine" counts, the impossible one included: the
+ * card is where that verdict is explained (beyond HOSAKA too, line up a
+ * nearer cursor), and a button that flipped back to COMMIT as the cursor
+ * went further read as the cloud no longer being needed.
+ */
 export function offloadWanted(need: OfferView | null, mode: CloudMode): boolean {
-  return need !== null && mode !== 'off' && (need.verdict.tier === 'cloud' || need.verdict.tier === 'cloud-unknown')
+  return need !== null && mode !== 'off'
 }
 
 /** The offer to show right now, or null. `hidden` is the caller's veto (a menu, a secret). */

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -14,7 +14,9 @@
 import { create } from 'zustand'
 import { useCalibration } from '../lib/calibration'
 import type { CloudMode } from '../lib/cloud'
+import { localOnly, planSummary } from '../lib/movePlan'
 import { offerVerdict, type OfferVerdict } from '../lib/offer'
+import type { Position } from '../lib/space'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
 
 interface OfferState {
@@ -36,7 +38,16 @@ export interface OfferView {
   verdict: OfferVerdict
   cursorKey: string
   machineCeiling: number
+  /**
+   * This machine can walk it without the cloud: hops to each wall and a
+   * Merkle sidestep through it. False only when some wall is taller than the
+   * machine's sidestep ceiling, which is the one case nothing local crosses.
+   */
+  localFeasible: boolean
 }
+
+const localFeasibleFor = (position: Position, cursor: Position, hop: number, sidestep: number): boolean =>
+  planSummary(position, cursor, localOnly(hop, sidestep), 20_000).infeasibleAt === null
 
 const cursorKeyOf = (c: { x: bigint; y: bigint; z: bigint }, plane: number): string => `${c.x}:${c.y}:${c.z}:${plane}`
 
@@ -51,7 +62,7 @@ export function offerNeed(): OfferView | null {
     cloudHop: s.cloud.limits?.max_hop_height ?? 0,
     cloudSidestep: s.cloud.limits?.max_sidestep_height ?? 0,
   }, s.cloud.limits !== null)
-  return verdict ? { verdict, cursorKey: cursorKeyOf(s.cursor, s.plane), machineCeiling } : null
+  return verdict ? { verdict, cursorKey: cursorKeyOf(s.cursor, s.plane), machineCeiling, localFeasible: localFeasibleFor(s.position, s.cursor, machineCeiling, cal.sidestepHeight) } : null
 }
 
 /** The same, for a component: recomputed as the cursor, the caps or the ceilings change. */
@@ -69,18 +80,20 @@ export function useOfferNeed(): OfferView | null {
     cloudHop: limits?.max_hop_height ?? 0,
     cloudSidestep: limits?.max_sidestep_height ?? 0,
   }, limits !== null)
-  return verdict ? { verdict, cursorKey: cursorKeyOf(cursor, plane), machineCeiling } : null
+  return verdict ? { verdict, cursorKey: cursorKeyOf(cursor, plane), machineCeiling, localFeasible: localFeasibleFor(position, cursor, machineCeiling, sidestepCeil) } : null
 }
 
 /**
- * This machine cannot do the move and the cloud is not OFF: COMMIT reads
- * OFFLOAD. Every tier but "machine" counts, the impossible one included: the
- * card is where that verdict is explained (beyond HOSAKA too, line up a
- * nearer cursor), and a button that flipped back to COMMIT as the cursor
- * went further read as the cloud no longer being needed.
+ * COMMIT reads OFFLOAD only when HOSAKA is actually needed: some wall on the
+ * way is taller than this machine's sidestep ceiling, so no local walk
+ * crosses it. A wall above the hop ceiling alone is not that: the machine
+ * hops to it, sidesteps through, and hops on, in more steps and more time,
+ * which the proof panel's preview shows. Whether the cloud is ON, ASK or OFF
+ * does not change what is needed, so the mode is not consulted here; the
+ * card's own mode control turns it on.
  */
-export function offloadWanted(need: OfferView | null, mode: CloudMode): boolean {
-  return need !== null && mode !== 'off'
+export function offloadWanted(need: OfferView | null, _mode?: CloudMode): boolean {
+  return need !== null && !need.localFeasible
 }
 
 /** The offer to show right now, or null. `hidden` is the caller's veto (a menu, a secret). */
@@ -91,10 +104,11 @@ export function useOfferView(hidden: boolean): OfferView | null {
   const busy = useCyberspace((s) => (s.plan !== null && s.plan.status !== 'funding') || (s.plan === null && s.cloud.status !== 'idle') || s.proof.status === 'computing')
   const dismissedFor = useOffer((s) => s.dismissedFor)
   const requestedFor = useOffer((s) => s.requestedFor)
-  const mode = useCyberspace((s) => s.cloudPrefs.mode)
   const need = useOfferNeed()
 
-  if (hidden || !atHead || busy || mode === 'off' || need === null) return null
+  // The cloud mode is not a veto here: the card appears only when asked for,
+  // and its mode control is how the cloud is turned on when a move needs it.
+  if (hidden || !atHead || busy || need === null) return null
   if (dismissedFor === need.cursorKey) return null
   // Only for the cursor OFFLOAD was pressed for: a moved cursor puts it away.
   if (requestedFor !== need.cursorKey) return null

--- a/src/styles.css
+++ b/src/styles.css
@@ -2909,6 +2909,16 @@ kbd {
   font-weight: 700;
 }
 
+/* Nobody computes a boundary this high: the button says so and takes no press. */
+.touchops__commit.is-too-far,
+.touchops__commit.is-too-far:disabled {
+  color: var(--danger, #ff3b6b);
+  border-color: var(--danger, #ff3b6b);
+  background: rgba(255, 59, 107, 0.1);
+  opacity: 1;
+  cursor: not-allowed;
+}
+
 .touchops__cancel:active,
 .touchops__commit:active {
   transform: scale(0.95);


### PR DESCRIPTION
Targets v2 directly. #78 merged before its two follow-up fixes landed, so this PR carries them as its first two commits: OFFLOAD for every tier this machine cannot do (the impossible one included, which used to flip back to COMMIT), and OFFLOAD only when a local way does not exist (the needed-only rule).

**One step per commit.** A commit executes exactly one step of the way to the cursor and lands where it lands. The cursor stays, so the next commit names the next step. No route runs in the background any more; the whole path is shown (#79), never run.

**The button names the step:**
- **COMMIT**: this machine hops to the cursor.
- **HOP TO BOUNDARY**: the hop to the leaf touching a boundary this machine cannot hop across. The landing is computed for you; no gibson-precise cursor placement.
- **SIDESTEP**: one gibson through that boundary.
- **OFFLOAD** (blue): the step is HOSAKA's. Press opens the card; press again goes.
- **TOO FAR** (red, disabled): a boundary on the way is higher than anyone computes. Bring the cursor nearer or ride hyperspace.

Space follows the same rule.

**Local first.** When a local way exists, the step is this machine's, however long the walk. HOSAKA is used only when no local way exists, whatever the cloud mode (the card's mode control turns it on when needed). Consequence worth stating: a walkable move can no longer be handed to HOSAKA to save the steps; if you want that back, an "OFFLOAD INSTEAD" link in the walk notice is a small follow-up.

**Also:** the #72 long-walk refusal is removed with the walks it guarded; "wall" becomes "boundary" in the panels' text.

Tests rewritten for one step per commit (walk, pause and resume, mixed local and cloud way); the cloud fixture now says what it meant (sidestep ceiling 12, so the h13 move is genuinely the cloud's). 460 tests, tsc and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz

**Swept headlessly** on a machine benchmarked at hop 2^17 / sidestep 2^24 with HOSAKA's caps 27 / 29 known, the cursor placed across each boundary height:

| boundary | button |
|---|---|
| h10, h17 | COMMIT |
| h18 to h24 | HOP TO BOUNDARY |
| h25 to h29 | OFFLOAD |
| h30 and up | TOO FAR |