### PR TITLE
Workshop: the turn pivots where the shape stays put, bigger pad, the tool in the chip, our own mixer

### DIFF
--- a/src/lib/hsv.test.ts
+++ b/src/lib/hsv.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { hexToRgb, rgbToHex } from './shards'
+import { hsvToRgb, rgbToHsv } from './hsv'
+
+describe('hsv', () => {
+  it('names the corners of the cube', () => {
+    expect(rgbToHsv([1, 0, 0])).toEqual([0, 100, 100])
+    expect(rgbToHsv([0, 1, 0])).toEqual([120, 100, 100])
+    expect(rgbToHsv([0, 0, 1])).toEqual([240, 100, 100])
+    expect(rgbToHsv([1, 1, 1])).toEqual([0, 0, 100])
+    expect(rgbToHsv([0, 0, 0])).toEqual([0, 0, 0])
+    expect(rgbToHsv([0.5, 0.5, 0.5])).toEqual([0, 0, 50])
+  })
+  it('round-trips every palette colour through hex', () => {
+    for (const hex of ['#00e5ff', '#ff3b6b', '#52e39f', '#ffb020', '#c07dff', '#f7931a', '#ffffff', '#000000', '#123456', '#abcdef']) {
+      expect(rgbToHex(hsvToRgb(rgbToHsv(hexToRgb(hex))))).toBe(hex)
+    }
+  })
+  it('keeps hue continuous across the red seam', () => {
+    expect(rgbToHsv(hsvToRgb([359, 80, 80]))[0]).toBeCloseTo(359, 5)
+    expect(rgbToHsv(hsvToRgb([1, 80, 80]))[0]).toBeCloseTo(1, 5)
+  })
+})

--- a/src/lib/hsv.ts
+++ b/src/lib/hsv.ts
@@ -1,0 +1,35 @@
+/**
+ * hsv.ts — hue, saturation and brightness for the workshop's mixer.
+ *
+ * RGB is the store's form, three floats in 0..1. HSV is the mixer's: hue in
+ * degrees 0..360, saturation and brightness in percent, since those are the
+ * numbers a person drags.
+ */
+
+export type Rgb = [number, number, number]
+export type Hsv = [number, number, number]
+
+export function rgbToHsv([r, g, b]: Rgb): Hsv {
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const d = max - min
+  let h = 0
+  if (d > 0) {
+    if (max === r) h = ((g - b) / d) % 6
+    else if (max === g) h = (b - r) / d + 2
+    else h = (r - g) / d + 4
+    h *= 60
+    if (h < 0) h += 360
+  }
+  return [h, max === 0 ? 0 : (d / max) * 100, max * 100]
+}
+
+export function hsvToRgb([h, s, v]: Hsv): Rgb {
+  const S = s / 100
+  const V = v / 100
+  const c = V * S
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = V - c
+  const [r, g, b]: Rgb = h < 60 ? [c, x, 0] : h < 120 ? [x, c, 0] : h < 180 ? [0, c, x] : h < 240 ? [0, x, c] : h < 300 ? [x, 0, c] : [c, 0, x]
+  return [r + m, g + m, b + m]
+}

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -231,6 +231,35 @@ describe('workshop', () => {
     expect(w().current()!.vertices.map((v) => ticksOf(v).join())).toEqual([`${8 * T},0,0`, `${8 * T},0,${3 * T}`])
   })
 
+  it('turns an odd shape in place, and a mixed one about one remembered point', () => {
+    // Three wide: the middle is half a unit off the grid on both axes, and a
+    // turn about exactly that keeps every corner on the grid.
+    w().clearShard()
+    for (const p of [[0, 0, 0], [3 * T, 0, 0], [3 * T, 0, 3 * T], [0, 0, 3 * T], [T, 0, 0]] as Array<[number, number, number]>) w().addVertex(p)
+    w().setSelection([0, 1, 2, 3, 4])
+    const pts = (): Set<string> => new Set(w().current()!.vertices.map((v) => ticksOf(v).join()))
+    w().rotateSelected(1)
+    expect(pts()).toEqual(new Set(['0,0,0', `${3 * T},0,0`, `${3 * T},0,${3 * T}`, `0,0,${3 * T}`, `0,0,${2 * T}`]))
+    expect(w().turnPivot?.at).toEqual([1.5 * T, 1.5 * T])
+    // Two by three: no turn keeps it still, so the same point serves every
+    // turn and four of them bring it home.
+    w().clearShard()
+    for (const p of [[0, 0, 0], [2 * T, 0, 0], [2 * T, 0, 3 * T], [0, 0, 3 * T]] as Array<[number, number, number]>) w().addVertex(p)
+    w().setSelection([0, 1, 2, 3])
+    const home = pts()
+    const pivots = new Set<string>()
+    for (let i = 0; i < 4; i++) {
+      w().rotateSelected(1)
+      pivots.add(w().turnPivot!.at.join())
+      for (const v of w().current()!.vertices) for (const c of ticksOf(v)) expect(Math.abs(c % T)).toBe(0)
+    }
+    expect(pivots.size).toBe(1)
+    expect(pts()).toEqual(home)
+    // A move in between forgets the point.
+    w().moveSelected(0, T)
+    expect(w().turnPivot).toBeNull()
+  })
+
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
     w().setTool('add')
     w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -67,6 +67,25 @@ const HEX = /^#[0-9a-f]{6}$/
 
 type P3 = [number, number, number]
 
+/**
+ * Where a quarter turn pivots. The middle of the points' extent serves when a
+ * turn about it keeps every point on the snap grid: that is when the middle's
+ * x and z are both on a grid line or both halfway between lines, which is
+ * every square footprint, odd or even. Otherwise (a two by three, say) the
+ * middle snapped to the grid, and the caller keeps that point for the next
+ * turn so the shape cycles home in four instead of walking a step each time.
+ */
+function turnPivotFor(pts: P3[], step: number): [number, number] {
+  let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity
+  for (const [x, , z] of pts) { minX = Math.min(minX, x); maxX = Math.max(maxX, x); minZ = Math.min(minZ, z); maxZ = Math.max(maxZ, z) }
+  const cx = (minX + maxX) / 2, cz = (minZ + maxZ) / 2
+  const rem = (v: number): number => ((v % step) + step) % step
+  const half = step / 2
+  if ((rem(cx) === 0 && rem(cz) === 0) || (rem(cx) === half && rem(cz) === half)) return [cx, cz]
+  const snap = (v: number): number => Math.round(v / step) * step
+  return [snap(cx), snap(cz)]
+}
+
 export interface WorkshopState {
   shards: ShardModel[]
   currentId: string | null
@@ -105,6 +124,8 @@ export interface WorkshopState {
   future: ShardModel[]
   /** One line about the last action, shown on the bench until the next edit. */
   notice: string | null
+  /** Where the last turn pivoted, kept while the same selection turns again. */
+  turnPivot: { key: string; at: [number, number] } | null
 
   openWorkshop: (id?: string) => void
   closeWorkshop: () => void
@@ -274,7 +295,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     if (!next) return false
     const list = shards.slice()
     list[i] = { ...next, updatedAt: Date.now() }
-    set({ shards: list, past: [...past.slice(-(HISTORY - 1)), shards[i]], future: [], notice })
+    set({ shards: list, past: [...past.slice(-(HISTORY - 1)), shards[i]], future: [], notice, turnPivot: null })
     save(list)
     return true
   }
@@ -296,6 +317,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     palette: loadPalette(),
     level: 0,
     division: 1,
+    turnPivot: null,
     showAvatar: loadShowAvatar(),
     color: [0, 0.9, 1],
     stampKind: 'block',
@@ -476,30 +498,32 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     },
 
     rotateSelected: (turns) => {
-      const { selection } = get()
-      if (selection.length === 0) return
+      const { selection, turnPivot } = get()
+      const s = get().current()
+      if (!s || selection.length === 0) return
       const step = get().step()
+      const chosen = [...new Set(selection.filter((i) => s.vertices[i]))]
+      if (chosen.length === 0) return
+      const pts = chosen.map((i) => ticksOf(s.vertices[i]))
+      // The same selection turned again turns about the same point; any other
+      // edit forgets it (edit() clears it), and so does a change of DIVISION.
+      const key = `${step}:${[...chosen].sort((a, b) => a - b).join(',')}`
+      const at = turnPivot?.key === key ? turnPivot.at : turnPivotFor(pts, step)
+      const [cx, cz] = at
       let refused = false
-      edit((s) => {
-        const chosen = [...new Set(selection.filter((i) => s.vertices[i]))]
-        if (chosen.length === 0) return null
-        const pts = chosen.map((i) => ticksOf(s.vertices[i]))
-        let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity
-        for (const [x, , z] of pts) { minX = Math.min(minX, x); maxX = Math.max(maxX, x); minZ = Math.min(minZ, z); maxZ = Math.max(maxZ, z) }
-        // The pivot: the middle of the selection's extent, on the snap grid.
-        const snap = (v: number): number => Math.round(v / step) * step
-        const cx = snap((minX + maxX) / 2), cz = snap((minZ + maxZ) / 2)
-        const vertices = s.vertices.slice()
+      edit((m) => {
+        const vertices = m.vertices.slice()
         chosen.forEach((i, k) => {
           const [x, y, z] = pts[k]
           const dx = x - cx, dz = z - cz
           const p: P3 = turns === 1 ? [cx + dz, y, cz - dx] : [cx - dz, y, cz + dx]
-          if (!validPoint(p, s.extent)) refused = true
+          if (!validPoint(p, m.extent)) refused = true
           vertices[i] = vertexAt(p, vertices[i].c)
         })
-        return refused ? null : { ...s, vertices }
+        return refused ? null : { ...m, vertices }
       })
       if (refused) set({ notice: 'That turn would carry a point off the grid.' })
+      else set({ turnPivot: { key, at } })
     },
 
     colorSelected: (c) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2328,28 +2328,23 @@ kbd {
 
 /* The picker: a dashed swatch with a pipette on it, so it reads as "any
  * color" beside the fixed ones. */
-.workshop__picker {
-  position: relative;
-  display: inline-flex;
-}
-
+/* The mixer's handle: a dashed pipette, solid while the mixer is up. */
 .workshop__color {
   width: 38px;
   height: 30px;
   padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
   border: 1px dashed rgba(255, 255, 255, 0.6);
   border-radius: 5px;
   background: transparent;
   cursor: pointer;
 }
-
-.workshop__picker-icon {
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  pointer-events: none;
-  color: #fff;
-  filter: drop-shadow(0 0 2px #000) drop-shadow(0 0 1px #000);
+.workshop__color.is-on {
+  border-style: solid;
+  background: rgba(0, 229, 255, 0.15);
 }
 
 .workshop__swatches {
@@ -2657,8 +2652,8 @@ kbd {
  * corners the scale keys have out there. */
 .benchpad {
   display: grid;
-  grid-template-columns: repeat(3, 38px);
-  grid-template-rows: repeat(3, 38px);
+  grid-template-columns: repeat(3, 48px);
+  grid-template-rows: repeat(3, 48px);
   gap: 4px;
   grid-template-areas:
     "away    up   toward"
@@ -2668,7 +2663,22 @@ kbd {
 .benchpad .touchpad__key--connect { grid-area: connect; color: var(--accent); }
 .benchpad .touchpad__key--delete { grid-area: delete; color: var(--danger); }
 .benchpad .touchpad__key--connect .touchpad__sub,
-.benchpad .touchpad__key--delete .touchpad__sub { font-size: 6px; }
+.benchpad .touchpad__key--delete .touchpad__sub { font-size: 7px; }
+/* Glyph over word in every cell: the cells are big enough here for both. */
+.benchpad .touchpad__key,
+.benchturn .touchpad__key {
+  flex-direction: column;
+  gap: 2px;
+  font-size: 17px;
+}
+.benchpad .touchpad__sub,
+.benchturn .touchpad__sub { font-size: 8px; }
+.benchturn {
+  display: grid;
+  grid-template-columns: repeat(2, 48px);
+  grid-template-rows: 48px;
+  gap: 4px;
+}
 .benchops {
   display: flex;
   align-items: center;
@@ -2698,6 +2708,67 @@ kbd {
 .ws__color .workshop__swatches {
   display: grid;
   grid-template-columns: repeat(2, 22px);
+}
+/* The mixer rises above the corner stack, clear of the pad on the left. */
+.ws__mixer {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  width: 220px;
+  padding: 10px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: 10px;
+  background: rgba(6, 14, 22, 0.92);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(8px);
+}
+.ws__mixer-head { display: flex; align-items: center; gap: 8px; }
+.ws__mixer-head .workshop__swatch--sample { width: 30px; height: 30px; margin: 0; }
+.ws__mixer-hex {
+  flex: 1;
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  font: inherit;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--fg);
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.ws__mixer-row { display: flex; flex-direction: column; gap: 4px; }
+.ws__mixer-row .workshop__label { min-width: 0; }
+.ws__mixer input[type='range'] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 16px;
+  margin: 0;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.ws__mixer input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #000;
+  box-shadow: 0 0 0 1px #fff;
+}
+.ws__mixer input[type='range']::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid #000;
+  box-shadow: 0 0 0 1px #fff;
 }
 @media (max-width: 640px) {
   .ws__panel--up {

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -19,11 +19,12 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, Stamp, Trash2, Triangle, Undo2, Wrench, X, type LucideIcon } from 'lucide-react'
+import { Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, RotateCcw, RotateCw, Stamp, Trash2, Triangle, Undo2, Wrench, X, type LucideIcon } from 'lucide-react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { ConfirmModal } from '../hud/ConfirmModal'
 import { Explanation } from '../hud/Explanation'
 import { DIVISIONS, MAX_EXTENT, MIN_EXTENT, MODES, TICKS_PER_UNIT, hexToRgb, neededExtent, rgbToHex, ticksOf, toPayload, unitsLabel, type ShardMode } from '../lib/shards'
+import { hsvToRgb, rgbToHsv, type Hsv } from '../lib/hsv'
 import { formatCellSize } from '../lib/scale'
 import { FACED, FACING_LABEL, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
@@ -145,6 +146,60 @@ function ControlsPad({ points }: { points: number }): JSX.Element {
   )
 }
 
+/**
+ * The mixer: HUE, SATURATION and BRIGHTNESS, each a slider on a track painted
+ * with what that slider would give, the colour they make at the top and a hex
+ * field for a colour from elsewhere. It opens on the colour in hand; when that
+ * has no saturation or no brightness (white, grey, black) those two open at
+ * the middle, so the first touch of HUE gives a colour rather than another grey.
+ */
+const MID = 50
+function opening(hex: string): Hsv {
+  const [h, s, v] = rgbToHsv(hexToRgb(hex))
+  return [Math.round(h), s === 0 ? MID : Math.round(s), v === 0 ? MID : Math.round(v)]
+}
+function Mixer({ hex, onChange, onSettle }: { hex: string; onChange: (hex: string) => void; onSettle: (hex: string) => void }): JSX.Element {
+  const [hsv, setHsv] = useState<Hsv>(() => opening(hex))
+  const [text, setText] = useState(hex)
+  const made = rgbToHex(hsvToRgb(hsv))
+  // A swatch tapped while the mixer is up moves the sliders to it.
+  useEffect(() => { if (hex !== made) { setHsv(opening(hex)); setText(hex) } }, [hex]) // eslint-disable-line react-hooks/exhaustive-deps
+  const slide = (i: 0 | 1 | 2) => (e: { target: { value: string } }): void => {
+    const next = [...hsv] as Hsv
+    next[i] = Number(e.target.value)
+    const out = rgbToHex(hsvToRgb(next))
+    setHsv(next); setText(out); onChange(out)
+  }
+  const typed = (value: string): void => {
+    setText(value)
+    const m = /^#?([0-9a-f]{6})$/i.exec(value.trim())
+    if (!m) return
+    const out = '#' + m[1].toLowerCase()
+    setHsv(opening(out)); onChange(out)
+  }
+  const at = (h: number, sat: number, v: number): string => rgbToHex(hsvToRgb([h, sat, v]))
+  const tracks = [
+    'linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00)',
+    `linear-gradient(to right, ${at(hsv[0], 0, hsv[2])}, ${at(hsv[0], 100, hsv[2])})`,
+    `linear-gradient(to right, #000, ${at(hsv[0], hsv[1], 100)})`,
+  ]
+  const rows: Array<[string, number, number]> = [['HUE', 360, hsv[0]], ['SATURATION', 100, hsv[1]], ['BRIGHTNESS', 100, hsv[2]]]
+  return (
+    <div className="ws__mixer" role="group" aria-label="Mix a color">
+      <div className="ws__mixer-head">
+        <span className="workshop__swatch workshop__swatch--sample" style={{ background: made }} aria-hidden />
+        <input className="ws__mixer-hex" value={text} onChange={(e) => typed(e.target.value)} onBlur={() => onSettle(made)} spellCheck={false} aria-label="Hex color" />
+      </div>
+      {rows.map(([label, max, value], i) => (
+        <label key={label} className="ws__mixer-row">
+          <span className="workshop__label">{label}</span>
+          <input type="range" min={0} max={max} step={1} value={value} style={{ background: tracks[i] }} onChange={slide(i as 0 | 1 | 2)} onPointerUp={() => onSettle(made)} onKeyUp={() => onSettle(made)} aria-label={label} />
+        </label>
+      ))}
+    </div>
+  )
+}
+
 export function Workshop(): JSX.Element | null {
   const open = useWorkshop((s) => s.open)
   const shard = useWorkshop((s) => s.current())
@@ -165,6 +220,7 @@ export function Workshop(): JSX.Element | null {
   const canRedo = useWorkshop((s) => s.future.length > 0)
   const [panel, setPanel] = useState<Panel | null>(null)
   const [colorOpen, setColorOpen] = useState(false)
+  const [pickerOpen, setPickerOpen] = useState(false)
   // On a phone the open colour bar and the TOOLS panel share the bottom, so
   // they take turns; on a wide screen they have corners of their own.
   const [narrow, setNarrow] = useState<boolean>(() => typeof window !== 'undefined' && window.matchMedia('(max-width: 640px)').matches)
@@ -174,6 +230,7 @@ export function Workshop(): JSX.Element | null {
     mq.addEventListener('change', on)
     return () => mq.removeEventListener('change', on)
   }, [])
+  const colorBar = (colorOpen || tool === 'select') && !(narrow && panel === 'tools')
   const [pasteOpen, setPasteOpen] = useState(false)
   const [pasteText, setPasteText] = useState('')
   const [deleteColor, setDeleteColor] = useState<string | null>(null)
@@ -196,6 +253,18 @@ export function Workshop(): JSX.Element | null {
   // ADD, SELECT and FACE have nothing under them, so choosing one by key puts
   // the TOOLS panel away; STAMP keeps it for the shape, size and facing.
   useEffect(() => { if (tool !== 'stamp') setPanel((p) => (p === 'tools' ? null : p)) }, [tool])
+  // The mixer shuts with the column, and on a tap anywhere else.
+  useEffect(() => { if (!colorBar) setPickerOpen(false) }, [colorBar])
+  useEffect(() => {
+    if (!pickerOpen) return
+    const shut = (e: PointerEvent): void => {
+      const el = e.target as HTMLElement | null
+      if (el?.closest('.ws__mixer, .workshop__color')) return
+      setPickerOpen(false)
+    }
+    document.addEventListener('pointerdown', shut, true)
+    return () => document.removeEventListener('pointerdown', shut, true)
+  }, [pickerOpen])
   const bind = useRepeatable()
 
   if (!open) return null
@@ -243,7 +312,7 @@ export function Workshop(): JSX.Element | null {
   }
 
   const facing = tool === 'face' && selection.length === 0 && (selectedFace !== null || facePick.length > 0)
-  const colorBar = (colorOpen || tool === 'select') && !(narrow && panel === 'tools')
+  const ToolIcon = TOOL_ICON[tool]
 
   return (
     <div className="workshop" role="dialog" aria-label="Shard workshop">
@@ -392,10 +461,15 @@ export function Workshop(): JSX.Element | null {
           its panel, which opens upward over the chip. */}
       <div className="ws__tools">
         {selection.length > 0 && (
-          <div className="benchops" role="group" aria-label="Turn the selection">
-            <span className="workshop__label">TURN</span>
-            <button className="workshop__btn" onClick={() => w().rotateSelected(-1)} title="A quarter turn this way about the vertical (Q)">↺</button>
-            <button className="workshop__btn" onClick={() => w().rotateSelected(1)} title="A quarter turn the other way (E)">↻</button>
+          <div className="benchturn" role="group" aria-label="Turn the selection">
+            <button className="touchpad__key" title="A quarter turn left about the vertical (Q)" aria-label="Turn left" {...noCallout} onClick={() => w().rotateSelected(-1)}>
+              <RotateCcw size={18} strokeWidth={2.25} aria-hidden />
+              <span className="touchpad__sub">LEFT</span>
+            </button>
+            <button className="touchpad__key" title="A quarter turn right (E)" aria-label="Turn right" {...noCallout} onClick={() => w().rotateSelected(1)}>
+              <RotateCw size={18} strokeWidth={2.25} aria-hidden />
+              <span className="touchpad__sub">RIGHT</span>
+            </button>
           </div>
         )}
         {selection.length > 0 && <ControlsPad points={selectedPoints} />}
@@ -440,7 +514,7 @@ export function Workshop(): JSX.Element | null {
       )}
 
         <button className={`chip ws__chip ${panel === 'tools' ? 'is-on' : ''}`} aria-pressed={panel === 'tools'} onClick={() => toggle('tools')}>
-          <Wrench size={12} strokeWidth={2.25} aria-hidden />TOOLS · {tool.toUpperCase()}
+          <Wrench size={12} strokeWidth={2.25} aria-hidden />TOOLS · <ToolIcon size={12} strokeWidth={2.25} aria-hidden />{tool.toUpperCase()}
         </button>
       </div>
 
@@ -475,11 +549,9 @@ export function Workshop(): JSX.Element | null {
         {(tool !== 'face' || selectedFace !== null) && (colorBar ? (
           <div className={`ws__color ${tool === 'select' ? '' : 'is-open'}`} role="group" aria-label="Color">
             <span className="workshop__label">COLOR</span>
-            <span className="workshop__picker" title="Pick any color; it joins the palette">
-              <input type="color" className="workshop__color" value={hex} list="workshop-palette" onChange={(e) => pick(e.target.value)} onBlur={(e) => settled(e.target.value)} aria-label="Pick a color" {...noCallout} />
-              <Pipette className="workshop__picker-icon" size={13} strokeWidth={2.25} aria-hidden />
-              <datalist id="workshop-palette">{palette.map((h) => <option key={h} value={h} />)}</datalist>
-            </span>
+            <button className={`workshop__color ${pickerOpen ? 'is-on' : ''}`} onClick={() => setPickerOpen((o) => !o)} aria-pressed={pickerOpen} title="Mix a color: hue, saturation, brightness" aria-label="Mix a color" {...noCallout}>
+              <Pipette size={13} strokeWidth={2.25} aria-hidden />
+            </button>
             <div className="workshop__swatches">
               {palette.map((h) => (
                 <Swatch key={h} hex={h} on={h === hex} onUse={() => w().colorSelected(hexToRgb(h))} onHold={() => setDeleteColor(h)} />
@@ -490,6 +562,7 @@ export function Workshop(): JSX.Element | null {
         ) : (
           <button className="chip ws__colorchip" style={{ background: hex }} onClick={() => { setColorOpen(true); if (narrow && panel === 'tools') setPanel(null) }} title={`Color ${hex}. Tap for the palette.`} aria-label={`Color ${hex}, tap for the palette`} />
         ))}
+        {colorBar && pickerOpen && (tool !== 'face' || selectedFace !== null) && <Mixer hex={hex} onChange={pick} onSettle={settled} />}
       </div>
 
       {deleteColor !== null && (


### PR DESCRIPTION
Four workshop fixes from the last round of feedback.

- **The turn no longer walks.** It pivots on the exact middle of the selection's extent whenever a turn about it keeps every point on the snap grid: when the middle's x and z are both on a grid line or both halfway between lines, which is every square footprint, odd or even. A wedge of size 1 or 3 now turns in place. A footprint that cannot stay still (two by three, say) pivots on the middle snapped to the grid, and that point is remembered for the same selection so four turns bring it home; any other edit, or a change of DIVISION, forgets it.
- **Bigger pad and TURN keys.** Cells grow from 38 to 48 px with the glyph over its word. TURN is two cells of the same size with proper turn icons, LEFT (Q) and RIGHT (E).
- **The tool in the chip.** The collapsed TOOLS chip shows the current tool's icon beside its name.
- **Our own mixer.** The browser's colour dialog named its sliders hue, saturation and value and could not be relabelled, so it is replaced: HUE, SATURATION and BRIGHTNESS on tracks painted with what each would give, the colour they make and a hex field at the top. It paints the selection live and joins the palette once a slider settles. It opens on the colour in hand; for white, grey or black, a slider at zero opens at the middle so the first touch of HUE gives a colour. It rises above the corner stack, clear of the pad, and shuts on a tap anywhere else.

Verified on a 390×844 phone viewport and a 1400×900 desktop: a size-3 wedge keeps the same footprint through four LEFT turns and lands home; the mixer opens at the colour in hand, BRIGHTNESS 40 darkens the selection live, white opens with SATURATION at the middle, an outside tap shuts it; the chip reads `TOOLS · + ADD` with the icon. Tests: 518 passing, with new cases for the odd square in place, the two-by-three cycling home on one pivot, a move forgetting the pivot, and HSV round trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz