### PR TITLE
Workshop: lit faces with dark backs, and FILL for a selection

### DIFF
--- a/src/lib/orient.test.ts
+++ b/src/lib/orient.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { orientFaces } from './orient'
+import { newell, type P3 } from './triangulate'
+import { compile, STAMPS } from './stamps'
+
+const outwardCount = (pts: P3[], faces: Array<[number, number, number]>): { outward: number; inward: number } => {
+  const c = pts.reduce<P3>((a, p) => [a[0] + p[0] / pts.length, a[1] + p[1] / pts.length, a[2] + p[2] / pts.length], [0, 0, 0])
+  let outward = 0, inward = 0
+  for (const f of faces) {
+    const [a, b, d] = f.map((i) => pts[i])
+    const n = newell([a, b, d])
+    const m = [(a[0] + b[0] + d[0]) / 3 - c[0], (a[1] + b[1] + d[1]) / 3 - c[1], (a[2] + b[2] + d[2]) / 3 - c[2]]
+    const dot = n[0] * m[0] + n[1] * m[1] + n[2] * m[2]
+    if (dot > 1e-9) outward++; else if (dot < -1e-9) inward++
+  }
+  return { outward, inward }
+}
+
+describe('orientFaces', () => {
+  it('turns every closed stamp fully outward, whatever it was authored as', () => {
+    for (const k of STAMPS) {
+      const s = compile(k, 2, 0, [0, 0, 0])
+      if (s.faces.length === 0) continue
+      const before = outwardCount(s.points, s.faces)
+      const after = outwardCount(s.points, orientFaces(s.points, s.faces))
+      if (before.outward + before.inward === s.faces.length) {
+        // A closed shape: all outward afterwards.
+        expect(after.inward, k).toBe(0)
+        expect(after.outward, k).toBe(s.faces.length)
+      }
+    }
+  })
+  it('agrees across a shared edge and faces a flat plate up', () => {
+    const pts: P3[] = [[0, 0, 0], [1, 0, 0], [1, 0, 1], [0, 0, 1]]
+    // Two triangles of one square, wound against each other.
+    const faces: Array<[number, number, number]> = [[0, 1, 2], [0, 3, 2]]
+    const out = orientFaces(pts, faces)
+    const n0 = newell(out[0].map((i) => pts[i])), n1 = newell(out[1].map((i) => pts[i]))
+    expect(Math.sign(n0[1])).toBe(Math.sign(n1[1]))
+    expect(n0[1]).toBeGreaterThan(0)
+  })
+  it('leaves the stored faces alone', () => {
+    const pts: P3[] = [[0, 0, 0], [1, 0, 0], [0, 0, 1]]
+    const faces: Array<[number, number, number]> = [[0, 2, 1]]
+    orientFaces(pts, faces)
+    expect(faces[0]).toEqual([0, 2, 1])
+  })
+})

--- a/src/lib/orient.ts
+++ b/src/lib/orient.ts
@@ -1,0 +1,76 @@
+/**
+ * orient.ts - faces wound the same way, for shading.
+ *
+ * A shard's faces come from stamps, from hand-picked corners and from FILL,
+ * and their windings agree with nothing: half a stamped block's triangles
+ * wind inward. Drawn unlit and two-sided, as in the world, that never showed.
+ * The bench lights its faces and paints their backs dark, so that an open
+ * shape shows its inside, and for that every face must wind outward.
+ *
+ * This pass rewinds a copy for drawing; the stored faces are untouched. Faces
+ * that share an edge are made to agree (a shared edge runs opposite ways in
+ * two consistently wound faces), component by component; a closed component
+ * is then flipped outward by its signed volume, and a flat one is turned to
+ * face up, or the nearest axis its normal leans along.
+ */
+
+import { newell, type P3 } from './triangulate'
+
+type Face = [number, number, number]
+
+const key = (a: number, b: number): string => `${a}>${b}`
+
+export function orientFaces(points: P3[], faces: Face[]): Face[] {
+  const out: Face[] = faces.map((f) => [f[0], f[1], f[2]])
+  const n = out.length
+  if (n === 0) return out
+  // Directed edges as wound now: edge a>b of face i.
+  const byEdge = new Map<string, number[]>()
+  const add = (a: number, b: number, i: number): void => {
+    const k = a < b ? key(a, b) : key(b, a)
+    byEdge.set(k, [...(byEdge.get(k) ?? []), i])
+  }
+  out.forEach((f, i) => { add(f[0], f[1], i); add(f[1], f[2], i); add(f[2], f[0], i) })
+  const seen = new Array<boolean>(n).fill(false)
+  const component: number[] = []
+  const flip = (f: Face): void => { const t = f[1]; f[1] = f[2]; f[2] = t }
+  const hasDirected = (f: Face, a: number, b: number): boolean =>
+    (f[0] === a && f[1] === b) || (f[1] === a && f[2] === b) || (f[2] === a && f[0] === b)
+  for (let start = 0; start < n; start++) {
+    if (seen[start]) continue
+    const queue = [start]
+    seen[start] = true
+    component.length = 0
+    while (queue.length) {
+      const i = queue.shift() as number
+      component.push(i)
+      const f = out[i]
+      for (const [a, b] of [[f[0], f[1]], [f[1], f[2]], [f[2], f[0]]] as Array<[number, number]>) {
+        const k = a < b ? key(a, b) : key(b, a)
+        for (const j of byEdge.get(k) ?? []) {
+          if (j === i || seen[j]) continue
+          // Consistent neighbours run the shared edge the other way: b>a.
+          if (hasDirected(out[j], a, b)) flip(out[j])
+          seen[j] = true
+          queue.push(j)
+        }
+      }
+    }
+    // The component as a whole: outward when closed, up when flat.
+    let volume = 0
+    let nx = 0, ny = 0, nz = 0
+    for (const i of component) {
+      const [a, b, c] = out[i].map((v) => points[v])
+      volume += (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0]) + a[2] * (b[0] * c[1] - b[1] * c[0])) / 6
+      const m = newell([a, b, c]); nx += m[0]; ny += m[1]; nz += m[2]
+    }
+    let inward: boolean
+    if (Math.abs(volume) > 1e-9) inward = volume < 0
+    else {
+      const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz)
+      inward = ay >= ax && ay >= az ? ny < 0 : ax >= az ? nx < 0 : nz < 0
+    }
+    if (inward) for (const i of component) flip(out[i])
+  }
+  return out
+}

--- a/src/lib/triangulate.ts
+++ b/src/lib/triangulate.ts
@@ -22,7 +22,7 @@ export type P3 = [number, number, number]
 type P2 = [number, number]
 
 /** Newell's method: the normal of a (possibly non-planar) loop, unnormalised. */
-function newell(points: P3[]): P3 {
+export function newell(points: P3[]): P3 {
   const n: P3 = [0, 0, 0]
   for (let i = 0; i < points.length; i++) {
     const a = points[i], b = points[(i + 1) % points.length]

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -16,7 +16,6 @@ import { useFrame, type ThreeEvent } from '@react-three/fiber'
 import {
   AddEquation,
   AdditiveBlending,
-  BackSide,
   FrontSide,
   CustomBlending,
   OneFactor,
@@ -94,6 +93,22 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
     return g
   }, [posAttr, colAttr, index])
 
+  // The inside of every face as a front face of its own: the same triangles
+  // wound the other way. Flat shading takes a face's normal from the screen,
+  // and a back face's points away from the viewer, so drawn as back faces the
+  // insides could only ever be ambient; drawn as front faces they take the
+  // lights like the outsides do.
+  const inside = useMemo(() => {
+    if (!lit) return null
+    const g = new BufferGeometry()
+    g.setAttribute('position', posAttr)
+    g.setAttribute('color', colAttr)
+    const flipped: number[] = []
+    for (let i = 0; i + 2 < index.length; i += 3) flipped.push(index[i], index[i + 2], index[i + 1])
+    g.setIndex(flipped)
+    return g
+  }, [posAttr, colAttr, index, lit])
+
   const line = useMemo(() => {
     const l = new Line(plain, new LineBasicMaterial({ vertexColors: true, toneMapped: false, transparent: true, opacity: ghost ? 0.45 : 1 }))
     l.frustumCulled = false
@@ -104,6 +119,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
   // is a primitive, which R3F never disposes, so its material is ours too.
   useEffect(() => () => { plain.dispose() }, [plain])
   useEffect(() => () => { indexed.dispose() }, [indexed])
+  useEffect(() => () => { inside?.dispose() }, [inside])
   useEffect(() => () => { line.material.dispose() }, [line])
 
   // The scrambled start: each vertex thrown somewhere in the model's extent.
@@ -160,10 +176,10 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
               ? <meshLambertMaterial vertexColors flatShading side={FrontSide} transparent opacity={opacity} />
               : <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} {...(world && !ghost ? TAG_BLEND : {})} />}
           </mesh>
-          {lit && (
-            <mesh geometry={indexed} frustumCulled={false}>
-              {/* The inside of a face: the vertex colour at a quarter. */}
-              <meshBasicMaterial vertexColors color="#404040" side={BackSide} transparent opacity={opacity} />
+          {lit && inside && (
+            <mesh geometry={inside} frustumCulled={false}>
+              {/* The inside of a face: lit like the outside, darker by a multiplier so it still reads as inside. */}
+              <meshLambertMaterial vertexColors flatShading color="#6a6a6a" side={FrontSide} transparent opacity={opacity} />
             </mesh>
           )}
         </group>

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -16,6 +16,8 @@ import { useFrame, type ThreeEvent } from '@react-three/fiber'
 import {
   AddEquation,
   AdditiveBlending,
+  BackSide,
+  FrontSide,
   CustomBlending,
   OneFactor,
   ZeroFactor,
@@ -27,6 +29,7 @@ import {
 } from 'three'
 import { easeOutCubic, hash01, scrambleOffset, seedOf, SHARD_DECODE_MS } from '../lib/decode'
 import { flatten, type ShardModel } from '../lib/shards'
+import { orientFaces } from '../lib/orient'
 
 interface Props {
   shard: ShardModel
@@ -34,6 +37,13 @@ interface Props {
   scale?: number
   /** Dimmed, for a preview that is not yet real. */
   ghost?: boolean
+  /**
+   * Lit, as on the bench: faces shaded flat by the scene's lights, wound
+   * consistently outward (lib/orient.ts) and their backs painted dark, so an
+   * open shape shows its inside and a missing face is plain to see. The
+   * world draws unlit under its bloom instead.
+   */
+  lit?: boolean
   /**
    * Drawn in the world, under its bloom. The bloom adds a blurred copy of
    * everything lit back onto the frame, and across a filled face that is
@@ -58,8 +68,11 @@ const STATIC = [0, 0.9, 1] as const
  */
 const TAG_BLEND = { blending: CustomBlending, blendEquation: AddEquation, blendSrc: OneFactor, blendDst: ZeroFactor, blendSrcAlpha: ZeroFactor, blendDstAlpha: ZeroFactor } as const
 
-export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick, world = false }: Props): JSX.Element | null {
-  const { positions, colors, index } = useMemo(() => flatten(shard), [shard.vertices, shard.faces])
+export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick, world = false, lit = false }: Props): JSX.Element | null {
+  const { positions, colors, index } = useMemo(() => {
+    const f = flatten(shard)
+    return lit ? { ...f, index: orientFaces(shard.vertices.map((v) => v.p), shard.faces).flat() } : f
+  }, [shard.vertices, shard.faces, lit])
 
   // Live copies: the decode writes into these, the targets stay untouched.
   const posAttr = useMemo(() => new Float32BufferAttribute(positions.slice(), 3), [positions])
@@ -141,9 +154,19 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
   return (
     <group scale={scale}>
       {shard.mode === 'solid' && index.length > 0 && (
-        <mesh geometry={indexed} frustumCulled={false} {...(onFaceClick ? { onClick: onFaceClick } : {})}>
-          <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} {...(world && !ghost ? TAG_BLEND : {})} />
-        </mesh>
+        <group>
+          <mesh geometry={indexed} frustumCulled={false} {...(onFaceClick ? { onClick: onFaceClick } : {})}>
+            {lit
+              ? <meshLambertMaterial vertexColors flatShading side={FrontSide} transparent opacity={opacity} />
+              : <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} {...(world && !ghost ? TAG_BLEND : {})} />}
+          </mesh>
+          {lit && (
+            <mesh geometry={indexed} frustumCulled={false}>
+              {/* The inside of a face: the vertex colour at a quarter. */}
+              <meshBasicMaterial vertexColors color="#404040" side={BackSide} transparent opacity={opacity} />
+            </mesh>
+          )}
+        </group>
       )}
       {shard.mode === 'lines' && shard.vertices.length > 1 && <primitive object={line} />}
       {(shard.mode === 'points' || shard.mode === 'solid' || shard.mode === 'lines') && (

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -151,6 +151,31 @@ describe('workshop', () => {
     expect(w().current()!.extent).toBe(8)        // an older payload lands on the default
   })
 
+  it('FILL on a selection: a flat set becomes one polygon, a solid set its hull, repeats are skipped', () => {
+    w().setTool('add')
+    for (const p of [[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]] as Array<[number, number, number]>) w().addVertex(p)
+    w().setSelection([0, 1, 2, 3])
+    w().fillSelection()
+    expect(w().current()!.faces).toHaveLength(2)
+    expect(w().notice).toMatch(/2 faces across 4 points/)
+    w().fillSelection()
+    expect(w().current()!.faces).toHaveLength(2)
+    expect(w().notice).toMatch(/already there/)
+    w().clearShard()
+    w().placeStamp([0, 0, 0])
+    const block = w().current()!
+    // The corners only, as points, on a fresh shard: their hull is the block back.
+    w().clearShard()
+    for (const v of block.vertices) w().addVertex(v.p)
+    expect(w().current()!.faces).toHaveLength(0)
+    w().setSelection(w().current()!.vertices.map((_, i) => i))
+    w().fillSelection()
+    expect(w().current()!.faces).toHaveLength(12)
+    expect(w().notice).toMatch(/12 faces around 8 points/)
+    w().setSelection([0, 1]); w().fillSelection()
+    expect(w().notice).toMatch(/three or more/)
+  })
+
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
     w().setTool('add')
     w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -23,6 +23,7 @@
 import { create } from 'zustand'
 import {
   GRID_HALF,
+  centroid,
   MAX_EXTENT,
   MIN_EXTENT,
   neededExtent,
@@ -41,7 +42,9 @@ import {
   type ShardVertex,
 } from '../lib/shards'
 import { MAX_SIZE, MIN_SIZE, stamp, type Facing, type StampKind } from '../lib/stamps'
-import { triangulate } from '../lib/triangulate'
+import { newell, triangulate } from '../lib/triangulate'
+import { Vector3 } from 'three'
+import { ConvexHull } from 'three/examples/jsm/math/ConvexHull.js'
 
 export type Tool = 'stamp' | 'add' | 'select' | 'face'
 
@@ -133,6 +136,8 @@ export interface WorkshopState {
   clearFacePick: () => void
   /** Make faces from the picked corners, in order. */
   fill: () => void
+  /** Faces for the selected points at once: a flat set becomes one polygon, a solid set its convex hull. */
+  fillSelection: () => void
   removeFace: (index: number) => void
   clearShard: () => void
   undo: () => void
@@ -184,6 +189,55 @@ function group(s: ShardModel, index: number): number[] {
 }
 
 const faceKey = (f: [number, number, number]): string => [...f].sort((a, b) => a - b).join(',')
+
+type Tri = [number, number, number]
+type Tris = Tri[] & { hull?: boolean }
+
+/**
+ * Faces for a set of points with no order given. Flat (all on one plane): the
+ * points are walked around their centre and the polygon triangulated. Not
+ * flat: their convex hull, every triangle outward. Null when they lie on a
+ * line. Indices are into `pts`.
+ */
+function facesFor(pts: P3[]): Tris | null {
+  const c: P3 = [0, 0, 0]
+  for (const p of pts) for (let a = 0; a < 3; a++) c[a] += p[a] / pts.length
+  const n = newell(pts)
+  const len = Math.hypot(n[0], n[1], n[2])
+  // Distance of every point from the best plane through them.
+  const flat = len > 1e-9 && pts.every((p) => Math.abs(((p[0] - c[0]) * n[0] + (p[1] - c[1]) * n[1] + (p[2] - c[2]) * n[2]) / len) < 1e-6)
+  if (flat) {
+    const u: P3 = Math.abs(n[0]) < 0.9 * len ? [0, n[2], -n[1]] : [n[2], 0, -n[0]]
+    const ul = Math.hypot(u[0], u[1], u[2]); u[0] /= ul; u[1] /= ul; u[2] /= ul
+    const v: P3 = [n[1] * u[2] - n[2] * u[1], n[2] * u[0] - n[0] * u[2], n[0] * u[1] - n[1] * u[0]]
+    const vl = Math.hypot(v[0], v[1], v[2]); v[0] /= vl; v[1] /= vl; v[2] /= vl
+    const angle = (p: P3): number => Math.atan2((p[0] - c[0]) * v[0] + (p[1] - c[1]) * v[1] + (p[2] - c[2]) * v[2], (p[0] - c[0]) * u[0] + (p[1] - c[1]) * u[1] + (p[2] - c[2]) * u[2])
+    const order = pts.map((p, i) => ({ i, a: angle(p) })).sort((x, y) => x.a - y.a).map((x) => x.i)
+    const tris = triangulate(order.map((i) => pts[i]))
+    if (!tris) return null
+    return tris.map((t) => [order[t[0]], order[t[1]], order[t[2]]] as Tri)
+  }
+  const hull = new ConvexHull().setFromPoints(pts.map((p) => new Vector3(p[0], p[1], p[2])))
+  const at = new Map(pts.map((p, i) => [pointKey(p), i]))
+  const out: Tris = []
+  for (const face of hull.faces) {
+    const corners: number[] = []
+    let e = face.edge
+    do { corners.push(at.get(pointKey([e.head().point.x, e.head().point.y, e.head().point.z] as P3)) as number); e = e.next } while (e !== face.edge)
+    if (corners.length === 3 && corners.every((i) => i !== undefined)) out.push([corners[0], corners[1], corners[2]])
+  }
+  if (out.length === 0) return null
+  out.hull = true
+  return out
+}
+
+/** The face wound so its normal points away from `centre`. */
+function awayFrom(s: ShardModel, f: Tri, centre: P3): Tri {
+  const [a, b, c] = f.map((i) => s.vertices[i].p)
+  const n = newell([a, b, c])
+  const m: P3 = [(a[0] + b[0] + c[0]) / 3 - centre[0], (a[1] + b[1] + c[1]) / 3 - centre[1], (a[2] + b[2] + c[2]) / 3 - centre[2]]
+  return n[0] * m[0] + n[1] * m[1] + n[2] * m[2] < 0 ? [f[0], f[2], f[1]] : f
+}
 
 export const useWorkshop = create<WorkshopState>((set, get) => {
   /** Apply an edit to the current shard, remember what it was, stamp it, persist. */
@@ -457,6 +511,35 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
         return { ...next, mode: solidIfFirstFaces(cur, next).mode }
       }, solidIfFirstFaces(s, { ...s, faces: [[0, 0, 0]] }).notice)
       set({ facePick: [] })
+    },
+
+    fillSelection: () => {
+      const s = get().current()
+      const { selection } = get()
+      if (!s) return
+      // One vertex per point, so a shared point counts once.
+      const firstAt = new Map<string, number>()
+      for (const i of selection) { const v = s.vertices[i]; if (v && !firstAt.has(pointKey(v.p))) firstAt.set(pointKey(v.p), i) }
+      const idx = [...firstAt.values()]
+      if (idx.length < 3) { set({ notice: 'Select three or more points to fill.' }); return }
+      const pts = idx.map((i) => s.vertices[i].p)
+      const faces = facesFor(pts)
+      if (!faces) { set({ notice: 'Those points do not make a face: they lie on one line.' }); return }
+      const centre = centroid(s)
+      const before = s.faces.length
+      edit((cur) => {
+        const have = new Set(cur.faces.map(faceKey))
+        const fresh = faces
+          .map((t) => [idx[t[0]], idx[t[1]], idx[t[2]]] as [number, number, number])
+          .filter((f) => validFace(f, cur.vertices.length) && !have.has(faceKey(f)))
+          // A flat fill faces away from the shard's middle; the hull already does.
+          .map((f) => faces.hull ? f : awayFrom(cur, f, centre))
+        if (!fresh.length) return null
+        const next = { ...cur, faces: [...cur.faces, ...fresh] }
+        return { ...next, mode: solidIfFirstFaces(cur, next).mode }
+      })
+      const added = (get().current()?.faces.length ?? before) - before
+      set({ notice: added ? `${added} face${added === 1 ? '' : 's'} ${faces.hull ? 'around' : 'across'} ${idx.length} points.` : 'Those faces are already there.' })
     },
 
     removeFace: (index) => edit((s) => (s.faces[index] ? { ...s, faces: s.faces.filter((_, i) => i !== index) } : null)),

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -18,7 +18,7 @@
 import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
-import { BufferGeometry, DoubleSide, Float32BufferAttribute, Line, LineBasicMaterial, Vector3 } from 'three'
+import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
 import { GRID_HALF, centroid, pointKey, rgbToHex } from '../lib/shards'
 import { benchAxes, nudgeFor, sameAxes, useBenchView, type NudgeName } from './benchAxes'
@@ -34,6 +34,24 @@ type P3 = [number, number, number]
 /** The grid point a pointer over the plane means, at the level the store says. */
 function snap(p: Vector3, level: number): P3 {
   return [Math.round(p.x), level, Math.round(p.z)]
+}
+
+/**
+ * You, to scale, at the grid's centre. An avatar is one gibson wide, and a
+ * grid unit is 2^multiplier gibsons, so this is the body the shard is being
+ * built around: a whole unit at multiplier 0, a speck at 2^10, gone by 2^20,
+ * which is the point. White, as another identity is drawn in the world.
+ */
+function ScaleAvatar(): JSX.Element {
+  const unit = useWorkshop((s) => s.current()?.unit ?? 0)
+  const geometry = useMemo(() => new EdgesGeometry(new IcosahedronGeometry(0.5, 1)), [])
+  useEffect(() => () => geometry.dispose(), [geometry])
+  const k = Math.pow(2, -unit)
+  return (
+    <lineSegments geometry={geometry} scale={k} frustumCulled={false}>
+      <lineBasicMaterial color="#ffffff" transparent opacity={0.85} toneMapped={false} />
+    </lineSegments>
+  )
 }
 
 function Grid(): JSX.Element {
@@ -226,10 +244,11 @@ function Aim(): null {
   const id = useWorkshop((s) => s.currentId)
   const controls = useThree((s) => s.controls) as unknown as { target: Vector3; update: () => void } | null
   const camera = useThree((s) => s.camera)
+  const scene = useThree((s) => s.scene)
   useEffect(() => {
-    // The browser harness projects handle positions through this to click them.
-    if (import.meta.env.DEV) (window as unknown as { __benchCamera?: unknown }).__benchCamera = camera
-  }, [camera])
+    // The browser harness projects handle positions through the camera to click them, and reaches the lights through the scene.
+    if (import.meta.env.DEV) Object.assign(window as unknown as Record<string, unknown>, { __benchCamera: camera, __benchScene: scene })
+  }, [camera, scene])
   const target = useMemo(() => {
     const shard = useWorkshop.getState().current()
     return shard ? centroid(shard) : [0, 0, 0]
@@ -412,9 +431,9 @@ export function Bench(): JSX.Element {
     >
       {/* A key light high and to one side, a dim fill from behind: faces read by
           their tilt, and the dark backs (ShardMesh lit) show through any hole. */}
-      <ambientLight intensity={0.55} />
+      <ambientLight intensity={0.4} />
       <directionalLight position={[8, 12, 6]} intensity={0.9} />
-      <directionalLight position={[-6, 3, -8]} intensity={0.3} />
+      <directionalLight position={[-9, 2, -3]} intensity={0.6} />
       {/* One finger or left drag orbits, except in SELECT where that drag is the
           marquee's. Two fingers, or the right button, pan the view in the screen
           plane; pinch or the wheel dollies. These are the controls' own bindings. */}
@@ -426,6 +445,7 @@ export function Bench(): JSX.Element {
       {/* Axes, in the compass's colors, so X is red here and out there. */}
       <axesHelper key={extent} args={[extent + 1]} />
       <Grid />
+      <ScaleAvatar />
       {shard && <ShardMesh shard={shard} lit onFaceClick={tool === 'face' ? onFace : undefined} />}
       <Ghost />
       <PickLoop />

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -352,7 +352,7 @@ function Keys(): null {
       }
       if (nudge[e.code]) { e.preventDefault(); const n = nudgeFor(benchAxes(camera), nudge[e.code]); w.moveSelected(n.axis, n.delta); return }
       if (e.code === 'Delete' || e.code === 'Backspace') { e.preventDefault(); if (w.selectedFace !== null) w.deleteSelectedFace(); else w.deleteSelected(); return }
-      if (e.code === 'Enter') { if (w.facePick.length >= 3) { e.preventDefault(); w.fill() } return }
+      if (e.code === 'Enter') { e.preventDefault(); if (w.facePick.length >= 3) w.fill(); else if (w.selection.length >= 3) w.fillSelection(); return }
       if (e.code === 'Escape') { e.preventDefault(); if (w.selection.length || w.selectedFace !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
       if (e.code === 'KeyC') { w.selectConnected(); return }
       if (e.code === 'Digit1') w.setTool('stamp')
@@ -410,7 +410,11 @@ export function Bench(): JSX.Element {
         if (w.selection.length || w.selectedFace !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() }
       }}
     >
-      <ambientLight intensity={1} />
+      {/* A key light high and to one side, a dim fill from behind: faces read by
+          their tilt, and the dark backs (ShardMesh lit) show through any hole. */}
+      <ambientLight intensity={0.55} />
+      <directionalLight position={[8, 12, 6]} intensity={0.9} />
+      <directionalLight position={[-6, 3, -8]} intensity={0.3} />
       {/* One finger or left drag orbits, except in SELECT where that drag is the
           marquee's. Two fingers, or the right button, pan the view in the screen
           plane; pinch or the wheel dollies. These are the controls' own bindings. */}
@@ -422,7 +426,7 @@ export function Bench(): JSX.Element {
       {/* Axes, in the compass's colors, so X is red here and out there. */}
       <axesHelper key={extent} args={[extent + 1]} />
       <Grid />
-      {shard && <ShardMesh shard={shard} onFaceClick={tool === 'face' ? onFace : undefined} />}
+      {shard && <ShardMesh shard={shard} lit onFaceClick={tool === 'face' ? onFace : undefined} />}
       <Ghost />
       <PickLoop />
       <FaceHighlight />

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -384,6 +384,12 @@ export function Workshop(): JSX.Element | null {
 
       {/* Bottom right: the pad while points are selected, face actions while a face is in hand, the color bar under either. */}
       <div className="ws__corner">
+        {selectedPoints >= 3 && (
+          <div className="benchops" role="group" aria-label="Fill the selection">
+            <span className="workshop__value workshop__value--wide">{selectedPoints} points</span>
+            <button className="workshop__btn" onClick={() => w().fillSelection()} title="Faces across these points: a flat set becomes one face, a solid set its hull (Enter)">FILL</button>
+          </div>
+        )}
         {selection.length > 0 && <ControlsPad points={selectedPoints} />}
         {facing && selectedFace !== null && (
           <div className="benchops" role="group" aria-label="Selected face">


### PR DESCRIPTION
Two of the three workshop notes, plus the two follow-ups; the grid precision one is a design question answered in chat.

**Shading on the bench.** Faces are shaded flat by a key light high to one side and a fill from the left, and the inside of every face is drawn darker and shaded too, so an open shape shows its inside wall by wall and a missing face is plain to see. The world still draws unlit under its bloom.

That needed every face to wind outward, and a shard's faces never agreed: half of a stamped block's twelve triangles wind inward. `lib/orient.ts` rewinds a copy for drawing: faces sharing an edge are made to agree, component by component, then a closed component is flipped outward by its signed volume and a flat one is turned to face up. Stored faces are untouched, so nothing changes on the wire. The insides are drawn as front faces of their own with reversed winding, because flat shading gives a back face a normal that points away from the viewer and leaves it ambient-only.

**You, to scale, at the centre.** A white wireframe avatar stands at the grid's origin one gibson wide, which is 2^multiplier-th of a grid unit: a whole unit at multiplier 0, a speck at 2^10, gone by 2^20.

**FILL for a selection.** With three or more points selected, FILL appears above the pad (Enter does the same). A flat set is walked around its centre and triangulated into one polygon facing away from the shard's middle; a solid set becomes its convex hull with every triangle outward; faces already present are skipped; a set on one line is refused with a notice.

Verified on the bench from three angles: a red block with its top removed shows a floor and four walls in distinct shades; selecting the four rim points and FILL closes it with two lit faces. Tests cover the orientation pass on every stamp and on a plate, and FILL on a square, on a block's eight corners, and on repeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz