### PR TITLE
Shards: model +Z is cyberspace +Z, drawn along render -Z as the world draws it

### DIFF
--- a/src/lib/shards.test.ts
+++ b/src/lib/shards.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { flatten, fromPayload, newShard, toPayload, validFace, validPoint, type ShardModel, TICKS_PER_UNIT, packTicks, unpackTicks, unitsLabel } from './shards'
+import { flatten, fromPayload, newShard, toPayload, validFace, validPoint, type ShardModel, TICKS_PER_UNIT, packTicks, unpackTicks, unitsLabel, toRender } from './shards'
 
 const tri: ShardModel = {
   ...newShard('tri'),
@@ -83,6 +83,11 @@ describe('ticks', () => {
     expect(unpackTicks([-3], 4)).toBeNull()
     expect(unpackTicks([[120, 0, 0]], 1)).toBeNull()
     expect(packTicks([])).toEqual([])
+  })
+  it('draws model +Z along render -Z, as the world draws cyberspace', () => {
+    expect(toRender([TICKS_PER_UNIT, 2 * TICKS_PER_UNIT, 3 * TICKS_PER_UNIT])).toEqual([1, 2, -3])
+    const one = { ...newShard('z'), vertices: [{ p: [0, 0, TICKS_PER_UNIT] as [number, number, number], c: [1, 1, 1] as [number, number, number] }] }
+    expect(Array.from(flatten(one).positions)).toEqual([0, 0, -1])
   })
   it('prints ticks as units', () => {
     expect(unitsLabel(0)).toBe('0')

--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -210,11 +210,23 @@ export function fromPayload(raw: unknown, id: string): ShardModel | null {
 }
 
 /** The flat arrays three.js wants, in one place so every drawer agrees. */
+/**
+ * A model position as the scene draws it. Model axes are cyberspace axes,
+ * and the world draws cyberspace with Z negated (lib/space.ts
+ * flipHandedness), so model +Z is render -Z here too: the bench and the
+ * world show the same object, and the bench's blue arrow points where the
+ * world's compass does.
+ */
+export function toRender(p: [number, number, number]): [number, number, number] {
+  // 0 - z rather than -z: negating a zero gives -0, which equality tests and keys treat as different.
+  return [p[0] / TICKS_PER_UNIT, p[1] / TICKS_PER_UNIT, (0 - p[2]) / TICKS_PER_UNIT]
+}
+
 export function flatten(s: ShardModel): { positions: Float32Array; colors: Float32Array; index: number[] } {
   const positions = new Float32Array(s.vertices.length * 3)
   const colors = new Float32Array(s.vertices.length * 3)
   s.vertices.forEach((v, i) => {
-    positions.set([v.p[0] / TICKS_PER_UNIT, v.p[1] / TICKS_PER_UNIT, v.p[2] / TICKS_PER_UNIT], i * 3)
+    positions.set(toRender(v.p), i * 3)
     colors.set(v.c, i * 3)
   })
   return { positions, colors, index: s.faces.flat() }

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -27,7 +27,7 @@ import {
   LineBasicMaterial,
 } from 'three'
 import { easeOutCubic, hash01, scrambleOffset, seedOf, SHARD_DECODE_MS } from '../lib/decode'
-import { flatten, type ShardModel } from '../lib/shards'
+import { flatten, toRender, type ShardModel } from '../lib/shards'
 import { orientFaces } from '../lib/orient'
 
 interface Props {
@@ -70,7 +70,7 @@ const TAG_BLEND = { blending: CustomBlending, blendEquation: AddEquation, blendS
 export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick, world = false, lit = false }: Props): JSX.Element | null {
   const { positions, colors, index } = useMemo(() => {
     const f = flatten(shard)
-    return lit ? { ...f, index: orientFaces(shard.vertices.map((v) => v.p), shard.faces).flat() } : f
+    return lit ? { ...f, index: orientFaces(shard.vertices.map((v) => toRender(v.p)), shard.faces).flat() } : f
   }, [shard.vertices, shard.faces, lit])
 
   // Live copies: the decode writes into these, the targets stay untouched.

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -20,7 +20,7 @@ import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
 import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
-import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex } from '../lib/shards'
+import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, toRender } from '../lib/shards'
 import { benchAxes, nudgeFor, sameAxes, useBenchView, type NudgeName } from './benchAxes'
 import { landing, preview } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
@@ -40,14 +40,19 @@ const UNIT_LINE_DIVIDED = '#166c86'
 type P3 = [number, number, number]
 
 /** The grid point a pointer over the plane means, at the level the store says. */
-/** The bench point (units) to the nearest snap step, in ticks, on the current level. */
+/**
+ * The bench point (render units) to the nearest snap step, in model ticks, on
+ * the current level. Model +Z is render -Z (shards.ts toRender), so the tap's
+ * render z comes back negated.
+ */
 function snap(p: Vector3, level: number, step: number): P3 {
   const q = (v: number): number => Math.round((v * TICKS_PER_UNIT) / step) * step
-  return [q(p.x), level, q(p.z)]
+  return [q(p.x), level, -q(p.z)]
 }
-/** Ticks to bench units. */
+/** Ticks to render units, one axis (for Y, which is not mirrored). */
 const U = (t: number): number => t / TICKS_PER_UNIT
-const UP = (p: P3): [number, number, number] => [U(p[0]), U(p[1]), U(p[2])]
+/** A model position as the bench draws it. */
+const UP = toRender
 
 /**
  * You, to scale, at the grid's centre. An avatar is one gibson wide, and a
@@ -63,6 +68,26 @@ function ScaleAvatar(): JSX.Element {
   return (
     <lineSegments geometry={geometry} scale={k} frustumCulled={false}>
       <lineBasicMaterial color="#ffffff" transparent opacity={0.85} toneMapped={false} />
+    </lineSegments>
+  )
+}
+
+/**
+ * The axes, in the compass's colors: X red, Y green, Z blue. Not three's own
+ * helper, whose blue points along render +Z: cyberspace +Z is drawn along
+ * render -Z here as in the world, so the blue arrow goes that way.
+ */
+function BenchAxes({ reach }: { reach: number }): JSX.Element {
+  const geometry = useMemo(() => {
+    const g = new BufferGeometry()
+    g.setAttribute('position', new Float32BufferAttribute([0, 0, 0, reach, 0, 0, 0, 0, 0, 0, reach, 0, 0, 0, 0, 0, 0, -reach], 3))
+    g.setAttribute('color', new Float32BufferAttribute([1, 0.2, 0.2, 1, 0.2, 0.2, 0.2, 1, 0.2, 0.2, 1, 0.2, 0.2, 0.4, 1, 0.2, 0.4, 1], 3))
+    return g
+  }, [reach])
+  useEffect(() => () => geometry.dispose(), [geometry])
+  return (
+    <lineSegments geometry={geometry} frustumCulled={false}>
+      <lineBasicMaterial vertexColors toneMapped={false} />
     </lineSegments>
   )
 }
@@ -314,7 +339,7 @@ function Marquee(): null {
       const r = canvas.getBoundingClientRect()
       const out: number[] = []
       shard.vertices.forEach((vert, i) => {
-        v.set(U(vert.p[0]), U(vert.p[1]), U(vert.p[2])).project(camera)
+        v.set(...UP(vert.p)).project(camera)
         if (v.z > 1) return
         const px = ((v.x + 1) / 2) * r.width
         const py = ((1 - v.y) / 2) * r.height
@@ -459,7 +484,7 @@ export function Bench(): JSX.Element {
       <Keys />
       <AxesReporter />
       {/* Axes, in the compass's colors, so X is red here and out there. */}
-      <axesHelper key={extent} args={[extent + 1]} />
+      <BenchAxes reach={extent + 1} />
       <Grid />
       <ScaleAvatar />
       {shard && <ShardMesh shard={shard} lit onFaceClick={tool === 'face' ? onFace : undefined} />}

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -85,8 +85,9 @@ function BenchAxes({ reach }: { reach: number }): JSX.Element {
     return g
   }, [reach])
   useEffect(() => () => geometry.dispose(), [geometry])
+  // A hair above the grid plane, or the grid's centre lines draw over the red and blue.
   return (
-    <lineSegments geometry={geometry} frustumCulled={false}>
+    <lineSegments geometry={geometry} position={[0, 0.004, 0]} frustumCulled={false}>
       <lineBasicMaterial vertexColors toneMapped={false} />
     </lineSegments>
   )

--- a/src/workshop/benchAxes.test.ts
+++ b/src/workshop/benchAxes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_AXES, nudgeFor, nudgeLabel } from './benchAxes'
+
+describe('benchAxes', () => {
+  it('turns screen directions into model moves, with Z mirrored as the bench draws it', () => {
+    expect(nudgeFor(DEFAULT_AXES, 'right')).toEqual({ axis: 0, delta: 1 })
+    expect(nudgeFor(DEFAULT_AXES, 'left')).toEqual({ axis: 0, delta: -1 })
+    expect(nudgeFor(DEFAULT_AXES, 'up')).toEqual({ axis: 1, delta: 1 })
+    expect(nudgeFor(DEFAULT_AXES, 'down')).toEqual({ axis: 1, delta: -1 })
+    // Toward the viewer is render +Z, which is model -Z; away is model +Z, where cyberspace +Z points.
+    expect(nudgeFor(DEFAULT_AXES, 'toward')).toEqual({ axis: 2, delta: -1 })
+    expect(nudgeFor(DEFAULT_AXES, 'away')).toEqual({ axis: 2, delta: 1 })
+    expect(nudgeLabel(nudgeFor(DEFAULT_AXES, 'away'))).toBe('+Z')
+  })
+})

--- a/src/workshop/benchAxes.ts
+++ b/src/workshop/benchAxes.ts
@@ -52,10 +52,15 @@ export interface Nudge {
   delta: 1 | -1
 }
 
-/** The world move a screen direction means under these axes. */
+/**
+ * The model move a screen direction means under these axes. The axes are in
+ * render terms; model +Z is render -Z (shards.ts toRender), so a move along
+ * render Z comes out with its sign turned.
+ */
 export function nudgeFor(axes: BenchAxes, name: NudgeName): Nudge {
-  const flip = (a: BenchAxis): Nudge => ({ axis: a.axis, delta: a.dir === 1 ? -1 : 1 })
-  const keep = (a: BenchAxis): Nudge => ({ axis: a.axis, delta: a.dir })
+  const model = (n: Nudge): Nudge => (n.axis === 2 ? { axis: 2, delta: n.delta === 1 ? -1 : 1 } : n)
+  const flip = (a: BenchAxis): Nudge => model({ axis: a.axis, delta: a.dir === 1 ? -1 : 1 })
+  const keep = (a: BenchAxis): Nudge => model({ axis: a.axis, delta: a.dir })
   switch (name) {
     case 'right': return keep(axes.right)
     case 'left': return flip(axes.right)


### PR DESCRIPTION
Stacked on #89.

**The finding.** The world draws cyberspace with Z negated on the way to the screen, which is why the compass shows +Z into the screen from the canonical view. Shards were drawn from their model coordinates raw, in the world and on the bench alike, so a shard's model +Z landed at cyberspace −Z when deployed. The bench's blue arrow and the world's compass disagreed because the data meant the opposite of what the bench said. The stored numbers were never wrong; their meaning was inverted.

**The fix.** Every drawing of a shard goes through one function that negates Z, so model +Z is cyberspace +Z. The bench's taps, box and nudges come back through the same mirror, its axes are drawn with the blue arrow along render −Z where cyberspace +Z is, and its lit faces are oriented on the drawn points. R (away from the viewer) now moves a point toward cyberspace +Z, F toward −Z.

**The consequence.** Shards that already exist appear mirrored front to back once, in the world and on the bench alike: their Z values now mean what they should have meant. Nothing on the wire changes.

Verified on the bench: a vertex at model z = +1 unit draws at render z = −1, R takes it to +2, F twice brings it back to 0; the axes show blue pointing the way the world's compass does. Tests cover the mapping, a flattened vertex, and the screen-to-model nudges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz