### PR TITLE
Workshop: the memory line is gone

### DIFF
--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -47,20 +47,6 @@ describe('stamps', () => {
     expect(Math.max(...points.map((p) => p[0]))).toBe(4 * T)
   })
 
-  it('centres every size on the tap, odd sizes on half units', () => {
-    const one = compile('block', 1, 0, [3 * T, 0, 0]).points
-    expect(Math.min(...one.map((p) => p[0]))).toBe(3 * T - T / 2)
-    expect(Math.max(...one.map((p) => p[0]))).toBe(3 * T + T / 2)
-    expect(Math.min(...one.map((p) => p[2]))).toBe(-T / 2)
-    const three = compile('block', 3, 0, [0, 0, 0]).points
-    expect(Math.min(...three.map((p) => p[0]))).toBe(-1.5 * T)
-    expect(Math.max(...three.map((p) => p[0]))).toBe(1.5 * T)
-    const post = compile('column', 2, 0, [0, 0, 0]).points
-    expect(Math.min(...post.map((p) => p[0]))).toBe(-T / 2)
-    expect(Math.max(...post.map((p) => p[2]))).toBe(T / 2)
-    for (const p of [...one, ...three, ...post]) for (const c of p) expect(Number.isInteger(c)).toBe(true)
-  })
-
   it('is pushed back inside the grid when tapped at the edge', () => {
     for (const kind of STAMPS) {
       const { points } = compile(kind, 4, 0, [GRID_HALF * T, GRID_HALF * T, GRID_HALF * T])
@@ -103,8 +89,7 @@ describe('stamps', () => {
   it('never merges vertices, so a seam between colors stays crisp', () => {
     const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
     const b = stamp(a.shard, 'block', 1, 0, [T, 0, 0], [0, 0, 1])!
-    // Blocks centre on the tap: the two meet on the plane x = T/2.
-    const at = b.shard.vertices.filter((v) => ticksOf(v).join() === `${T / 2},0,${-T / 2}`)
+    const at = b.shard.vertices.filter((v) => ticksOf(v).join() === `${T},0,0`)
     expect(at).toHaveLength(2)
     expect(at.map((v) => v.c.join()).sort()).toEqual(['0,0,1', '1,0,0'])
   })

--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -47,6 +47,20 @@ describe('stamps', () => {
     expect(Math.max(...points.map((p) => p[0]))).toBe(4 * T)
   })
 
+  it('centres every size on the tap, odd sizes on half units', () => {
+    const one = compile('block', 1, 0, [3 * T, 0, 0]).points
+    expect(Math.min(...one.map((p) => p[0]))).toBe(3 * T - T / 2)
+    expect(Math.max(...one.map((p) => p[0]))).toBe(3 * T + T / 2)
+    expect(Math.min(...one.map((p) => p[2]))).toBe(-T / 2)
+    const three = compile('block', 3, 0, [0, 0, 0]).points
+    expect(Math.min(...three.map((p) => p[0]))).toBe(-1.5 * T)
+    expect(Math.max(...three.map((p) => p[0]))).toBe(1.5 * T)
+    const post = compile('column', 2, 0, [0, 0, 0]).points
+    expect(Math.min(...post.map((p) => p[0]))).toBe(-T / 2)
+    expect(Math.max(...post.map((p) => p[2]))).toBe(T / 2)
+    for (const p of [...one, ...three, ...post]) for (const c of p) expect(Number.isInteger(c)).toBe(true)
+  })
+
   it('is pushed back inside the grid when tapped at the edge', () => {
     for (const kind of STAMPS) {
       const { points } = compile(kind, 4, 0, [GRID_HALF * T, GRID_HALF * T, GRID_HALF * T])
@@ -89,7 +103,8 @@ describe('stamps', () => {
   it('never merges vertices, so a seam between colors stays crisp', () => {
     const a = stamp(empty(), 'block', 1, 0, [0, 0, 0], red)!
     const b = stamp(a.shard, 'block', 1, 0, [T, 0, 0], [0, 0, 1])!
-    const at = b.shard.vertices.filter((v) => ticksOf(v).join() === `${T},0,0`)
+    // Blocks centre on the tap: the two meet on the plane x = T/2.
+    const at = b.shard.vertices.filter((v) => ticksOf(v).join() === `${T / 2},0,${-T / 2}`)
     expect(at).toHaveLength(2)
     expect(at.map((v) => v.c.join()).sort()).toEqual(['0,0,1', '1,0,0'])
   })

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -81,9 +81,13 @@ function box(x0: number, x1: number, y0: number, y1: number, z0: number, z1: num
 }
 
 /** Where a shape of side s sits so the tap is at or near its middle: [−⌊s/2⌋, s − ⌊s/2⌋]. */
+/**
+ * A shape's footprint across the tap: from -s/2 to s/2, so every size is
+ * centred on the tap and an avatar at the tap stands in the middle. An odd
+ * size puts its corners on half units, which ticks carry exactly (60 of 120).
+ */
 function span(s: number): [number, number] {
-  const lo = -Math.floor(s / 2)
-  return [lo, lo + s]
+  return [-s / 2, s / 2]
 }
 
 /** Points on a circle of radius r at n even steps, snapped to the grid, runs of repeats collapsed. */
@@ -109,7 +113,7 @@ function flat(points: P3[]): Shape {
 function local(kind: StampKind, s: number): Shape {
   switch (kind) {
     case 'block': { const [x0, x1] = span(s); const [z0, z1] = span(s); return box(x0, x1, 0, s, z0, z1) }
-    case 'column': return box(0, 1, 0, 2 * s, 0, 1)
+    case 'column': return box(-0.5, 0.5, 0, 2 * s, -0.5, 0.5)
     case 'pyramid': return {
       points: [[-s, 0, -s], [s, 0, -s], [s, 0, s], [-s, 0, s], [0, 2 * s, 0]],
       faces: [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4], ...quad(0, 1, 2, 3)],

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -82,12 +82,14 @@ function box(x0: number, x1: number, y0: number, y1: number, z0: number, z1: num
 
 /** Where a shape of side s sits so the tap is at or near its middle: [−⌊s/2⌋, s − ⌊s/2⌋]. */
 /**
- * A shape's footprint across the tap: from -s/2 to s/2, so every size is
- * centred on the tap and an avatar at the tap stands in the middle. An odd
- * size puts its corners on half units, which ticks carry exactly (60 of 120).
+ * A shape's footprint across the tap, on whole units: an even size sits
+ * centred on the tap, an odd size hangs one more unit to the positive side.
+ * Corners land on gibsons, as hand-placed vertices do; a finer DIVISION is
+ * the way between them.
  */
 function span(s: number): [number, number] {
-  return [-s / 2, s / 2]
+  const lo = -Math.floor(s / 2)
+  return [lo, lo + s]
 }
 
 /** Points on a circle of radius r at n even steps, snapped to the grid, runs of repeats collapsed. */
@@ -113,7 +115,7 @@ function flat(points: P3[]): Shape {
 function local(kind: StampKind, s: number): Shape {
   switch (kind) {
     case 'block': { const [x0, x1] = span(s); const [z0, z1] = span(s); return box(x0, x1, 0, s, z0, z1) }
-    case 'column': return box(-0.5, 0.5, 0, 2 * s, -0.5, 0.5)
+    case 'column': return box(0, 1, 0, 2 * s, 0, 1)
     case 'pyramid': return {
       points: [[-s, 0, -s], [s, 0, -s], [s, 0, s], [-s, 0, s], [0, 2 * s, 0]],
       faces: [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4], ...quad(0, 1, 2, 3)],

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -477,27 +477,6 @@ function Rig(): JSX.Element {
 }
 
 /**
- * One console line every 30 s: what the renderer holds and what the heap
- * weighs. A tab was seen at 10 GB after fifteen idle minutes and no probe here
- * reproduces it; this puts the numbers where the person who sees it can read
- * them. `localStorage.setItem('onosendai:memlog', '0')` silences it.
- */
-function MemoryLog(): null {
-  const gl = useThree((s) => s.gl)
-  useEffect(() => {
-    try { if (localStorage.getItem('onosendai:memlog') === '0') return } catch { /* private mode: log anyway */ }
-    const tick = (): void => {
-      const m = gl.info.memory
-      const heap = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory?.usedJSHeapSize
-      console.info(`[mem] geometries=${m.geometries} textures=${m.textures} programs=${gl.info.programs?.length ?? 0}${heap ? ` heap=${Math.round(heap / 1048576)}MB` : ''}`)
-    }
-    const t = window.setInterval(tick, 30_000)
-    return () => window.clearInterval(t)
-  }, [gl])
-  return null
-}
-
-/**
  * R3F zeroes the clock whenever the frameloop changes. Several things here
  * time themselves from clock.elapsedTime (fleet cube fades, the crossing
  * flash, a glide), so a pause would leave them waiting for a time that had
@@ -590,7 +569,6 @@ export function Scene(): JSX.Element {
       style={{ background: BG }}
       frameloop={covered ? 'never' : 'always'}
     >
-      <MemoryLog />
       <ClockKeeper />
       {/* Fog to pure black: the only distance cue in an otherwise empty field. */}
       <fog attach="fog" args={[0x000000, GRID_RADIUS * 0.9, GRID_RADIUS * 4]} />

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -72,12 +72,12 @@ describe('workshop', () => {
     w().setColor([1, 0, 0])
     w().placeStamp([T, 0, 0])
     const s = w().current()!
-    const shared = s.vertices.map((v, i) => (ticksOf(v).join() === `${T / 2},0,${-T / 2}` ? i : -1)).filter((i) => i >= 0)
+    const shared = s.vertices.map((v, i) => (ticksOf(v).join() === `${T},0,0` ? i : -1)).filter((i) => i >= 0)
     expect(shared).toHaveLength(2)
     w().selectVertex(shared[0])
     // Off to a free point: landing on the blocks' top corners would join those too.
     w().moveSelected(2, -T)
-    for (const i of shared) expect(ticksOf(w().current()!.vertices[i])).toEqual([T / 2, 0, -T / 2 - T])
+    for (const i of shared) expect(ticksOf(w().current()!.vertices[i])).toEqual([T, 0, -T])
     w().colorSelected([0, 1, 0])
     for (const i of shared) expect(w().current()!.vertices[i].c).toEqual([0, 1, 0])
     const facesBefore = w().current()!.faces.length

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -72,12 +72,12 @@ describe('workshop', () => {
     w().setColor([1, 0, 0])
     w().placeStamp([T, 0, 0])
     const s = w().current()!
-    const shared = s.vertices.map((v, i) => (ticksOf(v).join() === `${T},0,0` ? i : -1)).filter((i) => i >= 0)
+    const shared = s.vertices.map((v, i) => (ticksOf(v).join() === `${T / 2},0,${-T / 2}` ? i : -1)).filter((i) => i >= 0)
     expect(shared).toHaveLength(2)
     w().selectVertex(shared[0])
     // Off to a free point: landing on the blocks' top corners would join those too.
     w().moveSelected(2, -T)
-    for (const i of shared) expect(ticksOf(w().current()!.vertices[i])).toEqual([T, 0, -T])
+    for (const i of shared) expect(ticksOf(w().current()!.vertices[i])).toEqual([T / 2, 0, -T / 2 - T])
     w().colorSelected([0, 1, 0])
     for (const i of shared) expect(w().current()!.vertices[i].c).toEqual([0, 1, 0])
     const facesBefore = w().current()!.faces.length
@@ -93,10 +93,11 @@ describe('workshop', () => {
     w().placeStamp([0, 0, 0])          // a block: 8 corners
     w().addVertex([5 * T, 0, 5 * T])
     const s = w().current()!
-    const corner = s.vertices.findIndex((v) => ticksOf(v).join() === '0,0,0')
+    const corner = 0
+    const cornerKey = ticksOf(s.vertices[0]).join()
     w().selectVertex(null)
     w().toggleVertex(corner); w().toggleVertex(s.vertices.length - 1)
-    expect(new Set(w().selection.map((i) => ticksOf(s.vertices[i]).join()))).toEqual(new Set(['0,0,0', `${5 * T},0,${5 * T}`]))
+    expect(new Set(w().selection.map((i) => ticksOf(s.vertices[i]).join()))).toEqual(new Set([cornerKey, `${5 * T},0,${5 * T}`]))
     w().toggleVertex(corner)
     expect(w().selection.map((i) => ticksOf(s.vertices[i]).join())).toEqual([`${5 * T},0,${5 * T}`])
     w().setSelection([corner])
@@ -122,7 +123,7 @@ describe('workshop', () => {
     w().placeStamp([5 * T, 0, 5 * T])    // another, apart
     w().addVertex([-4 * T, 0, -4 * T])   // a lone point
     const s = w().current()!
-    const a = s.vertices.findIndex((v) => ticksOf(v).join() === '0,0,0')
+    const a = 0
     w().setSelection([a]); w().selectConnected()
     const points = new Set(w().selection.map((i) => ticksOf(s.vertices[i]).join()))
     expect(points.size).toBe(8)


### PR DESCRIPTION
One small close, after a detour.

- **The `[mem]` console line is gone.** It printed every thirty seconds for the memory hunt, which closed on the Vercel preview toolbar; it has been noise in every console since.
- Stamps stay on the gibsons. A first commit centred every stamp size on the tap, which put odd sizes' corners between gibsons; that sat oddly beside hand-placed vertices, which always land on one, so it is reverted here. A finer DIVISION is the way between gibsons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz