### PR TITLE
Workshop: the bench full-screen, the controls as overlays, nudging in screen directions

### DIFF
--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -30,6 +30,8 @@ export interface ShardModel {
   name: string
   /** One model unit is 2^unit gibsons. */
   unit: number
+  /** Half-width of this shard's build grid, in units: the grid runs from -extent to +extent on every axis. */
+  extent: number
   mode: ShardMode
   vertices: ShardVertex[]
   /** Triangles as vertex indices; drawn in `solid` mode only. */
@@ -43,6 +45,8 @@ export interface ShardPayload {
   type: 'shard'
   name: string
   unit: number
+  /** Grid half-width the shard was built on; absent in older payloads (8). */
+  extent?: number
   mode: ShardMode
   vertices: Array<[number, number, number]>
   colors: Array<[number, number, number]>
@@ -51,8 +55,10 @@ export interface ShardPayload {
 
 export const MODES: ShardMode[] = ['solid', 'points', 'lines']
 
-/** Half-width of the build grid, in units. */
+/** Default half-width of the build grid, in units; each shard keeps its own (`extent`). */
 export const GRID_HALF = 8
+export const MIN_EXTENT = 1
+export const MAX_EXTENT = 64
 
 export const MAX_VERTICES = 512
 export const MAX_FACES = 1024
@@ -63,7 +69,7 @@ export const MAX_FACES = 1024
  * the first stamp with faces lands (see the workshop store).
  */
 export function newShard(name = 'Untitled shard'): ShardModel {
-  return { id: uuid(), name, unit: 0, mode: 'lines', vertices: [], faces: [], updatedAt: Date.now() }
+  return { id: uuid(), name, unit: 0, extent: GRID_HALF, mode: 'lines', vertices: [], faces: [], updatedAt: Date.now() }
 }
 
 /** A grid point as a map key, so "the same point" is one string compare. */
@@ -77,8 +83,15 @@ export function uuid(): string {
 }
 
 /** Integers inside the grid; anything else is not a vertex. */
-export function validPoint(p: [number, number, number]): boolean {
-  return p.every((v) => Number.isInteger(v) && Math.abs(v) <= GRID_HALF)
+export function validPoint(p: [number, number, number], extent: number = GRID_HALF): boolean {
+  return p.every((v) => Number.isInteger(v) && Math.abs(v) <= extent)
+}
+
+/** The grid half-width a shard needs to hold every vertex it has. */
+export function neededExtent(s: Pick<ShardModel, 'vertices'>): number {
+  let m = MIN_EXTENT
+  for (const v of s.vertices) for (const c of v.p) m = Math.max(m, Math.abs(c))
+  return m
 }
 
 export function clampColor(c: [number, number, number]): [number, number, number] {
@@ -96,6 +109,7 @@ export function toPayload(s: ShardModel): ShardPayload {
     type: 'shard',
     name: s.name,
     unit: s.unit,
+    extent: s.extent,
     mode: s.mode,
     vertices: s.vertices.map((v) => v.p),
     colors: s.vertices.map((v) => v.c),
@@ -131,10 +145,12 @@ export function fromPayload(raw: unknown, id: string): ShardModel | null {
     if (!validFace(face, vertices.length)) return null
     faces.push(face)
   }
+  const extent = Number.isInteger(p.extent) && (p.extent as number) >= MIN_EXTENT && (p.extent as number) <= MAX_EXTENT ? (p.extent as number) : GRID_HALF
   return {
     id,
     name: typeof p.name === 'string' ? p.name.slice(0, 64) : 'shard',
     unit: p.unit as number,
+    extent: Math.max(extent, neededExtent({ vertices })),
     mode: p.mode as ShardMode,
     vertices,
     faces,

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -153,13 +153,13 @@ function turned(kind: StampKind, size: number, facing: Facing): Shape {
 const moved = (points: P3[], by: P3): P3[] => points.map((p) => [p[0] + by[0], p[1] + by[1], p[2] + by[2]] as P3)
 
 /** The push that brings a shape back inside the grid: zero on an axis it already fits. */
-function fit(points: P3[]): P3 {
+function fit(points: P3[], extent: number = GRID_HALF): P3 {
   const shift: P3 = [0, 0, 0]
   for (let a = 0; a < 3; a++) {
     let lo = Infinity, hi = -Infinity
     for (const p of points) { lo = Math.min(lo, p[a]); hi = Math.max(hi, p[a]) }
-    if (lo < -GRID_HALF) shift[a] = -GRID_HALF - lo
-    else if (hi > GRID_HALF) shift[a] = GRID_HALF - hi
+    if (lo < -extent) shift[a] = -extent - lo
+    else if (hi > extent) shift[a] = extent - hi
   }
   return shift
 }
@@ -169,15 +169,15 @@ function fit(points: P3[]): P3 {
  * inside the grid if any of it would poke out. Nothing here is wider than
  * the grid, so the push always succeeds.
  */
-export function compile(kind: StampKind, size: number, facing: Facing, origin: P3): Shape {
+export function compile(kind: StampKind, size: number, facing: Facing, origin: P3, extent: number = GRID_HALF): Shape {
   const t = turned(kind, size, facing)
   const points = moved(t.points, origin)
-  return { points: moved(points, fit(points)), faces: t.faces }
+  return { points: moved(points, fit(points, extent)), faces: t.faces }
 }
 
 /** Where a stamp aimed at `origin` lands: `origin` itself unless the grid's edge pushed it back. */
-export function landing(kind: StampKind, size: number, facing: Facing, origin: P3): P3 {
-  const shift = fit(moved(turned(kind, size, facing).points, origin))
+export function landing(kind: StampKind, size: number, facing: Facing, origin: P3, extent: number = GRID_HALF): P3 {
+  const shift = fit(moved(turned(kind, size, facing).points, origin), extent)
   return [origin[0] + shift[0], origin[1] + shift[1], origin[2] + shift[2]]
 }
 
@@ -199,7 +199,7 @@ export interface Stamped {
  * one corner for corner is dropped along with the one it matched.
  */
 export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: Facing, origin: P3, color: [number, number, number]): Stamped | null {
-  const shape = compile(kind, size, facing, origin)
+  const shape = compile(kind, size, facing, origin, shard.extent)
   const base = shard.vertices.length
   const vertices: ShardVertex[] = [
     ...shard.vertices,
@@ -235,6 +235,7 @@ export function preview(kind: StampKind, size: number, facing: Facing, color: [n
     id: 'ghost',
     name: kind,
     unit: 0,
+    extent: GRID_HALF,
     mode: shape.faces.length ? 'solid' : 'lines',
     vertices: shape.points.map((p) => ({ p, c: [...color] as [number, number, number] })),
     faces: shape.faces,

--- a/src/store/useCeremony.ts
+++ b/src/store/useCeremony.ts
@@ -12,7 +12,7 @@ import { create } from 'zustand'
 import type { Plane } from 'cyberspace-core'
 import { messagePreview, type Hidden } from '../lib/hidden'
 import { regionLabel } from '../lib/loot'
-import type { ShardModel } from '../lib/shards'
+import { GRID_HALF, type ShardModel } from '../lib/shards'
 import { useCyberspace } from './useCyberspace'
 import { useShards } from './useShards'
 
@@ -52,6 +52,7 @@ function previewShard(unit: number): ShardModel {
     id: 'preview-construct',
     name: 'Tessier-Ashpool construct',
     unit,
+    extent: GRID_HALF,
     mode: 'lines',
     vertices: path.map((p, i) => ({ p, c: i < 16 ? [0, 0.9, 1] : [0.97, 0.58, 0.1] })),
     faces: [],

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -131,6 +131,26 @@ describe('workshop', () => {
     expect(w().selection).toEqual([s.vertices.length - 1])
   })
 
+  it('keeps a grid scale per shard, never below what its points need, and carries it in the payload', () => {
+    w().addVertex([5, 0, 0])
+    expect(w().current()!.extent).toBe(8)
+    w().setExtent(3)
+    expect(w().current()!.extent).toBe(5)        // the point at x=5 holds it
+    w().setExtent(999)
+    expect(w().current()!.extent).toBe(64)
+    w().setLevel(50); expect(w().level).toBe(50)
+    w().setExtent(6)
+    expect(w().level).toBe(6)                    // the level follows the grid down
+    expect(w().addVertex([7, 0, 0]), 'outside the grid').toBeUndefined()
+    expect(w().current()!.vertices).toHaveLength(1)
+    const text = w().exportCurrent()!
+    expect(JSON.parse(text).extent).toBe(6)
+    const id = w().importText(text)!
+    expect(w().shards.find((s) => s.id === id)!.extent).toBe(6)
+    expect(w().importText(JSON.stringify({ ...JSON.parse(text), extent: undefined }))).not.toBeNull()
+    expect(w().current()!.extent).toBe(8)        // an older payload lands on the default
+  })
+
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
     w().setTool('add')
     w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -23,6 +23,9 @@
 import { create } from 'zustand'
 import {
   GRID_HALF,
+  MAX_EXTENT,
+  MIN_EXTENT,
+  neededExtent,
   MAX_FACES,
   MAX_VERTICES,
   clampColor,
@@ -98,6 +101,8 @@ export interface WorkshopState {
   remove: (id: string) => void
   setMode: (mode: ShardMode) => void
   setUnit: (unit: number) => void
+  /** The build grid's half-width for the current shard, never below what its vertices need. */
+  setExtent: (extent: number) => void
   setTool: (tool: Tool) => void
   setLevel: (level: number) => void
   setColor: (c: [number, number, number]) => void
@@ -146,7 +151,9 @@ function load(): ShardModel[] {
     const raw = localStorage.getItem(STORAGE)
     if (!raw) return []
     const list = JSON.parse(raw)
-    return Array.isArray(list) ? list.filter((s) => s && typeof s.id === 'string' && Array.isArray(s.vertices)) : []
+    return Array.isArray(list)
+      ? list.filter((s) => s && typeof s.id === 'string' && Array.isArray(s.vertices)).map((s) => ({ ...s, extent: Number.isInteger(s.extent) ? s.extent : Math.max(GRID_HALF, neededExtent(s)) }))
+      : []
   } catch { return [] }
 }
 
@@ -259,7 +266,18 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     setMode: (mode) => edit((s) => ({ ...s, mode })),
     setUnit: (unit) => edit((s) => ({ ...s, unit: Math.max(0, Math.min(84, Math.round(unit))) })),
     setTool: (tool) => set({ tool, facePick: [], selectedFace: null, aim: null }),
-    setLevel: (level) => set({ level: Math.max(-GRID_HALF, Math.min(GRID_HALF, Math.round(level))) }),
+    setExtent: (extent) => {
+      const s = get().current()
+      if (!s) return
+      const e = Math.max(Math.max(MIN_EXTENT, neededExtent(s)), Math.min(MAX_EXTENT, Math.round(extent)))
+      if (e === s.extent) return
+      edit((cur) => ({ ...cur, extent: e }))
+      set({ level: Math.max(-e, Math.min(e, get().level)) })
+    },
+    setLevel: (level) => {
+      const e = get().current()?.extent ?? GRID_HALF
+      set({ level: Math.max(-e, Math.min(e, Math.round(level))) })
+    },
     setColor: (c) => set({ color: clampColor(c) }),
     setStampKind: (stampKind) => set({ stampKind }),
     setStampSize: (size) => set({ stampSize: Math.max(MIN_SIZE, Math.min(MAX_SIZE, Math.round(size))) }),
@@ -274,7 +292,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     placeStamp: (at) => {
       const { stampKind, stampSize, stampFacing, color } = get()
       const s = get().current()
-      if (!s || !validPoint(at)) return
+      if (!s || !validPoint(at, s.extent)) return
       const res = stamp(s, stampKind, stampSize, stampFacing, at, color)
       if (!res) { set({ notice: `No room: a shard holds up to ${MAX_VERTICES} vertices and ${MAX_FACES} faces.` }); return }
       const { mode, notice } = solidIfFirstFaces(s, res.shard)
@@ -283,7 +301,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     },
 
     addVertex: (p) => {
-      if (!validPoint(p)) return
+      if (!validPoint(p, get().current()?.extent ?? GRID_HALF)) return
       let added = -1
       edit((s) => {
         // One vertex per point by hand: adding where one already is selects it instead.
@@ -366,7 +384,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
         for (const i of chosen) {
           const p = [...vertices[i].p] as P3
           p[axis] += delta
-          if (!validPoint(p)) return null
+          if (!validPoint(p, s.extent)) return null
           vertices[i] = { ...vertices[i], p }
         }
         return { ...s, vertices }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2134,21 +2134,9 @@ kbd {
   position: fixed;
   inset: 0;
   z-index: 200;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
   background: var(--bg);
   color: var(--fg);
   font-family: var(--mono);
-}
-
-.workshop__head {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border);
-  background: var(--panel);
 }
 
 .workshop__list-btn,
@@ -2203,11 +2191,6 @@ kbd {
   font-weight: 700;
 }
 
-.workshop__close {
-  margin-left: auto;
-  color: var(--dim);
-}
-
 .workshop__name {
   flex: 1 1 120px;
   min-width: 80px;
@@ -2231,18 +2214,11 @@ kbd {
 }
 
 .workshop__list {
-  position: absolute;
-  top: 48px;
-  left: 10px;
-  z-index: 1;
-  width: min(320px, calc(100vw - 20px));
-  max-height: 60vh;
-  overflow-y: auto;
-  padding: 8px;
-  border-radius: 8px;
-  background: rgba(6, 14, 22, 0.96);
-  border: 1px solid var(--border);
-  backdrop-filter: blur(8px);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
 }
 
 .workshop__list ul {
@@ -2301,8 +2277,8 @@ kbd {
 }
 
 .workshop__bench {
-  position: relative;
-  min-height: 0;
+  position: absolute;
+  inset: 0;
 }
 
 /* The SELECT tool's drag box, drawn over the bench canvas (Bench.tsx Marquee). */
@@ -2316,26 +2292,6 @@ kbd {
 
 .workshop__bench canvas {
   display: block;
-}
-
-.workshop__stats {
-  position: absolute;
-  left: 10px;
-  bottom: 8px;
-  font-size: 9px;
-  letter-spacing: 0.08em;
-  color: var(--dim);
-  pointer-events: none;
-  text-shadow: 0 0 4px var(--bg);
-}
-
-.workshop__tools {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 10px 10px;
-  border-top: 1px solid var(--border);
-  background: var(--panel);
 }
 
 .workshop__row {
@@ -2367,12 +2323,6 @@ kbd {
   flex: 1 1 200px;
   font-size: 9px;
   color: var(--dim);
-}
-
-.workshop__pad {
-  display: grid;
-  grid-template-columns: repeat(6, auto);
-  gap: 4px;
 }
 
 .workshop__btn--x { color: #ff4444; }
@@ -2521,7 +2471,7 @@ kbd {
 /* The first-visit card: three steps, then never again. */
 .workshop__intro {
   position: absolute;
-  top: 12px;
+  top: 56px;
   right: 12px;
   z-index: 2;
   width: min(300px, calc(100vw - 24px));
@@ -2560,14 +2510,190 @@ kbd {
   color: var(--accent);
 }
 
-/* The EXPLAIN pill ends the tool row; its well, when open, takes a full row. */
-.workshop__tools .explain {
-  display: contents;
+/* ---------- Workshop overlays: chips, panels, corner pad, color bar ----------
+ *
+ * The bench fills the screen; everything else floats on it the way the
+ * instruments float on the world. Top left, the chip row and the history;
+ * top right, DEPLOY and the way out; bottom right, the CONTROLS pad and the
+ * COLOR bar. One panel at a time opens under the chip row. */
+.ws__top {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  pointer-events: none;
 }
-
-.workshop__tools .explain__well {
-  flex: 1 1 100%;
-  margin-top: 2px;
+.ws__top > * { pointer-events: auto; }
+/* Room on the right for DEPLOY and the way out, which share the top edge. */
+.ws__chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding-right: 124px;
+}
+.ws__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 12px;
+}
+.ws__chip.is-on {
+  color: #05070d;
+  background: var(--accent);
+  border-color: var(--accent);
+  font-weight: 700;
+}
+.ws__history {
+  display: inline-flex;
+  gap: 6px;
+}
+.ws__icon {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+.ws__icon:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.ws__exit {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ws__exit .workshop__deploy {
+  height: 34px;
+  border-radius: 9px;
+}
+.ws__panel {
+  width: min(380px, 100%);
+  box-sizing: border-box;
+  max-height: calc(100vh - 210px);
+  overflow: auto;
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(6, 14, 22, 0.92);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+/* Rules written for the old toolbar rows gave these a flex basis; in a column panel that becomes height. */
+.ws__panel .workshop__help,
+.ws__panel .workshop__name {
+  flex: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+.ws__panel-title {
+  font-size: 8px;
+  letter-spacing: 0.16em;
+  color: var(--dim);
+  margin-top: 4px;
+}
+.ws__stats {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+.ws__toast {
+  position: absolute;
+  top: 56px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  pointer-events: none;
+  max-width: min(360px, calc(100vw - 24px));
+  padding: 7px 10px;
+  border-radius: 9px;
+  text-align: center;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+  background: rgba(6, 14, 22, 0.88);
+  border: 1px solid rgba(0, 229, 255, 0.3);
+}
+.ws__corner {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+/* The main pad's nine cells, for the selection: CONNECT and DELETE take the
+ * corners the scale keys have out there. */
+.benchpad {
+  display: grid;
+  grid-template-columns: repeat(3, 38px);
+  grid-template-rows: repeat(3, 38px);
+  gap: 4px;
+  grid-template-areas:
+    "away    up   toward"
+    "left    hub  right"
+    "connect down delete";
+}
+.benchpad .touchpad__key--connect { grid-area: connect; color: var(--accent); }
+.benchpad .touchpad__key--delete { grid-area: delete; color: var(--danger); }
+.benchpad .touchpad__key--connect .touchpad__sub,
+.benchpad .touchpad__key--delete .touchpad__sub { font-size: 6px; }
+.benchops {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 9px;
+  background: rgba(6, 14, 22, 0.85);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+}
+.ws__color {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-width: min(440px, calc(100vw - 28px));
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(6, 14, 22, 0.85);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+}
+.ws__color .workshop__label { min-width: 0; }
+@media (max-width: 640px) {
+  .ws__corner {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0 10px 10px;
+  }
+  .ws__color {
+    width: 100%;
+    max-width: none;
+    box-sizing: border-box;
+    border-radius: 10px;
+  }
+  .ws__panel {
+    max-height: calc(100vh - 260px);
+  }
 }
 
 @media (max-width: 600px) {

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -15,12 +15,13 @@
  * guessing.
  */
 
-import { Canvas, useThree, type ThreeEvent } from '@react-three/fiber'
+import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
 import { BufferGeometry, DoubleSide, Float32BufferAttribute, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
 import { GRID_HALF, centroid, pointKey, rgbToHex } from '../lib/shards'
+import { benchAxes, nudgeFor, sameAxes, useBenchView, type NudgeName } from './benchAxes'
 import { landing, preview } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
 import { useWorkshop } from '../store/useWorkshop'
@@ -37,6 +38,7 @@ function snap(p: Vector3, level: number): P3 {
 
 function Grid(): JSX.Element {
   const level = useWorkshop((s) => s.level)
+  const extent = useWorkshop((s) => s.current()?.extent ?? GRID_HALF)
   const tool = useWorkshop((s) => s.tool)
   const places = tool === 'add' || tool === 'stamp'
 
@@ -65,7 +67,7 @@ function Grid(): JSX.Element {
   return (
     <group position={[0, level, 0]}>
       {/* The visible lattice. One cell per unit, so what you tap is what you get. */}
-      <gridHelper args={[GRID_HALF * 2, GRID_HALF * 2, ACCENT, '#1d3547']} />
+      <gridHelper key={extent} args={[extent * 2, extent * 2, ACCENT, '#1d3547']} />
       {/*
         The surface taps land on, in the placing tools only. In select and face
         mode it carries no handler at all, so the raycaster ignores it: a raised
@@ -75,7 +77,7 @@ function Grid(): JSX.Element {
       */}
       {places && (
         <mesh rotation={[-Math.PI / 2, 0, 0]} onClick={onClick} onPointerMove={onMove} onPointerUp={onUp} onPointerLeave={() => useWorkshop.getState().setAim(null)}>
-          <planeGeometry args={[GRID_HALF * 2 + 1, GRID_HALF * 2 + 1]} />
+          <planeGeometry key={extent} args={[extent * 2 + 1, extent * 2 + 1]} />
           <meshBasicMaterial transparent opacity={0} depthWrite={false} />
         </mesh>
       )}
@@ -94,6 +96,7 @@ function Ghost(): JSX.Element | null {
   // Built once per shape and color; the aim only moves it. Built per cell, the
   // ghost cost a fresh geometry every time the pointer crossed a grid line.
   const model = useMemo(() => (tool === 'stamp' ? preview(kind, size, facing, color) : null), [tool, kind, size, facing, color])
+  const extent = useWorkshop((s) => s.current()?.extent ?? GRID_HALF)
   if (!aim) return null
   if (tool === 'add') {
     return (
@@ -105,7 +108,7 @@ function Ghost(): JSX.Element | null {
   }
   if (!model) return null
   return (
-    <group position={landing(kind, size, facing, aim)}>
+    <group position={landing(kind, size, facing, aim, extent)}>
       <ShardMesh shard={model} ghost />
     </group>
   )
@@ -327,6 +330,7 @@ function Marquee(): null {
 }
 
 function Keys(): null {
+  const camera = useThree((s) => s.camera)
   useEffect(() => {
     const onKey = (e: KeyboardEvent): void => {
       const tag = (e.target as HTMLElement | null)?.tagName
@@ -338,12 +342,15 @@ function Keys(): null {
         return
       }
       if (e.altKey) return
-      const nudge: Record<string, [0 | 1 | 2, number]> = {
-        ArrowRight: [0, 1], ArrowLeft: [0, -1], KeyD: [0, 1], KeyA: [0, -1],
-        ArrowUp: [2, -1], ArrowDown: [2, 1], KeyW: [2, -1], KeyS: [2, 1],
-        KeyR: [1, 1], KeyF: [1, -1],
+      // Screen directions, as the cursor's keys are in the world: W up, S down,
+      // A left, D right, R into the screen, F out of it, whatever way the bench
+      // camera has been turned.
+      const nudge: Record<string, NudgeName> = {
+        ArrowRight: 'right', ArrowLeft: 'left', KeyD: 'right', KeyA: 'left',
+        ArrowUp: 'up', ArrowDown: 'down', KeyW: 'up', KeyS: 'down',
+        KeyR: 'away', KeyF: 'toward',
       }
-      if (nudge[e.code]) { e.preventDefault(); w.moveSelected(...nudge[e.code]); return }
+      if (nudge[e.code]) { e.preventDefault(); const n = nudgeFor(benchAxes(camera), nudge[e.code]); w.moveSelected(n.axis, n.delta); return }
       if (e.code === 'Delete' || e.code === 'Backspace') { e.preventDefault(); if (w.selectedFace !== null) w.deleteSelectedFace(); else w.deleteSelected(); return }
       if (e.code === 'Enter') { if (w.facePick.length >= 3) { e.preventDefault(); w.fill() } return }
       if (e.code === 'Escape') { e.preventDefault(); if (w.selection.length || w.selectedFace !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
@@ -358,13 +365,24 @@ function Keys(): null {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [])
+  }, [camera])
+  return null
+}
+
+/** Publishes the camera's snapped axes for the pad outside the canvas, only when they change. */
+function AxesReporter(): null {
+  const camera = useThree((s) => s.camera)
+  useFrame(() => {
+    const axes = benchAxes(camera)
+    if (!sameAxes(axes, useBenchView.getState().axes)) useBenchView.setState({ axes })
+  })
   return null
 }
 
 export function Bench(): JSX.Element {
   const shard = useWorkshop((s) => s.current())
   const tool = useWorkshop((s) => s.tool)
+  const extent = shard?.extent ?? GRID_HALF
   const first = useRef(true)
   useEffect(() => { first.current = false }, [])
 
@@ -400,8 +418,9 @@ export function Bench(): JSX.Element {
       <Marquee />
       <Aim />
       <Keys />
+      <AxesReporter />
       {/* Axes, in the compass's colors, so X is red here and out there. */}
-      <axesHelper args={[GRID_HALF + 1]} />
+      <axesHelper key={extent} args={[extent + 1]} />
       <Grid />
       {shard && <ShardMesh shard={shard} onFaceClick={tool === 'face' ? onFace : undefined} />}
       <Ghost />

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -1,51 +1,49 @@
 /**
- * Workshop.tsx — where shards are made.
+ * Workshop.tsx - the shard workshop's shell: the bench full-screen, and the
+ * controls as overlays on it, the way the main scene's instruments sit on
+ * the world.
  *
- * A full-screen bench over the world. The tools are few and exact, in the
- * order a first visit meets them: STAMP lands a whole shape where you tap
- * (a block, a wedge, a pyramid, a column, a ring, a star, an arrow), sized in
- * whole units and turned a quarter at a time; ADD places one vertex; SELECT
- * picks a point so the pad can nudge it a unit along X, Y or Z, color it or
- * delete it; FACE collects corners and FILL joins them into a face, any
- * number of corners, notches and all. Color applies to the selection or to
- * everything. The mode, solid, points or lines, is part of the shard and
- * previews live. Every edit undoes.
- *
- * v1's modeller wanted a mouse: drag handles for every axis, bars to drag for
- * every color channel. This wants a thumb. Every action is a tap or a button,
- * every position an integer, and the keyboard is a shortcut, not a requirement.
- * The tray shows the row the current tool needs and nothing else, so a phone
- * keeps most of its screen for the bench.
+ * Top left, a row of chips: MENU (the shard itself: name, mode, the list,
+ * clear, explain), TOOLS (STAMP, ADD, SELECT, FACE and each tool's options)
+ * and GRID (the level the placing tools work on, the deploy scale multiplier,
+ * and the grid's own scale), each opening one panel below the row; UNDO and
+ * REDO float beside them. Top right, DEPLOY and the way out. Bottom right,
+ * the CONTROLS pad, present only while points are selected: the main pad's
+ * shape, nudging the selection in screen directions, with CONNECT and DELETE
+ * in its corners; and below it the COLOR bar, gone while FACE is the tool
+ * since a face has no color of its own. On a phone the color bar spans the
+ * bottom and the pad stacks above it.
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { MousePointer2, Pipette, Plus, Stamp, Triangle, type LucideIcon } from 'lucide-react'
+import { Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, Stamp, Trash2, Triangle, Undo2, Wrench, X, type LucideIcon } from 'lucide-react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { ConfirmModal } from '../hud/ConfirmModal'
 import { Explanation } from '../hud/Explanation'
-import { GRID_HALF, MODES, hexToRgb, rgbToHex, toPayload, type ShardMode } from '../lib/shards'
+import { MAX_EXTENT, MIN_EXTENT, MODES, hexToRgb, neededExtent, rgbToHex, toPayload, type ShardMode } from '../lib/shards'
 import { formatCellSize } from '../lib/scale'
 import { FACED, FACING_LABEL, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { Bench } from './Bench'
+import { nudgeFor, nudgeLabel, useBenchView, type NudgeName } from './benchAxes'
 
 const TOOLS: Tool[] = ['stamp', 'add', 'select', 'face']
 const TOOL_ICON: Record<Tool, LucideIcon> = { stamp: Stamp, add: Plus, select: MousePointer2, face: Triangle }
 
-/** A press this long on a swatch asks to delete it rather than using it. */
 const LONG_PRESS_MS = 550
-/** The picker fires on every step through the wheel; the palette gets the color you stop on. */
 const SETTLE_MS = 500
+const TOAST_MS = 4000
 
-const TOOL_HELP: Record<Tool, string> = {
+/** One line under the tool row. SELECT needs none: the pad appears when something is selected. */
+const TOOL_HELP: Partial<Record<Tool, string>> = {
   stamp: 'Tap the grid to place the shape where the ghost shows. Q turns it.',
   add: 'Tap the grid to place a vertex at the current level.',
-  select: 'Tap points, or drag a box around them, then nudge, color or delete them together. CONNECTED takes everything joined by faces.',
   face: 'Tap corners in order, then the first again or FILL. Tap a face to select it; DELETE FACE removes it.',
 }
 
-/** Shown once, the first time the workshop opens on this device. */
+type Panel = 'menu' | 'tools' | 'grid'
+
 const INTRO_KEY = 'onosendai:workshop-intro'
 
 function Intro(): JSX.Element | null {
@@ -56,8 +54,8 @@ function Intro(): JSX.Element | null {
     <div className="workshop__intro" role="note" aria-label="How to make a shard">
       <h3 className="workshop__intro-title">MAKE A SHARD</h3>
       <ol className="workshop__intro-steps">
-        <li><b>STAMP</b> a shape: pick one below, tap the grid where the ghost shows.</li>
-        <li><b>Drag</b> to look around. <b>LEVEL</b> raises the grid to stack things.</li>
+        <li><b>STAMP</b> a shape: pick one under TOOLS, tap the grid where the ghost shows.</li>
+        <li>One finger <b>orbits</b>, two fingers <b>pan</b>. GRID raises the level to stack things.</li>
         <li><b>DEPLOY</b> hides it in the world at a place you choose.</li>
       </ol>
       <button className="workshop__btn workshop__intro-ok" onClick={done}>GOT IT</button>
@@ -65,7 +63,6 @@ function Intro(): JSX.Element | null {
   )
 }
 
-/** A swatch: tap to use it, hold to be asked whether to delete it. */
 function Swatch({ hex, on, onUse, onHold }: { hex: string; on: boolean; onUse: () => void; onHold: () => void }): JSX.Element {
   const timer = useRef<number>()
   const held = useRef(false)
@@ -88,6 +85,63 @@ function Swatch({ hex, on, onUse, onHold }: { hex: string; on: boolean; onUse: (
   )
 }
 
+/** The store's one-line notice, shown for a moment at the top and then gone. */
+function Toast(): JSX.Element | null {
+  const notice = useWorkshop((s) => s.notice)
+  const [shown, setShown] = useState<string | null>(null)
+  useEffect(() => {
+    if (!notice) { setShown(null); return }
+    setShown(notice)
+    const t = window.setTimeout(() => setShown(null), TOAST_MS)
+    return () => window.clearTimeout(t)
+  }, [notice])
+  if (!shown) return null
+  return <div className="ws__toast" role="status">{shown}</div>
+}
+
+/**
+ * The CONTROLS pad: the main pad's nine cells, for the selection. Arrows move
+ * it a unit in screen directions (the sub-label says which world axis that is
+ * right now), the corners CONNECT and DELETE, the hub counts the points and
+ * clears them.
+ */
+function ControlsPad({ points }: { points: number }): JSX.Element {
+  const axes = useBenchView((s) => s.axes)
+  const bind = useRepeatable()
+  const w = useWorkshop.getState
+  const move = (name: NudgeName) => () => { const n = nudgeFor(useBenchView.getState().axes, name); w().moveSelected(n.axis, n.delta) }
+  const sub = (name: NudgeName): string => nudgeLabel(nudgeFor(axes, name))
+  const arrows: Array<{ cell: string; glyph: string; name: NudgeName; key: string }> = [
+    { cell: 'away', glyph: '⊗', name: 'away', key: 'R' },
+    { cell: 'up', glyph: '▲', name: 'up', key: 'W' },
+    { cell: 'toward', glyph: '⊙', name: 'toward', key: 'F' },
+    { cell: 'left', glyph: '◀', name: 'left', key: 'A' },
+    { cell: 'right', glyph: '▶', name: 'right', key: 'D' },
+    { cell: 'down', glyph: '▼', name: 'down', key: 'S' },
+  ]
+  return (
+    <div className="benchpad" role="group" aria-label="Move the selected points">
+      {arrows.map((a) => (
+        <button key={a.cell} className={`touchpad__key touchpad__key--${a.cell}`} title={`${a.name} (${a.key}): ${sub(a.name)}`} aria-label={`Move ${a.name}, ${sub(a.name)}`} {...bind(move(a.name))}>
+          {a.glyph}
+          <span className="touchpad__sub">{sub(a.name)}</span>
+        </button>
+      ))}
+      <button className="touchpad__key touchpad__key--connect" title="Select everything joined by faces (C)" aria-label="Select connected" {...noCallout} onClick={() => w().selectConnected()}>
+        <Link size={14} strokeWidth={2.25} aria-hidden />
+        <span className="touchpad__sub">JOINED</span>
+      </button>
+      <button className="touchpad__key touchpad__key--delete" title="Delete the selected points (Del)" aria-label="Delete selected" {...noCallout} onClick={() => w().deleteSelected()}>
+        <Trash2 size={14} strokeWidth={2.25} aria-hidden />
+        <span className="touchpad__sub">DELETE</span>
+      </button>
+      <button className="touchpad__hub" title="Clear the selection (Esc)" aria-label={`${points} points selected. Tap to clear.`} {...noCallout} onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); w().selectVertex(null) }}>
+        {points} {points === 1 ? 'PT' : 'PTS'}
+      </button>
+    </div>
+  )
+}
+
 export function Workshop(): JSX.Element | null {
   const open = useWorkshop((s) => s.open)
   const shard = useWorkshop((s) => s.current())
@@ -104,8 +158,7 @@ export function Workshop(): JSX.Element | null {
   const stampFacing = useWorkshop((s) => s.stampFacing)
   const canUndo = useWorkshop((s) => s.past.length > 0)
   const canRedo = useWorkshop((s) => s.future.length > 0)
-  const notice = useWorkshop((s) => s.notice)
-  const [listOpen, setListOpen] = useState(false)
+  const [panel, setPanel] = useState<Panel | null>(null)
   const [pasteOpen, setPasteOpen] = useState(false)
   const [pasteText, setPasteText] = useState('')
   const [deleteColor, setDeleteColor] = useState<string | null>(null)
@@ -116,11 +169,12 @@ export function Workshop(): JSX.Element | null {
 
   if (!open) return null
   const w = useWorkshop.getState
-
-  const nudge = (axis: 0 | 1 | 2, d: number) => () => w().moveSelected(axis, d)
-  const canNudge = selection.length > 0
-  const selectedPoints = shard ? new Set(selection.map((i) => shard.vertices[i]?.p.join(','))).size : 0
   const say = (notice: string): void => useWorkshop.setState({ notice })
+  const toggle = (p: Panel): void => setPanel((cur) => (cur === p ? null : p))
+
+  const selectedPoints = shard ? new Set(selection.map((i) => shard.vertices[i]?.p.join(','))).size : 0
+  const extent = shard?.extent ?? MIN_EXTENT
+  const minExtent = shard ? Math.max(MIN_EXTENT, neededExtent(shard)) : MIN_EXTENT
 
   // The picker paints live and, once the wheel has settled, puts the color at
   // the front of the palette; leaving the picker settles it at once.
@@ -143,13 +197,11 @@ export function Workshop(): JSX.Element | null {
     if (!s) return
     navigator.clipboard?.writeText(JSON.stringify(toPayload(s))).then(() => say(`Copied "${s.name}" to the clipboard. PASTE it here or anywhere.`)).catch(() => say('The clipboard is not available here.'))
   }
-
   const importText = (text: string): void => {
     const id = w().importText(text)
-    if (id) { setPasteOpen(false); setPasteText(''); setListOpen(false); say('Pasted as a new shard.') }
+    if (id) { setPasteOpen(false); setPasteText(''); say('Pasted as a new shard.') }
     else say('That is not a shard.')
   }
-
   const paste = async (): Promise<void> => {
     try {
       const text = await navigator.clipboard.readText()
@@ -158,221 +210,211 @@ export function Workshop(): JSX.Element | null {
     setPasteOpen(true)
   }
 
+  const facing = tool === 'face' && selection.length === 0 && (selectedFace !== null || facePick.length > 0)
+
   return (
     <div className="workshop" role="dialog" aria-label="Shard workshop">
-      <header className="workshop__head">
-        <button className="workshop__list-btn" onClick={() => setListOpen((v) => !v)} aria-expanded={listOpen}>
-          SHARDS ({shards.length})
-        </button>
-        {shard && (
-          <input
-            className="workshop__name"
-            value={shard.name}
-            onChange={(e) => w().rename(shard.id, e.target.value)}
-            aria-label="Shard name"
-            spellCheck={false}
-          />
-        )}
-        <div className="workshop__modes" role="group" aria-label="Render mode">
-          {MODES.map((m: ShardMode) => (
-            <button key={m} className={`workshop__mode ${shard?.mode === m ? 'is-on' : ''}`} aria-pressed={shard?.mode === m} onClick={() => w().setMode(m)}>
-              {m.toUpperCase()}
-            </button>
-          ))}
-        </div>
-        <button
-          className="workshop__deploy"
-          disabled={!shard || shard.vertices.length === 0}
-          onClick={() => { if (shard) { useShards.getState().startDeployShard(shard.id); w().closeWorkshop() } }}
-          title="Place this shard in the world"
-        >DEPLOY ▸</button>
-        <button className="workshop__close" onClick={() => w().closeWorkshop()}>CLOSE</button>
-      </header>
+      <div className="workshop__bench">
+        <Bench />
+      </div>
+      <Intro />
+      <Toast />
 
-      {listOpen && (
-        <aside className="workshop__list">
+      {/* Top left: the three chips and the history in one row, wrapping on a phone,
+          and the open panel under whatever the row wrapped to. */}
+      <div className="ws__top">
+      <div className="ws__chips">
+        <button className={`chip ws__chip ${panel === 'menu' ? 'is-on' : ''}`} aria-pressed={panel === 'menu'} onClick={() => toggle('menu')}>
+          <Menu size={12} strokeWidth={2.25} aria-hidden />MENU
+        </button>
+        <button className={`chip ws__chip ${panel === 'tools' ? 'is-on' : ''}`} aria-pressed={panel === 'tools'} onClick={() => toggle('tools')}>
+          <Wrench size={12} strokeWidth={2.25} aria-hidden />TOOLS · {tool.toUpperCase()}
+        </button>
+        <button className={`chip ws__chip ${panel === 'grid' ? 'is-on' : ''}`} aria-pressed={panel === 'grid'} onClick={() => toggle('grid')}>
+          <Grid3x3 size={12} strokeWidth={2.25} aria-hidden />GRID
+        </button>
+        <span className="ws__history">
+          <button className="chip ws__icon" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)" aria-label="Undo"><Undo2 size={15} strokeWidth={2.25} aria-hidden /></button>
+          <button className="chip ws__icon" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)" aria-label="Redo"><Redo2 size={15} strokeWidth={2.25} aria-hidden /></button>
+        </span>
+      </div>
+      {panel === 'menu' && shard && (
+        <div className="ws__panel" role="region" aria-label="Menu">
+          <input className="workshop__name" value={shard.name} onChange={(e) => w().rename(shard.id, e.target.value)} aria-label="Shard name" spellCheck={false} />
+          <div className="ws__stats">
+            {shard.vertices.length} vertices · {shard.faces.length} faces · unit 2^{shard.unit} = {formatCellSize(shard.unit)}
+            {shard.mode !== 'solid' && shard.faces.length > 0 && <> · faces draw in SOLID</>}
+          </div>
+          <div className="workshop__row">
+            <span className="workshop__label">DRAW</span>
+            <div className="workshop__modes" role="group" aria-label="Render mode">
+              {MODES.map((m: ShardMode) => (
+                <button key={m} className={`workshop__mode ${shard.mode === m ? 'is-on' : ''}`} aria-pressed={shard.mode === m} onClick={() => w().setMode(m)}>{m.toUpperCase()}</button>
+              ))}
+            </div>
+          </div>
+          <div className="ws__panel-title">SHARDS ({shards.length})</div>
           <div className="workshop__list-row">
-            <button className="workshop__new" onClick={() => { w().create(); setListOpen(false) }}>+ NEW SHARD</button>
+            <button className="workshop__new" onClick={() => w().create()}>+ NEW SHARD</button>
             <button className="workshop__btn" onClick={() => void paste()} title="A shard copied from here or anywhere">PASTE</button>
           </div>
           {pasteOpen && (
             <div className="workshop__paste">
-              <textarea
-                className="workshop__paste-box"
-                value={pasteText}
-                onChange={(e) => setPasteText(e.target.value)}
-                placeholder='Paste a shard here: {"v":1,"type":"shard",...}'
-                aria-label="Shard to import"
-                spellCheck={false}
-              />
+              <textarea className="workshop__paste-box" value={pasteText} onChange={(e) => setPasteText(e.target.value)} placeholder='Paste a shard here: {"v":1,"type":"shard",...}' aria-label="Shard to import" spellCheck={false} />
               <div className="workshop__list-row">
                 <button className="workshop__btn" disabled={!pasteText.trim()} onClick={() => importText(pasteText)}>IMPORT</button>
                 <button className="workshop__btn" onClick={() => { setPasteOpen(false); setPasteText('') }}>CANCEL</button>
               </div>
             </div>
           )}
-          <ul>
+          <ul className="workshop__list">
             {shards.map((s) => (
-              <li key={s.id} className={s.id === shard?.id ? 'is-current' : ''}>
-                <button className="workshop__pick" onClick={() => { w().select(s.id); setListOpen(false) }}>
+              <li key={s.id} className={s.id === shard.id ? 'is-current' : ''}>
+                <button className="workshop__pick" onClick={() => w().select(s.id)}>
                   <span className="workshop__pick-name">{s.name}</span>
                   <span className="workshop__pick-meta">{s.vertices.length} v · {s.faces.length} f · {s.mode}</span>
                 </button>
                 <button className="workshop__mini" title="Duplicate" onClick={() => w().duplicate(s.id)}>⧉</button>
                 <button className="workshop__mini workshop__mini--wide" title="Copy to the clipboard" onClick={() => copy(s.id)}>COPY</button>
-                <button className="workshop__mini workshop__mini--danger" title="Delete" onClick={() => { if (window.confirm(`Delete "${s.name}"? This cannot be undone.`)) w().remove(s.id) }}>✕</button>
+                <button className="workshop__mini workshop__mini--danger" title="Delete" onClick={() => { if (window.confirm(`Delete "${s.name}"? This cannot be undone.`)) w().remove(s.id) }}>×</button>
               </li>
             ))}
           </ul>
-        </aside>
+          <div className="workshop__row">
+            <button className="workshop__btn workshop__btn--danger" disabled={shard.vertices.length === 0} onClick={() => { if (window.confirm('Clear every vertex and face of this shard?')) w().clearShard() }} title="Empty this shard (undoable)">CLEAR SHARD</button>
+            <span className="workshop__gap" />
+            <Explanation>
+              A shard is colored points on a grid of whole units, drawn SOLID (faces, colors blending
+              across them), POINTS (every point a light) or LINES (one line through the points in the
+              order they were made). STAMP places a whole shape; ADD one point; SELECT points, by tap
+              or by dragging a box, to move, color or delete them together, and CONNECT takes everything
+              faces join to them; FACE picks corners and FILL joins them, and a tap on a face selects it
+              for DELETE FACE. The palette keeps every color the picker settles on; hold a swatch to
+              delete it. Stamps keep their own corners even where they touch, so a red block against a
+              blue one keeps a crisp edge. Under GRID, LEVEL is the height the placing tools work at,
+              DEPLOY SCALE MULTIPLIER says how big one grid unit is in the world, from a picometre to
+              the width of a sector, and SCALE is how far the grid reaches from the origin. DEPLOY shows
+              the shard at true size before you place it. Keys: 1 2 3 4 tools, Q turns a stamp, WASD and
+              RF or the arrows nudge the selection in screen directions, C selects what faces join, Del
+              deletes, Enter fills, [ ] change the level, Ctrl+Z undoes, Esc clears then closes.
+            </Explanation>
+          </div>
+        </div>
       )}
 
-      <div className="workshop__bench">
-        <Bench />
-        <Intro />
-        {shard && (
-          <div className="workshop__stats">
-            {shard.vertices.length} vertices · {shard.faces.length} faces · unit 2^{shard.unit} = {formatCellSize(shard.unit)}
-            {selection.length === 1 && shard.vertices[selection[0]] && (
-              <> · selected ({shard.vertices[selection[0]].p.join(', ')})</>
-            )}
-            {selectedPoints > 1 && <> · {selectedPoints} points selected</>}
-            {selectedFace !== null && <> · face {selectedFace + 1} selected</>}
-            {tool === 'face' && facePick.length > 0 && <> · {facePick.length} corner{facePick.length === 1 ? '' : 's'}</>}
-            {shard.mode !== 'solid' && shard.faces.length > 0 && <> · faces draw in SOLID</>}
-            {notice && <div className="workshop__notice">{notice}</div>}
+      {panel === 'tools' && (
+        <div className="ws__panel" role="region" aria-label="Tools">
+          <div className="workshop__row" role="group" aria-label="Tool">
+            {TOOLS.map((t, i) => {
+              const Icon = TOOL_ICON[t]
+              return (
+                <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => w().setTool(t)} title={`${t} (${i + 1})`}>
+                  <Icon size={12} strokeWidth={2.25} aria-hidden />{t.toUpperCase()}
+                </button>
+              )
+            })}
           </div>
-        )}
+          {TOOL_HELP[tool] && <div className="workshop__help">{TOOL_HELP[tool]}</div>}
+          {tool === 'stamp' && (
+            <>
+              <div className="workshop__row" role="group" aria-label="Shape">
+                <span className="workshop__label">SHAPE</span>
+                <div className="workshop__shapes">
+                  {STAMPS.map((k: StampKind) => (
+                    <button key={k} className={`workshop__tool ${stampKind === k ? 'is-on' : ''}`} aria-pressed={stampKind === k} onClick={() => w().setStampKind(k)} title={STAMP_HELP[k]}>{k.toUpperCase()}</button>
+                  ))}
+                </div>
+              </div>
+              <div className="workshop__row">
+                <span className="workshop__label">SIZE</span>
+                <button className="workshop__btn" {...bind(() => w().setStampSize(w().stampSize - 1))} disabled={stampSize <= MIN_SIZE} aria-label="Smaller">−</button>
+                <span className="workshop__value">{stampSize}</span>
+                <button className="workshop__btn" {...bind(() => w().setStampSize(w().stampSize + 1))} disabled={stampSize >= MAX_SIZE} aria-label="Larger">+</button>
+                {FACED[stampKind] && (
+                  <>
+                    <span className="workshop__label workshop__label--gap">FACING</span>
+                    <button className="workshop__btn" onClick={() => w().turnStamp()} title="Turn a quarter (Q)">{FACING_LABEL[stampFacing]} ↻</button>
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {panel === 'grid' && shard && (
+        <div className="ws__panel" role="region" aria-label="Grid">
+          <div className="workshop__row">
+            <span className="workshop__label">LEVEL Y</span>
+            <button className="workshop__btn" {...bind(() => w().setLevel(w().level - 1))} disabled={level <= -extent} aria-label="Level down">−</button>
+            <span className="workshop__value">{level}</span>
+            <button className="workshop__btn" {...bind(() => w().setLevel(w().level + 1))} disabled={level >= extent} aria-label="Level up">+</button>
+            <span className="workshop__unit-size">the height the placing tools work at</span>
+          </div>
+          <div className="workshop__row">
+            <span className="workshop__label">DEPLOY SCALE MULTIPLIER</span>
+            <span className="workshop__value">2^</span>
+            <button className="workshop__btn" {...bind(() => w().setUnit((w().current()?.unit ?? 0) - 1))} disabled={shard.unit <= 0} aria-label="Smaller unit">−</button>
+            <span className="workshop__value">{shard.unit}</span>
+            <button className="workshop__btn" {...bind(() => w().setUnit((w().current()?.unit ?? 0) + 1))} disabled={shard.unit >= 84} aria-label="Larger unit">+</button>
+            <span className="workshop__unit-size" title="What one grid unit is in the world. DEPLOY shows the shard at this size.">one unit = {formatCellSize(shard.unit)}</span>
+          </div>
+          <div className="workshop__row">
+            <span className="workshop__label">SCALE</span>
+            <button className="workshop__btn" {...bind(() => w().setExtent((w().current()?.extent ?? MIN_EXTENT) - 1))} disabled={extent <= minExtent} aria-label="Smaller grid">−</button>
+            <span className="workshop__value">{extent}</span>
+            <button className="workshop__btn" {...bind(() => w().setExtent((w().current()?.extent ?? MIN_EXTENT) + 1))} disabled={extent >= MAX_EXTENT} aria-label="Larger grid">+</button>
+            <span className="workshop__unit-size" title="Saved with the shard. Never below what its points need.">gibsons each side of each axis</span>
+          </div>
+        </div>
+      )}
+
       </div>
 
-      <div className="workshop__tools">
-        <div className="workshop__row" role="group" aria-label="Tool">
-          {TOOLS.map((t, i) => {
-            const Icon = TOOL_ICON[t]
-            return (
-              <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => w().setTool(t)} title={`${t} (${i + 1})`}>
-                <Icon size={12} strokeWidth={2.25} aria-hidden />{t.toUpperCase()}
-              </button>
-            )
-          })}
-          <span className="workshop__gap" />
-          <button className="workshop__btn" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)">UNDO</button>
-          <button className="workshop__btn" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)">REDO</button>
-          <span className="workshop__help">{TOOL_HELP[tool]}</span>
-          <Explanation>
-            A shard is colored points on a grid of whole units, drawn SOLID (faces, colors blending
-            across them), POINTS (every point a light) or LINES (one line through the points in the
-            order they were made). STAMP places a whole shape; ADD one point; SELECT a point to move,
-            color or delete it; FACE picks corners and FILL joins them, and a tap on a face selects it
-            for DELETE FACE. The palette keeps every color the picker settles on; hold a swatch to
-            delete it. Stamps keep their own corners
-            even where they touch, so a red block against a blue one keeps a crisp edge. UNIT says how
-            big one grid unit is in the world, from a picometre to the width of a sector; DEPLOY shows
-            the shard at true size before you place it. Keys: 1 2 3 4 tools, Q turns a stamp, WASD /
-            RF or arrows nudge, Del deletes, Enter fills, [ ] change the level, Ctrl+Z undoes, Esc
-            deselects then closes.
-          </Explanation>
-        </div>
+      {/* Top right: the way out, and the way into the world. */}
+      <div className="ws__exit">
+        <button
+          className="workshop__deploy"
+          disabled={!shard || shard.vertices.length === 0}
+          onClick={() => { if (shard) { useShards.getState().startDeployShard(shard.id); w().closeWorkshop() } }}
+          title="Place this shard in the world"
+        >DEPLOY ▸</button>
+        <button className="chip ws__icon" onClick={() => w().closeWorkshop()} title="Close the workshop (Esc)" aria-label="Close"><X size={15} strokeWidth={2.25} aria-hidden /></button>
+      </div>
 
-        {tool === 'stamp' && (
-          <div className="workshop__row" role="group" aria-label="Shape">
-            <span className="workshop__label">SHAPE</span>
-            <div className="workshop__shapes">
-              {STAMPS.map((k: StampKind) => (
-                <button key={k} className={`workshop__tool ${stampKind === k ? 'is-on' : ''}`} aria-pressed={stampKind === k} onClick={() => w().setStampKind(k)} title={STAMP_HELP[k]}>
-                  {k.toUpperCase()}
-                </button>
-              ))}
-            </div>
-            <span className="workshop__label workshop__label--gap">SIZE</span>
-            <button className="workshop__btn" {...bind(() => w().setStampSize(w().stampSize - 1))} disabled={stampSize <= MIN_SIZE} aria-label="Smaller">−</button>
-            <span className="workshop__value">{stampSize}</span>
-            <button className="workshop__btn" {...bind(() => w().setStampSize(w().stampSize + 1))} disabled={stampSize >= MAX_SIZE} aria-label="Larger">+</button>
-            {FACED[stampKind] && (
-              <>
-                <span className="workshop__label workshop__label--gap">FACING</span>
-                <button className="workshop__btn" onClick={() => w().turnStamp()} title="Turn a quarter (Q)">{FACING_LABEL[stampFacing]} ↻</button>
-              </>
-            )}
-          </div>
-        )}
-
-        {tool === 'select' && (
-          <div className="workshop__row">
-            <span className="workshop__label">NUDGE</span>
-            <div className="workshop__pad" role="group" aria-label="Move selected point">
-              <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, -1))} title="−X (A)">−X</button>
-              <button className="workshop__btn workshop__btn--x" disabled={!canNudge} {...bind(nudge(0, 1))} title="+X (D)">+X</button>
-              <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, -1))} title="−Y (F)">−Y</button>
-              <button className="workshop__btn workshop__btn--y" disabled={!canNudge} {...bind(nudge(1, 1))} title="+Y (R)">+Y</button>
-              <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, -1))} title="−Z (W)">−Z</button>
-              <button className="workshop__btn workshop__btn--z" disabled={!canNudge} {...bind(nudge(2, 1))} title="+Z (S)">+Z</button>
-            </div>
-            <button className="workshop__btn" disabled={!canNudge} onClick={() => w().selectConnected()} title="Select everything joined to the selection by faces (C)">CONNECTED</button>
-            <button className="workshop__btn" disabled={!canNudge} onClick={() => w().selectVertex(null)} title="Clear the selection (Esc)">CLEAR</button>
-            <button className="workshop__btn workshop__btn--danger" disabled={!canNudge} onClick={() => w().deleteSelected()} title="Delete the selected points (Del)">DELETE</button>
-          </div>
-        )}
-
-        {tool === 'face' && selectedFace !== null && (
-          <div className="workshop__row">
-            <span className="workshop__label">FACE</span>
+      {/* Bottom right: the pad while points are selected, face actions while a face is in hand, the color bar under either. */}
+      <div className="ws__corner">
+        {selection.length > 0 && <ControlsPad points={selectedPoints} />}
+        {facing && selectedFace !== null && (
+          <div className="benchops" role="group" aria-label="Selected face">
             <span className="workshop__value workshop__value--wide">face {selectedFace + 1} of {shard?.faces.length ?? 0}</span>
             <button className="workshop__btn workshop__btn--danger" onClick={() => w().deleteSelectedFace()} title="Remove this face (Del)">DELETE FACE</button>
             <button className="workshop__btn" onClick={() => w().selectFace(null)} title="Keep it (Esc)">CANCEL</button>
           </div>
         )}
-
-        {tool === 'face' && selectedFace === null && (
-          <div className="workshop__row">
-            <span className="workshop__label">FACE</span>
+        {facing && selectedFace === null && (
+          <div className="benchops" role="group" aria-label="Face corners">
             <span className="workshop__value workshop__value--wide">{facePick.length} corner{facePick.length === 1 ? '' : 's'}</span>
             <button className="workshop__btn" disabled={facePick.length < 3} onClick={() => w().fill()} title="Join the corners into a face (Enter)">FILL</button>
-            <button className="workshop__btn" disabled={facePick.length === 0} onClick={() => w().clearFacePick()} title="Drop the picks (Esc)">CANCEL</button>
+            <button className="workshop__btn" onClick={() => w().clearFacePick()} title="Drop the picks (Esc)">CANCEL</button>
           </div>
         )}
-
-        <div className="workshop__row">
-          <span className="workshop__label">LEVEL Y</span>
-          <button className="workshop__btn" {...bind(() => w().setLevel(w().level - 1))} disabled={level <= -GRID_HALF} aria-label="Level down">−</button>
-          <span className="workshop__value">{level}</span>
-          <button className="workshop__btn" {...bind(() => w().setLevel(w().level + 1))} disabled={level >= GRID_HALF} aria-label="Level up">+</button>
-
-          <span className="workshop__sep" aria-hidden />
-          <span className="workshop__label">UNIT 2^</span>
-          {/* Read the unit from the store, not the render: held, the button repeats, and the closure's shard is the one from before the first step. */}
-          <button className="workshop__btn" {...bind(() => w().setUnit((w().current()?.unit ?? 0) - 1))} disabled={!shard || shard.unit <= 0} aria-label="Smaller unit">−</button>
-          <span className="workshop__value">{shard?.unit ?? 0}</span>
-          <button className="workshop__btn" {...bind(() => w().setUnit((w().current()?.unit ?? 0) + 1))} disabled={!shard || shard.unit >= 84} aria-label="Larger unit">+</button>
-          <span className="workshop__unit-size" title="What one grid unit is in the world. DEPLOY shows the shard at this size.">= {formatCellSize(shard?.unit ?? 0)}</span>
-          <span className="workshop__gap" />
-          <button className="workshop__btn workshop__btn--danger" disabled={!shard || shard.vertices.length === 0} onClick={() => { if (window.confirm('Clear every vertex and face of this shard? (UNDO brings it back.)')) w().clearShard() }}>CLEAR</button>
-        </div>
-
-        <div className="workshop__row">
-          <span className="workshop__label">COLOR</span>
-          <span className="workshop__picker" title="Pick any color; it joins the palette">
-            <input
-              type="color"
-              className="workshop__color"
-              value={hex}
-              list="workshop-palette"
-              onChange={(e) => pick(e.target.value)}
-              onBlur={(e) => settled(e.target.value)}
-              aria-label="Pick a color"
-              {...noCallout}
-            />
-            <Pipette className="workshop__picker-icon" size={13} strokeWidth={2.25} aria-hidden />
-            {/* Browsers that honour it (Chrome, desktop and Android) offer these inside the picker as starting points. */}
-            <datalist id="workshop-palette">{palette.map((h) => <option key={h} value={h} />)}</datalist>
-          </span>
-          <div className="workshop__swatches">
-            {palette.map((h) => (
-              <Swatch key={h} hex={h} on={h === hex} onUse={() => w().colorSelected(hexToRgb(h))} onHold={() => setDeleteColor(h)} />
-            ))}
+        {tool !== 'face' && (
+          <div className="ws__color" role="group" aria-label="Color">
+            <span className="workshop__label">COLOR</span>
+            <span className="workshop__picker" title="Pick any color; it joins the palette">
+              <input type="color" className="workshop__color" value={hex} list="workshop-palette" onChange={(e) => pick(e.target.value)} onBlur={(e) => settled(e.target.value)} aria-label="Pick a color" {...noCallout} />
+              <Pipette className="workshop__picker-icon" size={13} strokeWidth={2.25} aria-hidden />
+              <datalist id="workshop-palette">{palette.map((h) => <option key={h} value={h} />)}</datalist>
+            </span>
+            <div className="workshop__swatches">
+              {palette.map((h) => (
+                <Swatch key={h} hex={h} on={h === hex} onUse={() => w().colorSelected(hexToRgb(h))} onHold={() => setDeleteColor(h)} />
+              ))}
+            </div>
+            <button className="workshop__btn" disabled={!shard || shard.vertices.length === 0} onClick={() => w().colorAll(w().color)} title="Apply the color to every vertex">ALL</button>
           </div>
-          <button className="workshop__btn" disabled={!shard || shard.vertices.length === 0} onClick={() => w().colorAll(w().color)} title="Apply the color to every vertex">ALL</button>
-        </div>
+        )}
       </div>
 
       {deleteColor !== null && (

--- a/src/workshop/benchAxes.ts
+++ b/src/workshop/benchAxes.ts
@@ -1,0 +1,82 @@
+/**
+ * benchAxes.ts - which way is up on the bench.
+ *
+ * The nudge keys and pad speak in screen terms, as the cursor's do in the
+ * world: W is screen up, S screen down, A left, D right, R into the screen,
+ * F out of it. The bench camera orbits freely, so each of those is snapped to
+ * the world axis it most nearly points along, and re-snapped as the camera
+ * turns. A small store carries the snapped axes out of the canvas for the
+ * pad's labels.
+ */
+
+import { create } from 'zustand'
+import { Vector3, type Camera } from 'three'
+
+export type NudgeName = 'up' | 'down' | 'left' | 'right' | 'away' | 'toward'
+
+export interface BenchAxis {
+  axis: 0 | 1 | 2
+  dir: 1 | -1
+}
+
+export interface BenchAxes {
+  /** World axis pointing right on screen. */
+  right: BenchAxis
+  /** World axis pointing up on screen. */
+  up: BenchAxis
+  /** World axis pointing out of the screen, toward the viewer. */
+  out: BenchAxis
+}
+
+const snap = (v: Vector3): BenchAxis => {
+  const a = [Math.abs(v.x), Math.abs(v.y), Math.abs(v.z)]
+  const axis: 0 | 1 | 2 = a[0] >= a[1] && a[0] >= a[2] ? 0 : a[1] >= a[2] ? 1 : 2
+  const c = axis === 0 ? v.x : axis === 1 ? v.y : v.z
+  return { axis, dir: c >= 0 ? 1 : -1 }
+}
+
+const RIGHT = new Vector3(), UP = new Vector3(), OUT = new Vector3()
+
+/** The camera's basis, snapped to world axes. */
+export function benchAxes(camera: Camera): BenchAxes {
+  const q = camera.quaternion
+  return {
+    right: snap(RIGHT.set(1, 0, 0).applyQuaternion(q)),
+    up: snap(UP.set(0, 1, 0).applyQuaternion(q)),
+    out: snap(OUT.set(0, 0, 1).applyQuaternion(q)),
+  }
+}
+
+export interface Nudge {
+  axis: 0 | 1 | 2
+  delta: 1 | -1
+}
+
+/** The world move a screen direction means under these axes. */
+export function nudgeFor(axes: BenchAxes, name: NudgeName): Nudge {
+  const flip = (a: BenchAxis): Nudge => ({ axis: a.axis, delta: a.dir === 1 ? -1 : 1 })
+  const keep = (a: BenchAxis): Nudge => ({ axis: a.axis, delta: a.dir })
+  switch (name) {
+    case 'right': return keep(axes.right)
+    case 'left': return flip(axes.right)
+    case 'up': return keep(axes.up)
+    case 'down': return flip(axes.up)
+    case 'toward': return keep(axes.out)
+    case 'away': return flip(axes.out)
+  }
+}
+
+/** "+Y", "−Z": what the pad prints under each arrow. */
+export function nudgeLabel(n: Nudge): string {
+  return `${n.delta > 0 ? '+' : '−'}${'XYZ'[n.axis]}`
+}
+
+export const sameAxes = (a: BenchAxes, b: BenchAxes): boolean =>
+  a.right.axis === b.right.axis && a.right.dir === b.right.dir &&
+  a.up.axis === b.up.axis && a.up.dir === b.up.dir &&
+  a.out.axis === b.out.axis && a.out.dir === b.out.dir
+
+/** The bench's default view: X right, Y up, Z toward the viewer. */
+export const DEFAULT_AXES: BenchAxes = { right: { axis: 0, dir: 1 }, up: { axis: 1, dir: 1 }, out: { axis: 2, dir: 1 } }
+
+export const useBenchView = create<{ axes: BenchAxes }>(() => ({ axes: DEFAULT_AXES }))


### PR DESCRIPTION
Stacked on #86 (base is its branch; retarget to v2 once #86 merges).

**The shell, rebuilt like the main scene.** The bench fills the screen and the controls float on it.

- Top left, a chip row: **MENU** (name, draw mode, the shard list with NEW, PASTE, COPY, duplicate, delete, CLEAR SHARD, EXPLAIN), **TOOLS** (STAMP, ADD, SELECT, FACE and the current tool's options; the SELECT hint text is gone), **GRID** (LEVEL, DEPLOY SCALE MULTIPLIER, SCALE). One panel opens at a time, under whatever the row wraps to on a phone. UNDO and REDO float beside the chips as icons, left aligned.
- Top right: DEPLOY and an X.
- Bottom right: the **CONTROLS** pad, only while points are selected. The main pad's nine cells: arrows nudge the selection in screen directions with the world axis printed under each, CONNECT and DELETE in the corners, the point count in the hub (tap clears). FACE's FILL and DELETE FACE sit in that corner while a face is in hand.
- Under those, the **COLOR** bar, absent while FACE is the tool. On a phone it spans the bottom and the pad stacks above it.

**Nudging follows the camera**, as the cursor's keys do in the world: W screen up, S down, A left, D right, R into the screen, F out of it. Each is snapped to the world axis it most nearly points along and re-snapped as the bench orbits; the pad's labels show the same.

**SCALE** is how many gibsons the grid reaches from the origin on each axis: 8 by default, 1 at least, 64 at most, never below what the shard's points need. It is saved with the shard and travels in its payload; older payloads land on 8. Stamps fit inside it and the level stays within it.

Screenshots taken on a 390×844 phone and a 1400×900 desktop across eight states (closed, MENU, TOOLS with STAMP, TOOLS with FACE and no color bar, two face corners picked, GRID, eight points selected with pad and color, pad with TOOLS open). Tests: grid scale clamping, level following, payload round trip, older payload default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz