### PR TITLE
Shards: units and ticks kept apart in the model, as on the wire; stored models read as they are

### DIFF
--- a/src/lib/shards.test.ts
+++ b/src/lib/shards.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { flatten, fromPayload, newShard, toPayload, validFace, validPoint, type ShardModel, TICKS_PER_UNIT, packTicks, unpackTicks, unitsLabel, toRender } from './shards'
+import { flatten, fromPayload, newShard, toPayload, validFace, validPoint, type ShardModel, TICKS_PER_UNIT, packTicks, unpackTicks, unitsLabel, toRender, ticksOf, vertexAt, normalizeStored } from './shards'
 
 const tri: ShardModel = {
   ...newShard('tri'),
@@ -12,8 +12,8 @@ const tri: ShardModel = {
   unit: 3,
   vertices: [
     { p: [0, 0, 0], c: [1, 0, 0] },
-    { p: [2 * TICKS_PER_UNIT, 0, 0], c: [0, 1, 0] },
-    { p: [0, 2 * TICKS_PER_UNIT, 0], c: [0, 0, 1] },
+    { p: [2, 0, 0], c: [0, 1, 0] },
+    { p: [0, 2, 0], c: [0, 0, 1] },
   ],
   faces: [[0, 1, 2]],
 }
@@ -71,23 +71,31 @@ describe('geometry', () => {
 
 describe('ticks', () => {
   it('carries thirds, quarters and fifths exactly, with the run shorthand, and reads an old payload as whole units', () => {
-    const v = (p: [number, number, number]) => ({ p, c: [1, 0, 0] as [number, number, number] })
+    const v = (total: [number, number, number]) => vertexAt(total, [1, 0, 0])
     const s = { ...newShard('t'), vertices: [v([0, 0, 0]), v([TICKS_PER_UNIT, 0, 0]), v([40, -30, 24 + 2 * TICKS_PER_UNIT]), v([0, 0, 0])] }
+    expect(s.vertices[2]).toEqual({ p: [0, -1, 2], t: [40, 90, 24], c: [1, 0, 0] })
+    expect(s.vertices[1]).toEqual({ p: [1, 0, 0], c: [1, 0, 0] })
     const wire = toPayload(s)
     expect(wire.vertices).toEqual([[0, 0, 0], [1, 0, 0], [0, -1, 2], [0, 0, 0]])
     expect(wire.ticks).toEqual([-2, [40, 90, 24], -1])
     const back = fromPayload(wire, 'x')!
-    expect(back.vertices.map((x) => x.p)).toEqual(s.vertices.map((x) => x.p))
+    expect(back.vertices).toEqual(s.vertices)
     const old = { ...wire, ticks: undefined }
-    expect(fromPayload(old, 'y')!.vertices.map((x) => x.p)).toEqual([[0, 0, 0], [TICKS_PER_UNIT, 0, 0], [0, -TICKS_PER_UNIT, 2 * TICKS_PER_UNIT], [0, 0, 0]])
+    expect(fromPayload(old, 'y')!.vertices.map((x) => ticksOf(x))).toEqual([[0, 0, 0], [TICKS_PER_UNIT, 0, 0], [0, -TICKS_PER_UNIT, 2 * TICKS_PER_UNIT], [0, 0, 0]])
     expect(unpackTicks([-3], 4)).toBeNull()
     expect(unpackTicks([[120, 0, 0]], 1)).toBeNull()
     expect(packTicks([])).toEqual([])
   })
   it('draws model +Z along render -Z, as the world draws cyberspace', () => {
     expect(toRender([TICKS_PER_UNIT, 2 * TICKS_PER_UNIT, 3 * TICKS_PER_UNIT])).toEqual([1, 2, -3])
-    const one = { ...newShard('z'), vertices: [{ p: [0, 0, TICKS_PER_UNIT] as [number, number, number], c: [1, 1, 1] as [number, number, number] }] }
+    const one = { ...newShard('z'), vertices: [{ p: [0, 0, 1] as [number, number, number], c: [1, 1, 1] as [number, number, number] }] }
     expect(Array.from(flatten(one).positions)).toEqual([0, 0, -1])
+  })
+  it('normalizes a model saved while positions were kept in ticks, and leaves a unit model alone', () => {
+    const units = { ...newShard('u'), vertices: [{ p: [3, 0, -2] as [number, number, number], c: [1, 1, 1] as [number, number, number] }] }
+    expect(normalizeStored(units)).toBe(units)
+    const interim = { ...newShard('i'), vertices: [{ p: [360, 40, -240] as [number, number, number], c: [1, 1, 1] as [number, number, number] }] }
+    expect(normalizeStored(interim).vertices[0]).toEqual({ p: [3, 0, -2], t: [0, 40, 0], c: [1, 1, 1] })
   })
   it('prints ticks as units', () => {
     expect(unitsLabel(0)).toBe('0')

--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -19,8 +19,10 @@
 export type ShardMode = 'solid' | 'points' | 'lines'
 
 export interface ShardVertex {
-  /** Model units, integers. */
+  /** Whole units per axis: the point's floor, what the wire's `vertices` carries. */
   p: [number, number, number]
+  /** The rest of the position in ticks, 0..119 per axis; absent when the point is whole. */
+  t?: [number, number, number]
   /** 0..1 per channel. */
   c: [number, number, number]
 }
@@ -41,7 +43,7 @@ export interface ShardModel {
   unit: number
   /** Half-width of this shard's build grid, in units: the grid runs from -extent to +extent on every axis. */
   extent: number
-  /** Vertex positions are in TICKS (120 to a unit), never units: see ShardVertex. */
+  /** A vertex is whole units plus ticks, kept apart as on the wire: see ShardVertex. */
   mode: ShardMode
   vertices: ShardVertex[]
   /** Triangles as vertex indices; drawn in `solid` mode only. */
@@ -90,8 +92,22 @@ export function newShard(name = 'Untitled shard'): ShardModel {
 }
 
 /** A grid point as a map key, so "the same point" is one string compare. */
+/** A point's key, from its position in total ticks. */
 export function pointKey(p: [number, number, number]): string {
   return `${p[0]},${p[1]},${p[2]}`
+}
+
+/** A vertex's position as total ticks, the form arithmetic and keys use. */
+export function ticksOf(v: Pick<ShardVertex, 'p' | 't'>): [number, number, number] {
+  const t = v.t ?? [0, 0, 0]
+  return [v.p[0] * TICKS_PER_UNIT + t[0], v.p[1] * TICKS_PER_UNIT + t[1], v.p[2] * TICKS_PER_UNIT + t[2]]
+}
+
+/** A vertex from a position in total ticks: whole units, and the rest as ticks only when there is any. */
+export function vertexAt(total: [number, number, number], c: [number, number, number]): ShardVertex {
+  const p = total.map((x) => Math.floor(x / TICKS_PER_UNIT)) as [number, number, number]
+  const t = total.map((x, a) => x - p[a] * TICKS_PER_UNIT) as [number, number, number]
+  return t[0] === 0 && t[1] === 0 && t[2] === 0 ? { p, c } : { p, t, c }
 }
 
 export function uuid(): string {
@@ -104,10 +120,22 @@ export function validPoint(p: [number, number, number], extent: number = GRID_HA
   return p.every((v) => Number.isInteger(v) && Math.abs(v) <= extent * TICKS_PER_UNIT)
 }
 
+/**
+ * A stored model made whole again. Models have always kept `p` in units; for
+ * a short while after ticks arrived they kept total ticks there instead, and
+ * such a model shows itself by a coordinate no grid could hold (above
+ * MAX_EXTENT units). Those are split back into units and ticks.
+ */
+export function normalizeStored(s: ShardModel): ShardModel {
+  const inTicks = s.vertices.some((v) => v.t === undefined && v.p.some((c) => Math.abs(c) > MAX_EXTENT))
+  if (!inTicks) return s
+  return { ...s, vertices: s.vertices.map((v) => vertexAt(v.p, v.c)) }
+}
+
 /** The grid half-width a shard needs to hold every vertex it has. */
 export function neededExtent(s: Pick<ShardModel, 'vertices'>): number {
   let m = MIN_EXTENT
-  for (const v of s.vertices) for (const c of v.p) m = Math.max(m, Math.ceil(Math.abs(c) / TICKS_PER_UNIT))
+  for (const v of s.vertices) for (const c of ticksOf(v)) m = Math.max(m, Math.ceil(Math.abs(c) / TICKS_PER_UNIT))
   return m
 }
 
@@ -128,8 +156,8 @@ export function toPayload(s: ShardModel): ShardPayload {
     unit: s.unit,
     extent: s.extent,
     mode: s.mode,
-    vertices: s.vertices.map((v) => v.p.map((t) => Math.floor(t / TICKS_PER_UNIT)) as [number, number, number]),
-    ticks: packTicks(s.vertices.map((v) => v.p.map((t) => t - Math.floor(t / TICKS_PER_UNIT) * TICKS_PER_UNIT) as [number, number, number])),
+    vertices: s.vertices.map((v) => v.p),
+    ticks: packTicks(s.vertices.map((v) => v.t ?? [0, 0, 0])),
     colors: s.vertices.map((v) => v.c),
     faces: s.faces,
   }
@@ -186,8 +214,9 @@ export function fromPayload(raw: unknown, id: string): ShardModel | null {
     if (!Array.isArray(pt) || pt.length !== 3 || !Array.isArray(c) || c.length !== 3) return null
     const whole = pt.map(Number) as [number, number, number]
     if (!whole.every(Number.isInteger)) return null
-    const point = whole.map((u, a) => u * TICKS_PER_UNIT + rest[i][a]) as [number, number, number]
-    vertices.push({ p: point, c: clampColor(c.map(Number) as [number, number, number]) })
+    const r = rest[i]
+    const colour = clampColor(c.map(Number) as [number, number, number])
+    vertices.push(r[0] === 0 && r[1] === 0 && r[2] === 0 ? { p: whole, c: colour } : { p: whole, t: r, c: colour })
   }
   const faces: Array<[number, number, number]> = []
   for (const f of p.faces) {
@@ -218,6 +247,7 @@ export function fromPayload(raw: unknown, id: string): ShardModel | null {
  * world's compass does.
  */
 export function toRender(p: [number, number, number]): [number, number, number] {
+  // `p` is a position in total ticks (ticksOf).
   // 0 - z rather than -z: negating a zero gives -0, which equality tests and keys treat as different.
   return [p[0] / TICKS_PER_UNIT, p[1] / TICKS_PER_UNIT, (0 - p[2]) / TICKS_PER_UNIT]
 }
@@ -226,7 +256,7 @@ export function flatten(s: ShardModel): { positions: Float32Array; colors: Float
   const positions = new Float32Array(s.vertices.length * 3)
   const colors = new Float32Array(s.vertices.length * 3)
   s.vertices.forEach((v, i) => {
-    positions.set(toRender(v.p), i * 3)
+    positions.set(toRender(ticksOf(v)), i * 3)
     colors.set(v.c, i * 3)
   })
   return { positions, colors, index: s.faces.flat() }
@@ -236,7 +266,7 @@ export function flatten(s: ShardModel): { positions: Float32Array; colors: Float
 export function centroid(s: ShardModel): [number, number, number] {
   if (s.vertices.length === 0) return [0, 0, 0]
   const sum = [0, 0, 0]
-  for (const v of s.vertices) for (let i = 0; i < 3; i++) sum[i] += v.p[i]
+  for (const v of s.vertices) { const t = ticksOf(v); for (let i = 0; i < 3; i++) sum[i] += t[i] }
   return sum.map((x) => x / s.vertices.length) as [number, number, number]
 }
 

--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { GRID_HALF, MAX_VERTICES, TICKS_PER_UNIT as T, newShard, validFace, validPoint, type ShardModel } from './shards'
+import { GRID_HALF, MAX_VERTICES, TICKS_PER_UNIT as T, newShard, ticksOf, validFace, validPoint, type ShardModel } from './shards'
 import { STAMPS, FACED, compile, landing, preview, stamp, type Facing, type StampKind } from './stamps'
 
 const red: [number, number, number] = [1, 0, 0]
@@ -89,7 +89,7 @@ describe('stamps', () => {
   it('never merges vertices, so a seam between colors stays crisp', () => {
     const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
     const b = stamp(a.shard, 'block', 1, 0, [T, 0, 0], [0, 0, 1])!
-    const at = b.shard.vertices.filter((v) => v.p.join() === `${T},0,0`)
+    const at = b.shard.vertices.filter((v) => ticksOf(v).join() === `${T},0,0`)
     expect(at).toHaveLength(2)
     expect(at.map((v) => v.c.join()).sort()).toEqual(['0,0,1', '1,0,0'])
   })
@@ -112,7 +112,7 @@ describe('ghost placement', () => {
     for (const kind of STAMPS) {
       for (const origin of [[0, 0, 0], [GRID_HALF * T, 0, GRID_HALF * T], [-GRID_HALF * T, 3 * T, 2 * T]] as Array<[number, number, number]>) {
         const at = landing(kind, 4, 1, origin)
-        const ghost = preview(kind, 4, 1, red).vertices.map((v) => [v.p[0] + at[0], v.p[1] + at[1], v.p[2] + at[2]])
+        const ghost = preview(kind, 4, 1, red).vertices.map((v) => { const t = ticksOf(v); return [t[0] + at[0], t[1] + at[1], t[2] + at[2]] })
         expect(ghost).toEqual(compile(kind, 4, 1, origin).points)
       }
     }

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -20,7 +20,7 @@
  * Pure: a stamp is a function of (kind, size, facing) and where you put it.
  */
 
-import { GRID_HALF, MAX_FACES, MAX_VERTICES, TICKS_PER_UNIT, pointKey, type ShardModel, type ShardVertex } from './shards'
+import { GRID_HALF, MAX_FACES, MAX_VERTICES, TICKS_PER_UNIT, pointKey, ticksOf, vertexAt, type ShardModel, type ShardVertex } from './shards'
 import { triangulate, type P3 } from './triangulate'
 
 export type StampKind = 'block' | 'wedge' | 'pyramid' | 'column' | 'ring' | 'star' | 'arrow'
@@ -205,11 +205,11 @@ export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: 
   const base = shard.vertices.length
   const vertices: ShardVertex[] = [
     ...shard.vertices,
-    ...shape.points.map((p) => ({ p: [...p] as P3, c: [...color] as [number, number, number] })),
+    ...shape.points.map((p) => vertexAt(p, [...color] as [number, number, number])),
   ]
   const existing = new Map<string, number[]>()
   shard.faces.forEach((f, i) => {
-    const k = triKey(shard.vertices[f[0]].p, shard.vertices[f[1]].p, shard.vertices[f[2]].p)
+    const k = triKey(ticksOf(shard.vertices[f[0]]), ticksOf(shard.vertices[f[1]]), ticksOf(shard.vertices[f[2]]))
     existing.set(k, [...(existing.get(k) ?? []), i])
   })
   const drop = new Set<number>()
@@ -239,7 +239,7 @@ export function preview(kind: StampKind, size: number, facing: Facing, color: [n
     unit: 0,
     extent: GRID_HALF,
     mode: shape.faces.length ? 'solid' : 'lines',
-    vertices: shape.points.map((p) => ({ p, c: [...color] as [number, number, number] })),
+    vertices: shape.points.map((p) => vertexAt(p, [...color] as [number, number, number])),
     faces: shape.faces,
     updatedAt: 0,
   }

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -27,7 +27,7 @@ import {
   LineBasicMaterial,
 } from 'three'
 import { easeOutCubic, hash01, scrambleOffset, seedOf, SHARD_DECODE_MS } from '../lib/decode'
-import { flatten, toRender, type ShardModel } from '../lib/shards'
+import { flatten, ticksOf, toRender, type ShardModel } from '../lib/shards'
 import { orientFaces } from '../lib/orient'
 
 interface Props {
@@ -70,7 +70,7 @@ const TAG_BLEND = { blending: CustomBlending, blendEquation: AddEquation, blendS
 export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick, world = false, lit = false }: Props): JSX.Element | null {
   const { positions, colors, index } = useMemo(() => {
     const f = flatten(shard)
-    return lit ? { ...f, index: orientFaces(shard.vertices.map((v) => toRender(v.p)), shard.faces).flat() } : f
+    return lit ? { ...f, index: orientFaces(shard.vertices.map((v) => toRender(ticksOf(v))), shard.faces).flat() } : f
   }, [shard.vertices, shard.faces, lit])
 
   // Live copies: the decode writes into these, the targets stay untouched.

--- a/src/store/useCeremony.ts
+++ b/src/store/useCeremony.ts
@@ -12,7 +12,7 @@ import { create } from 'zustand'
 import type { Plane } from 'cyberspace-core'
 import { messagePreview, type Hidden } from '../lib/hidden'
 import { regionLabel } from '../lib/loot'
-import { GRID_HALF, TICKS_PER_UNIT, type ShardModel } from '../lib/shards'
+import { GRID_HALF, type ShardModel } from '../lib/shards'
 import { useCyberspace } from './useCyberspace'
 import { useShards } from './useShards'
 
@@ -54,7 +54,7 @@ function previewShard(unit: number): ShardModel {
     unit,
     extent: GRID_HALF,
     mode: 'lines',
-    vertices: path.map((p, i) => ({ p: p.map((u) => u * TICKS_PER_UNIT) as [number, number, number], c: i < 16 ? [0, 0.9, 1] : [0.97, 0.58, 0.1] })),
+    vertices: path.map((p, i) => ({ p, c: i < 16 ? [0, 0.9, 1] : [0.97, 0.58, 0.1] })),
     faces: [],
     updatedAt: Math.floor(Date.now() / 1000),
   }

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -14,6 +14,7 @@
  * up near you and could decrypt and verify.
  */
 
+import { normalizeStored } from '../lib/shards'
 import { create } from 'zustand'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
 import { publishMany, query, relaySet } from '../lib/relay'
@@ -119,7 +120,7 @@ function loadMine(): MyDeployment[] {
     const raw = localStorage.getItem(MINE_KEY)
     if (!raw) return []
     const list = JSON.parse(raw)
-    return Array.isArray(list) ? list.filter((d) => d && d.eventId && d.inner && (d.shard || d.text)) : []
+    return Array.isArray(list) ? list.filter((d) => d && d.eventId && d.inner && (d.shard || d.text)).map((d) => (d.shard ? { ...d, shard: normalizeStored(d.shard) } : d)) : []
   } catch { return [] }
 }
 

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
-import { TICKS_PER_UNIT as T } from '../lib/shards'
+import { TICKS_PER_UNIT as T, ticksOf } from '../lib/shards'
 import { DEFAULT_PALETTE, useWorkshop } from './useWorkshop'
 
 const w = () => useWorkshop.getState()
@@ -27,7 +27,7 @@ describe('workshop', () => {
     w().addVertex([T, 2 * T, 3 * T])
     w().addVertex([T, 2 * T, 3 * T])
     expect(w().current()!.vertices).toHaveLength(1)
-    expect(w().current()!.vertices[0].p).toEqual([T, 2 * T, 3 * T])
+    expect(ticksOf(w().current()!.vertices[0])).toEqual([T, 2 * T, 3 * T])
     expect(w().selection).toEqual([0])
     w().addVertex([9 * T, 0, 0])
     expect(w().current()!.vertices).toHaveLength(1)
@@ -37,12 +37,12 @@ describe('workshop', () => {
     w().addVertex([0, 0, 0]); w().addVertex([T, 0, 0])
     w().selectVertex(0)
     w().moveSelected(1, T)
-    expect(w().current()!.vertices[0].p).toEqual([0, T, 0])
+    expect(ticksOf(w().current()!.vertices[0])).toEqual([0, T, 0])
     w().moveSelected(1, -T); w().moveSelected(0, T)
-    expect(w().current()!.vertices[0].p).toEqual([T, 0, 0])
+    expect(ticksOf(w().current()!.vertices[0])).toEqual([T, 0, 0])
     w().selectVertex(1)
     for (let i = 0; i < 20; i++) w().moveSelected(0, T)
-    expect(w().current()!.vertices[1].p[0]).toBe(8 * T)
+    expect(ticksOf(w().current()!.vertices[1])[0]).toBe(8 * T)
   })
 
   it('stamps a shape, and the first faces switch LINES to SOLID once', () => {
@@ -72,12 +72,12 @@ describe('workshop', () => {
     w().setColor([1, 0, 0])
     w().placeStamp([T, 0, 0])
     const s = w().current()!
-    const shared = s.vertices.map((v, i) => (v.p.join() === `${T},0,0` ? i : -1)).filter((i) => i >= 0)
+    const shared = s.vertices.map((v, i) => (ticksOf(v).join() === `${T},0,0` ? i : -1)).filter((i) => i >= 0)
     expect(shared).toHaveLength(2)
     w().selectVertex(shared[0])
     // Off to a free point: landing on the blocks' top corners would join those too.
     w().moveSelected(2, -T)
-    for (const i of shared) expect(w().current()!.vertices[i].p).toEqual([T, 0, -T])
+    for (const i of shared) expect(ticksOf(w().current()!.vertices[i])).toEqual([T, 0, -T])
     w().colorSelected([0, 1, 0])
     for (const i of shared) expect(w().current()!.vertices[i].c).toEqual([0, 1, 0])
     const facesBefore = w().current()!.faces.length
@@ -93,12 +93,12 @@ describe('workshop', () => {
     w().placeStamp([0, 0, 0])          // a block: 8 corners
     w().addVertex([5 * T, 0, 5 * T])
     const s = w().current()!
-    const corner = s.vertices.findIndex((v) => v.p.join() === '0,0,0')
+    const corner = s.vertices.findIndex((v) => ticksOf(v).join() === '0,0,0')
     w().selectVertex(null)
     w().toggleVertex(corner); w().toggleVertex(s.vertices.length - 1)
-    expect(new Set(w().selection.map((i) => s.vertices[i].p.join()))).toEqual(new Set(['0,0,0', `${5 * T},0,${5 * T}`]))
+    expect(new Set(w().selection.map((i) => ticksOf(s.vertices[i]).join()))).toEqual(new Set(['0,0,0', `${5 * T},0,${5 * T}`]))
     w().toggleVertex(corner)
-    expect(w().selection.map((i) => s.vertices[i].p.join())).toEqual([`${5 * T},0,${5 * T}`])
+    expect(w().selection.map((i) => ticksOf(s.vertices[i]).join())).toEqual([`${5 * T},0,${5 * T}`])
     w().setSelection([corner])
     expect(w().selection).toEqual([corner])
   })
@@ -107,13 +107,13 @@ describe('workshop', () => {
     w().addVertex([0, 0, 0]); w().addVertex([8 * T, 0, 0]); w().addVertex([3 * T, 0, 3 * T])
     w().setSelection([0, 1, 2])
     w().moveSelected(0, T)               // 8 -> 9 is off the grid: nothing moves
-    expect(w().current()!.vertices.map((v) => v.p[0])).toEqual([0, 8 * T, 3 * T])
+    expect(w().current()!.vertices.map((v) => ticksOf(v)[0])).toEqual([0, 8 * T, 3 * T])
     w().moveSelected(2, T)
-    expect(w().current()!.vertices.map((v) => v.p[2])).toEqual([T, T, 4 * T])
+    expect(w().current()!.vertices.map((v) => ticksOf(v)[2])).toEqual([T, T, 4 * T])
     w().colorSelected([1, 0, 0])
     expect(w().current()!.vertices.every((v) => v.c.join() === '1,0,0')).toBe(true)
     w().setSelection([0, 2]); w().deleteSelected()
-    expect(w().current()!.vertices.map((v) => v.p.join())).toEqual([`${8 * T},0,${T}`])
+    expect(w().current()!.vertices.map((v) => ticksOf(v).join())).toEqual([`${8 * T},0,${T}`])
     expect(w().selection).toEqual([])
   })
 
@@ -122,9 +122,9 @@ describe('workshop', () => {
     w().placeStamp([5 * T, 0, 5 * T])    // another, apart
     w().addVertex([-4 * T, 0, -4 * T])   // a lone point
     const s = w().current()!
-    const a = s.vertices.findIndex((v) => v.p.join() === '0,0,0')
+    const a = s.vertices.findIndex((v) => ticksOf(v).join() === '0,0,0')
     w().setSelection([a]); w().selectConnected()
-    const points = new Set(w().selection.map((i) => s.vertices[i].p.join()))
+    const points = new Set(w().selection.map((i) => ticksOf(s.vertices[i]).join()))
     expect(points.size).toBe(8)
     expect(points.has(`${5 * T},0,${5 * T}`)).toBe(false)
     expect(points.has(`${-4 * T},0,${-4 * T}`)).toBe(false)
@@ -185,9 +185,9 @@ describe('workshop', () => {
     expect(w().step()).toBe(30)
     w().addVertex([30, 0, 0])
     w().setSelection([0]); w().moveSelected(0, w().step())
-    expect(w().current()!.vertices.map((v) => v.p)).toEqual([[70, 0, 80], [30, 0, 0]])
+    expect(w().current()!.vertices.map((v) => ticksOf(v))).toEqual([[70, 0, 80], [30, 0, 0]])
     w().setDivision(1)
-    expect(w().current()!.vertices.map((v) => v.p)).toEqual([[70, 0, 80], [30, 0, 0]])
+    expect(w().current()!.vertices.map((v) => ticksOf(v))).toEqual([[70, 0, 80], [30, 0, 0]])
     const wire = JSON.parse(w().exportCurrent()!)
     expect(wire.vertices).toEqual([[0, 0, 0], [0, 0, 0]])
     expect(wire.ticks).toEqual([[70, 0, 80], [30, 0, 0]])

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -56,6 +56,7 @@ export type Tool = 'stamp' | 'add' | 'select' | 'face'
 
 const STORAGE = 'onosendai:shards'
 const PALETTE_STORAGE = 'onosendai:palette'
+const AVATAR_KEY = 'onosendai:workshop-avatar'
 /** Undo depth per shard. */
 const HISTORY = 64
 /** The swatches every workshop starts with. */
@@ -89,6 +90,8 @@ export interface WorkshopState {
   level: number
   /** Snap: the grid the placing tools, the marquee and the nudges use is a unit over this. A tool setting, not the shard's. */
   division: Division
+  /** The to-scale avatar at the grid's centre, on or off. Kept between visits. */
+  showAvatar: boolean
   /** The color new vertices get, and the color input shows. */
   color: [number, number, number]
   stampKind: StampKind
@@ -117,6 +120,7 @@ export interface WorkshopState {
   setTool: (tool: Tool) => void
   setLevel: (level: number) => void
   setDivision: (division: Division) => void
+  setShowAvatar: (on: boolean) => void
   /** One snap step, in ticks. */
   step: () => number
   setColor: (c: [number, number, number]) => void
@@ -183,6 +187,10 @@ function loadPalette(): string[] {
     const list: unknown = raw ? JSON.parse(raw) : null
     return Array.isArray(list) && list.every((h) => typeof h === 'string' && HEX.test(h)) ? list : DEFAULT_PALETTE
   } catch { return DEFAULT_PALETTE }
+}
+
+function loadShowAvatar(): boolean {
+  try { return localStorage.getItem(AVATAR_KEY) !== '0' } catch { return true }
 }
 
 function savePalette(palette: string[]): void {
@@ -282,6 +290,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     palette: loadPalette(),
     level: 0,
     division: 1,
+    showAvatar: loadShowAvatar(),
     color: [0, 0.9, 1],
     stampKind: 'block',
     stampSize: 2,
@@ -345,6 +354,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       set({ level: Math.max(-e, Math.min(e, Math.round(level))) })
     },
     setDivision: (division) => { if (DIVISIONS.includes(division)) set({ division }) },
+    setShowAvatar: (on) => { set({ showAvatar: on }); try { localStorage.setItem(AVATAR_KEY, on ? '1' : '0') } catch { /* private mode */ } },
     step: () => TICKS_PER_UNIT / get().division,
     setColor: (c) => set({ color: clampColor(c) }),
     setStampKind: (stampKind) => set({ stampKind }),

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -26,6 +26,9 @@ import {
   GRID_HALF,
   TICKS_PER_UNIT,
   centroid,
+  normalizeStored,
+  ticksOf,
+  vertexAt,
   type Division,
   MAX_EXTENT,
   MIN_EXTENT,
@@ -165,7 +168,7 @@ function load(): ShardModel[] {
     if (!raw) return []
     const list = JSON.parse(raw)
     return Array.isArray(list)
-      ? list.filter((s) => s && typeof s.id === 'string' && Array.isArray(s.vertices)).map((s) => ({ ...s, extent: Number.isInteger(s.extent) ? s.extent : Math.max(GRID_HALF, neededExtent(s)) }))
+      ? list.filter((s) => s && typeof s.id === 'string' && Array.isArray(s.vertices)).map((s) => normalizeStored(s)).map((s) => ({ ...s, extent: Number.isInteger(s.extent) ? s.extent : Math.max(GRID_HALF, neededExtent(s)) }))
       : []
   } catch { return [] }
 }
@@ -190,9 +193,9 @@ function savePalette(palette: string[]): void {
 function group(s: ShardModel, index: number): number[] {
   const v = s.vertices[index]
   if (!v) return []
-  const key = pointKey(v.p)
+  const key = pointKey(ticksOf(v))
   const out: number[] = []
-  s.vertices.forEach((o, i) => { if (pointKey(o.p) === key) out.push(i) })
+  s.vertices.forEach((o, i) => { if (pointKey(ticksOf(o)) === key) out.push(i) })
   return out
 }
 
@@ -241,7 +244,7 @@ function facesFor(pts: P3[]): Tris | null {
 
 /** The face wound so its normal points away from `centre`. */
 function awayFrom(s: ShardModel, f: Tri, centre: P3): Tri {
-  const [a, b, c] = f.map((i) => s.vertices[i].p)
+  const [a, b, c] = f.map((i) => ticksOf(s.vertices[i]))
   const n = newell([a, b, c])
   const m: P3 = [(a[0] + b[0] + c[0]) / 3 - centre[0], (a[1] + b[1] + c[1]) / 3 - centre[1], (a[2] + b[2] + c[2]) / 3 - centre[2]]
   return n[0] * m[0] + n[1] * m[1] + n[2] * m[2] < 0 ? [f[0], f[2], f[1]] : f
@@ -370,10 +373,10 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       let added = -1
       edit((s) => {
         // One vertex per point by hand: adding where one already is selects it instead.
-        const existing = s.vertices.findIndex((v) => pointKey(v.p) === pointKey(p))
+        const existing = s.vertices.findIndex((v) => pointKey(ticksOf(v)) === pointKey(p))
         if (existing >= 0) { added = existing; return null }
         added = s.vertices.length
-        return { ...s, vertices: [...s.vertices, { p: [...p] as P3, c: [...get().color] as ShardVertex['c'] }] }
+        return { ...s, vertices: [...s.vertices, vertexAt(p, [...get().color] as ShardVertex['c'])] }
       })
       if (added >= 0) set({ selection: group(get().current()!, added), selectedFace: null })
     },
@@ -408,12 +411,12 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       const find = (i: number): number => { while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i] } return i }
       const join = (a: number, b: number): void => { const ra = find(a), rb = find(b); if (ra !== rb) parent[ra] = rb }
       const byPoint = new Map<string, number>()
-      s.vertices.forEach((v, i) => { const k = pointKey(v.p); const first = byPoint.get(k); if (first === undefined) byPoint.set(k, i); else join(first, i) })
+      s.vertices.forEach((v, i) => { const k = pointKey(ticksOf(v)); const first = byPoint.get(k); if (first === undefined) byPoint.set(k, i); else join(first, i) })
       for (const f of s.faces) { join(f[0], f[1]); join(f[1], f[2]) }
       const roots = new Set(selection.map(find))
       const out = s.vertices.map((_, i) => i).filter((i) => roots.has(find(i)))
       const grew = out.length > selection.length
-      set({ selection: out, selectedFace: null, notice: grew ? `${new Set(out.map((i) => pointKey(s.vertices[i].p))).size} points connected by faces.` : 'Nothing else is joined to the selection by faces.' })
+      set({ selection: out, selectedFace: null, notice: grew ? `${new Set(out.map((i) => pointKey(ticksOf(s.vertices[i])))).size} points connected by faces.` : 'Nothing else is joined to the selection by faces.' })
     },
 
     selectFace: (index) => set({ selectedFace: index, selection: index === null ? get().selection : [] }),
@@ -447,10 +450,10 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
         if (chosen.size === 0) return null
         const vertices = s.vertices.slice()
         for (const i of chosen) {
-          const p = [...vertices[i].p] as P3
+          const p = ticksOf(vertices[i])
           p[axis] += delta
           if (!validPoint(p, s.extent)) return null
-          vertices[i] = { ...vertices[i], p }
+          vertices[i] = vertexAt(p, vertices[i].c)
         }
         return { ...s, vertices }
       })
@@ -498,8 +501,8 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       const { facePick } = get()
       if (!s || !s.vertices[index]) return
       // Picks are points, not vertices: any vertex on a picked point counts as that pick.
-      const key = pointKey(s.vertices[index].p)
-      const at = facePick.findIndex((i) => pointKey(s.vertices[i].p) === key)
+      const key = pointKey(ticksOf(s.vertices[index]))
+      const at = facePick.findIndex((i) => pointKey(ticksOf(s.vertices[i])) === key)
       // Tapping the first corner again closes the loop.
       if (at === 0 && facePick.length >= 3) { get().fill(); return }
       if (at >= 0) { set({ facePick: facePick.filter((_, i) => i !== at), selectedFace: null }); return }
@@ -512,7 +515,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       const s = get().current()
       const { facePick } = get()
       if (!s || facePick.length < 3) return
-      const tris = triangulate(facePick.map((i) => s.vertices[i].p))
+      const tris = triangulate(facePick.map((i) => ticksOf(s.vertices[i])))
       if (!tris) { set({ notice: 'Those corners do not make a face. Pick them in order around its edge.' }); return }
       edit((cur) => {
         const have = new Set(cur.faces.map(faceKey))
@@ -532,10 +535,10 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       if (!s) return
       // One vertex per point, so a shared point counts once.
       const firstAt = new Map<string, number>()
-      for (const i of selection) { const v = s.vertices[i]; if (v && !firstAt.has(pointKey(v.p))) firstAt.set(pointKey(v.p), i) }
+      for (const i of selection) { const v = s.vertices[i]; if (v && !firstAt.has(pointKey(ticksOf(v)))) firstAt.set(pointKey(ticksOf(v)), i) }
       const idx = [...firstAt.values()]
       if (idx.length < 3) { set({ notice: 'Select three or more points to fill.' }); return }
-      const pts = idx.map((i) => s.vertices[i].p)
+      const pts = idx.map((i) => ticksOf(s.vertices[i]))
       const faces = facesFor(pts)
       if (!faces) { set({ notice: 'Those points do not make a face: they lie on one line.' }); return }
       const centre = centroid(s)

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -444,6 +444,7 @@ export function Bench(): JSX.Element {
   const shard = useWorkshop((s) => s.current())
   const tool = useWorkshop((s) => s.tool)
   const extent = shard?.extent ?? GRID_HALF
+  const showAvatar = useWorkshop((s) => s.showAvatar)
   const first = useRef(true)
   useEffect(() => { first.current = false }, [])
 
@@ -487,7 +488,7 @@ export function Bench(): JSX.Element {
       {/* Axes, in the compass's colors, so X is red here and out there. */}
       <BenchAxes reach={extent + 1} />
       <Grid />
-      <ScaleAvatar />
+      {showAvatar && <ScaleAvatar />}
       {shard && <ShardMesh shard={shard} lit onFaceClick={tool === 'face' ? onFace : undefined} />}
       <Ghost />
       <PickLoop />

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -20,7 +20,7 @@ import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
 import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
-import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, toRender } from '../lib/shards'
+import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, ticksOf, toRender } from '../lib/shards'
 import { benchAxes, nudgeFor, sameAxes, useBenchView, type NudgeName } from './benchAxes'
 import { landing, preview } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
@@ -186,7 +186,7 @@ function Handles(): JSX.Element | null {
   const chosen = useMemo(() => new Set(selection), [selection])
   const groups = useMemo(() => {
     const m = new Map<string, number[]>()
-    shard?.vertices.forEach((v, i) => { const k = pointKey(v.p); m.set(k, [...(m.get(k) ?? []), i]) })
+    shard?.vertices.forEach((v, i) => { const k = pointKey(ticksOf(v)); m.set(k, [...(m.get(k) ?? []), i]) })
     return [...m.values()]
   }, [shard?.vertices])
   if (!shard) return null
@@ -209,7 +209,7 @@ function Handles(): JSX.Element | null {
         const isSel = g.some((i) => chosen.has(i))
         const picked = facePick.some((i) => g.includes(i))
         return (
-          <group key={first} position={UP(v.p)}>
+          <group key={first} position={UP(ticksOf(v))}>
             {/* A generous invisible hit target; the visible handle is small. */}
             <mesh onClick={onClick(first, isSel)}>
               <sphereGeometry args={[0.42, 10, 10]} />
@@ -238,7 +238,7 @@ function PickLoop(): JSX.Element | null {
   const facePick = useWorkshop((s) => s.facePick)
   const line = useMemo(() => {
     if (!shard || facePick.length < 2) return null
-    const pts = facePick.map((i) => shard.vertices[i]?.p).filter((p): p is P3 => !!p).map(UP)
+    const pts = facePick.map((i) => shard.vertices[i]).filter((v) => !!v).map((v) => UP(ticksOf(v)))
     if (pts.length >= 3) pts.push(pts[0])
     const g = new BufferGeometry()
     g.setAttribute('position', new Float32BufferAttribute(pts.flat(), 3))
@@ -257,7 +257,7 @@ function FaceHighlight(): JSX.Element | null {
   const lit = useMemo(() => {
     const f = face === null ? undefined : shard?.faces[face]
     if (!shard || !f) return null
-    const pts = f.map((i) => UP(shard.vertices[i].p))
+    const pts = f.map((i) => UP(ticksOf(shard.vertices[i])))
     // Four points: the mesh draws the first three as its one triangle, the line closes the loop.
     const g = new BufferGeometry()
     g.setAttribute('position', new Float32BufferAttribute([...pts, pts[0]].flat(), 3))
@@ -340,7 +340,7 @@ function Marquee(): null {
       const r = canvas.getBoundingClientRect()
       const out: number[] = []
       shard.vertices.forEach((vert, i) => {
-        v.set(...UP(vert.p)).project(camera)
+        v.set(...UP(ticksOf(vert))).project(camera)
         if (v.z > 1) return
         const px = ((v.x + 1) / 2) * r.width
         const py = ((1 - v.y) / 2) * r.height

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -21,7 +21,7 @@ import { Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, Stamp, Trash2
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { ConfirmModal } from '../hud/ConfirmModal'
 import { Explanation } from '../hud/Explanation'
-import { DIVISIONS, MAX_EXTENT, MIN_EXTENT, MODES, TICKS_PER_UNIT, hexToRgb, neededExtent, rgbToHex, toPayload, unitsLabel, type ShardMode } from '../lib/shards'
+import { DIVISIONS, MAX_EXTENT, MIN_EXTENT, MODES, TICKS_PER_UNIT, hexToRgb, neededExtent, rgbToHex, ticksOf, toPayload, unitsLabel, type ShardMode } from '../lib/shards'
 import { formatCellSize } from '../lib/scale'
 import { FACED, FACING_LABEL, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
@@ -174,7 +174,7 @@ export function Workshop(): JSX.Element | null {
   const say = (notice: string): void => useWorkshop.setState({ notice })
   const toggle = (p: Panel): void => setPanel((cur) => (cur === p ? null : p))
 
-  const selectedPoints = shard ? new Set(selection.map((i) => shard.vertices[i]?.p.join(','))).size : 0
+  const selectedPoints = shard ? new Set(selection.map((i) => { const v = shard.vertices[i]; return v ? ticksOf(v).join(',') : '' })).size : 0
   const one = selection.length === 1 && shard ? shard.vertices[selection[0]] : null
   const extent = shard?.extent ?? MIN_EXTENT
   const minExtent = shard ? Math.max(MIN_EXTENT, neededExtent(shard)) : MIN_EXTENT
@@ -398,7 +398,7 @@ export function Workshop(): JSX.Element | null {
       <div className="ws__corner">
         {one && (
           <div className="benchops" role="status" aria-label="Selected point">
-            <span className="workshop__value workshop__value--wide">at ({one.p.map(unitsLabel).join(', ')})</span>
+            <span className="workshop__value workshop__value--wide">at ({ticksOf(one).map(unitsLabel).join(', ')})</span>
           </div>
         )}
         {selectedPoints >= 3 && (

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -154,6 +154,7 @@ export function Workshop(): JSX.Element | null {
   const palette = useWorkshop((s) => s.palette)
   const level = useWorkshop((s) => s.level)
   const division = useWorkshop((s) => s.division)
+  const showAvatar = useWorkshop((s) => s.showAvatar)
   const color = useWorkshop((s) => s.color)
   const stampKind = useWorkshop((s) => s.stampKind)
   const stampSize = useWorkshop((s) => s.stampSize)
@@ -254,6 +255,13 @@ export function Workshop(): JSX.Element | null {
               {MODES.map((m: ShardMode) => (
                 <button key={m} className={`workshop__mode ${shard.mode === m ? 'is-on' : ''}`} aria-pressed={shard.mode === m} onClick={() => w().setMode(m)}>{m.toUpperCase()}</button>
               ))}
+            </div>
+          </div>
+          <div className="workshop__row" role="group" aria-label="Scale avatar">
+            <span className="workshop__label">AVATAR</span>
+            <div className="workshop__modes">
+              <button className={`workshop__mode ${showAvatar ? 'is-on' : ''}`} aria-pressed={showAvatar} onClick={() => w().setShowAvatar(true)} title="Show the to-scale avatar at the grid's centre">SHOW</button>
+              <button className={`workshop__mode ${!showAvatar ? 'is-on' : ''}`} aria-pressed={!showAvatar} onClick={() => w().setShowAvatar(false)} title="Hide it">HIDE</button>
             </div>
           </div>
           <div className="ws__panel-title">SHARDS ({shards.length})</div>


### PR DESCRIPTION
Fixes the clump: existing workshop models and local deployment records rendered at a hundred and twentieth of their size after #89.

**Cause.** Inside the model I had folded each position into one integer of total ticks and let the renderer divide by 120 to get units back. Every model saved before that, in local storage, still held units and was never converted, so it drew tiny at the origin. The wire had kept units and ticks apart all along; the model should have too.

**Fix.** A vertex keeps whole units in `p` and the rest in ticks in `t`, absent when the point is whole, exactly as the payload does. A model saved before ticks is therefore valid as it stands and nothing divides units by anything. All arithmetic and keys go through total ticks and back, so thirds and fifths stay exact. Models saved during the short window when positions were total ticks show themselves by a coordinate no grid could hold (above 64 units) and are split back on load, both in the workshop's list and in the local deployment records.

**Also.** The MENU panel gets an AVATAR row, SHOW or HIDE, for the to-scale avatar at the grid's centre; the choice is kept between visits.

Verified by seeding local storage with a pre-ticks block (units, no ticks) and an interim model (total ticks in `p`): the block loads unchanged and draws at units 0 to 2, the interim model comes back as 3 units plus 40 ticks. 513 tests, including the normaliser and the split payload round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
