### PR TITLE
Covering box: dispose the outline and fill each cursor step replaces

### DIFF
--- a/src/scene/CoveringBox.tsx
+++ b/src/scene/CoveringBox.tsx
@@ -156,6 +156,13 @@ export function CoveringBox({ axes }: Props): JSX.Element | null {
     }
   }, [position, anchor, target, scaleExp, plane, axes, atHead])
 
+  // Every cursor step builds a fresh outline and fill, and a geometry the
+  // renderer has drawn once stays in its cache, buffers and all, until it is
+  // disposed: sixty steps left a hundred and twenty of them behind, and a
+  // session's worth of steering left thousands. The walls below already do
+  // this; the box itself did not.
+  useEffect(() => () => { if (box) { box.geometry.dispose(); box.fill.dispose() } }, [box])
+
   // The HUD's zoom-out key echoes the clipped state (see useUiHints). Keyed on
   // the boolean so it is written only when the state actually flips, never per
   // frame and never per cursor step; the store guards once more on its side.


### PR DESCRIPTION
The geometry count lead from the memory log. A headless probe on v2 showed the renderer's geometry count climbing by two per cursor step with the scene holding no more objects: sixty steps added 127 geometries, 115 of them orphans. Hops, panel toggles and idle added nothing.

The covering box rebuilds its outline and fill on every cursor step and dropped the previous pair without disposing them; a geometry the renderer has drawn once stays in its cache, GL buffers and all, until dispose() is called. The breathing walls already disposed theirs. One cleanup effect, same pattern as the walls and the path trail.

After the fix the same probe reports zero orphans across the same steps. The heap sawtooth itself was the route walk fixed in #80; this is the slower, permanent part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz