### PR TITLE
Workshop: TOOLS steps aside, COLOR stands up, the pad moves over TOOLS

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2471,8 +2471,9 @@ kbd {
 /* The first-visit card: three steps, then never again. */
 .workshop__intro {
   position: absolute;
-  top: 56px;
-  right: 12px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 2;
   width: min(300px, calc(100vw - 24px));
   padding: 12px 14px 10px;
@@ -2686,30 +2687,27 @@ kbd {
   border: 1px solid var(--border);
   backdrop-filter: blur(8px);
 }
+/* COLOR open: a column rising from the corner, two swatches wide, so it never
+ * runs along the bottom into TOOLS. */
 .ws__color {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  max-width: min(440px, calc(100vw - 28px));
-  padding: 8px 10px;
+  gap: 8px;
+  max-height: calc(100vh - 140px);
+  overflow: auto;
+  padding: 8px 6px;
   border-radius: 10px;
   background: rgba(6, 14, 22, 0.85);
   border: 1px solid var(--border);
   backdrop-filter: blur(8px);
 }
 .ws__color .workshop__label { min-width: 0; }
+.ws__color .workshop__swatches {
+  display: grid;
+  grid-template-columns: repeat(2, 22px);
+}
 @media (max-width: 640px) {
-  /* The open bar takes the width above the two corner chips; folded, the
-     corner stays a corner. */
-  .ws__color {
-    position: fixed;
-    left: 10px;
-    right: 10px;
-    bottom: 60px;
-    max-width: none;
-    box-sizing: border-box;
-  }
   .ws__panel--up {
     max-height: calc(100vh - 220px);
   }
@@ -2746,7 +2744,7 @@ kbd {
   /* The tray's contextual row only shows the current tool's controls, so the
    * bench keeps most of the screen; the explanation opens over a full row. */
   .workshop__tools { gap: 5px; padding: 6px 8px 8px; }
-  .workshop__intro { top: 8px; right: 8px; left: 8px; width: auto; }
+  .workshop__intro { width: calc(100vw - 16px); }
 }
 
 /* ---------- Relays panel ---------- */

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -193,6 +193,9 @@ export function Workshop(): JSX.Element | null {
     document.addEventListener('pointerdown', shut, true)
     return () => document.removeEventListener('pointerdown', shut, true)
   }, [colorOpen])
+  // ADD, SELECT and FACE have nothing under them, so choosing one by key puts
+  // the TOOLS panel away; STAMP keeps it for the shape, size and facing.
+  useEffect(() => { if (tool !== 'stamp') setPanel((p) => (p === 'tools' ? null : p)) }, [tool])
   const bind = useRepeatable()
 
   if (!open) return null
@@ -385,15 +388,24 @@ export function Workshop(): JSX.Element | null {
         <button className="chip ws__icon" onClick={() => w().closeWorkshop()} title="Close the workshop (Esc)" aria-label="Close"><X size={15} strokeWidth={2.25} aria-hidden /></button>
       </div>
 
-      {/* Bottom left: TOOLS, its panel opening upward over the chip. */}
+      {/* Bottom left: TURN and the pad while points are selected, over TOOLS and
+          its panel, which opens upward over the chip. */}
       <div className="ws__tools">
+        {selection.length > 0 && (
+          <div className="benchops" role="group" aria-label="Turn the selection">
+            <span className="workshop__label">TURN</span>
+            <button className="workshop__btn" onClick={() => w().rotateSelected(-1)} title="A quarter turn this way about the vertical (Q)">↺</button>
+            <button className="workshop__btn" onClick={() => w().rotateSelected(1)} title="A quarter turn the other way (E)">↻</button>
+          </div>
+        )}
+        {selection.length > 0 && <ControlsPad points={selectedPoints} />}
       {panel === 'tools' && (
         <div className="ws__panel ws__panel--up" role="region" aria-label="Tools">
           <div className="workshop__row" role="group" aria-label="Tool">
             {TOOLS.map((t, i) => {
               const Icon = TOOL_ICON[t]
               return (
-                <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => w().setTool(t)} title={`${t} (${i + 1})`}>
+                <button key={t} className={`workshop__tool ${tool === t ? 'is-on' : ''}`} aria-pressed={tool === t} onClick={() => { w().setTool(t); if (t !== 'stamp') setPanel(null) }} title={`${t} (${i + 1})`}>
                   <Icon size={12} strokeWidth={2.25} aria-hidden />{t.toUpperCase()}
                 </button>
               )
@@ -432,7 +444,8 @@ export function Workshop(): JSX.Element | null {
         </button>
       </div>
 
-      {/* Bottom right: the pad while points are selected, face actions while a face is in hand, the color bar under either. */}
+      {/* Bottom right: FILL for a set of points, face actions while a face is in
+          hand, the color column under either. */}
       <div className="ws__corner">
         {one && (
           <div className="benchops" role="status" aria-label="Selected point">
@@ -445,14 +458,6 @@ export function Workshop(): JSX.Element | null {
             <button className="workshop__btn" onClick={() => w().fillSelection()} title="Faces across these points: a flat set becomes one face, a solid set its hull (Enter)">FILL</button>
           </div>
         )}
-        {selection.length > 0 && (
-          <div className="benchops" role="group" aria-label="Turn the selection">
-            <span className="workshop__label">TURN</span>
-            <button className="workshop__btn" onClick={() => w().rotateSelected(-1)} title="A quarter turn this way about the vertical (Q)">↺</button>
-            <button className="workshop__btn" onClick={() => w().rotateSelected(1)} title="A quarter turn the other way (E)">↻</button>
-          </div>
-        )}
-        {selection.length > 0 && <ControlsPad points={selectedPoints} />}
         {facing && selectedFace !== null && (
           <div className="benchops" role="group" aria-label="Selected face">
             <span className="workshop__value workshop__value--wide">face {selectedFace + 1} of {shard?.faces.length ?? 0}</span>


### PR DESCRIPTION
Four shell changes, mostly for the phone. Stacked on #94 (TURN), which it builds on; once #94 lands this rebases onto v2.

- **TOOLS steps aside.** Tapping ADD, SELECT or FACE closes the TOOLS panel, since none of them has anything under it. STAMP keeps it open for the shape, size and facing. Choosing a tool by its number key behaves the same way.
- **COLOR stands up.** The palette opens as a column rising from the bottom-right corner, two swatches wide, with the picker at the top and ALL at the bottom. It no longer runs along the bottom into TOOLS, and the phone rule that made it a full-width bar is gone.
- **The pad moves over TOOLS.** While points are selected, the nudge pad and the TURN row sit at the bottom left, directly above the TOOLS chip (and above its panel when that is open). The right corner keeps FILL, the face actions and the color column.
- **The arrival note is centered** in the viewport, where the chips and corners no longer cover it on a phone.

Verified on a 390×844 phone viewport and a 1400×900 desktop: the note centered, STAMP keeping the panel and SELECT shutting it (by tap and by key), the pad directly above TOOLS with the color column on the right while points are selected, and the column opening from the chip in ADD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz