### PR TITLE
HOSAKA marks: panel sign at the head, pulse on the button's axis, job-complete chip

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { DeploymentDetail } from './hud/DeploymentDetail'
 import { SecretModal } from './hud/SecretModal'
 import { FocusBar } from './hud/FocusBar'
 import { KeyFoundChip } from './hud/KeyFoundChip'
+import { ToastChip } from './hud/ToastChip'
 import { LootDetail } from './hud/LootDetail'
 import { CloudApproval, CreditedModal, InvoiceModal, PaidModal } from './hud/InvoiceModal'
 import { HosakaOffer } from './hud/HosakaOffer'
@@ -150,6 +151,7 @@ export default function App(): JSX.Element {
           <HyperspaceBar />
           <FocusBar />
           <KeyFoundChip />
+          <ToastChip />
           <ChainExplorer />
           <BitReadout />
         </div>
@@ -176,7 +178,8 @@ export default function App(): JSX.Element {
       <SecretModal />
       <LootDetail />
       <HosakaOffer hidden={crowded || secretOpen} />
-      <HosakaPulse />
+      {/* While the panels are open the job is on screen in Cloud compute; the pulse is for when it is not. */}
+      {!showPanels && <HosakaPulse />}
       <CloudApproval />
       <InvoiceModal />
       <PaidModal />

--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -85,6 +85,11 @@ export function CloudPanel(): JSX.Element {
         <span className={`tag tag--cloud ${cloud.status === 'error' ? 'tag--danger' : active ? 'tag--live' : ''}`}>{tag}</span>
       </header>
 
+      {/* The provider's mark, first thing under the title: this is the panel
+          whose work happens on someone else's machine. HOSAKA's for now; the
+          plan is for the connected provider to serve its own (hosaka-api #6). */}
+      <img className="cloud__mark" src="/hosaka-mark.png" alt="HOSAKA" width={308} height={334} decoding="async" />
+
       <div className="cloud__modes" role="radiogroup" aria-label="Cloud mode">
         {MODES.map(([mode, label]) => (
           <button
@@ -248,11 +253,6 @@ export function CloudPanel(): JSX.Element {
           learns the cantor root of every region it computes for you.
         </p>
       </Explanation>
-
-      {/* The HOSAKA mark as a watermark, the pulse mark's size, so this panel is
-          not one more panel: it is the one whose work happens on someone else's
-          machine. */}
-      <img className="cloud__watermark" src="/hosaka-mark.png" alt="" aria-hidden="true" width={308} height={334} decoding="async" />
     </section>
   )
 }

--- a/src/hud/HosakaPulse.tsx
+++ b/src/hud/HosakaPulse.tsx
@@ -1,8 +1,9 @@
 /**
  * HosakaPulse.tsx: the HOSAKA mark, breathing just above the menu button
- * while a job is under way, the width of that button. The job itself lives in the Cloud compute panel, which
- * on a phone is behind the menu; this is the one sign on the scene that
- * something is being computed for you elsewhere.
+ * while a job is under way, the width of that button and on its axis. The
+ * job itself lives in the Cloud compute panel, so App mounts this only while
+ * the panels are closed: it is the one sign on the scene that something is
+ * being computed for you elsewhere.
  */
 
 import { jobInProgress } from '../lib/cloud'

--- a/src/hud/ToastChip.tsx
+++ b/src/hud/ToastChip.tsx
@@ -1,0 +1,30 @@
+/**
+ * ToastChip.tsx - the chip for a cloud job that just finished, in the
+ * instrument stack next to KEY FOUND: the provider's mark, the job, thanks.
+ * Its clock starts when it is on screen, so a job finishing behind the menu
+ * is still announced when the scene comes back. Tap to dismiss.
+ */
+
+import { useEffect } from 'react'
+import { TOAST_MS, useToast } from '../store/useToast'
+
+export function ToastChip(): JSX.Element | null {
+  const toast = useToast((s) => s.toast)
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = window.setTimeout(() => useToast.getState().dismiss(), TOAST_MS)
+    return () => window.clearTimeout(timer)
+  }, [toast])
+
+  if (!toast) return null
+  return (
+    <div className="hyperbar hyperbar--found hyperbar--toast" role="status" onClick={() => useToast.getState().dismiss()}>
+      <img className="hyperbar__mark" src="/hosaka-mark.png" alt="HOSAKA" width={308} height={334} decoding="async" />
+      <span className="hyperbar__text">
+        <span className="hyperbar__label">{toast.label}</span>
+        <span className="hyperbar__meta">{toast.meta}</span>
+      </span>
+    </div>
+  )
+}

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -53,6 +53,7 @@ import { HosakaError, type HosakaDeposit, type HosakaJob, type HosakaLimits } fr
 import type { Position } from '../lib/space'
 import { postProof } from '../lib/workers'
 import { useCyberspace } from './useCyberspace'
+import { useToast } from './useToast'
 
 const LIMITS: HosakaLimits = { max_hop_height: 25, max_sidestep_height: 29, hop_min_msats: 1000, deposit_min_msats: 1000, deposit_max_msats: 5e9, invoice_ttl_seconds: 3600 }
 
@@ -151,6 +152,8 @@ describe('cloud routes', () => {
     expect(s.plan).toBeNull()
     expect(s.events).toHaveLength(before + 1)
     expect(s.position).toEqual(to)
+    expect(useToast.getState().toast?.label).toMatch(/^CLOUD COMPUTE JOB COMPLETE - [0-9a-z-]{1,8}$/)
+    expect(useToast.getState().toast?.meta).toBe('Thanks for using HOSAKA!')
     expect(s.proof.status).toBe('done')
     expect(s.proof.source).toBe('cloud')
     expect(s.proof.costMsats).toBe(1000)

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -121,6 +121,7 @@ import {
 import { nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
+import { useToast } from './useToast'
 
 /**
  * The explored chain, parsed once per events change rather than on every
@@ -1268,6 +1269,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       set({ cloud: { ...get().cloud, status: 'error', message: `${get().plan?.message ?? get().proof.message ?? 'Signing failed.'} The verified cloud result is kept.` } })
       return
     }
+    useToast.getState().show({ label: `CLOUD COMPUTE JOB COMPLETE - ${final.jobId.slice(0, 8)}`, meta: 'Thanks for using HOSAKA!', mark: 'hosaka' })
     // The event landed, and a route may already have moved on to its next
     // step (which bumps the request id): the bookkeeping below is about the
     // step that landed, so it runs regardless.

--- a/src/store/useToast.ts
+++ b/src/store/useToast.ts
@@ -1,0 +1,34 @@
+/**
+ * useToast.ts - one chip in the instrument stack for something that just
+ * finished elsewhere, the way KEY FOUND announces a find: a cloud job done.
+ * One at a time; a new one replaces the last.
+ */
+
+import { create } from 'zustand'
+
+export interface Toast {
+  id: string
+  label: string
+  meta: string
+  /** Whose mark stands as the chip's glyph. */
+  mark: 'hosaka'
+  at: number
+}
+
+interface ToastState {
+  toast: Toast | null
+  show: (toast: Omit<Toast, 'id' | 'at'>) => void
+  dismiss: () => void
+}
+
+/** How long the chip stays up once it is on screen. */
+export const TOAST_MS = 10_000
+
+export const useToast = create<ToastState>((set) => ({
+  toast: null,
+  show: (toast) => {
+    const now = Date.now()
+    set({ toast: { ...toast, id: `${now}`, at: now } })
+  },
+  dismiss: () => set({ toast: null }),
+}))

--- a/src/styles.css
+++ b/src/styles.css
@@ -4052,6 +4052,17 @@ kbd {
 .hyperbar--found .hyperbar__label {
   color: var(--accent);
 }
+/* A chip for a cloud job that just finished: the found chip's pill, with the
+ * provider's mark where the glyph goes. */
+.hyperbar__mark {
+  flex: none;
+  width: 20px;
+  height: auto;
+}
+.hyperbar--toast .hyperbar__label {
+  color: var(--accent);
+}
+
 .foundchip__decode {
   margin-left: auto;
   max-width: 46ch;
@@ -4395,28 +4406,18 @@ kbd {
   font-size: 8px;
 }
 
-/* The HOSAKA mark inline in the Cloud compute panel's title. Taller than
-   the 10px type so it can be read; the negative vertical margins keep the
-   header the height every other panel's is. */
-/* The HOSAKA mark as a watermark in the panel's corner: the pulse mark's
- * width, steady, so the panel is signed rather than decorated. */
-.panel--cloud {
-  position: relative;
-}
-
-.cloud__watermark {
-  position: absolute;
-  right: 10px;
-  bottom: 10px;
-  width: 56px;
+/* The provider's mark at the head of the Cloud compute panel, centered,
+ * a little larger than the pulse so it reads as the panel's sign. */
+.cloud__mark {
+  display: block;
+  width: 72px;
   height: auto;
-  opacity: 0.9;
-  pointer-events: none;
+  margin: 2px auto 12px;
 }
 
 @media (min-width: 1101px) {
-  .cloud__watermark {
-    width: 46px;
+  .cloud__mark {
+    width: 64px;
   }
 }
 
@@ -4428,10 +4429,11 @@ kbd {
  * left edge, as it does the stack and the button. */
 .hosaka-pulse {
   position: fixed;
-  left: 8px;
+  left: 12px; /* the menu button's left, so the two share one axis */
   bottom: 78px; /* the button's 12px + 56px, and a 10px gap */
   width: 56px; /* the menu button's width, so the two read as one column */
   height: auto;
+  object-fit: contain;
   z-index: 150;
   pointer-events: none;
   opacity: 0.1;


### PR DESCRIPTION
Three HUD notes from testing, off v2 (independent of #80/#81).

- **Cloud compute panel**: the HOSAKA mark is the first element under the title, centered, 72px (64px desktop), and the corner watermark is gone, so a running job's rows are never under it. The mark's place is fixed now; the mark itself is to come from the connected provider later: hosaka-api #6 proposes a provider-info endpoint (logo, pricing, services, payments) as the standard for how compute providers talk to ONOSENDAI and other cyberspace clients.
- **Breathing pulse**: it sat at the instrument stack's 8px left while the menu button is at 12px, so it was 4px off the button's axis on a phone; now it shares the button's left and width, and it is not mounted while the panels are open, since the job is then on screen in Cloud compute.
- **Job complete**: a chip in the instrument stack next to KEY FOUND, with the HOSAKA mark as its glyph: `CLOUD COMPUTE JOB COMPLETE - <first 8 of the job id>` over `Thanks for using HOSAKA!`. Ten seconds once on screen, tap to dismiss. Covered by the cloud route test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz