### PR TITLE
Workshop: TURN the selection a quarter turn about the vertical

### DIFF
--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -204,6 +204,32 @@ describe('workshop', () => {
     expect(w().selectedFace).toBe(0)
   })
 
+  it('turns the selection a quarter turn about the middle of its extent, on the grid, and refuses a turn off it', () => {
+    // An L: three along x, one up z. Its extent's middle snaps to (T, T).
+    for (const p of [[0, 0, 0], [T, 0, 0], [2 * T, 0, 0], [0, 0, T]] as Array<[number, number, number]>) w().addVertex(p)
+    w().setSelection([0, 1, 2, 3])
+    w().rotateSelected(1)
+    const after = w().current()!.vertices.map((v) => ticksOf(v).join())
+    expect(new Set(after)).toEqual(new Set([`0,0,${2 * T}`, `0,0,${T}`, '0,0,0', `${T},0,${2 * T}`]))
+    for (const v of w().current()!.vertices) for (const c of ticksOf(v)) expect(c % T).toBe(0)
+    w().rotateSelected(-1)
+    expect(new Set(w().current()!.vertices.map((v) => ticksOf(v).join()))).toEqual(new Set(['0,0,0', `${T},0,0`, `${2 * T},0,0`, `0,0,${T}`]))
+    // A square turns in place.
+    w().clearShard()
+    for (const p of [[0, 0, 0], [2 * T, 0, 0], [2 * T, 0, 2 * T], [0, 0, 2 * T]] as Array<[number, number, number]>) w().addVertex(p)
+    w().setSelection([0, 1, 2, 3])
+    const before = new Set(w().current()!.vertices.map((v) => ticksOf(v).join()))
+    w().rotateSelected(1)
+    expect(new Set(w().current()!.vertices.map((v) => ticksOf(v).join()))).toEqual(before)
+    // At the grid's edge a turn that would leave it is refused whole.
+    w().clearShard()
+    for (const p of [[8 * T, 0, 0], [8 * T, 0, 3 * T]] as Array<[number, number, number]>) w().addVertex(p)
+    w().setSelection([0, 1])
+    w().rotateSelected(1)
+    expect(w().notice).toMatch(/off the grid/)
+    expect(w().current()!.vertices.map((v) => ticksOf(v).join())).toEqual([`${8 * T},0,0`, `${8 * T},0,${3 * T}`])
+  })
+
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
     w().setTool('add')
     w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -144,6 +144,12 @@ export interface WorkshopState {
   rememberColor: (hex: string) => void
   forgetColor: (hex: string) => void
   moveSelected: (axis: 0 | 1 | 2, delta: number) => void
+  /**
+   * Turn the selected points a quarter turn about the vertical, +1 one way
+   * and -1 the other, around the middle of their extent snapped to the
+   * current DIVISION's grid, so every point stays on that grid.
+   */
+  rotateSelected: (turns: 1 | -1) => void
   colorSelected: (c: [number, number, number]) => void
   colorAll: (c: [number, number, number]) => void
   deleteSelected: () => void
@@ -467,6 +473,33 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
         }
         return { ...s, vertices }
       })
+    },
+
+    rotateSelected: (turns) => {
+      const { selection } = get()
+      if (selection.length === 0) return
+      const step = get().step()
+      let refused = false
+      edit((s) => {
+        const chosen = [...new Set(selection.filter((i) => s.vertices[i]))]
+        if (chosen.length === 0) return null
+        const pts = chosen.map((i) => ticksOf(s.vertices[i]))
+        let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity
+        for (const [x, , z] of pts) { minX = Math.min(minX, x); maxX = Math.max(maxX, x); minZ = Math.min(minZ, z); maxZ = Math.max(maxZ, z) }
+        // The pivot: the middle of the selection's extent, on the snap grid.
+        const snap = (v: number): number => Math.round(v / step) * step
+        const cx = snap((minX + maxX) / 2), cz = snap((minZ + maxZ) / 2)
+        const vertices = s.vertices.slice()
+        chosen.forEach((i, k) => {
+          const [x, y, z] = pts[k]
+          const dx = x - cx, dz = z - cz
+          const p: P3 = turns === 1 ? [cx + dz, y, cz - dx] : [cx - dz, y, cz + dx]
+          if (!validPoint(p, s.extent)) refused = true
+          vertices[i] = vertexAt(p, vertices[i].c)
+        })
+        return refused ? null : { ...s, vertices }
+      })
+      if (refused) set({ notice: 'That turn would carry a point off the grid.' })
     },
 
     colorSelected: (c) => {

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -420,7 +420,9 @@ function Keys(): null {
       if (e.code === 'Digit2') w.setTool('add')
       if (e.code === 'Digit3') w.setTool('select')
       if (e.code === 'Digit4') w.setTool('face')
-      if (e.code === 'KeyQ') w.turnStamp()
+      // Q and E turn the selection a quarter turn while SELECT holds one; Q turns the stamp otherwise.
+      if (e.code === 'KeyQ') { if (w.tool === 'select' && w.selection.length) w.rotateSelected(-1); else w.turnStamp() }
+      if (e.code === 'KeyE') { if (w.tool === 'select' && w.selection.length) w.rotateSelected(1) }
       if (e.code === 'BracketRight') w.setLevel(w.level + w.step())
       if (e.code === 'BracketLeft') w.setLevel(w.level - w.step())
     }

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -445,6 +445,13 @@ export function Workshop(): JSX.Element | null {
             <button className="workshop__btn" onClick={() => w().fillSelection()} title="Faces across these points: a flat set becomes one face, a solid set its hull (Enter)">FILL</button>
           </div>
         )}
+        {selection.length > 0 && (
+          <div className="benchops" role="group" aria-label="Turn the selection">
+            <span className="workshop__label">TURN</span>
+            <button className="workshop__btn" onClick={() => w().rotateSelected(-1)} title="A quarter turn this way about the vertical (Q)">↺</button>
+            <button className="workshop__btn" onClick={() => w().rotateSelected(1)} title="A quarter turn the other way (E)">↻</button>
+          </div>
+        )}
         {selection.length > 0 && <ControlsPad points={selectedPoints} />}
         {facing && selectedFace !== null && (
           <div className="benchops" role="group" aria-label="Selected face">


### PR DESCRIPTION
The selected points turn ninety degrees about the vertical.

- **Pivot:** the middle of the selection's extent, snapped to the current DIVISION's grid. A quarter turn about a grid point maps grid points to grid points, so every point stays on the grid and nothing ever lands at an odd angle; a two-wide block turns in place.
- **Refusal:** a turn that would carry any point off the grid is refused whole, with a notice, so a shape never tears.
- **Controls:** Q turns one way and E the other while SELECT holds a selection; Q still turns a stamp before it lands otherwise, in the same sense, so Q means the same thing everywhere. Two buttons in a TURN row above the pad do the same. Colours and faces ride along unchanged; each turn is one undo step.

Verified from straight above with a stamped arrow: Q takes its tip from +X to +Z, E twice brings it to −Z, and every point stays on whole units. Tests: an L shape turned and turned back, a square turning in place, and a refusal at the grid's edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz