### PR TITLE
OFFLOAD for any HOSAKA step on the way, and the route live above the controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useDiscovery } from './hooks/useDiscovery'
 import { Hud } from './hud/Hud'
 import { Targets } from './hud/Targets'
 import { TouchControls } from './hud/TouchControls'
+import { RouteOverlay } from './hud/RouteOverlay'
 import { ViewMenu } from './hud/ViewMenu'
 import { Compass3D } from './scene/Compass3D'
 import { Scene } from './scene/Scene'
@@ -161,6 +162,7 @@ export default function App(): JSX.Element {
       {!crowded && !offerUp && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
       {!crowded && !offerUp && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && !offerUp && <TouchControls />}
+      {showPad && !offerUp && <RouteOverlay />}
       {/* Off-head too: tapping a block hides the pad like any scene tap, and
           without this there was no way to bring it back while viewing. */}
       {!crowded && !padOpen && !offerUp && (

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -8,15 +8,13 @@
  * the real computation.
  */
 
-import { useMemo } from 'react'
 import { CloudUpload, Footprints, OctagonAlert } from 'lucide-react'
 import { Explanation } from './Explanation'
-import { estimateHopCost } from 'cyberspace-core'
 import { useCalibration } from '../lib/calibration'
 import { satsOf } from '../lib/cloud'
-import { buildMovePlan, localOnly, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
+import { previewWindow, routeLabel, useRoutePreview } from './routePreview'
 import { formatMs, formatOps } from '../lib/space'
-import { MAX_COMPUTE_HEIGHT, samePosition, useCyberspace, type CloudState, type MovePlan } from '../store/useCyberspace'
+import { MAX_COMPUTE_HEIGHT, useCyberspace, type CloudState, type MovePlan } from '../store/useCyberspace'
 
 function StatusLabel({ status }: { status: string }): JSX.Element {
   const label: Record<string, string> = {
@@ -44,56 +42,25 @@ function StatusLabel({ status }: { status: string }): JSX.Element {
 
 export function ProofPanel(): JSX.Element {
   const proof = useCyberspace((s) => s.proof)
-  const position = useCyberspace((s) => s.position)
-  const cursor = useCyberspace((s) => s.cursor)
-  const plane = useCyberspace((s) => s.plane)
   // What calibration measured this machine finishing in budget: conservative
   // defaults until the quiet benchmark lands, then the line updates in place.
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
+  // This machine's hop ceiling as the commit attempts it: the protocol cap,
+  // lowered to what calibration measured (the preview hook uses the same).
+  const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
 
   const plan = useCyberspace((s) => s.plan)
   const cloud = useCyberspace((s) => s.cloud)
   const resumePlan = useCyberspace((s) => s.resumePlan)
   const cancelPlan = useCyberspace((s) => s.cancelPlan)
-  // What a commit would plan with right now: this machine's calibrated
-  // ceilings, and HOSAKA's caps when the cloud is on and has answered. The
-  // same numbers the store uses.
-  const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
   // HOSAKA's caps whatever the cloud mode: what a move needs does not depend
   // on a setting, and the button (useOffer) reads it the same way.
   const cloudOn = cloud.limits !== null
-  const ceilings: Ceilings = useMemo(() => ({
-    hop: ceiling,
-    sidestep: sidestepCeil,
-    cloudHop: cloud.limits?.max_hop_height ?? 0,
-    cloudSidestep: cloud.limits?.max_sidestep_height ?? 0,
-  }), [ceiling, sidestepCeil, cloud.limits])
 
-  // Live preview of the action the cursor is lining up. The hop estimate is
-  // closed-form; the route summary walks the route's steps without keeping
-  // them, cheap for anything a person would line up.
-  const preview = useMemo(() => {
-    if (samePosition(position, cursor)) return null
-    const hop = estimateHopCost(
-      position.x, position.y, position.z,
-      cursor.x, cursor.y, cursor.z,
-      plane,
-      ceiling,
-    )
-    if (!hop.exceedsLimit) return { hop, route: null as PlanSummary | null, steps: null as PlanStep[] | null, needsCloud: false }
-    // Local first, as the commit and the button are: when this machine can
-    // walk there, that is the way shown, however long. HOSAKA's caps enter
-    // only when no local way exists, which is when the cloud is needed.
-    const local = localOnly(ceiling, sidestepCeil)
-    const way = planSummary(position, cursor, local, 20_000).infeasibleAt === null ? local : ceilings
-    // The steps themselves, for the list the running route shows, so a route
-    // reads the same before COMMIT as after. A walk longer than the list
-    // could show is summarised only.
-    let steps: PlanStep[] | null = null
-    try { steps = buildMovePlan(position, cursor, way, PREVIEW_STEPS_MAX) } catch { steps = null }
-    return { hop, route: planSummary(position, cursor, way, 20_000), steps, needsCloud: way !== local }
-  }, [position, cursor, plane, ceiling, sidestepCeil, ceilings])
+  // Live preview of the action the cursor is lining up: the same data the
+  // route overlay above the controls shows (routePreview.ts).
+  const preview = useRoutePreview()
 
   const previewing = preview !== null && proof.status !== 'computing' && plan === null
   const status =
@@ -271,54 +238,6 @@ export function ProofPanel(): JSX.Element {
       </Explanation>
     </section>
   )
-}
-
-/** The preview lists this many steps at most; beyond it, the first and last few with a gap. */
-const PREVIEW_STEPS_MAX = 2_000
-const PREVIEW_HEAD = 6
-const PREVIEW_TAIL = 3
-
-interface PreviewRow { index: number; kind: string; height: string; state: string; label: string }
-
-function previewRow(step: PlanStep, index: number): PreviewRow {
-  return {
-    index,
-    kind: `${step.source === 'cloud' ? 'CLOUD ' : ''}${step.kind === 'sidestep' ? 'SIDESTEP' : 'HOP'}`,
-    height: `2^${step.maxHeight}`,
-    state: step.source === 'cloud' ? 'funding' : step.source === 'infeasible' ? 'failed' : 'next',
-    label: step.source === 'cloud' ? 'HOSAKA' : step.source === 'infeasible' ? 'beyond reach' : 'this machine',
-  }
-}
-
-/**
- * Every step when the route is short. When it is not, the first and last few
- * with the count of the rest between them (a number is a gap), and the step
- * nobody can do always shown, however deep in the walk it sits: the notice
- * names it, so the list must too.
- */
-function previewWindow(steps: PlanStep[]): Array<PreviewRow | number> {
-  if (steps.length <= PREVIEW_HEAD + PREVIEW_TAIL + 1) return steps.map(previewRow)
-  const keep = new Set<number>()
-  for (let i = 0; i < PREVIEW_HEAD; i++) keep.add(i)
-  for (let i = steps.length - PREVIEW_TAIL; i < steps.length; i++) keep.add(i)
-  const blocked = steps.findIndex((s) => s.source === 'infeasible')
-  if (blocked >= 0) keep.add(blocked)
-  const out: Array<PreviewRow | number> = []
-  let skipped = 0
-  steps.forEach((s, i) => {
-    if (keep.has(i)) {
-      if (skipped) { out.push(skipped); skipped = 0 }
-      out.push(previewRow(s, i))
-    } else skipped++
-  })
-  return out
-}
-
-function routeLabel(r: PlanSummary): string {
-  const more = r.capped ? '+' : ''
-  const hops = `${r.hops}${more} hop${r.hops === 1 ? '' : 's'}`
-  const sides = `${r.sidesteps}${more} sidestep${r.sidesteps === 1 ? '' : 's'}`
-  return `${hops}, ${sides}`
 }
 
 const CLOUD_STAGE: Record<string, string> = {

--- a/src/hud/RouteOverlay.tsx
+++ b/src/hud/RouteOverlay.tsx
@@ -1,0 +1,57 @@
+/**
+ * RouteOverlay.tsx - the route the cursor lines up, live, above the controls.
+ *
+ * The Movement proof panel lists the steps of the way to the cursor; on a
+ * phone that panel is behind the menu, and on any screen the cursor moves
+ * while it is read. This is the same list (routePreview.ts), compact, pinned
+ * above the pad, changing as the cursor does: what the COMMIT button will do
+ * first, and everything after it. Informational only: taps pass through.
+ */
+
+import { useCyberspace } from '../store/useCyberspace'
+import { previewWindow, routeLabel, useRoutePreview } from './routePreview'
+
+const HEAD = 4
+const TAIL = 2
+
+export function RouteOverlay(): JSX.Element | null {
+  const atHead = useCyberspace((s) => s.atHead())
+  const plan = useCyberspace((s) => s.plan)
+  const computing = useCyberspace((s) => s.proof.status === 'computing')
+  const preview = useRoutePreview()
+  if (!atHead || plan !== null || computing || preview === null) return null
+
+  const { hop, route, steps, needsCloud } = preview
+  const summary = route === null
+    ? 'ONE HOP'
+    : route.infeasibleAt !== null ? 'OUT OF REACH' : routeLabel(route).toUpperCase()
+  const rows = route === null
+    ? [{ index: 0, kind: 'HOP', height: `2^${hop.maxHeight}`, state: 'next', label: 'this machine' }]
+    : steps ? previewWindow(steps, HEAD, TAIL) : []
+
+  return (
+    <div className={`routeov ${needsCloud ? 'routeov--cloud' : ''} ${route?.infeasibleAt !== null && route !== null ? 'routeov--blocked' : ''}`} role="status" aria-live="off">
+      <div className="routeov__head">
+        <span className="routeov__title">ROUTE</span>
+        <span className="routeov__sum">{summary}{needsCloud ? ' · HOSAKA' : ''}</span>
+      </div>
+      {rows.length > 0 && (
+        <ul className="route route--preview route--overlay">
+          {rows.map((r, i) => typeof r === 'number' ? (
+            <li key={`gap-${i}`} className="route__step route__step--gap">
+              <span className="route__index">…</span>
+              <span className="route__kind">{`${r} more`}</span>
+            </li>
+          ) : (
+            <li key={r.index} className={`route__step route__step--${r.state}`}>
+              <span className="route__index">{r.index + 1}</span>
+              <span className="route__kind">{r.kind}</span>
+              <span className="route__height">{r.height}</span>
+              <span className="route__state">{r.label}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/hud/routePreview.ts
+++ b/src/hud/routePreview.ts
@@ -1,0 +1,110 @@
+/**
+ * routePreview.ts - the route the cursor lines up, as data the HUD can show
+ * live: the Movement proof panel and the route overlay above the controls
+ * read the same preview, so the two never disagree.
+ *
+ * The steps are built once per cursor position (buildMovePlan, capped) and
+ * the summary is read off them, so a cursor held on a key costs one walk of
+ * at most PREVIEW_STEPS_MAX steps per move; a walk longer than that is
+ * summarised with a "+" and its list shows the first and last few.
+ */
+
+import { useMemo } from 'react'
+import { estimateHopCost } from 'cyberspace-core'
+import { useCalibration } from '../lib/calibration'
+import { buildMovePlan, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
+import { MAX_COMPUTE_HEIGHT, samePosition, useCyberspace } from '../store/useCyberspace'
+
+/** The preview lists this many steps at most; beyond it, the first and last few with a gap. */
+export const PREVIEW_STEPS_MAX = 2_000
+const PREVIEW_HEAD = 6
+const PREVIEW_TAIL = 3
+
+export interface RoutePreview {
+  hop: ReturnType<typeof estimateHopCost>
+  /** Null when one hop reaches the cursor: nothing to list. */
+  route: PlanSummary | null
+  steps: PlanStep[] | null
+  /** Some step of the way is HOSAKA's. */
+  needsCloud: boolean
+}
+
+function summaryOf(steps: PlanStep[]): PlanSummary {
+  let hops = 0, sidesteps = 0, tallestWall = 0, cloudSteps = 0
+  let infeasibleAt: number | null = null
+  steps.forEach((s, i) => {
+    if (s.kind === 'hop') hops++
+    else { sidesteps++; if (s.maxHeight > tallestWall) tallestWall = s.maxHeight }
+    if (s.source === 'cloud') cloudSteps++
+    if (s.source === 'infeasible' && infeasibleAt === null) infeasibleAt = i
+  })
+  return { steps: steps.length, hops, sidesteps, tallestWall, capped: false, cloudSteps, infeasibleAt }
+}
+
+/** The route from the avatar to the cursor, with this machine's ceilings and HOSAKA's caps as they stand. */
+export function useRoutePreview(): RoutePreview | null {
+  const position = useCyberspace((s) => s.position)
+  const cursor = useCyberspace((s) => s.cursor)
+  const plane = useCyberspace((s) => s.plane)
+  const limits = useCyberspace((s) => s.cloud.limits)
+  const hopCeil = useCalibration((s) => s.hopHeight)
+  const sidestepCeil = useCalibration((s) => s.sidestepHeight)
+  const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
+  const cloudHop = limits?.max_hop_height ?? 0
+  const cloudSidestep = limits?.max_sidestep_height ?? 0
+  return useMemo(() => {
+    if (samePosition(position, cursor)) return null
+    const hop = estimateHopCost(position.x, position.y, position.z, cursor.x, cursor.y, cursor.z, plane, ceiling)
+    if (!hop.exceedsLimit) return { hop, route: null, steps: null, needsCloud: false }
+    // HOSAKA's caps whatever the cloud mode: what a move needs does not
+    // depend on a setting, and the button (useOffer) reads it the same way.
+    const ceilings: Ceilings = { hop: ceiling, sidestep: sidestepCeil, cloudHop, cloudSidestep }
+    let steps: PlanStep[] | null = null
+    try { steps = buildMovePlan(position, cursor, ceilings, PREVIEW_STEPS_MAX) } catch { steps = null }
+    const route = steps ? summaryOf(steps) : planSummary(position, cursor, ceilings, PREVIEW_STEPS_MAX)
+    return { hop, route, steps, needsCloud: route.cloudSteps > 0 }
+  }, [position, cursor, plane, ceiling, sidestepCeil, cloudHop, cloudSidestep])
+}
+
+export interface PreviewRow { index: number; kind: string; height: string; state: string; label: string }
+
+export function previewRow(step: PlanStep, index: number): PreviewRow {
+  return {
+    index,
+    kind: `${step.source === 'cloud' ? 'CLOUD ' : ''}${step.kind === 'sidestep' ? 'SIDESTEP' : 'HOP'}`,
+    height: `2^${step.maxHeight}`,
+    state: step.source === 'cloud' ? 'funding' : step.source === 'infeasible' ? 'failed' : 'next',
+    label: step.source === 'cloud' ? 'HOSAKA' : step.source === 'infeasible' ? 'beyond reach' : 'this machine',
+  }
+}
+
+/**
+ * Every step when the route is short. When it is not, the first and last few
+ * with the count of the rest between them (a number is a gap), and the step
+ * nobody can do always shown, however deep in the walk it sits: the notice
+ * names it, so the list must too.
+ */
+export function previewWindow(steps: PlanStep[], head: number = PREVIEW_HEAD, tail: number = PREVIEW_TAIL): Array<PreviewRow | number> {
+  if (steps.length <= head + tail + 1) return steps.map(previewRow)
+  const keep = new Set<number>()
+  for (let i = 0; i < head; i++) keep.add(i)
+  for (let i = steps.length - tail; i < steps.length; i++) keep.add(i)
+  const blocked = steps.findIndex((s) => s.source === 'infeasible')
+  if (blocked >= 0) keep.add(blocked)
+  const out: Array<PreviewRow | number> = []
+  let skipped = 0
+  steps.forEach((s, i) => {
+    if (keep.has(i)) {
+      if (skipped) { out.push(skipped); skipped = 0 }
+      out.push(previewRow(s, i))
+    } else skipped++
+  })
+  return out
+}
+
+export function routeLabel(r: PlanSummary): string {
+  const more = r.capped ? '+' : ''
+  const hops = `${r.hops}${more} hop${r.hops === 1 ? '' : 's'}`
+  const sides = `${r.sidesteps}${more} sidestep${r.sidesteps === 1 ? '' : 's'}`
+  return `${hops}, ${sides}`
+}

--- a/src/lib/movePlan.ts
+++ b/src/lib/movePlan.ts
@@ -81,6 +81,17 @@ export function routeFeasible(from: Position, to: Position, ceilings: number | C
   return h <= Math.max(c.hop, c.cloudHop) || h <= Math.max(c.sidestep, c.cloudSidestep)
 }
 
+/**
+ * Whether any step of the route is HOSAKA's: true when the tallest boundary
+ * on the way is above both of this machine's ceilings, so no local step
+ * crosses it. Constant time, like `routeFeasible`, and asked as often.
+ */
+export function routeNeedsCloud(from: Position, to: Position, ceilings: number | Ceilings): boolean {
+  const c = asCeilings(ceilings)
+  const h = Math.max(findLcaHeight(from.x, to.x), findLcaHeight(from.y, to.y), findLcaHeight(from.z, to.z))
+  return h > c.hop && h > c.sidestep
+}
+
 export type AxisMove =
   | { kind: 'none' }
   | { kind: 'hop'; to: bigint; height: number }

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -193,16 +193,22 @@ export function Cursor({ axes }: Props): JSX.Element | null {
     const landing = next?.step ? centre(next.step.to) : b
     const leg = [a, landing] as const
     const onCursor = next?.step ? samePosition(next.step.to, target) : true
+    // The leg is coloured by the step it draws, not by the button's word:
+    // OFFLOAD can name a route whose first step is still this machine's hop.
+    const src = next?.step?.source ?? null
+    const kind = next?.step?.kind ?? null
+    const localHop = src === 'local' && kind === 'hop'
+    const cloud = src === 'cloud' || (action === 'offload' && !next?.step)
     return {
       a,
       b,
-      hops: action === 'hop' || action === 'hop-to-boundary' ? [leg] : [],
-      sidesteps: action === 'sidestep' ? [leg] : [],
-      cloud: action === 'offload' ? [leg] : [],
+      hops: localHop ? [leg] : [],
+      sidesteps: src === 'local' && kind === 'sidestep' ? [leg] : [],
+      cloud: cloud ? [leg] : [],
       rest: action === 'too-far' ? leg : null,
       // A leg that ends on the cursor follows it within the frame.
-      lastIsHop: (action === 'hop' || action === 'hop-to-boundary') && onCursor,
-      lastIsCloud: action === 'offload' && onCursor,
+      lastIsHop: localHop && onCursor,
+      lastIsCloud: cloud && onCursor,
       ghost: action !== null && action !== 'too-far' && next?.step ? landing : null,
       ghostOnCursor: onCursor,
       targetCell: b,

--- a/src/store/useOffer.test.ts
+++ b/src/store/useOffer.test.ts
@@ -23,10 +23,12 @@ describe('nextActionFor', () => {
     expect(a && ['hop-to-boundary', 'sidestep'].includes(a.action)).toBe(true)
     expect(a?.step).not.toBeNull()
   })
-  it('walks toward a boundary only HOSAKA crosses, and is OFFLOAD only on reaching it', () => {
+  it('is OFFLOAD from the start when any step of the way is HOSAKA\'s, with the next step still this machine\'s', () => {
     // An h26 boundary on the way: above the local sidestep ceiling, within HOSAKA's hop cap.
-    expect(next(1n << 25n)?.action).toBe('hop-to-boundary')
-    expect(next(1n << 25n, null)?.action).toBe('hop-to-boundary')
+    const a = next(1n << 25n)
+    expect(a?.action).toBe('offload')
+    expect(a?.step?.source).toBe('local')   // the hop to the boundary is this machine's
+    expect(next(1n << 25n, null)?.action).toBe('offload')
     const atWall = (limits: typeof CAPS | null) => nextActionFor(at((1n << 25n) - 1n), at(1n << 25n), 0, 17, 24, limits)
     expect(atWall(CAPS)?.action).toBe('offload')
     expect(atWall(CAPS)?.step?.source).toBe('cloud')

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -13,7 +13,7 @@
 
 import { create } from 'zustand'
 import { useCalibration } from '../lib/calibration'
-import { localOnly, nextStep, routeFeasible, type Ceilings, type PlanStep } from '../lib/movePlan'
+import { localOnly, nextStep, routeFeasible, routeNeedsCloud, type Ceilings, type PlanStep } from '../lib/movePlan'
 import { offerVerdict, type OfferVerdict } from '../lib/offer'
 import type { Position } from '../lib/space'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
@@ -111,17 +111,19 @@ export function nextActionFor(position: Position, cursor: Position, plane: numbe
   const machineCeiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
   const cursorKey = cursorKeyOf(cursor, plane)
   // Local first, per step (lib/movePlan.ts): the next step is this machine's
-  // whenever it has one, however long the walk (the proof panel shows the
-  // length). HOSAKA enters only at a boundary this machine cannot cross,
-  // which is when it is actually needed. A cursor no one reaches is TOO FAR
-  // as soon as HOSAKA's caps are known; until they are, the walk goes on and
-  // OFFLOAD at the boundary asks.
+  // whenever it has one. HOSAKA enters only at a boundary this machine cannot
+  // cross, which is when it is actually needed; a route with such a boundary
+  // anywhere on it reads OFFLOAD from the start. A cursor no one reaches is
+  // TOO FAR as soon as HOSAKA's caps are known; until they are, OFFLOAD asks.
   const ceilings: Ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0 }
   if (limits !== null && !routeFeasible(position, cursor, ceilings)) return { action: 'too-far', step: null, cursorKey }
   const step = nextStep(position, cursor, ceilings)
   if (!step) return null
+  // OFFLOAD whenever any step of the way is HOSAKA's, not only when the next
+  // one is: the button names what the route costs. The step is still the
+  // next one, local or not, so the ghost stands where this commit lands.
   if (step.source === 'infeasible') return { action: 'offload', step: null, cursorKey }
-  if (step.source === 'cloud') return { action: 'offload', step, cursorKey }
+  if (routeNeedsCloud(position, cursor, ceilings)) return { action: 'offload', step, cursorKey }
   if (step.kind === 'sidestep') return { action: 'sidestep', step, cursorKey }
   const lands = step.to.x === cursor.x && step.to.y === cursor.y && step.to.z === cursor.z
   return { action: lands ? 'hop' : 'hop-to-boundary', step, cursorKey }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3022,6 +3022,50 @@ kbd {
   border-color: var(--accent, #00e5ff);
 }
 
+/* ---------- Route overlay: the lined-up route, live, above the pad ----------
+ *
+ * The pad's top edge is at 92 + 122 px; the overlay hangs 12 px above it and
+ * grows leftward from the pad's right edge. Taps pass through. */
+.routeov {
+  position: fixed;
+  right: 14px;
+  bottom: 226px;
+  z-index: 103;
+  width: 236px;
+  max-height: 38vh;
+  overflow: hidden;
+  padding: 6px 8px 7px;
+  border-radius: 9px;
+  color: var(--fg);
+  background: rgba(6, 14, 22, 0.82);
+  border: 1px solid rgba(0, 229, 255, 0.28);
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+}
+.routeov--cloud { border-color: rgba(47, 129, 247, 0.6); }
+.routeov--blocked { border-color: rgba(255, 59, 107, 0.6); }
+.routeov__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.routeov__title { color: var(--dim); }
+.routeov__sum { color: var(--accent); font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.routeov--cloud .routeov__sum { color: #6fa8ff; }
+.routeov--blocked .routeov__sum { color: #ff3b6b; }
+.route--overlay {
+  margin-top: 0.3rem;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+}
+.route--overlay .route__step {
+  grid-template-columns: 1.1rem 4.9rem 2.4rem 1fr;
+  gap: 0.3rem;
+  padding: 0.06rem 0.2rem;
+}
+
 /* COMMIT is the only control here that spends anything, so it is the only one
  * kept clear of the pad: no thumb aiming at an arrow should be able to graze
  * it. It stays inert until the cursor is actually somewhere else. */
@@ -3318,7 +3362,8 @@ kbd {
 @media (min-width: 1101px) {
   .touchpad,
   .touchops,
-  .touchhint {
+  .touchhint,
+  .routeov {
     right: 332px;
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3031,7 +3031,7 @@ kbd {
   right: 14px;
   bottom: 226px;
   z-index: 103;
-  width: 236px;
+  width: 282px;
   max-height: 38vh;
   overflow: hidden;
   padding: 6px 8px 7px;
@@ -3061,9 +3061,10 @@ kbd {
   letter-spacing: 0.04em;
 }
 .route--overlay .route__step {
-  grid-template-columns: 1.1rem 4.9rem 2.4rem 1fr;
+  grid-template-columns: 1.1rem 6.4rem 2.6rem 1fr;
   gap: 0.3rem;
   padding: 0.06rem 0.2rem;
+  white-space: nowrap;
 }
 
 /* COMMIT is the only control here that spends anything, so it is the only one


### PR DESCRIPTION
Two changes, as asked.

**OFFLOAD names the route, not just the next step.** The COMMIT button reads OFFLOAD, in blue, whenever any step of the way to the cursor is HOSAKA's. The test is constant time: the tallest boundary on the way is above both of this machine's ceilings. The step behind the button is still the next one, local or not, so the ghost stands where this commit lands, and the tether now takes its colour from that step (amber hop, purple sidestep, gold HOSAKA) rather than from the button's word. Pressing OFFLOAD opens the HOSAKA card as before; TOO FAR is unchanged.

**The route, live, above the pad.** A new overlay sits above the controls and shows the same step list the Movement proof panel shows, changing as the cursor moves: a summary line (ONE HOP, "2 HOPS, 1 SIDESTEP", "· HOSAKA" when a step is the cloud's, OUT OF REACH), then the first four and last two steps with a gap count between, each with its height and who does it. It follows the pad at both breakpoints, hides with it, and lets taps through. The panel and the overlay read one shared preview (routePreview.ts), one capped walk per cursor move.

Verified headlessly with a fixed calibration: one hop, a local walk across an h20 boundary (HOP TO BOUNDARY, three rows), a cloud sidestep at h29 two steps ahead (OFFLOAD blue, local first step, ghost present, HOSAKA row), and an h30 boundary (TOO FAR, OUT OF REACH, the blocked step marked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz