### PR TITLE
Bench: faces turn outward by what they can see, and faces buried in a join stay undrawn

### DIFF
--- a/src/lib/orient.test.ts
+++ b/src/lib/orient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { orientFaces } from './orient'
+import { orientFaces, orientShard } from './orient'
 import { newell, type P3 } from './triangulate'
 import { compile, STAMPS } from './stamps'
 
@@ -44,5 +44,54 @@ describe('orientFaces', () => {
     const faces: Array<[number, number, number]> = [[0, 2, 1]]
     orientFaces(pts, faces)
     expect(faces[0]).toEqual([0, 2, 1])
+  })
+})
+
+/**
+ * arkinox's arch (2026-09-07): two pillars with a lintel built by hand across
+ * their tops. The pillars' top squares stayed under the lintel, so each of
+ * their edges carries three faces, and the old walk carried agreement across
+ * them and turned the whole right pillar's outer faces inward.
+ */
+const ARCH_P = [[-4,0,-1],[-3,0,-1],[-3,0,0],[-4,0,0],[-4,4,-1],[-3,4,-1],[-3,4,0],[-4,4,0],[3,0,-1],[4,0,-1],[4,0,0],[3,0,0],[3,4,-1],[4,4,-1],[4,4,0],[3,4,0],[3,5,0],[3,5,-1],[4,5,-1],[4,5,0],[-4,4,0],[-4,4,-1],[-3,5,-1],[-3,5,0]]
+const ARCH_T = [[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[0,0,60],[60,60,60],[60,60,60],[0,0,60],[0,0,60]]
+const ARCH_F: Array<[number, number, number]> = [[0,1,2],[0,2,3],[4,5,6],[4,6,7],[0,1,5],[0,5,4],[3,2,6],[3,6,7],[0,3,7],[0,7,4],[1,2,6],[1,6,5],[8,10,11],[12,13,14],[12,14,15],[8,9,13],[8,13,12],[8,11,15],[8,15,12],[20,21,22],[22,23,20],[20,21,4],[4,7,20],[7,6,20],[23,20,6],[6,23,16],[16,15,6],[19,16,14],[16,15,14],[19,13,14],[19,18,13],[16,17,19],[18,17,19],[22,23,16],[16,17,22],[18,12,13],[18,17,12],[5,22,17],[12,17,5],[22,21,5],[4,5,21],[15,12,6],[5,6,12],[9,8,10],[14,13,9],[14,9,10],[15,14,10],[15,11,10]]
+const archPoints = (): P3[] => ARCH_P.map((p, i) => [p[0] + ARCH_T[i][0] / 120, p[1] + ARCH_T[i][1] / 120, 0 - (p[2] + ARCH_T[i][2] / 120)])
+
+describe('orientShard', () => {
+  it('turns every outer face of the arch outward, and finds the squares inside the joins', () => {
+    const pts = archPoints()
+    const { faces, interior } = orientShard(pts, ARCH_F)
+    const n = (i: number): P3 => { const m = newell(faces[i].map((v) => pts[v])); const l = Math.hypot(...m); return [m[0] / l, m[1] / l, m[2] / l] }
+    const expectDir = (i: number, d: P3): void => { const m = n(i); expect(m[0]).toBeCloseTo(d[0], 5); expect(m[1]).toBeCloseTo(d[1], 5); expect(m[2]).toBeCloseTo(d[2], 5) }
+    // Right pillar: bottom down, +X side out, inner side toward the opening, both z sides out.
+    expectDir(43, [0, -1, 0]); expectDir(12, [0, -1, 0])
+    expectDir(44, [1, 0, 0]); expectDir(45, [1, 0, 0])
+    expectDir(17, [-1, 0, 0]); expectDir(18, [-1, 0, 0])
+    expectDir(46, [0, 0, -1]); expectDir(47, [0, 0, -1])
+    expectDir(15, [0, 0, 1]); expectDir(16, [0, 0, 1])
+    // Left pillar the same way round.
+    expectDir(0, [0, -1, 0]); expectDir(8, [-1, 0, 0]); expectDir(10, [1, 0, 0]); expectDir(4, [0, 0, 1]); expectDir(6, [0, 0, -1])
+    // The lintel's top up and its underside down.
+    expectDir(31, [0, 1, 0]); expectDir(33, [0, 1, 0]); expectDir(41, [0, -1, 0]); expectDir(42, [0, -1, 0])
+    // Only the pillars' tops, buried under the lintel, are inside.
+    expect(interior.map((b, i) => (b ? i : -1)).filter((i) => i >= 0)).toEqual([2, 3, 13, 14])
+  })
+
+  it('finds the square between two blocks stamped one on the other, and keeps the rest outward', () => {
+    const lower = compile('block', 1, 0, [0, 0, 0])
+    const upper = compile('block', 1, 0, [0, 120, 0])
+    const points: P3[] = [...lower.points, ...upper.points].map((p) => [p[0] / 120, p[1] / 120, 0 - p[2] / 120])
+    const faces: Array<[number, number, number]> = [...lower.faces, ...upper.faces.map((f) => [f[0] + lower.points.length, f[1] + lower.points.length, f[2] + lower.points.length] as [number, number, number])]
+    const { faces: out, interior } = orientShard(points, faces)
+    const buried = interior.filter(Boolean).length
+    expect(buried).toBe(4)
+    out.forEach((f, i) => {
+      if (interior[i]) return
+      const m = newell(f.map((v) => points[v]))
+      const c = f.reduce((a, v) => [a[0] + points[v][0] / 3, a[1] + points[v][1] / 3, a[2] + points[v][2] / 3], [0, 0, 0])
+      // Outward from the joined column's middle, at (0.5, 1, -0.5).
+      expect((c[0] - 0.5) * m[0] + (c[1] - 1) * m[1] + (c[2] + 0.5) * m[2]).toBeGreaterThan(0)
+    })
   })
 })

--- a/src/lib/orient.ts
+++ b/src/lib/orient.ts
@@ -7,70 +7,163 @@
  * The bench lights its faces and paints their backs dark, so that an open
  * shape shows its inside, and for that every face must wind outward.
  *
- * This pass rewinds a copy for drawing; the stored faces are untouched. Faces
- * that share an edge are made to agree (a shared edge runs opposite ways in
- * two consistently wound faces), component by component; a closed component
- * is then flipped outward by its signed volume, and a flat one is turned to
- * face up, or the nearest axis its normal leans along.
+ * This pass rewinds a copy for drawing; the stored faces are untouched.
+ *
+ * Two facts decide a face's way round. Faces that share a clean edge (one
+ * with exactly two faces on it) are made to agree, since a shared edge runs
+ * opposite ways in two consistently wound faces; that groups the faces into
+ * patches. Then each patch is turned as a whole by what its faces can see: a
+ * ray from a face's middle along its normal crosses the rest of the shard an
+ * even number of times when the normal points out of a closed solid and an
+ * odd number when it points in. The patch goes the way most of its area
+ * votes. A patch whose rays cross nothing (a flat plate, an open shell) falls
+ * back to its signed volume, or to facing up.
+ *
+ * Edges with three or more faces on them do not carry agreement across. They
+ * are where solids touch: a block built on a block leaves the square between
+ * them inside the join, with the lower block's top, the upper block's sides
+ * and the lower block's sides all meeting on its edges. Passing agreement
+ * through such an edge is what used to turn a whole side of a shape inward,
+ * depending on which face the walk happened to reach first. A face whose
+ * rays cross an odd number of faces both ways is inside the solid; it is
+ * reported so the bench can leave it undrawn, where it would only fight the
+ * face it sits against.
  */
 
 import { newell, type P3 } from './triangulate'
 
 type Face = [number, number, number]
 
-const key = (a: number, b: number): string => `${a}>${b}`
+export interface Oriented {
+  /** The faces, rewound. */
+  faces: Face[]
+  /** Which faces sit inside the solid, with faces on both sides of them. */
+  interior: boolean[]
+}
 
-export function orientFaces(points: P3[], faces: Face[]): Face[] {
+const key = (a: number, b: number): string => (a < b ? `${a}>${b}` : `${b}>${a}`)
+
+const EPS = 1e-9
+/**
+ * Whether a ray from `o` along `d` meets triangle abc ahead of its start
+ * (Moller and Trumbore). Rays run at a slight slant to the axes, so on the
+ * axis-aligned shapes the bench makes they cross faces, not edges.
+ */
+function hit(o: P3, d: P3, a: P3, b: P3, c: P3): boolean {
+  const e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]]
+  const e2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]]
+  const p = [d[1] * e2[2] - d[2] * e2[1], d[2] * e2[0] - d[0] * e2[2], d[0] * e2[1] - d[1] * e2[0]]
+  const det = e1[0] * p[0] + e1[1] * p[1] + e1[2] * p[2]
+  if (Math.abs(det) < EPS) return false
+  const inv = 1 / det
+  const t = [o[0] - a[0], o[1] - a[1], o[2] - a[2]]
+  const u = (t[0] * p[0] + t[1] * p[1] + t[2] * p[2]) * inv
+  if (u < 0 || u > 1) return false
+  const q = [t[1] * e1[2] - t[2] * e1[1], t[2] * e1[0] - t[0] * e1[2], t[0] * e1[1] - t[1] * e1[0]]
+  const v = (d[0] * q[0] + d[1] * q[1] + d[2] * q[2]) * inv
+  if (v < 0 || u + v > 1) return false
+  const dist = (e2[0] * q[0] + e2[1] * q[1] + e2[2] * q[2]) * inv
+  return dist > 1e-7
+}
+
+/** How many other faces a ray from face `i`'s middle crosses along `dir`. */
+function crossings(points: P3[], faces: Face[], i: number, origin: P3, dir: P3): number {
+  let n = 0
+  for (let j = 0; j < faces.length; j++) {
+    if (j === i) continue
+    const f = faces[j]
+    if (hit(origin, dir, points[f[0]], points[f[1]], points[f[2]])) n++
+  }
+  return n
+}
+
+/** A slant that no axis-aligned edge lies along, added to every ray. */
+const SLANT: P3 = [0.0173, 0.0311, 0.0237]
+
+export function orientShard(points: P3[], faces: Face[]): Oriented {
   const out: Face[] = faces.map((f) => [f[0], f[1], f[2]])
   const n = out.length
-  if (n === 0) return out
-  // Directed edges as wound now: edge a>b of face i.
+  const interior = new Array<boolean>(n).fill(false)
+  if (n === 0) return { faces: out, interior }
+
+  // Which faces lie on each edge, whichever way they run it.
   const byEdge = new Map<string, number[]>()
-  const add = (a: number, b: number, i: number): void => {
-    const k = a < b ? key(a, b) : key(b, a)
-    byEdge.set(k, [...(byEdge.get(k) ?? []), i])
-  }
-  out.forEach((f, i) => { add(f[0], f[1], i); add(f[1], f[2], i); add(f[2], f[0], i) })
-  const seen = new Array<boolean>(n).fill(false)
-  const component: number[] = []
+  out.forEach((f, i) => {
+    for (const [a, b] of [[f[0], f[1]], [f[1], f[2]], [f[2], f[0]]]) byEdge.set(key(a, b), [...(byEdge.get(key(a, b)) ?? []), i])
+  })
   const flip = (f: Face): void => { const t = f[1]; f[1] = f[2]; f[2] = t }
   const hasDirected = (f: Face, a: number, b: number): boolean =>
     (f[0] === a && f[1] === b) || (f[1] === a && f[2] === b) || (f[2] === a && f[0] === b)
+
+  // Each face's middle, normal and area, and what its rays cross each way.
+  const normal: P3[] = [], area: number[] = [], fwd: number[] = [], back: number[] = []
+  for (let i = 0; i < n; i++) {
+    const [a, b, c] = out[i].map((v) => points[v])
+    const m = newell([a, b, c])
+    const len = Math.hypot(m[0], m[1], m[2])
+    normal.push(len > 0 ? [m[0] / len, m[1] / len, m[2] / len] : [0, 1, 0])
+    area.push(len / 2)
+    const mid: P3 = [(a[0] + b[0] + c[0]) / 3, (a[1] + b[1] + c[1]) / 3, (a[2] + b[2] + c[2]) / 3]
+    const d: P3 = [normal[i][0] + SLANT[0], normal[i][1] + SLANT[1], normal[i][2] + SLANT[2]]
+    fwd.push(crossings(points, out, i, mid, d))
+    back.push(crossings(points, out, i, mid, [-d[0], -d[1], -d[2]]))
+    interior[i] = fwd[i] % 2 === 1 && back[i] % 2 === 1
+  }
+
+  const seen = new Array<boolean>(n).fill(false)
+  const patch: number[] = []
   for (let start = 0; start < n; start++) {
     if (seen[start]) continue
     const queue = [start]
     seen[start] = true
-    component.length = 0
+    patch.length = 0
     while (queue.length) {
       const i = queue.shift() as number
-      component.push(i)
+      patch.push(i)
       const f = out[i]
-      for (const [a, b] of [[f[0], f[1]], [f[1], f[2]], [f[2], f[0]]] as Array<[number, number]>) {
-        const k = a < b ? key(a, b) : key(b, a)
-        for (const j of byEdge.get(k) ?? []) {
+      for (const [a, b] of [[f[0], f[1]], [f[1], f[2]], [f[2], f[0]]]) {
+        const on = byEdge.get(key(a, b)) ?? []
+        if (on.length !== 2) continue
+        for (const j of on) {
           if (j === i || seen[j]) continue
-          // Consistent neighbours run the shared edge the other way: b>a.
           if (hasDirected(out[j], a, b)) flip(out[j])
           seen[j] = true
           queue.push(j)
         }
       }
     }
-    // The component as a whole: outward when closed, up when flat.
-    let volume = 0
-    let nx = 0, ny = 0, nz = 0
-    for (const i of component) {
-      const [a, b, c] = out[i].map((v) => points[v])
-      volume += (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0]) + a[2] * (b[0] * c[1] - b[1] * c[0])) / 6
-      const m = newell([a, b, c]); nx += m[0]; ny += m[1]; nz += m[2]
+    // The patch as a whole, by what its faces see. A face's normal was
+    // measured as it was wound at the start; a face the walk flipped now
+    // faces the other way, so its vote turns with it.
+    let vote = 0
+    for (const i of patch) {
+      if (interior[i]) continue
+      const turned = hasDirected(out[i], faces[i][0], faces[i][1]) ? 1 : -1
+      const outward = fwd[i] % 2 === 0 && back[i] % 2 === 1 ? 1 : fwd[i] % 2 === 1 && back[i] % 2 === 0 ? -1 : 0
+      vote += turned * outward * area[i]
     }
     let inward: boolean
-    if (Math.abs(volume) > 1e-9) inward = volume < 0
+    if (vote !== 0) inward = vote < 0
     else {
-      const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz)
-      inward = ay >= ax && ay >= az ? ny < 0 : ax >= az ? nx < 0 : nz < 0
+      // Nothing to see: closed by its own volume, or flat and facing up.
+      let volume = 0, nx = 0, ny = 0, nz = 0
+      for (const i of patch) {
+        const [a, b, c] = out[i].map((v) => points[v])
+        volume += (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0]) + a[2] * (b[0] * c[1] - b[1] * c[0])) / 6
+        const m = newell([a, b, c]); nx += m[0]; ny += m[1]; nz += m[2]
+      }
+      if (Math.abs(volume) > 1e-9) inward = volume < 0
+      else {
+        const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz)
+        inward = ay >= ax && ay >= az ? ny < 0 : ax >= az ? nx < 0 : nz < 0
+      }
     }
-    if (inward) for (const i of component) flip(out[i])
+    if (inward) for (const i of patch) flip(out[i])
   }
-  return out
+  return { faces: out, interior }
+}
+
+/** The faces rewound outward; see orientShard. */
+export function orientFaces(points: P3[], faces: Face[]): Face[] {
+  return orientShard(points, faces).faces
 }

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -28,7 +28,7 @@ import {
 } from 'three'
 import { easeOutCubic, hash01, scrambleOffset, seedOf, SHARD_DECODE_MS } from '../lib/decode'
 import { flatten, ticksOf, toRender, type ShardModel } from '../lib/shards'
-import { orientFaces } from '../lib/orient'
+import { orientShard } from '../lib/orient'
 
 interface Props {
   shard: ShardModel
@@ -70,7 +70,11 @@ const TAG_BLEND = { blending: CustomBlending, blendEquation: AddEquation, blendS
 export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick, world = false, lit = false }: Props): JSX.Element | null {
   const { positions, colors, index } = useMemo(() => {
     const f = flatten(shard)
-    return lit ? { ...f, index: orientFaces(shard.vertices.map((v) => toRender(ticksOf(v))), shard.faces).flat() } : f
+    if (!lit) return f
+    // Wound outward, and without the faces buried inside a join, which would
+    // only fight the face they sit against (orient.ts).
+    const o = orientShard(shard.vertices.map((v) => toRender(ticksOf(v))), shard.faces)
+    return { ...f, index: o.faces.filter((_, i) => !o.interior[i]).flat() }
   }, [shard.vertices, shard.faces, lit])
 
   // Live copies: the decode writes into these, the targets stay untouched.


### PR DESCRIPTION
Fixes the inverted faces on the right pillar of arkinox's arch, and the class of shape that produced them.

**Cause.** Face orientation is decided at draw time, which is why deleting and re-adding the faces changed nothing. The pass made neighbouring faces agree by walking across every shared edge. The arch's pillars kept their top squares under the hand-built lintel, so each edge of those squares carried three faces: the pillar's side, the lintel's side, and the buried top. Three faces on one edge cannot all agree, so what the walk did there depended on which face it reached first, and on the right pillar it reached the wrong one and turned the +X side, the −Z side and the bottom inward.

**Fix.** Agreement passes only across clean edges (exactly two faces), which groups faces into patches. Each patch is then turned as a whole by what its faces can see: a ray from a face's middle along its normal crosses the rest of the shard an even number of times when the normal points out of a closed solid and an odd number when it points in; the patch goes the way most of its area votes. Rays run at a slight slant so on axis-aligned shapes they cross faces rather than edges. A patch whose rays cross nothing (a flat plate, an open shell) falls back to its signed volume or to facing up, as before.

**Buried faces.** A face whose rays cross an odd number both ways is inside the solid. The bench leaves those undrawn: they were only fighting the face they sat against. The world's unlit, two-sided drawing is untouched.

Tests: the arch (every outer face outward, exactly the four buried top triangles found), two blocks stamped one on the other (the four join triangles found, the rest outward), and the existing cases. A row of forty touching blocks finds all 156 join faces in 21 ms; at the 1024-face limit the pass takes about 60 ms, once per edit. Screenshots of the arch from three sides attached in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz