### PR TITLE
World shards: faces tagged out of the bloom, the bloom itself untouched

### DIFF
--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -23,6 +23,7 @@
 import { Canvas, useThree } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
+import type { BloomEffect } from 'postprocessing'
 import { useEffect, useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Vector3 } from 'three'
@@ -512,6 +513,42 @@ function ClockKeeper(): null {
   return null
 }
 
+/** The luminance line the bloom ships with, and the same line blind to tagged texels. */
+const LUMINANCE_LINE = 'float l=luminance(texel.rgb);'
+const LUMINANCE_TAG_AWARE = 'float l=luminance(texel.rgb)*step(0.0005,texel.a);'
+
+/**
+ * The bloom, blind to the world's shard faces.
+ *
+ * Those faces write their colour with alpha 0 (ShardMesh `world`), a tag
+ * nothing else in the frame carries: everything visible writes alpha above
+ * zero, and the untouched background is black. The bloom's luminance pass,
+ * patched here, treats a tagged texel as dark, so the faces draw at their
+ * own colours, as on the bench, while every line, ring, label and point
+ * field blooms exactly as it always has: same numbers, same passes, no depth
+ * texture, nothing drawn twice. The canvas composites premultiplied, which is
+ * how the bloom's own halos already show over alpha-0 background, so a
+ * tagged texel shows its colour too.
+ */
+function WorldBloom(): JSX.Element {
+  // The wrapper types its ref as the class; what it holds is the instance.
+  const ref = useRef<typeof BloomEffect>(null)
+  // After every render, not once: the wrapper rebuilds its effect when a prop changes.
+  useEffect(() => {
+    const m = (ref.current as unknown as BloomEffect | null)?.luminanceMaterial
+    if (!m || m.userData.tagAware) return
+    if (!m.fragmentShader.includes(LUMINANCE_LINE)) {
+      console.warn('[bloom] the luminance shader is not the one expected; shard faces will bloom')
+      m.userData.tagAware = true
+      return
+    }
+    m.fragmentShader = m.fragmentShader.replace(LUMINANCE_LINE, LUMINANCE_TAG_AWARE)
+    m.userData.tagAware = true
+    m.needsUpdate = true
+  })
+  return <Bloom ref={ref} mipmapBlur levels={3} intensity={2.6} luminanceThreshold={0.001} luminanceSmoothing={0} />
+}
+
 export function Scene(): JSX.Element {
   // The workshop is an opaque, full-screen bench with its own canvas. Drawing
   // the world under it is pure cost, and on a phone it was most of the frame:
@@ -548,7 +585,7 @@ export function Scene(): JSX.Element {
         and is invisible because the effect is a blur to begin with.
       */}
       <EffectComposer resolutionScale={0.25}>
-        <Bloom mipmapBlur levels={3} intensity={2.6} luminanceThreshold={0.001} luminanceSmoothing={0} />
+        <WorldBloom />
       </EffectComposer>
     </Canvas>
   )

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -23,7 +23,7 @@
 import { Canvas, useThree } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
-import type { BloomEffect } from 'postprocessing'
+import { BlendFunction, Effect, type BloomEffect } from 'postprocessing'
 import { useEffect, useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Vector3 } from 'three'
@@ -513,6 +513,26 @@ function ClockKeeper(): null {
   return null
 }
 
+/**
+ * The last word on a tagged texel: alpha 1. The tag (colour with alpha 0)
+ * is valid inside the composer's buffers but not on the canvas, which
+ * composites premultiplied: a compositor is free to clamp colour to alpha,
+ * and one did, drawing the faces black except where a halo lent them some.
+ * Merged into the bloom's own pass by postprocessing, so it costs nothing.
+ * Only the tag is touched; every other texel leaves exactly as it came.
+ */
+const OPAQUE_TAGGED_FRAGMENT = `
+void mainImage(const in vec4 inputColor, const in vec2 uv, out vec4 outputColor) {
+  vec4 o = texture(inputBuffer, uv);
+  float tagged = step(o.a, 0.0) * step(0.0005, max(o.r, max(o.g, o.b)));
+  outputColor = vec4(inputColor.rgb, max(inputColor.a, tagged));
+}`
+class OpaqueTaggedEffect extends Effect {
+  constructor() {
+    super('OpaqueTagged', OPAQUE_TAGGED_FRAGMENT, { blendFunction: BlendFunction.SET })
+  }
+}
+
 /** The luminance line the bloom ships with, and the same line blind to tagged texels. */
 const LUMINANCE_LINE = 'float l=luminance(texel.rgb);'
 const LUMINANCE_TAG_AWARE = 'float l=luminance(texel.rgb)*step(0.0005,texel.a);'
@@ -546,7 +566,13 @@ function WorldBloom(): JSX.Element {
     m.userData.tagAware = true
     m.needsUpdate = true
   })
-  return <Bloom ref={ref} mipmapBlur levels={3} intensity={2.6} luminanceThreshold={0.001} luminanceSmoothing={0} />
+  const opaque = useMemo(() => new OpaqueTaggedEffect(), [])
+  return (
+    <>
+      <Bloom ref={ref} mipmapBlur levels={3} intensity={2.6} luminanceThreshold={0.001} luminanceSmoothing={0} />
+      <primitive object={opaque} />
+    </>
+  )
 }
 
 export function Scene(): JSX.Element {

--- a/src/scene/ShardGhost.tsx
+++ b/src/scene/ShardGhost.tsx
@@ -64,7 +64,7 @@ export function ShardGhost({ axes }: Props): JSX.Element | null {
 
   return (
     <group ref={group}>
-      <ShardMesh shard={shard} scale={scale} ghost world />
+      <ShardMesh shard={shard} scale={scale} ghost />
     </group>
   )
 }

--- a/src/scene/ShardGhost.tsx
+++ b/src/scene/ShardGhost.tsx
@@ -64,7 +64,7 @@ export function ShardGhost({ axes }: Props): JSX.Element | null {
 
   return (
     <group ref={group}>
-      <ShardMesh shard={shard} scale={scale} ghost />
+      <ShardMesh shard={shard} scale={scale} ghost world />
     </group>
   )
 }

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useRef } from 'react'
 import { useFrame, type ThreeEvent } from '@react-three/fiber'
 import {
   AdditiveBlending,
+  NormalBlending,
   BufferGeometry,
   DoubleSide,
   Float32BufferAttribute,
@@ -30,6 +31,15 @@ interface Props {
   scale?: number
   /** Dimmed, for a preview that is not yet real. */
   ghost?: boolean
+  /**
+   * Drawn in the world, under its bloom. The bloom adds a blurred copy of
+   * everything lit, several times over for a filled face, so a face drawn at
+   * its own colour came out white with a tint. At WORLD_FACE of the colour the
+   * bloom's addition lands near the colour itself: the shard glows, and it is
+   * still red or green. Points lose the additive blend for the same reason.
+   * The bench has no bloom and draws everything at full strength.
+   */
+  world?: boolean
   /** performance.now() when this client opened the shard; runs the decode. */
   birth?: number
   /** A tap on a SOLID face (its index is `e.faceIndex`); the workshop's FACE tool. */
@@ -38,7 +48,12 @@ interface Props {
 
 const STATIC = [0, 0.9, 1] as const
 
-export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick }: Props): JSX.Element | null {
+/** Face brightness under the world's bloom (a multiplier on the vertex colours). */
+const WORLD_FACE = '#2e2e2e'
+/** Point brightness under the world's bloom. */
+const WORLD_POINT = '#808080'
+
+export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick, world = false }: Props): JSX.Element | null {
   const { positions, colors, index } = useMemo(() => flatten(shard), [shard.vertices, shard.faces])
 
   // Live copies: the decode writes into these, the targets stay untouched.
@@ -122,7 +137,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick 
     <group scale={scale}>
       {shard.mode === 'solid' && index.length > 0 && (
         <mesh geometry={indexed} frustumCulled={false} {...(onFaceClick ? { onClick: onFaceClick } : {})}>
-          <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} />
+          <meshBasicMaterial vertexColors color={world ? WORLD_FACE : '#ffffff'} side={DoubleSide} toneMapped={false} transparent opacity={opacity} />
         </mesh>
       )}
       {shard.mode === 'lines' && shard.vertices.length > 1 && <primitive object={line} />}
@@ -134,7 +149,8 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick 
             sizeAttenuation
             transparent
             opacity={shard.mode === 'points' ? opacity : opacity * 0.9}
-            blending={AdditiveBlending}
+            color={world ? WORLD_POINT : '#ffffff'}
+            blending={world ? NormalBlending : AdditiveBlending}
             depthWrite={false}
             toneMapped={false}
           />

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -14,8 +14,11 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { useFrame, type ThreeEvent } from '@react-three/fiber'
 import {
+  AddEquation,
   AdditiveBlending,
-  NormalBlending,
+  CustomBlending,
+  OneFactor,
+  ZeroFactor,
   BufferGeometry,
   DoubleSide,
   Float32BufferAttribute,
@@ -33,11 +36,12 @@ interface Props {
   ghost?: boolean
   /**
    * Drawn in the world, under its bloom. The bloom adds a blurred copy of
-   * everything lit, several times over for a filled face, so a face drawn at
-   * its own colour came out white with a tint. At WORLD_FACE of the colour the
-   * bloom's addition lands near the colour itself: the shard glows, and it is
-   * still red or green. Points lose the additive blend for the same reason.
-   * The bench has no bloom and draws everything at full strength.
+   * everything lit back onto the frame, and across a filled face that is
+   * several times the face's own colour, so faces came out white with a
+   * tint. Out there the faces write their colour with alpha 0, a tag the
+   * scene's bloom is blind to (Scene.tsx WorldBloom), so they draw at their
+   * own colours, as on the bench; points and lines are untagged and glow as
+   * they always did. Not for a ghost, whose translucency needs real alpha.
    */
   world?: boolean
   /** performance.now() when this client opened the shard; runs the decode. */
@@ -48,10 +52,11 @@ interface Props {
 
 const STATIC = [0, 0.9, 1] as const
 
-/** Face brightness under the world's bloom (a multiplier on the vertex colours). */
-const WORLD_FACE = '#2e2e2e'
-/** Point brightness under the world's bloom. */
-const WORLD_POINT = '#808080'
+/**
+ * Colour written opaque, alpha written as 0: the tag. (Blending needs the
+ * material transparent, which the face already is for its opacity.)
+ */
+const TAG_BLEND = { blending: CustomBlending, blendEquation: AddEquation, blendSrc: OneFactor, blendDst: ZeroFactor, blendSrcAlpha: ZeroFactor, blendDstAlpha: ZeroFactor } as const
 
 export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick, world = false }: Props): JSX.Element | null {
   const { positions, colors, index } = useMemo(() => flatten(shard), [shard.vertices, shard.faces])
@@ -137,7 +142,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
     <group scale={scale}>
       {shard.mode === 'solid' && index.length > 0 && (
         <mesh geometry={indexed} frustumCulled={false} {...(onFaceClick ? { onClick: onFaceClick } : {})}>
-          <meshBasicMaterial vertexColors color={world ? WORLD_FACE : '#ffffff'} side={DoubleSide} toneMapped={false} transparent opacity={opacity} />
+          <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} {...(world && !ghost ? TAG_BLEND : {})} />
         </mesh>
       )}
       {shard.mode === 'lines' && shard.vertices.length > 1 && <primitive object={line} />}
@@ -149,8 +154,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
             sizeAttenuation
             transparent
             opacity={shard.mode === 'points' ? opacity : opacity * 0.9}
-            color={world ? WORLD_POINT : '#ffffff'}
-            blending={world ? NormalBlending : AdditiveBlending}
+            blending={AdditiveBlending}
             depthWrite={false}
             toneMapped={false}
           />

--- a/src/scene/WorldShards.tsx
+++ b/src/scene/WorldShards.tsx
@@ -67,7 +67,7 @@ export function WorldShards({ axes }: Props): JSX.Element | null {
         }
         return (
           <group key={w.key} position={w.centre}>
-            <ShardMesh shard={w.shard} scale={w.scale} birth={births[w.key]} />
+            <ShardMesh shard={w.shard} scale={w.scale} birth={births[w.key]} world />
             {/* An invisible, generous tap target: shards can be a few pixels. */}
             <mesh onClick={open}>
               <sphereGeometry args={[hit, 8, 8]} />


### PR DESCRIPTION
Deployed shards washed out to white because the scene's bloom adds a blurred copy of everything lit back onto the frame, and across a filled face that is several times the face's own colour. Scaling the colour down does not work: how much the bloom adds depends on the GPU and on the face's size on screen, so 18 percent read as grey on your machine and near white on my headless one. The faces have to be invisible to the bloom.

- World shard faces write their colour opaque and their alpha as 0, a tag nothing else in the frame carries (everything visible writes alpha above zero, the untouched background is black).
- The bloom's luminance pass is patched to treat a tagged texel as dark. The bloom's numbers, passes and look are otherwise exactly what they were: every line, ring, label and point field glows as before.
- A last effect, merged into the bloom's own pass, gives exactly the tagged texels alpha 1 before they reach the canvas. Without it a compositor may clamp colour to alpha and draw the faces black (the blobs in shard3). Every other texel leaves as it came.
- No depth texture, nothing drawn twice. A selective bloom was tried first and dropped: its depth mask fights the composer's multisampling (a GL error every frame) and the faces still bloomed.
- Vertex points still glow, lines mode still glows, the bench is untouched, and the deploy ghost keeps its translucent bloomed look.

Verified under the real pass with two identical pastel faces, one tagged and one not, over a loud page background: the tagged one is exact and opaque, the untagged one white with a halo. Please eyeball a deployed shard on the preview against the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz