### PR TITLE
DEPLOY clears the screen and sits at the top; the size label waits for the cursor to leave

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,11 @@ export default function App(): JSX.Element {
   // folds instead of layering underneath it.
   const secretOpen = useShards((s) => s.selectedSecret !== null)
   useEffect(() => { if (secretOpen) setPanelsOpen(false) }, [secretOpen])
+  // Deploying is the same kind of thing: the bar sits at the top, the panels
+  // close at once so the scene is clear to choose a place, and the
+  // instruments and compass stay out of the way until it is placed or dropped.
+  const deploying = useShards((s) => s.pending !== null)
+  useEffect(() => { if (deploying) setPanelsOpen(false) }, [deploying])
 
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.
@@ -143,7 +148,7 @@ export default function App(): JSX.Element {
     <div className="app">
       <Scene />
       {!crowded && !offerUp && <Targets targets={targets} />}
-      {!crowded && !secretOpen && !offerUp && (
+      {!crowded && !secretOpen && !offerUp && !deploying && (
         <div className="instruments">
           {/* Ordered by how often each is reached for right now: hyperspace
               on top with its status bar, the chain under it, the XOR readout
@@ -159,8 +164,8 @@ export default function App(): JSX.Element {
       )}
       {showPanels && !offerUp && <Hud menuOpen={crowded} />}
       <SpectateBar />
-      {!crowded && !offerUp && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
-      {!crowded && !offerUp && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
+      {!crowded && !offerUp && !deploying && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
+      {!crowded && !offerUp && !deploying && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && !offerUp && <TouchControls />}
       {showPad && !offerUp && <RouteOverlay />}
       {/* Off-head too: tapping a block hides the pad like any scene tap, and

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -273,15 +273,12 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   return (
     <group position={[0, 0, 0.04]}>
       {/*
-        The scale reading is always up, even with the cursor parked on the
-        avatar. What one cell measures is a fact about the current zoom rather
-        than about any pending action, and it is the only thing on screen that
-        ties the abstract ladder to a physical size, so having it appear only
-        once you started moving meant the answer to "how big is a gibson here"
-        vanished exactly when you stopped to think about it. It rides the cursor,
-        which sits on the avatar while idle, so it has a home either way.
+        The scale reading rides the cursor, and shows once the cursor has left
+        the avatar's cell: parked on the avatar it read as a label on you, and
+        the SCALE panel already answers "how big is a gibson here" at rest.
+        Off your own head it stays up, since nothing else there names the size.
       */}
-      {!focused && <WorldLabel
+      {!focused && (!atHead || active) && <WorldLabel
         text={formatCellSize(scaleExp)}
         color={active ? targetColor : ACCENT}
         offset={[1.5, 0.7, 0]}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1803,7 +1803,7 @@ kbd {
 .deploybar {
   position: fixed;
   left: 14px;
-  bottom: 14px;
+  top: 14px;
   z-index: 101;
   width: min(360px, calc(100vw - 28px));
   display: flex;
@@ -1933,14 +1933,6 @@ kbd {
 @media (min-width: 1101px) {
   .deploybar {
     left: 332px;
-    bottom: 14px;
-  }
-}
-
-/* Above the movement pad on a phone. */
-@media (max-width: 1100px) {
-  .deploybar {
-    bottom: 150px;
   }
 }
 


### PR DESCRIPTION
Two small things in the world view.

- **DEPLOY from the workshop.** Pressing it closes the panels at once (the way reading a hidden thing does), the deploy bar sits at the top edge instead of the bottom, and the hyperspace, chain and XOR instruments and the 3D compass stay off while a deploy is pending. CANCEL or HIDE & PUBLISH brings them all back. The movement pad and route overlay stay, since choosing the place is the point.
- **The cell-size label on the cursor** (the `116 pm` at 2^0) no longer shows while the cursor is parked on the avatar. It appears once the cursor is a cell away. Off your own head it stays up as before, since nothing else there names the size; the SCALE panel still reads the size at rest.

Verified on a 390×844 phone viewport and a 1400×900 desktop: no label parked, label one gibson over, and on DEPLOY the panels, instruments and compass gone with the bar at the top, restored on CANCEL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz