### PR TITLE
Take cyberspace-core at the Cantor fold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2090,7 +2090,7 @@
     },
     "node_modules/cyberspace-core": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#e5c212d2d00f6b6fe0840f051fb9095e55670f6b",
+      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#7535cb9f60fb02c2bd198af338e02c1952e64339",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.6.0"


### PR DESCRIPTION
Bumps the `cyberspace-core` git dependency to master at 7535cb9, which carries cyberspace-cli-js #1 (progress that tracks the hop) and #2 (the Cantor fold: leaves folded with a stack instead of a level at a time, about 1.8× less memory at the same speed; h20 measured 329 MB down to 184 MB). The proof is unchanged: the fold is exact against the level-by-level build at every height it was checked.

Only `package-lock.json` changes. tsc and the suite (518) are green against the new dist; a headless local hop commit was run as a smoke test before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz