### PR TITLE
Workshop: VIEW is the tool you hold to look around; the compass and a pad that turns the working grid; the mixer's sliders no longer shut the column

### DIFF
--- a/src/lib/stamps.test.ts
+++ b/src/lib/stamps.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { GRID_HALF, MAX_VERTICES, TICKS_PER_UNIT as T, newShard, ticksOf, validFace, validPoint, type ShardModel } from './shards'
-import { STAMPS, FACED, compile, landing, preview, stamp, type Facing, type StampKind } from './stamps'
+import { FACED, STAMPS, compile, landing, onPlane, preview, stamp, type Facing, type StampKind } from './stamps'
 
 const red: [number, number, number] = [1, 0, 0]
 const empty = (): ShardModel => ({ ...newShard('t'), mode: 'solid' })
@@ -120,5 +120,18 @@ describe('ghost placement', () => {
   it('lands on the aim unless the grid edge pushes it back', () => {
     expect(landing('block', 2, 0, [T, 0, T])).toEqual([T, 0, T])
     expect(landing('block', 4, 0, [GRID_HALF * T, 0, GRID_HALF * T])[0]).toBeLessThan(GRID_HALF * T)
+  })
+})
+
+describe('onPlane', () => {
+  it('turns up along the plane normal by a proper rotation, and leaves the floor alone', () => {
+    const up: [number, number, number] = [0, 120, 0]
+    expect(onPlane([up], 1)).toEqual([up])
+    expect(onPlane([up], 0)).toEqual([[120, 0, 0]])
+    expect(onPlane([up], 2)).toEqual([[0, 0, 120]])
+    // Right-handed: x cross y stays z after the turn.
+    const [x, y, z] = onPlane([[1, 0, 0], [0, 1, 0], [0, 0, 1]], 2)
+    const cross = [x[1] * y[2] - x[2] * y[1], x[2] * y[0] - x[0] * y[2], x[0] * y[1] - x[1] * y[0]]
+    expect(cross).toEqual(z)
   })
 })

--- a/src/lib/stamps.ts
+++ b/src/lib/stamps.ts
@@ -159,6 +159,21 @@ function turned(kind: StampKind, size: number, facing: Facing): Shape {
 
 const moved = (points: P3[], by: P3): P3[] => points.map((p) => [p[0] + by[0], p[1] + by[1], p[2] + by[2]] as P3)
 
+/**
+ * The working grid's normal axis: 1 is the floor (the XZ plane, up is +Y),
+ * 0 stands the grid on its side facing +X (the YZ plane), 2 stands it up
+ * facing +Z (the XY plane). Shapes are authored with up along +Y; on another
+ * plane they turn so up follows the normal, by a proper rotation (no mirror):
+ * a quarter about Z for plane 0, a quarter about X for plane 2.
+ */
+export type WorkPlane = 0 | 1 | 2
+export const FLOOR: WorkPlane = 1
+export function onPlane(points: P3[], plane: WorkPlane): P3[] {
+  if (plane === 1) return points
+  // `0 - v` rather than `-v`: negating a zero would leave a -0 in the model.
+  return points.map(([x, y, z]) => (plane === 0 ? [y, 0 - x, z] : [x, 0 - z, y]) as P3)
+}
+
 /** The push that brings a shape back inside the grid: zero on an axis it already fits. */
 function fit(points: P3[], extent: number = GRID_HALF): P3 {
   const shift: P3 = [0, 0, 0]
@@ -177,15 +192,15 @@ function fit(points: P3[], extent: number = GRID_HALF): P3 {
  * inside the grid if any of it would poke out. Nothing here is wider than
  * the grid, so the push always succeeds.
  */
-export function compile(kind: StampKind, size: number, facing: Facing, origin: P3, extent: number = GRID_HALF): Shape {
+export function compile(kind: StampKind, size: number, facing: Facing, origin: P3, extent: number = GRID_HALF, plane: WorkPlane = FLOOR): Shape {
   const t = turned(kind, size, facing)
-  const points = moved(t.points, origin)
+  const points = moved(onPlane(t.points, plane), origin)
   return { points: moved(points, fit(points, extent)), faces: t.faces }
 }
 
 /** Where a stamp aimed at `origin` lands: `origin` itself unless the grid's edge pushed it back. */
-export function landing(kind: StampKind, size: number, facing: Facing, origin: P3, extent: number = GRID_HALF): P3 {
-  const shift = fit(moved(turned(kind, size, facing).points, origin), extent)
+export function landing(kind: StampKind, size: number, facing: Facing, origin: P3, extent: number = GRID_HALF, plane: WorkPlane = FLOOR): P3 {
+  const shift = fit(moved(onPlane(turned(kind, size, facing).points, plane), origin), extent)
   return [origin[0] + shift[0], origin[1] + shift[1], origin[2] + shift[2]]
 }
 
@@ -206,8 +221,8 @@ export interface Stamped {
  * triangles are re-indexed, and any triangle that exactly matches an existing
  * one corner for corner is dropped along with the one it matched.
  */
-export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: Facing, origin: P3, color: [number, number, number]): Stamped | null {
-  const shape = compile(kind, size, facing, origin, shard.extent)
+export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: Facing, origin: P3, color: [number, number, number], plane: WorkPlane = FLOOR): Stamped | null {
+  const shape = compile(kind, size, facing, origin, shard.extent, plane)
   const base = shard.vertices.length
   const vertices: ShardVertex[] = [
     ...shard.vertices,
@@ -237,8 +252,9 @@ export function stamp(shard: ShardModel, kind: StampKind, size: number, facing: 
  * ghost's geometry is built once per shape and merely moved as the pointer
  * crosses cells; building it afresh per cell was the ghost's whole cost.
  */
-export function preview(kind: StampKind, size: number, facing: Facing, color: [number, number, number]): ShardModel {
-  const shape = turned(kind, size, facing)
+export function preview(kind: StampKind, size: number, facing: Facing, color: [number, number, number], plane: WorkPlane = FLOOR): ShardModel {
+  const shape = { ...turned(kind, size, facing) }
+  shape.points = onPlane(shape.points, plane)
   return {
     id: 'ghost',
     name: kind,

--- a/src/scene/Compass3D.tsx
+++ b/src/scene/Compass3D.tsx
@@ -63,20 +63,22 @@ function Arrow({ dir, color }: { dir: Vector3; color: string }): JSX.Element {
   )
 }
 
-function CompassScene({ onLabelsUpdate }: { onLabelsUpdate: (labels: LabelPosition[]) => void }): JSX.Element {
+type Dirs = Record<'x' | 'y' | 'z', Vector3>
+
+function CompassScene({ onLabelsUpdate, pose, given }: { onLabelsUpdate: (labels: LabelPosition[]) => void; pose: Quaternion; given?: Dirs }): JSX.Element {
   const view = useCyberspace((s) => s.view)
   const axes = useMemo(() => useCyberspace.getState().axes(), [view])
   const { camera, size } = useThree()
 
-  const dirs = useMemo(() => ({
+  const dirs = useMemo<Dirs>(() => given ?? {
     x: localDir(axes, 'x'),
     y: localDir(axes, 'y'),
     z: localDir(axes, 'z'),
-  }), [axes])
+  }, [axes, given])
 
   useFrame(() => {
-    camera.quaternion.copy(cameraPose)
-    camera.position.copy(new Vector3(0, 0, CAMERA_DISTANCE).applyQuaternion(cameraPose))
+    camera.quaternion.copy(pose)
+    camera.position.copy(new Vector3(0, 0, CAMERA_DISTANCE).applyQuaternion(pose))
 
     const labels: LabelPosition[] = (['x', 'y', 'z'] as const).map((axis) => {
       const world = dirs[axis].clone().multiplyScalar(ARROW_LENGTH + LABEL_OFFSET)
@@ -105,7 +107,12 @@ function CompassScene({ onLabelsUpdate }: { onLabelsUpdate: (labels: LabelPositi
   )
 }
 
-export function Compass3D({ onTap }: { onTap?: () => void } = {}): JSX.Element {
+/**
+ * By default the main camera's pose and the cyberspace axes. The workshop
+ * passes the bench camera's pose and its own axis directions, and `bench`
+ * takes the compass out of its fixed spot so the corner can hold it.
+ */
+export function Compass3D({ onTap, pose = cameraPose, dirs, bench = false }: { onTap?: () => void; pose?: Quaternion; dirs?: Dirs; bench?: boolean } = {}): JSX.Element {
   const [labels, setLabels] = useState<LabelPosition[]>([])
 
   const handleLabelsUpdate = (newLabels: LabelPosition[]) => {
@@ -125,7 +132,7 @@ export function Compass3D({ onTap }: { onTap?: () => void } = {}): JSX.Element {
 
   return (
     <div
-      className={`compass-3d${onTap ? ' compass-3d--tappable' : ''}`}
+      className={`compass-3d${onTap ? ' compass-3d--tappable' : ''}${bench ? ' compass-3d--bench' : ''}`}
       onPointerDown={onTap ? (e) => { e.preventDefault(); e.stopPropagation(); onTap() } : undefined}
       role={onTap ? 'button' : undefined}
       aria-label={onTap ? 'View controls' : undefined}
@@ -137,7 +144,7 @@ export function Compass3D({ onTap }: { onTap?: () => void } = {}): JSX.Element {
       >
         <ambientLight intensity={0.6} />
         <pointLight position={[5, 5, 5]} intensity={0.8} />
-        <CompassScene onLabelsUpdate={handleLabelsUpdate} />
+        <CompassScene onLabelsUpdate={handleLabelsUpdate} pose={pose} given={dirs} />
       </Canvas>
       {labels.map(({ axis, screen }) => (
         <span

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -267,6 +267,17 @@ describe('workshop', () => {
     expect(w().tool).toBe('view')
   })
 
+  it('stamps on the working plane: a block on the +X grid is one unit thick along X', () => {
+    w().clearShard()
+    w().setTool('stamp'); w().setStampKind('block'); w().setStampSize(1)
+    w().setPlane(0)
+    w().placeStamp([0, 0, 0])
+    const xs = new Set(w().current()!.vertices.map((v) => ticksOf(v)[0]))
+    expect(xs).toEqual(new Set([0, T]))
+    w().setPlane(1)
+    expect(w().plane).toBe(1)
+  })
+
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
     w().setTool('add')
     w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -260,6 +260,13 @@ describe('workshop', () => {
     expect(w().turnPivot).toBeNull()
   })
 
+  it('opens holding VIEW, the tool that builds nothing', () => {
+    w().setTool('stamp')
+    w().closeWorkshop()
+    w().openWorkshop()
+    expect(w().tool).toBe('view')
+  })
+
   it('fills a loop of picked corners, closing on the first pick or by FILL', () => {
     w().setTool('add')
     w().addVertex([0, 0, 0]); w().addVertex([2, 0, 0]); w().addVertex([2, 0, 2]); w().addVertex([0, 0, 2])

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -47,7 +47,7 @@ import {
   type ShardModel,
   type ShardVertex,
 } from '../lib/shards'
-import { MAX_SIZE, MIN_SIZE, stamp, type Facing, type StampKind } from '../lib/stamps'
+import { FLOOR, MAX_SIZE, MIN_SIZE, stamp, type Facing, type StampKind, type WorkPlane } from '../lib/stamps'
 import { newell, triangulate } from '../lib/triangulate'
 import { Vector3 } from 'three'
 import { ConvexHull } from 'three/examples/jsm/math/ConvexHull.js'
@@ -108,6 +108,8 @@ export interface WorkshopState {
   palette: string[]
   /** The Y the add and stamp tools place on, in ticks: the grid plane moves up and down. */
   level: number
+  /** The working grid's normal axis: 1 the floor, 0 facing +X, 2 facing +Z (stamps.ts WorkPlane). */
+  plane: WorkPlane
   /** Snap: the grid the placing tools, the marquee and the nudges use is a unit over this. A tool setting, not the shard's. */
   division: Division
   /** The to-scale avatar at the grid's centre, on or off. Kept between visits. */
@@ -141,6 +143,7 @@ export interface WorkshopState {
   setExtent: (extent: number) => void
   setTool: (tool: Tool) => void
   setLevel: (level: number) => void
+  setPlane: (plane: WorkPlane) => void
   setDivision: (division: Division) => void
   setShowAvatar: (on: boolean) => void
   /** One snap step, in ticks. */
@@ -317,6 +320,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     selectedFace: null,
     palette: loadPalette(),
     level: 0,
+    plane: FLOOR,
     division: 1,
     turnPivot: null,
     showAvatar: loadShowAvatar(),
@@ -332,7 +336,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     openWorkshop: (id) => {
       const { shards } = get()
       const currentId = id ?? get().currentId ?? shards[0]?.id ?? get().create()
-      set({ open: true, currentId, selection: [], selectedFace: null, facePick: [], tool: 'view', aim: null, past: [], future: [], notice: null })
+      set({ open: true, currentId, selection: [], selectedFace: null, facePick: [], tool: 'view', plane: FLOOR, aim: null, past: [], future: [], notice: null })
     },
 
     closeWorkshop: () => set({ open: false, selection: [], selectedFace: null, facePick: [], aim: null }),
@@ -378,6 +382,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
       edit((cur) => ({ ...cur, extent: e }))
       set({ level: Math.max(-e * TICKS_PER_UNIT, Math.min(e * TICKS_PER_UNIT, get().level)) })
     },
+    setPlane: (plane) => set({ plane, aim: null }),
     setLevel: (level) => {
       const e = (get().current()?.extent ?? GRID_HALF) * TICKS_PER_UNIT
       set({ level: Math.max(-e, Math.min(e, Math.round(level))) })
@@ -397,10 +402,10 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     },
 
     placeStamp: (at) => {
-      const { stampKind, stampSize, stampFacing, color } = get()
+      const { stampKind, stampSize, stampFacing, color, plane } = get()
       const s = get().current()
       if (!s || !validPoint(at, s.extent)) return
-      const res = stamp(s, stampKind, stampSize, stampFacing, at, color)
+      const res = stamp(s, stampKind, stampSize, stampFacing, at, color, plane)
       if (!res) { set({ notice: `No room: a shard holds up to ${MAX_VERTICES} vertices and ${MAX_FACES} faces.` }); return }
       const { mode, notice } = solidIfFirstFaces(s, res.shard)
       edit(() => ({ ...res.shard, mode }), notice)

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -52,7 +52,8 @@ import { newell, triangulate } from '../lib/triangulate'
 import { Vector3 } from 'three'
 import { ConvexHull } from 'three/examples/jsm/math/ConvexHull.js'
 
-export type Tool = 'stamp' | 'add' | 'select' | 'face'
+/** VIEW builds nothing: it is the tool you hold to look around. */
+export type Tool = 'view' | 'stamp' | 'add' | 'select' | 'face'
 
 const STORAGE = 'onosendai:shards'
 const PALETTE_STORAGE = 'onosendai:palette'
@@ -310,7 +311,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     shards: load(),
     currentId: null,
     open: false,
-    tool: 'stamp',
+    tool: 'view',
     selection: [],
     facePick: [],
     selectedFace: null,
@@ -331,7 +332,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     openWorkshop: (id) => {
       const { shards } = get()
       const currentId = id ?? get().currentId ?? shards[0]?.id ?? get().create()
-      set({ open: true, currentId, selection: [], selectedFace: null, facePick: [], tool: 'stamp', aim: null, past: [], future: [], notice: null })
+      set({ open: true, currentId, selection: [], selectedFace: null, facePick: [], tool: 'view', aim: null, past: [], future: [], notice: null })
     },
 
     closeWorkshop: () => set({ open: false, selection: [], selectedFace: null, facePick: [], aim: null }),

--- a/src/styles.css
+++ b/src/styles.css
@@ -2631,6 +2631,35 @@ kbd {
 .ws__panel--up {
   max-height: calc(100vh - 140px);
 }
+/* TOOLS with a tool in hand: the chip and, joined to its right, the X that
+ * puts the tool down. */
+.ws__toolchips { display: inline-flex; }
+.ws__toolchips .ws__chip:first-child:not(:only-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.ws__chip--x {
+  padding: 0 9px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 0;
+}
+/* The compass and the view pad live in the corner on the bench, not at the
+ * screen's fixed spots. */
+.compass-3d.compass-3d--bench {
+  position: static;
+  transform: none;
+  width: 104px;
+  height: 104px;
+}
+/* Two classes, to outrank the fixed placements the world gives the menu
+ * further down, at every width. */
+.viewmenu.viewmenu--bench {
+  position: static;
+  top: auto;
+  right: auto;
+  bottom: auto;
+}
 /* COLOR folded: a swatch of the current colour, the picker's dashed edge. */
 .ws__colorchip {
   width: 34px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2638,11 +2638,23 @@ kbd {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
-.ws__chip--x {
+/* Two classes, to outrank .chip's own radius, which comes later in the sheet. */
+.ws__toolchips .ws__chip--x {
   padding: 0 9px;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-left: 0;
+}
+/* Top right, under DEPLOY and the way out: the compass, the grid pad under it. */
+.ws__view {
+  position: absolute;
+  top: 54px;
+  right: 12px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
 }
 /* The compass and the view pad live in the corner on the bench, not at the
  * screen's fixed spots. */

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -18,10 +18,10 @@
 import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
-import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
+import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Spherical, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
 import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, ticksOf, toRender } from '../lib/shards'
-import { benchAxes, nudgeFor, sameAxes, useBenchView, type NudgeName } from './benchAxes'
+import { benchAxes, benchPose, nudgeFor, requestView, sameAxes, useBenchView, type NudgeName } from './benchAxes'
 import { landing, preview } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
 import { useWorkshop } from '../store/useWorkshop'
@@ -403,6 +403,14 @@ function Keys(): null {
         return
       }
       if (e.altKey) return
+      // Shift+WASD turns the view a quarter and Tab brings the view before
+      // back, as out in the world.
+      if (e.shiftKey && (e.code === 'KeyW' || e.code === 'KeyA' || e.code === 'KeyS' || e.code === 'KeyD')) {
+        e.preventDefault()
+        requestView({ kind: 'rotate', dir: ({ KeyW: 'up', KeyS: 'down', KeyA: 'left', KeyD: 'right' } as const)[e.code] })
+        return
+      }
+      if (e.code === 'Tab') { e.preventDefault(); requestView({ kind: 'back' }); return }
       // Screen directions, as the cursor's keys are in the world: W up, S down,
       // A left, D right, R into the screen, F out of it, whatever way the bench
       // camera has been turned.
@@ -416,10 +424,11 @@ function Keys(): null {
       if (e.code === 'Enter') { e.preventDefault(); if (w.facePick.length >= 3) w.fill(); else if (w.selection.length >= 3) w.fillSelection(); return }
       if (e.code === 'Escape') { e.preventDefault(); if (w.selection.length || w.selectedFace !== null || w.facePick.length) { w.selectVertex(null); w.clearFacePick() } else w.closeWorkshop(); return }
       if (e.code === 'KeyC') { w.selectConnected(); return }
-      if (e.code === 'Digit1') w.setTool('stamp')
-      if (e.code === 'Digit2') w.setTool('add')
-      if (e.code === 'Digit3') w.setTool('select')
-      if (e.code === 'Digit4') w.setTool('face')
+      if (e.code === 'Digit1') w.setTool('view')
+      if (e.code === 'Digit2') w.setTool('stamp')
+      if (e.code === 'Digit3') w.setTool('add')
+      if (e.code === 'Digit4') w.setTool('select')
+      if (e.code === 'Digit5') w.setTool('face')
       // Q and E turn the selection a quarter turn while SELECT holds one; Q turns the stamp otherwise.
       if (e.code === 'KeyQ') { if (w.tool === 'select' && w.selection.length) w.rotateSelected(-1); else w.turnStamp() }
       if (e.code === 'KeyE') { if (w.tool === 'select' && w.selection.length) w.rotateSelected(1) }
@@ -433,6 +442,52 @@ function Keys(): null {
 }
 
 /** Publishes the camera's snapped axes for the pad outside the canvas, only when they change. */
+/**
+ * Turns the camera on request, a quarter at a time about the target, from
+ * whatever view it is in: the current view is snapped to the nearest square
+ * one first, so a turn from an oblique angle lands square. Arrows steer the
+ * scene the way the world's view pad does: RIGHT brings the model's right side
+ * round to face you. TOP looks straight down. BACK returns to the view before.
+ * Also shares the camera's orientation with the compass every frame.
+ */
+function ViewDriver(): null {
+  const camera = useThree((s) => s.camera)
+  const controls = useThree((s) => s.controls) as unknown as { target: Vector3; update: () => void } | null
+  const request = useBenchView((s) => s.request)
+  const history = useRef<Array<{ position: Vector3; target: Vector3 }>>([])
+  useFrame(() => { benchPose.copy(camera.quaternion) })
+  useEffect(() => {
+    if (!request || !controls) return
+    if (request.kind === 'back') {
+      const last = history.current.pop()
+      if (last) { camera.position.copy(last.position); controls.target.copy(last.target); controls.update() }
+      useBenchView.setState({ canGoBack: history.current.length > 0 })
+      return
+    }
+    const s = new Spherical().setFromVector3(camera.position.clone().sub(controls.target))
+    const Q = Math.PI / 2
+    let theta = Math.round(s.theta / Q) * Q
+    let phi = Math.round(s.phi / Q) * Q
+    if (request.kind === 'top') phi = 0
+    else if (request.dir === 'right') theta += Q
+    else if (request.dir === 'left') theta -= Q
+    else if (request.dir === 'up') phi -= Q
+    else phi += Q
+    // A hair off the poles, as the controls keep it, so up stays defined.
+    s.theta = theta
+    s.phi = Math.min(Math.max(phi, 1e-3), Math.PI - 1e-3)
+    const next = controls.target.clone().add(new Vector3().setFromSpherical(s))
+    // Already there (TOP from the top, say): nothing to remember, nothing to do.
+    if (next.distanceTo(camera.position) < 1e-4) return
+    history.current.push({ position: camera.position.clone(), target: controls.target.clone() })
+    if (history.current.length > 32) history.current.shift()
+    useBenchView.setState({ canGoBack: true })
+    camera.position.copy(next)
+    controls.update()
+  }, [request]) // eslint-disable-line react-hooks/exhaustive-deps
+  return null
+}
+
 function AxesReporter(): null {
   const camera = useThree((s) => s.camera)
   useFrame(() => {
@@ -487,6 +542,7 @@ export function Bench(): JSX.Element {
       <Aim />
       <Keys />
       <AxesReporter />
+      <ViewDriver />
       {/* Axes, in the compass's colors, so X is red here and out there. */}
       <BenchAxes reach={extent + 1} />
       <Grid />

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -18,11 +18,11 @@
 import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
-import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Spherical, Vector3 } from 'three'
+import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
 import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, ticksOf, toRender } from '../lib/shards'
-import { benchAxes, benchPose, nudgeFor, requestView, sameAxes, useBenchView, type NudgeName } from './benchAxes'
-import { landing, preview } from '../lib/stamps'
+import { benchAxes, benchPose, nudgeFor, planeAfter, sameAxes, useBenchView, type NudgeName } from './benchAxes'
+import { landing, preview, type WorkPlane } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
 import { useWorkshop } from '../store/useWorkshop'
 
@@ -45,10 +45,15 @@ type P3 = [number, number, number]
  * the current level. Model +Z is render -Z (shards.ts toRender), so the tap's
  * render z comes back negated.
  */
-function snap(p: Vector3, level: number, step: number): P3 {
+function snap(p: Vector3, level: number, step: number, plane: WorkPlane): P3 {
   const q = (v: number): number => Math.round((v * TICKS_PER_UNIT) / step) * step
+  // The two coordinates in the plane snap; the one along its normal is the level.
+  if (plane === 0) return [level, q(p.y), -q(p.z)]
+  if (plane === 2) return [q(p.x), q(p.y), level]
   return [q(p.x), level, -q(p.z)]
 }
+/** Where the camera sits from its target when sent home: the bench's opening view. */
+const HOME: P3 = [10, 9, 12]
 /** Ticks to render units, one axis (for Y, which is not mirrored). */
 const U = (t: number): number => t / TICKS_PER_UNIT
 /** A model position as the bench draws it. */
@@ -95,6 +100,7 @@ function BenchAxes({ reach }: { reach: number }): JSX.Element {
 
 function Grid(): JSX.Element {
   const level = useWorkshop((s) => s.level)
+  const plane = useWorkshop((s) => s.plane)
   const division = useWorkshop((s) => s.division)
   const extent = useWorkshop((s) => s.current()?.extent ?? GRID_HALF)
   const tool = useWorkshop((s) => s.tool)
@@ -107,14 +113,14 @@ function Grid(): JSX.Element {
     // changed a moment ago must apply to this tap even if the bench has not
     // re-rendered yet.
     const w = useWorkshop.getState()
-    const at = snap(e.point, w.level, w.step())
+    const at = snap(e.point, w.level, w.step(), w.plane)
     if (w.tool === 'stamp') w.placeStamp(at)
     else w.addVertex(at)
   }
 
   const onMove = (e: ThreeEvent<PointerEvent>): void => {
     const w = useWorkshop.getState()
-    w.setAim(snap(e.point, w.level, w.step()))
+    w.setAim(snap(e.point, w.level, w.step(), w.plane))
   }
 
   // A finger lifts and the ghost goes with it; a mouse keeps hovering.
@@ -122,8 +128,13 @@ function Grid(): JSX.Element {
     if (e.pointerType !== 'mouse') useWorkshop.getState().setAim(null)
   }
 
+  // The grid is drawn on the floor and turned to its plane: a quarter about Z
+  // to face +X, a quarter about X to face +Z (render -Z is model +Z, so the
+  // level along model Z sits at render -level).
+  const position: P3 = plane === 0 ? [U(level), 0, 0] : plane === 2 ? [0, 0, -U(level)] : [0, U(level), 0]
+  const rotation: P3 = plane === 0 ? [0, 0, -Math.PI / 2] : plane === 2 ? [Math.PI / 2, 0, 0] : [0, 0, 0]
   return (
-    <group position={[0, U(level), 0]}>
+    <group position={position} rotation={rotation}>
       {/* The visible lattice. One cell per unit, so what you tap is what you get. */}
       <gridHelper key={`u${extent}-${division > 1 ? 1 : 0}`} args={[extent * 2, extent * 2, ACCENT, division > 1 ? UNIT_LINE_DIVIDED : UNIT_LINE]} />
       {/* The snap grid between the unit lines when a unit is divided, in the unit lines' plain colour. */}
@@ -153,9 +164,10 @@ function Ghost(): JSX.Element | null {
   const size = useWorkshop((s) => s.stampSize)
   const facing = useWorkshop((s) => s.stampFacing)
   const color = useWorkshop((s) => s.color)
-  // Built once per shape and color; the aim only moves it. Built per cell, the
+  const plane = useWorkshop((s) => s.plane)
+  // Built once per shape, color and plane; the aim only moves it. Built per cell, the
   // ghost cost a fresh geometry every time the pointer crossed a grid line.
-  const model = useMemo(() => (tool === 'stamp' ? preview(kind, size, facing, color) : null), [tool, kind, size, facing, color])
+  const model = useMemo(() => (tool === 'stamp' ? preview(kind, size, facing, color, plane) : null), [tool, kind, size, facing, color, plane])
   const extent = useWorkshop((s) => s.current()?.extent ?? GRID_HALF)
   if (!aim) return null
   if (tool === 'add') {
@@ -168,7 +180,7 @@ function Ghost(): JSX.Element | null {
   }
   if (!model) return null
   return (
-    <group position={UP(landing(kind, size, facing, aim, extent))}>
+    <group position={UP(landing(kind, size, facing, aim, extent, plane))}>
       <ShardMesh shard={model} ghost />
     </group>
   )
@@ -403,14 +415,13 @@ function Keys(): null {
         return
       }
       if (e.altKey) return
-      // Shift+WASD turns the view a quarter and Tab brings the view before
-      // back, as out in the world.
+      // Shift+W/S tips the working grid a quarter about the screen's horizontal,
+      // Shift+A/D rolls it about the line of sight; the geometry stays put.
       if (e.shiftKey && (e.code === 'KeyW' || e.code === 'KeyA' || e.code === 'KeyS' || e.code === 'KeyD')) {
         e.preventDefault()
-        requestView({ kind: 'rotate', dir: ({ KeyW: 'up', KeyS: 'down', KeyA: 'left', KeyD: 'right' } as const)[e.code] })
+        w.setPlane(planeAfter(w.plane, useBenchView.getState().axes, e.code === 'KeyW' || e.code === 'KeyS' ? 'tip' : 'roll'))
         return
       }
-      if (e.code === 'Tab') { e.preventDefault(); requestView({ kind: 'back' }); return }
       // Screen directions, as the cursor's keys are in the world: W up, S down,
       // A left, D right, R into the screen, F out of it, whatever way the bench
       // camera has been turned.
@@ -443,46 +454,17 @@ function Keys(): null {
 
 /** Publishes the camera's snapped axes for the pad outside the canvas, only when they change. */
 /**
- * Turns the camera on request, a quarter at a time about the target, from
- * whatever view it is in: the current view is snapped to the nearest square
- * one first, so a turn from an oblique angle lands square. Arrows steer the
- * scene the way the world's view pad does: RIGHT brings the model's right side
- * round to face you. TOP looks straight down. BACK returns to the view before.
- * Also shares the camera's orientation with the compass every frame.
+ * Sends the camera home on request (the default oblique view, the target kept),
+ * and shares its orientation with the compass every frame.
  */
 function ViewDriver(): null {
   const camera = useThree((s) => s.camera)
   const controls = useThree((s) => s.controls) as unknown as { target: Vector3; update: () => void } | null
   const request = useBenchView((s) => s.request)
-  const history = useRef<Array<{ position: Vector3; target: Vector3 }>>([])
   useFrame(() => { benchPose.copy(camera.quaternion) })
   useEffect(() => {
     if (!request || !controls) return
-    if (request.kind === 'back') {
-      const last = history.current.pop()
-      if (last) { camera.position.copy(last.position); controls.target.copy(last.target); controls.update() }
-      useBenchView.setState({ canGoBack: history.current.length > 0 })
-      return
-    }
-    const s = new Spherical().setFromVector3(camera.position.clone().sub(controls.target))
-    const Q = Math.PI / 2
-    let theta = Math.round(s.theta / Q) * Q
-    let phi = Math.round(s.phi / Q) * Q
-    if (request.kind === 'top') phi = 0
-    else if (request.dir === 'right') theta += Q
-    else if (request.dir === 'left') theta -= Q
-    else if (request.dir === 'up') phi -= Q
-    else phi += Q
-    // A hair off the poles, as the controls keep it, so up stays defined.
-    s.theta = theta
-    s.phi = Math.min(Math.max(phi, 1e-3), Math.PI - 1e-3)
-    const next = controls.target.clone().add(new Vector3().setFromSpherical(s))
-    // Already there (TOP from the top, say): nothing to remember, nothing to do.
-    if (next.distanceTo(camera.position) < 1e-4) return
-    history.current.push({ position: camera.position.clone(), target: controls.target.clone() })
-    if (history.current.length > 32) history.current.shift()
-    useBenchView.setState({ canGoBack: true })
-    camera.position.copy(next)
+    camera.position.copy(controls.target).add(new Vector3(HOME[0], HOME[1], HOME[2]))
     controls.update()
   }, [request]) // eslint-disable-line react-hooks/exhaustive-deps
   return null

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -28,11 +28,11 @@ import { Explanation } from '../hud/Explanation'
 import { DIVISIONS, MAX_EXTENT, MIN_EXTENT, MODES, TICKS_PER_UNIT, hexToRgb, neededExtent, rgbToHex, ticksOf, toPayload, unitsLabel, type ShardMode } from '../lib/shards'
 import { hsvToRgb, rgbToHsv, type Hsv } from '../lib/hsv'
 import { formatCellSize } from '../lib/scale'
-import { FACED, FACING_LABEL, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
+import { FACED, FACING_LABEL, FLOOR, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { Bench } from './Bench'
-import { benchPose, nudgeFor, nudgeLabel, requestView, useBenchView, type NudgeName } from './benchAxes'
+import { benchPose, nudgeFor, nudgeLabel, planeAfter, requestView, useBenchView, type NudgeName } from './benchAxes'
 
 const TOOLS: Tool[] = ['view', 'stamp', 'add', 'select', 'face']
 const TOOL_ICON: Record<Tool, LucideIcon> = { view: Eye, stamp: Stamp, add: Plus, select: MousePointer2, face: Triangle }
@@ -207,26 +207,27 @@ function Mixer({ hex, onChange, onSettle }: { hex: string; onChange: (hex: strin
 const BENCH_DIRS = { x: new Vector3(1, 0, 0), y: new Vector3(0, 1, 0), z: new Vector3(0, 0, -1) }
 
 /**
- * The view controls from out in the world, for the bench: the pad turns the
- * model a quarter, BACK returns to the view before, TOP looks straight down.
- * EARTH, CYBERSPACE, SUN and the plane have no meaning on a bench.
+ * The view pad, for the bench: the arrows turn the working grid a quarter
+ * while the geometry stays put, so the next points go down on another plane.
+ * Up and down tip it about the screen's horizontal, left and right roll it
+ * about the line of sight (benchAxes planeAfter). SUN is the black sun's seat
+ * here: the grid back on the floor and the camera back where the bench opens.
  */
 function BenchViewMenu(): JSX.Element {
-  const canGoBack = useBenchView((s) => s.canGoBack)
+  const w = useWorkshop.getState
   const press = (fn: () => void) => (e: React.PointerEvent): void => { e.preventDefault(); e.stopPropagation(); fn() }
-  const turn = (dir: 'up' | 'down' | 'left' | 'right') => (): void => requestView({ kind: 'rotate', dir })
+  const turn = (about: 'tip' | 'roll') => (): void => w().setPlane(planeAfter(w().plane, useBenchView.getState().axes, about))
   return (
-    <div className="viewmenu viewmenu--bench" role="group" aria-label="View controls">
+    <div className="viewmenu viewmenu--bench" role="group" aria-label="Grid controls">
       <div className="viewmenu__pad">
-        <button className="viewmenu__key viewmenu__key--up" {...noCallout} onPointerDown={press(turn('up'))} aria-label="Rotate up">▲</button>
-        <button className="viewmenu__key viewmenu__key--left" {...noCallout} onPointerDown={press(turn('left'))} aria-label="Rotate left">◀</button>
-        <span className="viewmenu__hub" aria-hidden="true">ROT</span>
-        <button className="viewmenu__key viewmenu__key--right" {...noCallout} onPointerDown={press(turn('right'))} aria-label="Rotate right">▶</button>
-        <button className="viewmenu__key viewmenu__key--down" {...noCallout} onPointerDown={press(turn('down'))} aria-label="Rotate down">▼</button>
+        <button className="viewmenu__key viewmenu__key--up" {...noCallout} onPointerDown={press(turn('tip'))} aria-label="Tip the grid up">▲</button>
+        <button className="viewmenu__key viewmenu__key--left" {...noCallout} onPointerDown={press(turn('roll'))} aria-label="Roll the grid left">◀</button>
+        <span className="viewmenu__hub" aria-hidden="true">GRID</span>
+        <button className="viewmenu__key viewmenu__key--right" {...noCallout} onPointerDown={press(turn('roll'))} aria-label="Roll the grid right">▶</button>
+        <button className="viewmenu__key viewmenu__key--down" {...noCallout} onPointerDown={press(turn('tip'))} aria-label="Tip the grid down">▼</button>
       </div>
       <div className="viewmenu__row">
-        <button className="viewmenu__op" disabled={!canGoBack} {...noCallout} onPointerDown={press(() => requestView({ kind: 'back' }))}>BACK</button>
-        <button className="viewmenu__op" {...noCallout} onPointerDown={press(() => requestView({ kind: 'top' }))}>TOP</button>
+        <button className="viewmenu__op" {...noCallout} onPointerDown={press(() => { w().setPlane(FLOOR); requestView({ kind: 'home' }) })} title="The grid back on the floor, the view back where the bench opens">SUN</button>
       </div>
     </div>
   )
@@ -242,6 +243,7 @@ export function Workshop(): JSX.Element | null {
   const selectedFace = useWorkshop((s) => s.selectedFace)
   const palette = useWorkshop((s) => s.palette)
   const level = useWorkshop((s) => s.level)
+  const plane = useWorkshop((s) => s.plane)
   const division = useWorkshop((s) => s.division)
   const showAvatar = useWorkshop((s) => s.showAvatar)
   const color = useWorkshop((s) => s.color)
@@ -378,8 +380,8 @@ export function Workshop(): JSX.Element | null {
           <Grid3x3 size={12} strokeWidth={2.25} aria-hidden />GRID
         </button>
         <span className="ws__history">
-          <button className="chip ws__icon" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)" aria-label="Undo"><Undo2 size={15} strokeWidth={2.25} aria-hidden /></button>
-          <button className="chip ws__icon" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)" aria-label="Redo"><Redo2 size={15} strokeWidth={2.25} aria-hidden /></button>
+          <button className="chip ws__icon" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)" aria-label="Undo"><Undo2 size={20} strokeWidth={2.25} aria-hidden /></button>
+          <button className="chip ws__icon" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)" aria-label="Redo"><Redo2 size={20} strokeWidth={2.25} aria-hidden /></button>
         </span>
       </div>
       {panel === 'menu' && shard && (
@@ -456,7 +458,7 @@ export function Workshop(): JSX.Element | null {
       {panel === 'grid' && shard && (
         <div className="ws__panel" role="region" aria-label="Grid">
           <div className="workshop__row">
-            <span className="workshop__label">LEVEL Y</span>
+            <span className="workshop__label">LEVEL {'XYZ'[plane]}</span>
             <button className="workshop__btn" {...bind(() => w().setLevel(w().level - w().step()))} disabled={level <= -extent * TICKS_PER_UNIT} aria-label="Level down">−</button>
             <span className="workshop__value">{unitsLabel(level)}</span>
             <button className="workshop__btn" {...bind(() => w().setLevel(w().level + w().step()))} disabled={level >= extent * TICKS_PER_UNIT} aria-label="Level up">+</button>
@@ -501,6 +503,15 @@ export function Workshop(): JSX.Element | null {
         >DEPLOY ▸</button>
         <button className="chip ws__icon" onClick={() => w().closeWorkshop()} title="Close the workshop (Esc)" aria-label="Close"><X size={15} strokeWidth={2.25} aria-hidden /></button>
       </div>
+
+      {/* Top right, under DEPLOY and the way out: the compass while VIEW is in
+          hand, the grid pad under it when tapped. */}
+      {tool === 'view' && (
+        <div className="ws__view">
+          <Compass3D bench pose={benchPose} dirs={BENCH_DIRS} onTap={() => setViewOpen((o) => !o)} />
+          {viewOpen && <BenchViewMenu />}
+        </div>
+      )}
 
       {/* Bottom left: TURN and the pad while points are selected, over TOOLS and
           its panel, which opens upward over the chip. */}
@@ -575,8 +586,6 @@ export function Workshop(): JSX.Element | null {
       {/* Bottom right: FILL for a set of points, face actions while a face is in
           hand, the color column under either. */}
       <div className="ws__corner">
-        {tool === 'view' && viewOpen && <BenchViewMenu />}
-        {tool === 'view' && <Compass3D bench pose={benchPose} dirs={BENCH_DIRS} onTap={() => setViewOpen((o) => !o)} />}
         {one && (
           <div className="benchops" role="status" aria-label="Selected point">
             <span className="workshop__value workshop__value--wide">at ({ticksOf(one).map(unitsLabel).join(', ')})</span>

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -19,7 +19,9 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, RotateCcw, RotateCw, Stamp, Trash2, Triangle, Undo2, Wrench, X, type LucideIcon } from 'lucide-react'
+import { Vector3 } from 'three'
+import { Compass3D } from '../scene/Compass3D'
+import { Eye, Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, RotateCcw, RotateCw, Stamp, Trash2, Triangle, Undo2, Wrench, X, type LucideIcon } from 'lucide-react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { ConfirmModal } from '../hud/ConfirmModal'
 import { Explanation } from '../hud/Explanation'
@@ -30,10 +32,10 @@ import { FACED, FACING_LABEL, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type Stamp
 import { useWorkshop, type Tool } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { Bench } from './Bench'
-import { nudgeFor, nudgeLabel, useBenchView, type NudgeName } from './benchAxes'
+import { benchPose, nudgeFor, nudgeLabel, requestView, useBenchView, type NudgeName } from './benchAxes'
 
-const TOOLS: Tool[] = ['stamp', 'add', 'select', 'face']
-const TOOL_ICON: Record<Tool, LucideIcon> = { stamp: Stamp, add: Plus, select: MousePointer2, face: Triangle }
+const TOOLS: Tool[] = ['view', 'stamp', 'add', 'select', 'face']
+const TOOL_ICON: Record<Tool, LucideIcon> = { view: Eye, stamp: Stamp, add: Plus, select: MousePointer2, face: Triangle }
 
 const LONG_PRESS_MS = 550
 const SETTLE_MS = 500
@@ -41,6 +43,7 @@ const TOAST_MS = 4000
 
 /** One line under the tool row. SELECT needs none: the pad appears when something is selected. */
 const TOOL_HELP: Partial<Record<Tool, string>> = {
+  view: 'Look around: one finger orbits, two pan, pinch zooms. The compass turns the view a quarter at a time. Pick a tool to build.',
   stamp: 'Tap the grid to place the shape where the ghost shows. Q turns it.',
   add: 'Tap the grid to place a vertex at the current level.',
   face: 'Tap corners in order, then the first again or FILL. Tap a face to select it; DELETE FACE removes it.',
@@ -200,6 +203,35 @@ function Mixer({ hex, onChange, onSettle }: { hex: string; onChange: (hex: strin
   )
 }
 
+/** The bench's axes as the compass draws them: model +Z is render -Z (shards.ts toRender). */
+const BENCH_DIRS = { x: new Vector3(1, 0, 0), y: new Vector3(0, 1, 0), z: new Vector3(0, 0, -1) }
+
+/**
+ * The view controls from out in the world, for the bench: the pad turns the
+ * model a quarter, BACK returns to the view before, TOP looks straight down.
+ * EARTH, CYBERSPACE, SUN and the plane have no meaning on a bench.
+ */
+function BenchViewMenu(): JSX.Element {
+  const canGoBack = useBenchView((s) => s.canGoBack)
+  const press = (fn: () => void) => (e: React.PointerEvent): void => { e.preventDefault(); e.stopPropagation(); fn() }
+  const turn = (dir: 'up' | 'down' | 'left' | 'right') => (): void => requestView({ kind: 'rotate', dir })
+  return (
+    <div className="viewmenu viewmenu--bench" role="group" aria-label="View controls">
+      <div className="viewmenu__pad">
+        <button className="viewmenu__key viewmenu__key--up" {...noCallout} onPointerDown={press(turn('up'))} aria-label="Rotate up">▲</button>
+        <button className="viewmenu__key viewmenu__key--left" {...noCallout} onPointerDown={press(turn('left'))} aria-label="Rotate left">◀</button>
+        <span className="viewmenu__hub" aria-hidden="true">ROT</span>
+        <button className="viewmenu__key viewmenu__key--right" {...noCallout} onPointerDown={press(turn('right'))} aria-label="Rotate right">▶</button>
+        <button className="viewmenu__key viewmenu__key--down" {...noCallout} onPointerDown={press(turn('down'))} aria-label="Rotate down">▼</button>
+      </div>
+      <div className="viewmenu__row">
+        <button className="viewmenu__op" disabled={!canGoBack} {...noCallout} onPointerDown={press(() => requestView({ kind: 'back' }))}>BACK</button>
+        <button className="viewmenu__op" {...noCallout} onPointerDown={press(() => requestView({ kind: 'top' }))}>TOP</button>
+      </div>
+    </div>
+  )
+}
+
 export function Workshop(): JSX.Element | null {
   const open = useWorkshop((s) => s.open)
   const shard = useWorkshop((s) => s.current())
@@ -221,6 +253,7 @@ export function Workshop(): JSX.Element | null {
   const [panel, setPanel] = useState<Panel | null>(null)
   const [colorOpen, setColorOpen] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [viewOpen, setViewOpen] = useState(false)
   // On a phone the open colour bar and the TOOLS panel share the bottom, so
   // they take turns; on a wide screen they have corners of their own.
   const [narrow, setNarrow] = useState<boolean>(() => typeof window !== 'undefined' && window.matchMedia('(max-width: 640px)').matches)
@@ -244,7 +277,7 @@ export function Workshop(): JSX.Element | null {
     const shut = (e: PointerEvent): void => {
       if (useWorkshop.getState().tool === 'select') return
       const el = e.target as HTMLElement | null
-      if (el?.closest('.ws__color, .ws__colorchip')) return
+      if (el?.closest('.ws__color, .ws__colorchip, .ws__mixer')) return
       setColorOpen(false)
     }
     document.addEventListener('pointerdown', shut, true)
@@ -253,6 +286,18 @@ export function Workshop(): JSX.Element | null {
   // ADD, SELECT and FACE have nothing under them, so choosing one by key puts
   // the TOOLS panel away; STAMP keeps it for the shape, size and facing.
   useEffect(() => { if (tool !== 'stamp') setPanel((p) => (p === 'tools' ? null : p)) }, [tool])
+  // The view pad goes with the VIEW tool, and shuts on a tap anywhere else.
+  useEffect(() => { if (tool !== 'view') setViewOpen(false) }, [tool])
+  useEffect(() => {
+    if (!viewOpen) return
+    const shut = (e: PointerEvent): void => {
+      const el = e.target as HTMLElement | null
+      if (el?.closest('.viewmenu, .compass-3d')) return
+      setViewOpen(false)
+    }
+    document.addEventListener('pointerdown', shut, true)
+    return () => document.removeEventListener('pointerdown', shut, true)
+  }, [viewOpen])
   // The mixer shuts with the column, and on a tap anywhere else.
   useEffect(() => { if (!colorBar) setPickerOpen(false) }, [colorBar])
   useEffect(() => {
@@ -513,14 +558,25 @@ export function Workshop(): JSX.Element | null {
         </div>
       )}
 
-        <button className={`chip ws__chip ${panel === 'tools' ? 'is-on' : ''}`} aria-pressed={panel === 'tools'} onClick={() => toggle('tools')}>
-          <Wrench size={12} strokeWidth={2.25} aria-hidden />TOOLS · <ToolIcon size={12} strokeWidth={2.25} aria-hidden />{tool.toUpperCase()}
-        </button>
+        {/* The tool in hand, and an X joined to the chip that puts it down: VIEW,
+            the tool that builds nothing. */}
+        <div className="ws__toolchips">
+          <button className={`chip ws__chip ${panel === 'tools' ? 'is-on' : ''}`} aria-pressed={panel === 'tools'} onClick={() => toggle('tools')}>
+            <Wrench size={12} strokeWidth={2.25} aria-hidden />TOOLS · <ToolIcon size={12} strokeWidth={2.25} aria-hidden />{tool.toUpperCase()}
+          </button>
+          {tool !== 'view' && (
+            <button className="chip ws__chip ws__chip--x" onClick={() => w().setTool('view')} title="Put the tool down (1)" aria-label="Put the tool down">
+              <X size={13} strokeWidth={2.25} aria-hidden />
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Bottom right: FILL for a set of points, face actions while a face is in
           hand, the color column under either. */}
       <div className="ws__corner">
+        {tool === 'view' && viewOpen && <BenchViewMenu />}
+        {tool === 'view' && <Compass3D bench pose={benchPose} dirs={BENCH_DIRS} onTap={() => setViewOpen((o) => !o)} />}
         {one && (
           <div className="benchops" role="status" aria-label="Selected point">
             <span className="workshop__value workshop__value--wide">at ({ticksOf(one).map(unitsLabel).join(', ')})</span>

--- a/src/workshop/benchAxes.test.ts
+++ b/src/workshop/benchAxes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_AXES, nudgeFor, nudgeLabel } from './benchAxes'
+import { DEFAULT_AXES, nudgeFor, nudgeLabel, planeAfter } from './benchAxes'
 
 describe('benchAxes', () => {
   it('turns screen directions into model moves, with Z mirrored as the bench draws it', () => {
@@ -11,5 +11,20 @@ describe('benchAxes', () => {
     expect(nudgeFor(DEFAULT_AXES, 'toward')).toEqual({ axis: 2, delta: -1 })
     expect(nudgeFor(DEFAULT_AXES, 'away')).toEqual({ axis: 2, delta: 1 })
     expect(nudgeLabel(nudgeFor(DEFAULT_AXES, 'away'))).toBe('+Z')
+  })
+})
+
+describe('planeAfter', () => {
+  const top = { right: { axis: 0, dir: 1 }, up: { axis: 2, dir: -1 }, out: { axis: 1, dir: 1 } } as const
+  it('tips the floor up to face the viewer and rolls it to face the side', () => {
+    expect(planeAfter(1, DEFAULT_AXES, 'tip')).toBe(2)
+    expect(planeAfter(1, DEFAULT_AXES, 'roll')).toBe(0)
+    expect(planeAfter(2, DEFAULT_AXES, 'tip')).toBe(1)
+    expect(planeAfter(0, DEFAULT_AXES, 'roll')).toBe(1)
+  })
+  it('falls back to the screen vertical when the turn would be about the normal', () => {
+    // From straight above the line of sight is Y, the floor's own normal.
+    expect(planeAfter(1, top, 'roll')).toBe(0)
+    expect(planeAfter(1, top, 'tip')).toBe(2)
   })
 })

--- a/src/workshop/benchAxes.ts
+++ b/src/workshop/benchAxes.ts
@@ -10,7 +10,7 @@
  */
 
 import { create } from 'zustand'
-import { Vector3, type Camera } from 'three'
+import { Quaternion, Vector3, type Camera } from 'three'
 
 export type NudgeName = 'up' | 'down' | 'left' | 'right' | 'away' | 'toward'
 
@@ -84,4 +84,18 @@ export const sameAxes = (a: BenchAxes, b: BenchAxes): boolean =>
 /** The bench's default view: X right, Y up, Z toward the viewer. */
 export const DEFAULT_AXES: BenchAxes = { right: { axis: 0, dir: 1 }, up: { axis: 1, dir: 1 }, out: { axis: 2, dir: 1 } }
 
-export const useBenchView = create<{ axes: BenchAxes }>(() => ({ axes: DEFAULT_AXES }))
+/** The bench camera's orientation, for the compass in its own canvas. Mutable, per frame, never store state. */
+export const benchPose = new Quaternion()
+
+export type ViewDir = 'up' | 'down' | 'left' | 'right'
+/** What the view pad and keys ask of the camera. */
+export type ViewAsk = { kind: 'rotate'; dir: ViewDir } | { kind: 'top' } | { kind: 'back' }
+export type ViewRequest = ViewAsk & { id: number }
+
+export const useBenchView = create<{ axes: BenchAxes; request: ViewRequest | null; canGoBack: boolean }>(() => ({ axes: DEFAULT_AXES, request: null, canGoBack: false }))
+
+let asked = 0
+/** Ask the bench camera for a quarter turn, the top view, or the view before. */
+export function requestView(ask: ViewAsk): void {
+  useBenchView.setState({ request: { ...ask, id: ++asked } })
+}

--- a/src/workshop/benchAxes.ts
+++ b/src/workshop/benchAxes.ts
@@ -11,6 +11,7 @@
 
 import { create } from 'zustand'
 import { Quaternion, Vector3, type Camera } from 'three'
+import type { WorkPlane } from '../lib/stamps'
 
 export type NudgeName = 'up' | 'down' | 'left' | 'right' | 'away' | 'toward'
 
@@ -87,15 +88,29 @@ export const DEFAULT_AXES: BenchAxes = { right: { axis: 0, dir: 1 }, up: { axis:
 /** The bench camera's orientation, for the compass in its own canvas. Mutable, per frame, never store state. */
 export const benchPose = new Quaternion()
 
-export type ViewDir = 'up' | 'down' | 'left' | 'right'
-/** What the view pad and keys ask of the camera. */
-export type ViewAsk = { kind: 'rotate'; dir: ViewDir } | { kind: 'top' } | { kind: 'back' }
+/** What the view pad asks of the camera: only the way home, now that the arrows turn the grid. */
+export type ViewAsk = { kind: 'home' }
 export type ViewRequest = ViewAsk & { id: number }
 
-export const useBenchView = create<{ axes: BenchAxes; request: ViewRequest | null; canGoBack: boolean }>(() => ({ axes: DEFAULT_AXES, request: null, canGoBack: false }))
+/**
+ * The working grid after a quarter turn about a screen axis. 'tip' turns it
+ * about the screen's horizontal (the top comes toward you), 'roll' about the
+ * line of sight. A plane is its normal axis, so a turn about the normal itself
+ * changes nothing; then the turn is taken about the screen's vertical instead,
+ * so every arrow does something from every view. Either way round lands on
+ * the same plane, which is why the pad's opposite arrows agree.
+ */
+export function planeAfter(plane: WorkPlane, axes: BenchAxes, about: 'tip' | 'roll'): WorkPlane {
+  let a: number = about === 'tip' ? axes.right.axis : axes.out.axis
+  if (a === plane) a = axes.up.axis
+  if (a === plane) return plane
+  return (3 - plane - a) as WorkPlane
+}
+
+export const useBenchView = create<{ axes: BenchAxes; request: ViewRequest | null }>(() => ({ axes: DEFAULT_AXES, request: null }))
 
 let asked = 0
-/** Ask the bench camera for a quarter turn, the top view, or the view before. */
+/** Ask the bench camera for the default view. */
 export function requestView(ask: ViewAsk): void {
   useBenchView.setState({ request: { ...ask, id: ++asked } })
 }


### PR DESCRIPTION
From the last two rounds of feedback.

- **The slider bug.** A touch on the mixer's sliders closed the colour column, because the column's outside-tap rule did not know about the mixer, which sits outside the column. It does now; dragging BRIGHTNESS in ADD keeps the column and the mixer up and recolours live.
- **VIEW and the X.** VIEW is first in the tools and the one the workshop opens holding. It builds nothing: taps on the bench do nothing, the camera is all yours. An X joined to the right of the TOOLS chip is a shortcut that puts the tool in hand down and returns to VIEW; it shows only while a tool is in hand, and its inner corners are square now. Number keys: 1 VIEW, 2 STAMP, 3 ADD, 4 SELECT, 5 FACE.
- **The compass, under DEPLOY.** While VIEW is in hand the compass sits at the top right under DEPLOY and the way out, drawn from the bench camera's own pose along the bench's axes. Tapping it opens the pad under it.
- **The pad turns the grid, not the camera.** The working grid has a plane now: the floor as before, or stood up to face +X or +Z. The arrows turn it a quarter about a screen axis while the geometry stays put, so the next points and stamps go down on another plane. Up and down tip it about the screen's horizontal, left and right roll it about the line of sight; a turn that would be about the grid's own normal is taken about the screen's vertical instead, so every arrow does something from every view. Taps snap in the plane, LEVEL runs along its normal and the GRID panel names the axis, and stamps turn with the grid by a proper rotation, so a pyramid stamped on a standing grid points along its normal. SUN puts the grid back on the floor and the camera back where the bench opens. Shift+W/S tip and Shift+A/D roll from the keyboard. EARTH, CYBERSPACE, the plane toggle, BACK and TOP are not carried over.
- **Undo and redo** icons grow from 15 to 20 px.

Verified on a 390×844 phone viewport and a 1400×900 desktop: opens holding VIEW with the compass under DEPLOY; the pad opens under it; tip stands the grid up to face +Z with the pyramid in place; taps on the standing grid add points at the snapped in-plane coordinates on both standing planes; a pyramid stamped on the standing grid has its apex along +Z; roll from there gives the +X grid; SUN restores the floor and the opening view; the X's inner corners measure 0 px; a BRIGHTNESS drag in ADD keeps the column. Tests: 523 passing, with cases for the plane turn rule, the proper rotation of stamps, and a block stamped on the +X grid being one unit thick along X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz