### PR TITLE
Workshop: positions in ticks, a snap DIVISION, and a ticks column on the wire

### DIFF
--- a/src/lib/shards.test.ts
+++ b/src/lib/shards.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { flatten, fromPayload, newShard, toPayload, validFace, validPoint, type ShardModel } from './shards'
+import { flatten, fromPayload, newShard, toPayload, validFace, validPoint, type ShardModel, TICKS_PER_UNIT, packTicks, unpackTicks, unitsLabel } from './shards'
 
 const tri: ShardModel = {
   ...newShard('tri'),
@@ -12,8 +12,8 @@ const tri: ShardModel = {
   unit: 3,
   vertices: [
     { p: [0, 0, 0], c: [1, 0, 0] },
-    { p: [2, 0, 0], c: [0, 1, 0] },
-    { p: [0, 2, 0], c: [0, 0, 1] },
+    { p: [2 * TICKS_PER_UNIT, 0, 0], c: [0, 1, 0] },
+    { p: [0, 2 * TICKS_PER_UNIT, 0], c: [0, 0, 1] },
   ],
   faces: [[0, 1, 2]],
 }
@@ -59,11 +59,36 @@ describe('geometry', () => {
   })
 
   it('validates points and faces', () => {
-    expect(validPoint([1, -8, 8])).toBe(true)
-    expect(validPoint([9, 0, 0])).toBe(false)
+    expect(validPoint([TICKS_PER_UNIT, -8 * TICKS_PER_UNIT, 8 * TICKS_PER_UNIT])).toBe(true)
+    expect(validPoint([9 * TICKS_PER_UNIT, 0, 0])).toBe(false)
+    expect(validPoint([40, 30, -24])).toBe(true)     // a third, a quarter, a fifth
     expect(validPoint([0.5, 0, 0])).toBe(false)
     expect(validFace([0, 1, 2], 3)).toBe(true)
     expect(validFace([0, 1, 1], 3)).toBe(false)
     expect(validFace([0, 1, 3], 3)).toBe(false)
+  })
+})
+
+describe('ticks', () => {
+  it('carries thirds, quarters and fifths exactly, with the run shorthand, and reads an old payload as whole units', () => {
+    const v = (p: [number, number, number]) => ({ p, c: [1, 0, 0] as [number, number, number] })
+    const s = { ...newShard('t'), vertices: [v([0, 0, 0]), v([TICKS_PER_UNIT, 0, 0]), v([40, -30, 24 + 2 * TICKS_PER_UNIT]), v([0, 0, 0])] }
+    const wire = toPayload(s)
+    expect(wire.vertices).toEqual([[0, 0, 0], [1, 0, 0], [0, -1, 2], [0, 0, 0]])
+    expect(wire.ticks).toEqual([-2, [40, 90, 24], -1])
+    const back = fromPayload(wire, 'x')!
+    expect(back.vertices.map((x) => x.p)).toEqual(s.vertices.map((x) => x.p))
+    const old = { ...wire, ticks: undefined }
+    expect(fromPayload(old, 'y')!.vertices.map((x) => x.p)).toEqual([[0, 0, 0], [TICKS_PER_UNIT, 0, 0], [0, -TICKS_PER_UNIT, 2 * TICKS_PER_UNIT], [0, 0, 0]])
+    expect(unpackTicks([-3], 4)).toBeNull()
+    expect(unpackTicks([[120, 0, 0]], 1)).toBeNull()
+    expect(packTicks([])).toEqual([])
+  })
+  it('prints ticks as units', () => {
+    expect(unitsLabel(0)).toBe('0')
+    expect(unitsLabel(240)).toBe('2')
+    expect(unitsLabel(40)).toBe('1/3')
+    expect(unitsLabel(-30)).toBe('-1/4')
+    expect(unitsLabel(2 * 120 + 90)).toBe('2 3/4')
   })
 })

--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -25,6 +25,15 @@ export interface ShardVertex {
   c: [number, number, number]
 }
 
+/**
+ * Ticks to a grid unit. A position is stored as whole ticks, so a third, a
+ * quarter or a fifth of a unit is exact and they mix freely in one shard:
+ * 120 is divisible by every division the workshop offers and by eighths.
+ */
+export const TICKS_PER_UNIT = 120
+export const DIVISIONS = [1, 2, 3, 4, 5] as const
+export type Division = typeof DIVISIONS[number]
+
 export interface ShardModel {
   id: string
   name: string
@@ -32,6 +41,7 @@ export interface ShardModel {
   unit: number
   /** Half-width of this shard's build grid, in units: the grid runs from -extent to +extent on every axis. */
   extent: number
+  /** Vertex positions are in TICKS (120 to a unit), never units: see ShardVertex. */
   mode: ShardMode
   vertices: ShardVertex[]
   /** Triangles as vertex indices; drawn in `solid` mode only. */
@@ -48,7 +58,14 @@ export interface ShardPayload {
   /** Grid half-width the shard was built on; absent in older payloads (8). */
   extent?: number
   mode: ShardMode
+  /** Whole units per vertex, the floor of the position: what a reader from before ticks sees. */
   vertices: Array<[number, number, number]>
+  /**
+   * The rest of each position in ticks, 0..119 per axis, one entry per vertex
+   * in order; a negative number -N stands for N vertices of [0, 0, 0] in a
+   * row. Absent in older payloads: every position is whole.
+   */
+  ticks?: Array<[number, number, number] | number>
   colors: Array<[number, number, number]>
   faces: Array<[number, number, number]>
 }
@@ -84,13 +101,13 @@ export function uuid(): string {
 
 /** Integers inside the grid; anything else is not a vertex. */
 export function validPoint(p: [number, number, number], extent: number = GRID_HALF): boolean {
-  return p.every((v) => Number.isInteger(v) && Math.abs(v) <= extent)
+  return p.every((v) => Number.isInteger(v) && Math.abs(v) <= extent * TICKS_PER_UNIT)
 }
 
 /** The grid half-width a shard needs to hold every vertex it has. */
 export function neededExtent(s: Pick<ShardModel, 'vertices'>): number {
   let m = MIN_EXTENT
-  for (const v of s.vertices) for (const c of v.p) m = Math.max(m, Math.abs(c))
+  for (const v of s.vertices) for (const c of v.p) m = Math.max(m, Math.ceil(Math.abs(c) / TICKS_PER_UNIT))
   return m
 }
 
@@ -111,7 +128,8 @@ export function toPayload(s: ShardModel): ShardPayload {
     unit: s.unit,
     extent: s.extent,
     mode: s.mode,
-    vertices: s.vertices.map((v) => v.p),
+    vertices: s.vertices.map((v) => v.p.map((t) => Math.floor(t / TICKS_PER_UNIT)) as [number, number, number]),
+    ticks: packTicks(s.vertices.map((v) => v.p.map((t) => t - Math.floor(t / TICKS_PER_UNIT) * TICKS_PER_UNIT) as [number, number, number])),
     colors: s.vertices.map((v) => v.c),
     faces: s.faces,
   }
@@ -122,6 +140,36 @@ export function toPayload(s: ShardModel): ShardPayload {
  * back, and a shard with a face pointing at a vertex it does not have would
  * throw inside three.js at draw time, far from anything that could explain it.
  */
+/** The ticks column for the wire: runs of whole positions become one negative count. */
+export function packTicks(rest: Array<[number, number, number]>): Array<[number, number, number] | number> {
+  const out: Array<[number, number, number] | number> = []
+  let zeros = 0
+  for (const t of rest) {
+    if (t[0] === 0 && t[1] === 0 && t[2] === 0) { zeros++; continue }
+    if (zeros) { out.push(-zeros); zeros = 0 }
+    out.push(t)
+  }
+  if (zeros) out.push(-zeros)
+  return out
+}
+
+/** The ticks column read back, one triple per vertex, or null when it does not fit `count` vertices. */
+export function unpackTicks(packed: unknown, count: number): Array<[number, number, number]> | null {
+  if (packed === undefined) return Array.from({ length: count }, () => [0, 0, 0])
+  if (!Array.isArray(packed)) return null
+  const out: Array<[number, number, number]> = []
+  for (const e of packed) {
+    if (typeof e === 'number') {
+      if (!Number.isInteger(e) || e >= 0) return null
+      for (let i = 0; i < -e; i++) out.push([0, 0, 0])
+    } else if (Array.isArray(e) && e.length === 3 && e.every((t) => Number.isInteger(t) && t >= 0 && t < TICKS_PER_UNIT)) {
+      out.push([e[0], e[1], e[2]])
+    } else return null
+    if (out.length > count) return null
+  }
+  return out.length === count ? out : null
+}
+
 export function fromPayload(raw: unknown, id: string): ShardModel | null {
   if (!raw || typeof raw !== 'object') return null
   const p = raw as Partial<ShardPayload>
@@ -130,12 +178,15 @@ export function fromPayload(raw: unknown, id: string): ShardModel | null {
   if (p.vertices.length !== p.colors.length || p.vertices.length > MAX_VERTICES || p.faces.length > MAX_FACES) return null
   if (!MODES.includes(p.mode as ShardMode)) return null
   if (!Number.isInteger(p.unit) || (p.unit as number) < 0 || (p.unit as number) > 84) return null
+  const rest = unpackTicks(p.ticks, p.vertices.length)
+  if (!rest) return null
   const vertices: ShardVertex[] = []
   for (let i = 0; i < p.vertices.length; i++) {
     const pt = p.vertices[i], c = p.colors[i]
     if (!Array.isArray(pt) || pt.length !== 3 || !Array.isArray(c) || c.length !== 3) return null
-    const point = pt.map(Number) as [number, number, number]
-    if (!point.every(Number.isFinite)) return null
+    const whole = pt.map(Number) as [number, number, number]
+    if (!whole.every(Number.isInteger)) return null
+    const point = whole.map((u, a) => u * TICKS_PER_UNIT + rest[i][a]) as [number, number, number]
     vertices.push({ p: point, c: clampColor(c.map(Number) as [number, number, number]) })
   }
   const faces: Array<[number, number, number]> = []
@@ -163,7 +214,7 @@ export function flatten(s: ShardModel): { positions: Float32Array; colors: Float
   const positions = new Float32Array(s.vertices.length * 3)
   const colors = new Float32Array(s.vertices.length * 3)
   s.vertices.forEach((v, i) => {
-    positions.set(v.p, i * 3)
+    positions.set([v.p[0] / TICKS_PER_UNIT, v.p[1] / TICKS_PER_UNIT, v.p[2] / TICKS_PER_UNIT], i * 3)
     colors.set(v.c, i * 3)
   })
   return { positions, colors, index: s.faces.flat() }
@@ -185,4 +236,17 @@ export function hexToRgb(hex: string): [number, number, number] {
 
 export function rgbToHex(c: [number, number, number]): string {
   return '#' + c.map((v) => Math.round(Math.min(1, Math.max(0, v)) * 255).toString(16).padStart(2, '0')).join('')
+}
+
+/** A tick count as units for reading: "2", "1/3", "-2 3/4". */
+export function unitsLabel(ticks: number): string {
+  const sign = ticks < 0 ? '-' : ''
+  const a = Math.abs(ticks)
+  const whole = Math.floor(a / TICKS_PER_UNIT)
+  let num = a - whole * TICKS_PER_UNIT
+  if (num === 0) return `${sign}${whole}`
+  let den = TICKS_PER_UNIT
+  const gcd = (x: number, y: number): number => (y ? gcd(y, x % y) : x)
+  const g = gcd(num, den); num /= g; den /= g
+  return whole ? `${sign}${whole} ${num}/${den}` : `${sign}${num}/${den}`
 }

--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { GRID_HALF, MAX_VERTICES, newShard, validFace, validPoint, type ShardModel } from './shards'
+import { GRID_HALF, MAX_VERTICES, TICKS_PER_UNIT as T, newShard, validFace, validPoint, type ShardModel } from './shards'
 import { STAMPS, FACED, compile, landing, preview, stamp, type Facing, type StampKind } from './stamps'
 
 const red: [number, number, number] = [1, 0, 0]
@@ -40,26 +40,26 @@ describe('stamps', () => {
   })
 
   it('stands on the level and centres on the tap', () => {
-    const { points } = compile('block', 2, 0, [3, -2, 1])
-    expect(Math.min(...points.map((p) => p[1]))).toBe(-2)
+    const { points } = compile('block', 2, 0, [3 * T, -2 * T, 1 * T])
+    expect(Math.min(...points.map((p) => p[1]))).toBe(-2 * T)
     expect(Math.max(...points.map((p) => p[1]))).toBe(0)
-    expect(Math.min(...points.map((p) => p[0]))).toBe(2)
-    expect(Math.max(...points.map((p) => p[0]))).toBe(4)
+    expect(Math.min(...points.map((p) => p[0]))).toBe(2 * T)
+    expect(Math.max(...points.map((p) => p[0]))).toBe(4 * T)
   })
 
   it('is pushed back inside the grid when tapped at the edge', () => {
     for (const kind of STAMPS) {
-      const { points } = compile(kind, 4, 0, [GRID_HALF, GRID_HALF, GRID_HALF])
+      const { points } = compile(kind, 4, 0, [GRID_HALF * T, GRID_HALF * T, GRID_HALF * T])
       for (const p of points) expect(validPoint(p), `${kind} ${p}`).toBe(true)
     }
   })
 
   it('turns the faced shapes a quarter turn about Y and leaves the rest alone', () => {
     const tip = (f: Facing) => { const { points } = compile('arrow', 1, f, [0, 0, 0]); return points.reduce((a, b) => (Math.hypot(b[0], b[2]) > Math.hypot(a[0], a[2]) ? b : a)) }
-    expect(tip(0)).toEqual([3, 0, 0])
-    expect(tip(1)).toEqual([0, 0, 3])
-    expect(tip(2)).toEqual([-3, 0, 0])
-    expect(tip(3)).toEqual([0, 0, -3])
+    expect(tip(0)).toEqual([3 * T, 0, 0])
+    expect(tip(1)).toEqual([0, 0, 3 * T])
+    expect(tip(2)).toEqual([-3 * T, 0, 0])
+    expect(tip(3)).toEqual([0, 0, -3 * T])
     for (const kind of STAMPS) if (!FACED[kind]) expect(compile(kind, 2, 3, [0, 0, 0])).toEqual(compile(kind, 2, 0, [0, 0, 0]))
   })
 
@@ -74,22 +74,22 @@ describe('stamps', () => {
 
   it('drops the wall between two blocks that touch, on both sides', () => {
     const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
-    const b = stamp(a.shard, 'block', 1, 0, [1, 0, 0], [0, 0, 1])!
+    const b = stamp(a.shard, 'block', 1, 0, [T, 0, 0], [0, 0, 1])!
     expect(b.shard.vertices).toHaveLength(16)
     expect(b.culled).toBe(4)
     expect(b.shard.faces).toHaveLength(24 - 4)
     // Stacked, the same: the top of one and the bottom of the other.
-    const c = stamp(a.shard, 'block', 1, 0, [0, 1, 0], red)!
+    const c = stamp(a.shard, 'block', 1, 0, [0, T, 0], red)!
     expect(c.culled).toBe(4)
     // Diagonal neighbours share an edge, not a wall: nothing to drop.
-    const d = stamp(a.shard, 'block', 1, 0, [1, 1, 0], red)!
+    const d = stamp(a.shard, 'block', 1, 0, [T, T, 0], red)!
     expect(d.culled).toBe(0)
   })
 
   it('never merges vertices, so a seam between colors stays crisp', () => {
     const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
-    const b = stamp(a.shard, 'block', 1, 0, [1, 0, 0], [0, 0, 1])!
-    const at = b.shard.vertices.filter((v) => v.p.join() === '1,0,0')
+    const b = stamp(a.shard, 'block', 1, 0, [T, 0, 0], [0, 0, 1])!
+    const at = b.shard.vertices.filter((v) => v.p.join() === `${T},0,0`)
     expect(at).toHaveLength(2)
     expect(at.map((v) => v.c.join()).sort()).toEqual(['0,0,1', '1,0,0'])
   })
@@ -110,7 +110,7 @@ describe('ghost placement', () => {
   const red: [number, number, number] = [1, 0, 0]
   it('the preview moved to its landing is exactly the stamp, edge pushes included', () => {
     for (const kind of STAMPS) {
-      for (const origin of [[0, 0, 0], [GRID_HALF, 0, GRID_HALF], [-GRID_HALF, 3, 2]] as Array<[number, number, number]>) {
+      for (const origin of [[0, 0, 0], [GRID_HALF * T, 0, GRID_HALF * T], [-GRID_HALF * T, 3 * T, 2 * T]] as Array<[number, number, number]>) {
         const at = landing(kind, 4, 1, origin)
         const ghost = preview(kind, 4, 1, red).vertices.map((v) => [v.p[0] + at[0], v.p[1] + at[1], v.p[2] + at[2]])
         expect(ghost).toEqual(compile(kind, 4, 1, origin).points)
@@ -118,7 +118,7 @@ describe('ghost placement', () => {
     }
   })
   it('lands on the aim unless the grid edge pushes it back', () => {
-    expect(landing('block', 2, 0, [1, 0, 1])).toEqual([1, 0, 1])
-    expect(landing('block', 4, 0, [GRID_HALF, 0, GRID_HALF])[0]).toBeLessThan(GRID_HALF)
+    expect(landing('block', 2, 0, [T, 0, T])).toEqual([T, 0, T])
+    expect(landing('block', 4, 0, [GRID_HALF * T, 0, GRID_HALF * T])[0]).toBeLessThan(GRID_HALF * T)
   })
 })

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -20,7 +20,7 @@
  * Pure: a stamp is a function of (kind, size, facing) and where you put it.
  */
 
-import { GRID_HALF, MAX_FACES, MAX_VERTICES, pointKey, type ShardModel, type ShardVertex } from './shards'
+import { GRID_HALF, MAX_FACES, MAX_VERTICES, TICKS_PER_UNIT, pointKey, type ShardModel, type ShardVertex } from './shards'
 import { triangulate, type P3 } from './triangulate'
 
 export type StampKind = 'block' | 'wedge' | 'pyramid' | 'column' | 'ring' | 'star' | 'arrow'
@@ -147,7 +147,8 @@ function turned(kind: StampKind, size: number, facing: Facing): Shape {
   const s = Math.max(MIN_SIZE, Math.min(MAX_SIZE, Math.round(size)))
   const base = local(kind, s)
   const k = FACED[kind] ? facing : 0
-  return { points: base.points.map((p) => turn(p, k)), faces: base.faces }
+  // Shapes are authored in units; positions are ticks.
+  return { points: base.points.map((p) => { const t = turn(p, k); return [t[0] * TICKS_PER_UNIT, t[1] * TICKS_PER_UNIT, t[2] * TICKS_PER_UNIT] as P3 }), faces: base.faces }
 }
 
 const moved = (points: P3[], by: P3): P3[] => points.map((p) => [p[0] + by[0], p[1] + by[1], p[2] + by[2]] as P3)
@@ -158,8 +159,9 @@ function fit(points: P3[], extent: number = GRID_HALF): P3 {
   for (let a = 0; a < 3; a++) {
     let lo = Infinity, hi = -Infinity
     for (const p of points) { lo = Math.min(lo, p[a]); hi = Math.max(hi, p[a]) }
-    if (lo < -extent) shift[a] = -extent - lo
-    else if (hi > extent) shift[a] = extent - hi
+    const bound = extent * TICKS_PER_UNIT
+    if (lo < -bound) shift[a] = -bound - lo
+    else if (hi > bound) shift[a] = bound - hi
   }
   return shift
 }

--- a/src/store/useCeremony.ts
+++ b/src/store/useCeremony.ts
@@ -12,7 +12,7 @@ import { create } from 'zustand'
 import type { Plane } from 'cyberspace-core'
 import { messagePreview, type Hidden } from '../lib/hidden'
 import { regionLabel } from '../lib/loot'
-import { GRID_HALF, type ShardModel } from '../lib/shards'
+import { GRID_HALF, TICKS_PER_UNIT, type ShardModel } from '../lib/shards'
 import { useCyberspace } from './useCyberspace'
 import { useShards } from './useShards'
 
@@ -54,7 +54,7 @@ function previewShard(unit: number): ShardModel {
     unit,
     extent: GRID_HALF,
     mode: 'lines',
-    vertices: path.map((p, i) => ({ p, c: i < 16 ? [0, 0.9, 1] : [0.97, 0.58, 0.1] })),
+    vertices: path.map((p, i) => ({ p: p.map((u) => u * TICKS_PER_UNIT) as [number, number, number], c: i < 16 ? [0, 0.9, 1] : [0.97, 0.58, 0.1] })),
     faces: [],
     updatedAt: Math.floor(Date.now() / 1000),
   }

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
+import { TICKS_PER_UNIT as T } from '../lib/shards'
 import { DEFAULT_PALETTE, useWorkshop } from './useWorkshop'
 
 const w = () => useWorkshop.getState()
@@ -22,26 +23,26 @@ describe('workshop', () => {
   })
 
   it('adds vertices at the level, never twice on one point by hand, and selects them', () => {
-    w().setLevel(2)
-    w().addVertex([1, 2, 3])
-    w().addVertex([1, 2, 3])
+    w().setLevel(2 * T)
+    w().addVertex([T, 2 * T, 3 * T])
+    w().addVertex([T, 2 * T, 3 * T])
     expect(w().current()!.vertices).toHaveLength(1)
-    expect(w().current()!.vertices[0].p).toEqual([1, 2, 3])
+    expect(w().current()!.vertices[0].p).toEqual([T, 2 * T, 3 * T])
     expect(w().selection).toEqual([0])
-    w().addVertex([9, 0, 0])
+    w().addVertex([9 * T, 0, 0])
     expect(w().current()!.vertices).toHaveLength(1)
   })
 
   it('nudges the selection, may land on another vertex, and never leaves the grid', () => {
-    w().addVertex([0, 0, 0]); w().addVertex([1, 0, 0])
+    w().addVertex([0, 0, 0]); w().addVertex([T, 0, 0])
     w().selectVertex(0)
-    w().moveSelected(1, 1)
-    expect(w().current()!.vertices[0].p).toEqual([0, 1, 0])
-    w().moveSelected(1, -1); w().moveSelected(0, 1)
-    expect(w().current()!.vertices[0].p).toEqual([1, 0, 0])
+    w().moveSelected(1, T)
+    expect(w().current()!.vertices[0].p).toEqual([0, T, 0])
+    w().moveSelected(1, -T); w().moveSelected(0, T)
+    expect(w().current()!.vertices[0].p).toEqual([T, 0, 0])
     w().selectVertex(1)
-    for (let i = 0; i < 20; i++) w().moveSelected(0, 1)
-    expect(w().current()!.vertices[1].p[0]).toBe(8)
+    for (let i = 0; i < 20; i++) w().moveSelected(0, T)
+    expect(w().current()!.vertices[1].p[0]).toBe(8 * T)
   })
 
   it('stamps a shape, and the first faces switch LINES to SOLID once', () => {
@@ -69,14 +70,14 @@ describe('workshop', () => {
   it('moves, colors and deletes every vertex on the selected point together', () => {
     w().placeStamp([0, 0, 0])
     w().setColor([1, 0, 0])
-    w().placeStamp([1, 0, 0])
+    w().placeStamp([T, 0, 0])
     const s = w().current()!
-    const shared = s.vertices.map((v, i) => (v.p.join() === '1,0,0' ? i : -1)).filter((i) => i >= 0)
+    const shared = s.vertices.map((v, i) => (v.p.join() === `${T},0,0` ? i : -1)).filter((i) => i >= 0)
     expect(shared).toHaveLength(2)
     w().selectVertex(shared[0])
     // Off to a free point: landing on the blocks' top corners would join those too.
-    w().moveSelected(2, -1)
-    for (const i of shared) expect(w().current()!.vertices[i].p).toEqual([1, 0, -1])
+    w().moveSelected(2, -T)
+    for (const i of shared) expect(w().current()!.vertices[i].p).toEqual([T, 0, -T])
     w().colorSelected([0, 1, 0])
     for (const i of shared) expect(w().current()!.vertices[i].c).toEqual([0, 1, 0])
     const facesBefore = w().current()!.faces.length
@@ -90,58 +91,58 @@ describe('workshop', () => {
 
   it('selects many points: tap toggles, a box replaces, whole points always', () => {
     w().placeStamp([0, 0, 0])          // a block: 8 corners
-    w().addVertex([5, 0, 5])
+    w().addVertex([5 * T, 0, 5 * T])
     const s = w().current()!
     const corner = s.vertices.findIndex((v) => v.p.join() === '0,0,0')
     w().selectVertex(null)
     w().toggleVertex(corner); w().toggleVertex(s.vertices.length - 1)
-    expect(new Set(w().selection.map((i) => s.vertices[i].p.join()))).toEqual(new Set(['0,0,0', '5,0,5']))
+    expect(new Set(w().selection.map((i) => s.vertices[i].p.join()))).toEqual(new Set(['0,0,0', `${5 * T},0,${5 * T}`]))
     w().toggleVertex(corner)
-    expect(w().selection.map((i) => s.vertices[i].p.join())).toEqual(['5,0,5'])
+    expect(w().selection.map((i) => s.vertices[i].p.join())).toEqual([`${5 * T},0,${5 * T}`])
     w().setSelection([corner])
     expect(w().selection).toEqual([corner])
   })
 
   it('nudges, colors and deletes a whole selection at once, refusing a move that would leave the grid', () => {
-    w().addVertex([0, 0, 0]); w().addVertex([8, 0, 0]); w().addVertex([3, 0, 3])
+    w().addVertex([0, 0, 0]); w().addVertex([8 * T, 0, 0]); w().addVertex([3 * T, 0, 3 * T])
     w().setSelection([0, 1, 2])
-    w().moveSelected(0, 1)               // 8 -> 9 is off the grid: nothing moves
-    expect(w().current()!.vertices.map((v) => v.p[0])).toEqual([0, 8, 3])
-    w().moveSelected(2, 1)
-    expect(w().current()!.vertices.map((v) => v.p[2])).toEqual([1, 1, 4])
+    w().moveSelected(0, T)               // 8 -> 9 is off the grid: nothing moves
+    expect(w().current()!.vertices.map((v) => v.p[0])).toEqual([0, 8 * T, 3 * T])
+    w().moveSelected(2, T)
+    expect(w().current()!.vertices.map((v) => v.p[2])).toEqual([T, T, 4 * T])
     w().colorSelected([1, 0, 0])
     expect(w().current()!.vertices.every((v) => v.c.join() === '1,0,0')).toBe(true)
     w().setSelection([0, 2]); w().deleteSelected()
-    expect(w().current()!.vertices.map((v) => v.p.join())).toEqual(['8,0,1'])
+    expect(w().current()!.vertices.map((v) => v.p.join())).toEqual([`${8 * T},0,${T}`])
     expect(w().selection).toEqual([])
   })
 
   it('CONNECTED grows the selection along faces and shared points, and no further', () => {
     w().placeStamp([0, 0, 0])            // one block, 8 corners joined by faces
-    w().placeStamp([5, 0, 5])            // another, apart
-    w().addVertex([-4, 0, -4])           // a lone point
+    w().placeStamp([5 * T, 0, 5 * T])    // another, apart
+    w().addVertex([-4 * T, 0, -4 * T])   // a lone point
     const s = w().current()!
     const a = s.vertices.findIndex((v) => v.p.join() === '0,0,0')
     w().setSelection([a]); w().selectConnected()
     const points = new Set(w().selection.map((i) => s.vertices[i].p.join()))
     expect(points.size).toBe(8)
-    expect(points.has('5,0,5')).toBe(false)
-    expect(points.has('-4,0,-4')).toBe(false)
+    expect(points.has(`${5 * T},0,${5 * T}`)).toBe(false)
+    expect(points.has(`${-4 * T},0,${-4 * T}`)).toBe(false)
     w().setSelection([s.vertices.length - 1]); w().selectConnected()
     expect(w().selection).toEqual([s.vertices.length - 1])
   })
 
   it('keeps a grid scale per shard, never below what its points need, and carries it in the payload', () => {
-    w().addVertex([5, 0, 0])
+    w().addVertex([5 * T, 0, 0])
     expect(w().current()!.extent).toBe(8)
     w().setExtent(3)
     expect(w().current()!.extent).toBe(5)        // the point at x=5 holds it
     w().setExtent(999)
     expect(w().current()!.extent).toBe(64)
-    w().setLevel(50); expect(w().level).toBe(50)
+    w().setLevel(50 * T); expect(w().level).toBe(50 * T)
     w().setExtent(6)
-    expect(w().level).toBe(6)                    // the level follows the grid down
-    expect(w().addVertex([7, 0, 0]), 'outside the grid').toBeUndefined()
+    expect(w().level).toBe(6 * T)                // the level follows the grid down
+    expect(w().addVertex([7 * T, 0, 0]), 'outside the grid').toBeUndefined()
     expect(w().current()!.vertices).toHaveLength(1)
     const text = w().exportCurrent()!
     expect(JSON.parse(text).extent).toBe(6)
@@ -153,7 +154,7 @@ describe('workshop', () => {
 
   it('FILL on a selection: a flat set becomes one polygon, a solid set its hull, repeats are skipped', () => {
     w().setTool('add')
-    for (const p of [[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]] as Array<[number, number, number]>) w().addVertex(p)
+    for (const p of [[0, 0, 0], [2 * T, 0, 0], [2 * T, 0, 2 * T], [0, 0, 2 * T]] as Array<[number, number, number]>) w().addVertex(p)
     w().setSelection([0, 1, 2, 3])
     w().fillSelection()
     expect(w().current()!.faces).toHaveLength(2)
@@ -174,6 +175,22 @@ describe('workshop', () => {
     expect(w().notice).toMatch(/12 faces around 8 points/)
     w().setSelection([0, 1]); w().fillSelection()
     expect(w().notice).toMatch(/three or more/)
+  })
+
+  it('snaps by division: a third of a unit is 40 ticks, and changing the division moves nothing already placed', () => {
+    w().setDivision(3)
+    expect(w().step()).toBe(40)
+    w().addVertex([40, 0, 80])
+    w().setDivision(4)
+    expect(w().step()).toBe(30)
+    w().addVertex([30, 0, 0])
+    w().setSelection([0]); w().moveSelected(0, w().step())
+    expect(w().current()!.vertices.map((v) => v.p)).toEqual([[70, 0, 80], [30, 0, 0]])
+    w().setDivision(1)
+    expect(w().current()!.vertices.map((v) => v.p)).toEqual([[70, 0, 80], [30, 0, 0]])
+    const wire = JSON.parse(w().exportCurrent()!)
+    expect(wire.vertices).toEqual([[0, 0, 0], [0, 0, 0]])
+    expect(wire.ticks).toEqual([[70, 0, 80], [30, 0, 0]])
   })
 
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -193,6 +193,17 @@ describe('workshop', () => {
     expect(wire.ticks).toEqual([[70, 0, 80], [30, 0, 0]])
   })
 
+  it('colors a selected face\'s corners when no point is selected', () => {
+    w().placeStamp([0, 0, 0])
+    const s = w().current()!
+    w().selectVertex(null)
+    w().selectFace(0)
+    w().colorSelected([1, 0, 0])
+    const corners = new Set(s.faces[0])
+    s.vertices.forEach((_, i) => expect(w().current()!.vertices[i].c.join(), `vertex ${i}`).toBe(corners.has(i) ? '1,0,0' : s.vertices[i].c.join()))
+    expect(w().selectedFace).toBe(0)
+  })
+
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
     w().setTool('add')
     w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -457,11 +457,13 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     },
 
     colorSelected: (c) => {
-      const { selection } = get()
+      const { selection, selectedFace } = get()
       set({ color: clampColor(c) })
-      if (selection.length === 0) return
+      // With no points selected, a selected face takes the color for its corners.
+      const face = selection.length === 0 && selectedFace !== null ? get().current()?.faces[selectedFace] : undefined
+      if (selection.length === 0 && !face) return
       edit((s) => {
-        const chosen = new Set(selection.filter((i) => s.vertices[i]))
+        const chosen = new Set((face ?? selection).filter((i) => s.vertices[i]))
         if (chosen.size === 0) return null
         const vertices = s.vertices.slice()
         for (const i of chosen) vertices[i] = { ...vertices[i], c: clampColor(c) }

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -22,8 +22,11 @@
 
 import { create } from 'zustand'
 import {
+  DIVISIONS,
   GRID_HALF,
+  TICKS_PER_UNIT,
   centroid,
+  type Division,
   MAX_EXTENT,
   MIN_EXTENT,
   neededExtent,
@@ -79,8 +82,10 @@ export interface WorkshopState {
   selectedFace: number | null
   /** Swatches to hand: newest first, every color the picker ever settled on, then the defaults. */
   palette: string[]
-  /** The Y the add and stamp tools place on: the grid plane moves up and down. */
+  /** The Y the add and stamp tools place on, in ticks: the grid plane moves up and down. */
   level: number
+  /** Snap: the grid the placing tools, the marquee and the nudges use is a unit over this. A tool setting, not the shard's. */
+  division: Division
   /** The color new vertices get, and the color input shows. */
   color: [number, number, number]
   stampKind: StampKind
@@ -108,6 +113,9 @@ export interface WorkshopState {
   setExtent: (extent: number) => void
   setTool: (tool: Tool) => void
   setLevel: (level: number) => void
+  setDivision: (division: Division) => void
+  /** One snap step, in ticks. */
+  step: () => number
   setColor: (c: [number, number, number]) => void
   setStampKind: (kind: StampKind) => void
   setStampSize: (size: number) => void
@@ -270,6 +278,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     selectedFace: null,
     palette: loadPalette(),
     level: 0,
+    division: 1,
     color: [0, 0.9, 1],
     stampKind: 'block',
     stampSize: 2,
@@ -326,12 +335,14 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       const e = Math.max(Math.max(MIN_EXTENT, neededExtent(s)), Math.min(MAX_EXTENT, Math.round(extent)))
       if (e === s.extent) return
       edit((cur) => ({ ...cur, extent: e }))
-      set({ level: Math.max(-e, Math.min(e, get().level)) })
+      set({ level: Math.max(-e * TICKS_PER_UNIT, Math.min(e * TICKS_PER_UNIT, get().level)) })
     },
     setLevel: (level) => {
-      const e = get().current()?.extent ?? GRID_HALF
+      const e = (get().current()?.extent ?? GRID_HALF) * TICKS_PER_UNIT
       set({ level: Math.max(-e, Math.min(e, Math.round(level))) })
     },
+    setDivision: (division) => { if (DIVISIONS.includes(division)) set({ division }) },
+    step: () => TICKS_PER_UNIT / get().division,
     setColor: (c) => set({ color: clampColor(c) }),
     setStampKind: (stampKind) => set({ stampKind }),
     setStampSize: (size) => set({ stampSize: Math.max(MIN_SIZE, Math.min(MAX_SIZE, Math.round(size))) }),

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -28,6 +28,8 @@ import { useWorkshop } from '../store/useWorkshop'
 
 /** A press that travels further than this is an orbit, not a tap. */
 const TAP_SLOP = 8
+/** The division lines' colour: violet, apart from the unit grid's blue and the accent centre lines. */
+const DIVISION_LINE = '#35295c'
 
 type P3 = [number, number, number]
 
@@ -92,8 +94,9 @@ function Grid(): JSX.Element {
     <group position={[0, U(level), 0]}>
       {/* The visible lattice. One cell per unit, so what you tap is what you get. */}
       <gridHelper key={extent} args={[extent * 2, extent * 2, ACCENT, '#1d3547']} />
-      {/* The snap grid between the unit lines, dimmer, when a unit is divided. */}
-      {division > 1 && <gridHelper key={`d${extent}-${division}`} args={[extent * 2, extent * 2 * division, '#1b3a4d', '#1b3a4d']} position={[0, -0.002, 0]} />}
+      {/* The snap grid between the unit lines when a unit is divided: its own quiet
+          violet, so the unit lines stay the unit lines whatever the division. */}
+      {division > 1 && <gridHelper key={`d${extent}-${division}`} args={[extent * 2, extent * 2 * division, DIVISION_LINE, DIVISION_LINE]} position={[0, -0.002, 0]} />}
       {/*
         The surface taps land on, in the placing tools only. In select and face
         mode it carries no handler at all, so the raycaster ignores it: a raised

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -20,7 +20,7 @@ import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
 import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
-import { GRID_HALF, centroid, pointKey, rgbToHex } from '../lib/shards'
+import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex } from '../lib/shards'
 import { benchAxes, nudgeFor, sameAxes, useBenchView, type NudgeName } from './benchAxes'
 import { landing, preview } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
@@ -32,9 +32,14 @@ const TAP_SLOP = 8
 type P3 = [number, number, number]
 
 /** The grid point a pointer over the plane means, at the level the store says. */
-function snap(p: Vector3, level: number): P3 {
-  return [Math.round(p.x), level, Math.round(p.z)]
+/** The bench point (units) to the nearest snap step, in ticks, on the current level. */
+function snap(p: Vector3, level: number, step: number): P3 {
+  const q = (v: number): number => Math.round((v * TICKS_PER_UNIT) / step) * step
+  return [q(p.x), level, q(p.z)]
 }
+/** Ticks to bench units. */
+const U = (t: number): number => t / TICKS_PER_UNIT
+const UP = (p: P3): [number, number, number] => [U(p[0]), U(p[1]), U(p[2])]
 
 /**
  * You, to scale, at the grid's centre. An avatar is one gibson wide, and a
@@ -56,6 +61,7 @@ function ScaleAvatar(): JSX.Element {
 
 function Grid(): JSX.Element {
   const level = useWorkshop((s) => s.level)
+  const division = useWorkshop((s) => s.division)
   const extent = useWorkshop((s) => s.current()?.extent ?? GRID_HALF)
   const tool = useWorkshop((s) => s.tool)
   const places = tool === 'add' || tool === 'stamp'
@@ -67,14 +73,14 @@ function Grid(): JSX.Element {
     // changed a moment ago must apply to this tap even if the bench has not
     // re-rendered yet.
     const w = useWorkshop.getState()
-    const at = snap(e.point, w.level)
+    const at = snap(e.point, w.level, w.step())
     if (w.tool === 'stamp') w.placeStamp(at)
     else w.addVertex(at)
   }
 
   const onMove = (e: ThreeEvent<PointerEvent>): void => {
     const w = useWorkshop.getState()
-    w.setAim(snap(e.point, w.level))
+    w.setAim(snap(e.point, w.level, w.step()))
   }
 
   // A finger lifts and the ghost goes with it; a mouse keeps hovering.
@@ -83,9 +89,11 @@ function Grid(): JSX.Element {
   }
 
   return (
-    <group position={[0, level, 0]}>
+    <group position={[0, U(level), 0]}>
       {/* The visible lattice. One cell per unit, so what you tap is what you get. */}
       <gridHelper key={extent} args={[extent * 2, extent * 2, ACCENT, '#1d3547']} />
+      {/* The snap grid between the unit lines, dimmer, when a unit is divided. */}
+      {division > 1 && <gridHelper key={`d${extent}-${division}`} args={[extent * 2, extent * 2 * division, '#1b3a4d', '#1b3a4d']} position={[0, -0.002, 0]} />}
       {/*
         The surface taps land on, in the placing tools only. In select and face
         mode it carries no handler at all, so the raycaster ignores it: a raised
@@ -118,7 +126,7 @@ function Ghost(): JSX.Element | null {
   if (!aim) return null
   if (tool === 'add') {
     return (
-      <mesh position={aim}>
+      <mesh position={UP(aim)}>
         <sphereGeometry args={[0.2, 12, 12]} />
         <meshBasicMaterial color={rgbToHex(color)} transparent opacity={0.5} toneMapped={false} depthWrite={false} />
       </mesh>
@@ -126,7 +134,7 @@ function Ghost(): JSX.Element | null {
   }
   if (!model) return null
   return (
-    <group position={landing(kind, size, facing, aim, extent)}>
+    <group position={UP(landing(kind, size, facing, aim, extent))}>
       <ShardMesh shard={model} ghost />
     </group>
   )
@@ -167,7 +175,7 @@ function Handles(): JSX.Element | null {
         const isSel = g.some((i) => chosen.has(i))
         const picked = facePick.some((i) => g.includes(i))
         return (
-          <group key={first} position={v.p}>
+          <group key={first} position={UP(v.p)}>
             {/* A generous invisible hit target; the visible handle is small. */}
             <mesh onClick={onClick(first, isSel)}>
               <sphereGeometry args={[0.42, 10, 10]} />
@@ -196,7 +204,7 @@ function PickLoop(): JSX.Element | null {
   const facePick = useWorkshop((s) => s.facePick)
   const line = useMemo(() => {
     if (!shard || facePick.length < 2) return null
-    const pts = facePick.map((i) => shard.vertices[i]?.p).filter((p): p is P3 => !!p)
+    const pts = facePick.map((i) => shard.vertices[i]?.p).filter((p): p is P3 => !!p).map(UP)
     if (pts.length >= 3) pts.push(pts[0])
     const g = new BufferGeometry()
     g.setAttribute('position', new Float32BufferAttribute(pts.flat(), 3))
@@ -215,7 +223,7 @@ function FaceHighlight(): JSX.Element | null {
   const lit = useMemo(() => {
     const f = face === null ? undefined : shard?.faces[face]
     if (!shard || !f) return null
-    const pts = f.map((i) => shard.vertices[i].p)
+    const pts = f.map((i) => UP(shard.vertices[i].p))
     // Four points: the mesh draws the first three as its one triangle, the line closes the loop.
     const g = new BufferGeometry()
     g.setAttribute('position', new Float32BufferAttribute([...pts, pts[0]].flat(), 3))
@@ -251,7 +259,7 @@ function Aim(): null {
   }, [camera, scene])
   const target = useMemo(() => {
     const shard = useWorkshop.getState().current()
-    return shard ? centroid(shard) : [0, 0, 0]
+    return shard ? UP(centroid(shard)) : [0, 0, 0]
   }, [id])
   useEffect(() => {
     if (!controls) return
@@ -298,7 +306,7 @@ function Marquee(): null {
       const r = canvas.getBoundingClientRect()
       const out: number[] = []
       shard.vertices.forEach((vert, i) => {
-        v.set(vert.p[0], vert.p[1], vert.p[2]).project(camera)
+        v.set(U(vert.p[0]), U(vert.p[1]), U(vert.p[2])).project(camera)
         if (v.z > 1) return
         const px = ((v.x + 1) / 2) * r.width
         const py = ((1 - v.y) / 2) * r.height
@@ -369,7 +377,7 @@ function Keys(): null {
         ArrowUp: 'up', ArrowDown: 'down', KeyW: 'up', KeyS: 'down',
         KeyR: 'away', KeyF: 'toward',
       }
-      if (nudge[e.code]) { e.preventDefault(); const n = nudgeFor(benchAxes(camera), nudge[e.code]); w.moveSelected(n.axis, n.delta); return }
+      if (nudge[e.code]) { e.preventDefault(); const n = nudgeFor(benchAxes(camera), nudge[e.code]); w.moveSelected(n.axis, n.delta * w.step()); return }
       if (e.code === 'Delete' || e.code === 'Backspace') { e.preventDefault(); if (w.selectedFace !== null) w.deleteSelectedFace(); else w.deleteSelected(); return }
       if (e.code === 'Enter') { e.preventDefault(); if (w.facePick.length >= 3) w.fill(); else if (w.selection.length >= 3) w.fillSelection(); return }
       if (e.code === 'Escape') { e.preventDefault(); if (w.selection.length || w.selectedFace !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
@@ -379,8 +387,8 @@ function Keys(): null {
       if (e.code === 'Digit3') w.setTool('select')
       if (e.code === 'Digit4') w.setTool('face')
       if (e.code === 'KeyQ') w.turnStamp()
-      if (e.code === 'BracketRight') w.setLevel(w.level + 1)
-      if (e.code === 'BracketLeft') w.setLevel(w.level - 1)
+      if (e.code === 'BracketRight') w.setLevel(w.level + w.step())
+      if (e.code === 'BracketLeft') w.setLevel(w.level - w.step())
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -28,8 +28,14 @@ import { useWorkshop } from '../store/useWorkshop'
 
 /** A press that travels further than this is an orbit, not a tap. */
 const TAP_SLOP = 8
-/** The division lines' colour: violet, apart from the unit grid's blue and the accent centre lines. */
-const DIVISION_LINE = '#35295c'
+/** The unit grid's line colour when a unit is not divided. */
+const UNIT_LINE = '#1d3547'
+/**
+ * When a unit is divided the unit lines step up toward the axis lines'
+ * light blue, and the division lines take the unit lines' old colour, so
+ * the unit grid stays the unit grid however fine the snap.
+ */
+const UNIT_LINE_DIVIDED = '#166c86'
 
 type P3 = [number, number, number]
 
@@ -93,10 +99,9 @@ function Grid(): JSX.Element {
   return (
     <group position={[0, U(level), 0]}>
       {/* The visible lattice. One cell per unit, so what you tap is what you get. */}
-      <gridHelper key={extent} args={[extent * 2, extent * 2, ACCENT, '#1d3547']} />
-      {/* The snap grid between the unit lines when a unit is divided: its own quiet
-          violet, so the unit lines stay the unit lines whatever the division. */}
-      {division > 1 && <gridHelper key={`d${extent}-${division}`} args={[extent * 2, extent * 2 * division, DIVISION_LINE, DIVISION_LINE]} position={[0, -0.002, 0]} />}
+      <gridHelper key={`u${extent}-${division > 1 ? 1 : 0}`} args={[extent * 2, extent * 2, ACCENT, division > 1 ? UNIT_LINE_DIVIDED : UNIT_LINE]} />
+      {/* The snap grid between the unit lines when a unit is divided, in the unit lines' plain colour. */}
+      {division > 1 && <gridHelper key={`d${extent}-${division}`} args={[extent * 2, extent * 2 * division, UNIT_LINE, UNIT_LINE]} position={[0, -0.002, 0]} />}
       {/*
         The surface taps land on, in the placing tools only. In select and face
         mode it carries no handler at all, so the raycaster ignores it: a raised

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -295,7 +295,7 @@ export function Workshop(): JSX.Element | null {
               delete it. Stamps keep their own corners even where they touch, so a red block against a
               blue one keeps a crisp edge. Under GRID, LEVEL is the height the placing tools work at,
               DEPLOY SCALE MULTIPLIER says how big one grid unit is in the world, from a picometre to
-              the width of a sector, and SCALE is how far the grid reaches from the origin. DEPLOY shows
+              the width of a sector, and GRID SIZE is how far the grid reaches from the origin. DEPLOY shows
               the shard at true size before you place it. Keys: 1 2 3 4 tools, Q turns a stamp, WASD and
               RF or the arrows nudge the selection in screen directions, C selects what faces join, Del
               deletes, Enter fills, [ ] change the level, Ctrl+Z undoes, Esc clears then closes.
@@ -371,7 +371,7 @@ export function Workshop(): JSX.Element | null {
             <span className="workshop__unit-size" title="Where taps, the box, nudges and the level land. Positions already placed keep their exact spots.">the snap for placing and nudging</span>
           </div>
           <div className="workshop__row">
-            <span className="workshop__label">SCALE</span>
+            <span className="workshop__label">GRID SIZE</span>
             <button className="workshop__btn" {...bind(() => w().setExtent((w().current()?.extent ?? MIN_EXTENT) - 1))} disabled={extent <= minExtent} aria-label="Smaller grid">−</button>
             <span className="workshop__value">{extent}</span>
             <button className="workshop__btn" {...bind(() => w().setExtent((w().current()?.extent ?? MIN_EXTENT) + 1))} disabled={extent >= MAX_EXTENT} aria-label="Larger grid">+</button>

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -11,8 +11,9 @@
  * the CONTROLS pad, present only while points are selected: the main pad's
  * shape, nudging the selection in screen directions, with CONNECT and DELETE
  * in its corners; and below it the COLOR bar, gone while FACE is the tool
- * since a face has no color of its own. On a phone the color bar spans the
- * bottom and the pad stacks above it.
+ * with no face in hand, back once a face is selected so a color can be put
+ * on its corners. On a phone the color bar spans the bottom and the pad
+ * stacks above it.
  */
 
 import { useEffect, useRef, useState } from 'react'
@@ -421,7 +422,7 @@ export function Workshop(): JSX.Element | null {
             <button className="workshop__btn" onClick={() => w().clearFacePick()} title="Drop the picks (Esc)">CANCEL</button>
           </div>
         )}
-        {tool !== 'face' && (
+        {(tool !== 'face' || selectedFace !== null) && (
           <div className="ws__color" role="group" aria-label="Color">
             <span className="workshop__label">COLOR</span>
             <span className="workshop__picker" title="Pick any color; it joins the palette">

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -20,7 +20,7 @@ import { Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, Stamp, Trash2
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { ConfirmModal } from '../hud/ConfirmModal'
 import { Explanation } from '../hud/Explanation'
-import { MAX_EXTENT, MIN_EXTENT, MODES, hexToRgb, neededExtent, rgbToHex, toPayload, type ShardMode } from '../lib/shards'
+import { DIVISIONS, MAX_EXTENT, MIN_EXTENT, MODES, TICKS_PER_UNIT, hexToRgb, neededExtent, rgbToHex, toPayload, unitsLabel, type ShardMode } from '../lib/shards'
 import { formatCellSize } from '../lib/scale'
 import { FACED, FACING_LABEL, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
@@ -109,7 +109,7 @@ function ControlsPad({ points }: { points: number }): JSX.Element {
   const axes = useBenchView((s) => s.axes)
   const bind = useRepeatable()
   const w = useWorkshop.getState
-  const move = (name: NudgeName) => () => { const n = nudgeFor(useBenchView.getState().axes, name); w().moveSelected(n.axis, n.delta) }
+  const move = (name: NudgeName) => () => { const n = nudgeFor(useBenchView.getState().axes, name); w().moveSelected(n.axis, n.delta * w().step()) }
   const sub = (name: NudgeName): string => nudgeLabel(nudgeFor(axes, name))
   const arrows: Array<{ cell: string; glyph: string; name: NudgeName; key: string }> = [
     { cell: 'away', glyph: '⊗', name: 'away', key: 'R' },
@@ -152,6 +152,7 @@ export function Workshop(): JSX.Element | null {
   const selectedFace = useWorkshop((s) => s.selectedFace)
   const palette = useWorkshop((s) => s.palette)
   const level = useWorkshop((s) => s.level)
+  const division = useWorkshop((s) => s.division)
   const color = useWorkshop((s) => s.color)
   const stampKind = useWorkshop((s) => s.stampKind)
   const stampSize = useWorkshop((s) => s.stampSize)
@@ -173,6 +174,7 @@ export function Workshop(): JSX.Element | null {
   const toggle = (p: Panel): void => setPanel((cur) => (cur === p ? null : p))
 
   const selectedPoints = shard ? new Set(selection.map((i) => shard.vertices[i]?.p.join(','))).size : 0
+  const one = selection.length === 1 && shard ? shard.vertices[selection[0]] : null
   const extent = shard?.extent ?? MIN_EXTENT
   const minExtent = shard ? Math.max(MIN_EXTENT, neededExtent(shard)) : MIN_EXTENT
 
@@ -346,9 +348,9 @@ export function Workshop(): JSX.Element | null {
         <div className="ws__panel" role="region" aria-label="Grid">
           <div className="workshop__row">
             <span className="workshop__label">LEVEL Y</span>
-            <button className="workshop__btn" {...bind(() => w().setLevel(w().level - 1))} disabled={level <= -extent} aria-label="Level down">−</button>
-            <span className="workshop__value">{level}</span>
-            <button className="workshop__btn" {...bind(() => w().setLevel(w().level + 1))} disabled={level >= extent} aria-label="Level up">+</button>
+            <button className="workshop__btn" {...bind(() => w().setLevel(w().level - w().step()))} disabled={level <= -extent * TICKS_PER_UNIT} aria-label="Level down">−</button>
+            <span className="workshop__value">{unitsLabel(level)}</span>
+            <button className="workshop__btn" {...bind(() => w().setLevel(w().level + w().step()))} disabled={level >= extent * TICKS_PER_UNIT} aria-label="Level up">+</button>
             <span className="workshop__unit-size">the height the placing tools work at</span>
           </div>
           <div className="workshop__row">
@@ -358,6 +360,15 @@ export function Workshop(): JSX.Element | null {
             <span className="workshop__value">{shard.unit}</span>
             <button className="workshop__btn" {...bind(() => w().setUnit((w().current()?.unit ?? 0) + 1))} disabled={shard.unit >= 84} aria-label="Larger unit">+</button>
             <span className="workshop__unit-size" title="What one grid unit is in the world. DEPLOY shows the shard at this size.">one unit = {formatCellSize(shard.unit)}</span>
+          </div>
+          <div className="workshop__row" role="group" aria-label="Grid division">
+            <span className="workshop__label">DIVISION</span>
+            <div className="workshop__modes">
+              {DIVISIONS.map((d) => (
+                <button key={d} className={`workshop__mode ${division === d ? 'is-on' : ''}`} aria-pressed={division === d} onClick={() => w().setDivision(d)} title={d === 1 ? 'Snap to whole units' : `Snap to 1/${d} of a unit`}>{d === 1 ? '1' : `1/${d}`}</button>
+              ))}
+            </div>
+            <span className="workshop__unit-size" title="Where taps, the box, nudges and the level land. Positions already placed keep their exact spots.">the snap for placing and nudging</span>
           </div>
           <div className="workshop__row">
             <span className="workshop__label">SCALE</span>
@@ -384,6 +395,11 @@ export function Workshop(): JSX.Element | null {
 
       {/* Bottom right: the pad while points are selected, face actions while a face is in hand, the color bar under either. */}
       <div className="ws__corner">
+        {one && (
+          <div className="benchops" role="status" aria-label="Selected point">
+            <span className="workshop__value workshop__value--wide">at ({one.p.map(unitsLabel).join(', ')})</span>
+          </div>
+        )}
         {selectedPoints >= 3 && (
           <div className="benchops" role="group" aria-label="Fill the selection">
             <span className="workshop__value workshop__value--wide">{selectedPoints} points</span>


### PR DESCRIPTION
Stacked on #88 (base is its branch; retarget to v2 once #88 merges).

**Ticks.** A vertex position is stored as whole ticks, 120 to a grid unit, so a third, a quarter, a fifth or an eighth of a unit is exact and they mix freely in one shard. Nothing is a float, and arithmetic never drifts.

**DIVISION.** In the GRID panel: 1, 1/2, 1/3, 1/4, 1/5. A tool setting, not the shard's: it decides where taps, the marquee, nudges, LEVEL and stamp origins snap, in steps of 120 over the division, and changing it moves nothing already placed. The bench draws the snap lines between the unit lines when a unit is divided; readouts print units with the fraction, "1 2/3" rather than 200 ticks, including the selected point's position above the pad.

**The wire, as you specified.** `vertices` stays whole units, the floor of each position, so a reader from before sees a shard at whole units and nothing breaks. A new `ticks` array mirrors it with the rest of each position, 0..119 per axis, and a negative number -N stands for N whole vertices in a row, so a shard with no fractions carries one small number. Absent, every position is whole. Deploy scales ticks to gibsons through the multiplier and rounds once.

**Also in this PR.** The grid's reach is labelled GRID SIZE; above division 1 the unit lines step up toward the axis lines and the division lines take their old colour; and a selected face keeps the COLOR bar, a pick colouring its three corners.

Tests: exact thirds and quarters across a division change, the run shorthand both ways, an old payload without the column, malformed columns refused, the units printer, and every earlier test converted to ticks. Verified on the bench: a block at whole units and a point at (1/3, 1/3, 1 2/3), read off the pad's caption and the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
