### PR TITLE
Sidestep version 2: seeded trees and sampled openings, from this machine and from HOSAKA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2090,7 +2090,7 @@
     },
     "node_modules/cyberspace-core": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#7535cb9f60fb02c2bd198af338e02c1952e64339",
+      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#16584ec35faf25eb746d106cc5ece8afe2f0e270",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.6.0"

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -237,7 +237,7 @@ describe('cloudProofResponse', () => {
     const p = computeSidestepProof(0n, 0n, 0n, 4096n, 0n, 0n, 0, 'ab'.repeat(32))
     const result = {
       proof_hash: p.proofHash, merkle_x: bytesToHex(p.merkleX), merkle_y: bytesToHex(p.merkleY), merkle_z: bytesToHex(p.merkleZ),
-      inclusion_proofs: { x: p.inclusionProofs.x.map(bytesToHex), y: [], z: [] }, lca_heights: p.lcaHeights,
+      openings: { x: p.openings.x.map((q) => q.map(bytesToHex)), y: [], z: [] }, lca_heights: p.lcaHeights,
       previous_event_id: 'ab'.repeat(32), terrain_k: p.terrainK, region_m_hex: p.regionM.toString(16), compute_msats: 300,
     }
     const record: PendingCloudJob = { ...base, action: 'sidestep', to: wirePosition({ x: 4096n, y: 0n, z: 0n }), stage: 'computing', deposit: null }
@@ -249,7 +249,7 @@ describe('cloudProofResponse', () => {
     expect(msg.lca).toEqual({ x: 13, y: 0, z: 0 })
     expect(msg.sidestep).toEqual({
       merkleRoots: [bytesToHex(p.merkleX), bytesToHex(p.merkleY), bytesToHex(p.merkleZ)],
-      inclusionProofs: [p.inclusionProofs.x.map(bytesToHex).join(''), '', ''],
+      openings: [p.openings.x.map((q) => q.map(bytesToHex).join('')).join(''), '', ''],
       lcaHeights: [13, 0, 0],
     })
     expect(msg.source).toBe('cloud')

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -475,8 +475,8 @@ export function cloudProofResponse(id: number, record: PendingCloudJob, job: Hos
     totalOps: 0,
     sidestep: {
       merkleRoots: [r.merkle_x, r.merkle_y, r.merkle_z],
-      // 8.5: siblings concatenated leaf-first per axis, empty where the axis did not move.
-      inclusionProofs: [r.inclusion_proofs.x.join(''), r.inclusion_proofs.y.join(''), r.inclusion_proofs.z.join('')],
+      // 8.5: every opening's siblings leaf first per axis, empty where the axis did not move.
+      openings: [r.openings.x.map((p) => p.join('')).join(''), r.openings.y.map((p) => p.join('')).join(''), r.openings.z.map((p) => p.join('')).join('')],
       lcaHeights: r.lca_heights,
     },
     source: 'cloud',

--- a/src/lib/cloudVerify.test.ts
+++ b/src/lib/cloudVerify.test.ts
@@ -14,7 +14,6 @@ import { describe, expect, it } from 'vitest'
 import {
   bytesToHex,
   cantorPair,
-  computeAxisMerkleRoot,
   computeHopProof,
   computeSidestepProof,
   deriveRegionKeys,
@@ -129,13 +128,13 @@ describe('verifyCloudHop', () => {
 
 function sidestepResult(move: CloudMove): CloudSidestepResult {
   const p = computeSidestepProof(move.from.x, move.from.y, move.from.z, move.to.x, move.to.y, move.to.z, move.plane, move.prevEventId)
-  const hex = (b: Uint8Array[]): string[] => b.map(bytesToHex)
+  const hex = (paths: Uint8Array[][]): string[][] => paths.map((q) => q.map(bytesToHex))
   return {
     proof_hash: p.proofHash,
     merkle_x: bytesToHex(p.merkleX),
     merkle_y: bytesToHex(p.merkleY),
     merkle_z: bytesToHex(p.merkleZ),
-    inclusion_proofs: { x: hex(p.inclusionProofs.x), y: hex(p.inclusionProofs.y), z: hex(p.inclusionProofs.z) },
+    openings: { x: hex(p.openings.x), y: hex(p.openings.y), z: hex(p.openings.z) },
     lca_heights: p.lcaHeights,
     previous_event_id: move.prevEventId,
     terrain_k: p.terrainK,
@@ -159,29 +158,33 @@ describe('verifyCloudSidestep', () => {
   it('lands where the spec says and passes an honest result', () => {
     expect(SIDESTEP.to).toEqual({ x: 4096n, y: 256n, z: 0n })
     expect(good.lca_heights).toEqual([13, 9, 0])
-    expect(good.inclusion_proofs.x).toHaveLength(13)
-    expect(good.inclusion_proofs.z).toHaveLength(0)
+    // Nine openings of thirteen siblings on x (6.10), none on the still axis.
+    expect(good.openings.x).toHaveLength(9)
+    expect(good.openings.x[0]).toHaveLength(13)
+    expect(good.openings.z).toHaveLength(0)
     expect(verifyCloudSidestep(good, SIDESTEP)).toEqual([])
   })
 
   it('rejects one flipped sibling on one axis, and nothing else', () => {
-    const path = [...good.inclusion_proofs.x]
-    path[4] = path[4].startsWith('0') ? '1' + path[4].slice(1) : '0' + path[4].slice(1)
-    expect(verifyCloudSidestep({ ...good, inclusion_proofs: { ...good.inclusion_proofs, x: path } }, SIDESTEP)).toEqual(['inclusion:x'])
+    const paths = good.openings.x.map((q) => [...q])
+    paths[3][4] = paths[3][4].startsWith('0') ? '1' + paths[3][4].slice(1) : '0' + paths[3][4].slice(1)
+    expect(verifyCloudSidestep({ ...good, openings: { ...good.openings, x: paths } }, SIDESTEP)).toEqual(['openings:x'])
   })
 
-  it('rejects the leaf-0 path HOSAKA used to return instead of the destination path', () => {
-    // From 4096 toward 0 the destination IS leaf 0 of the same subtree, so its
-    // path is the old server's output for a 0 -> 4096 crossing.
-    const leafZero = computeAxisMerkleRoot(4096n, 0n)
-    expect(bytesToHex(leafZero.root)).toBe(good.merkle_x)
-    const failed = verifyCloudSidestep({ ...good, inclusion_proofs: { ...good.inclusion_proofs, x: leafZero.siblings.map(bytesToHex) } }, SIDESTEP)
-    expect(failed).toEqual(['inclusion:x'])
+  it('rejects a v1 result, one path per axis, and a tree built under another seed', () => {
+    // A v1 server returned the destination path alone; 6.15 says reject it.
+    expect(verifyCloudSidestep({ ...good, openings: { ...good.openings, x: [good.openings.x[0]] } }, SIDESTEP)).toEqual(['openings:x'])
+    // A tree seeded by someone else's chain position: its roots and openings
+    // are consistent with each other, and wrong for us on every moving axis.
+    const theirs = sidestepResult({ ...SIDESTEP, prevEventId: 'cd'.repeat(32) })
+    const failed = verifyCloudSidestep({ ...theirs, previous_event_id: PREV }, SIDESTEP)
+    expect(failed).toContain('openings:x')
+    expect(failed).toContain('openings:y')
   })
 
   it('rejects a changed root through the path, the region and the proof hash', () => {
     const failed = verifyCloudSidestep({ ...good, merkle_y: 'ee'.repeat(32) }, SIDESTEP)
-    expect(failed).toContain('inclusion:y')
+    expect(failed).toContain('openings:y')
     expect(failed).toContain('region_m')
     expect(failed).toContain('proof_hash')
   })
@@ -205,7 +208,7 @@ describe('verifyCloudSidestep', () => {
 
   it('rejects malformed roots and paths without throwing', () => {
     expect(verifyCloudSidestep({ ...good, merkle_x: 'zz' }, SIDESTEP)).toContain('merkle_x')
-    expect(verifyCloudSidestep({ ...good, inclusion_proofs: { ...good.inclusion_proofs, y: ['nope'] } }, SIDESTEP)).toEqual(['inclusion:y'])
+    expect(verifyCloudSidestep({ ...good, openings: { ...good.openings, y: [['nope']] } }, SIDESTEP)).toEqual(['openings:y'])
     expect(verifyCloudSidestep(undefined as unknown as CloudSidestepResult, SIDESTEP)).toEqual(['result'])
   })
 })

--- a/src/lib/cloudVerify.ts
+++ b/src/lib/cloudVerify.ts
@@ -24,6 +24,7 @@
 
 import {
   AXIS_BITS,
+  AXIS_BYTE,
   TEMPORAL_MAX_COMPUTE_HEIGHT,
   alignedBase,
   cantorPair,
@@ -32,12 +33,13 @@ import {
   findLcaHeight,
   hexToBytes,
   intToBytesBE,
+  seedPrefix,
   sha256,
   sha256Hex,
   sidestepLanding,
   terrainK,
-  verifyMerkleInclusion,
   type Plane,
+  verifyAxisOpenings,
 } from 'cyberspace-core'
 import type { CloudHopResult, CloudSidestepResult, HopEnvelope, HosakaAction } from './hosaka'
 import type { Position } from './space'
@@ -154,15 +156,17 @@ export function verifyCloudSidestep(result: CloudSidestepResult, move: CloudMove
     // 6.3: a crossing lands exactly 1 gibson past the boundary.
     if (h > 0 && sidestepLanding(from[axis], to[axis]) !== to[axis]) failed.push(`geometry:${axis}`)
 
-    const path = result.inclusion_proofs?.[axis]
-    if (!Array.isArray(path) || !path.every((s) => typeof s === 'string' && HEX64.test(s))) {
-      failed.push(`inclusion:${axis}`)
+    // 6.10 and 6.11: the destination's path and the eight sampled paths,
+    // each sampled leaf recomputed from our own seed (the previous event id
+    // and the axis) and carried to the root. The base is recomputed from our
+    // own coordinate, never read from the result.
+    const paths = result.openings?.[axis]
+    if (!Array.isArray(paths) || !paths.every((p) => Array.isArray(p) && p.every((s) => typeof s === 'string' && HEX64.test(s)))) {
+      failed.push(`openings:${axis}`)
       return
     }
-    // The base is recomputed from our own coordinate (6.4), never read from
-    // the result, where it is a JSON number too wide for a double.
-    const ok = verifyMerkleInclusion(to[axis], path.map(hexToBytes), hexToBytes(rootHex), h, alignedBase(from[axis], h))
-    if (!ok) failed.push(`inclusion:${axis}`)
+    const prefix = seedPrefix(hexToBytes(prevEventId), AXIS_BYTE[axis])
+    if (!verifyAxisOpenings(prefix, AXIS_BYTE[axis], from[axis], to[axis], hexToBytes(rootHex), paths.map((p) => p.map(hexToBytes)))) failed.push(`openings:${axis}`)
   })
 
   const K = terrainK(to.x, to.y, to.z, plane)

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -142,7 +142,7 @@ describe('sidestep (§8.5)', () => {
     createdAt: 1, genesisId: ZERO, previousId: ZERO, prevCoordHex: ZERO,
     to: { x: 8n, y: 0n, z: 0n }, plane: 0, proofHash: ZERO,
     merkleRoots: ['11'.repeat(32), '22'.repeat(32), '33'.repeat(32)],
-    inclusionProofs: ['aa'.repeat(32) + 'bb'.repeat(32), '', ''],
+    openings: ['aa'.repeat(32) + 'bb'.repeat(32), '', ''],
     lcaHeights: [2, 0, 0],
   })
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -137,9 +137,10 @@ export function hopTemplate(i: HopInput): EventTemplate {
 export interface SidestepInput extends HopInput {
   /** Per-axis Merkle roots, 64 hex chars each. */
   merkleRoots: [string, string, string]
-  /** Per-axis inclusion proofs, sibling hashes concatenated leaf-first; an
-   * axis that did not move contributes an empty string. */
-  inclusionProofs: [string, string, string]
+  /** Per-axis openings (spec 6.10, 8.5): the destination path then the eight
+   * sampled paths, every sibling leaf first, one hex string per axis; an axis
+   * that did not move contributes an empty string. */
+  openings: [string, string, string]
   lcaHeights: [number, number, number]
 }
 
@@ -153,7 +154,7 @@ export function sidestepTemplate(i: SidestepInput): EventTemplate {
       ['A', 'sidestep'],
       ...hop.tags.slice(1, 6),
       ['mr', i.merkleRoots.join(':')],
-      ['mp', i.inclusionProofs.join(':')],
+      ['mp', i.openings.join(':')],
       ['hx', String(hx)],
       ['hy', String(hy)],
       ['hz', String(hz)],

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -152,7 +152,8 @@ export interface CloudSidestepResult {
   merkle_y: string
   merkle_z: string
   /** Per axis, the destination leaf's sibling hashes leaf-first; empty where the axis did not move. */
-  inclusion_proofs: { x: string[]; y: string[]; z: string[] }
+  /** Per-axis openings (spec 6.10): the destination leaf's path, then eight sampled paths, each a list of sibling hashes leaf first; empty for a still axis. */
+  openings: { x: string[][]; y: string[][]; z: string[][] }
   lca_heights: [number, number, number]
   /** JSON numbers above 2^53: never read, only recomputed. */
   bases?: unknown

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -75,10 +75,10 @@ function hopResult(from: Position, to: Position, plane: 0 | 1, prev: string): Re
 
 function sidestepResult(from: Position, to: Position, plane: 0 | 1, prev: string): Record<string, unknown> {
   const p = computeSidestepProof(from.x, from.y, from.z, to.x, to.y, to.z, plane, prev)
-  const hex = (b: Uint8Array[]): string[] => b.map(bytesToHex)
+  const hex = (paths: Uint8Array[][]): string[][] => paths.map((q) => q.map(bytesToHex))
   return {
     proof_hash: p.proofHash, merkle_x: bytesToHex(p.merkleX), merkle_y: bytesToHex(p.merkleY), merkle_z: bytesToHex(p.merkleZ),
-    inclusion_proofs: { x: hex(p.inclusionProofs.x), y: hex(p.inclusionProofs.y), z: hex(p.inclusionProofs.z) },
+    openings: { x: hex(p.openings.x), y: hex(p.openings.y), z: hex(p.openings.z) },
     lca_heights: p.lcaHeights, previous_event_id: prev, terrain_k: p.terrainK, region_m_hex: p.regionM.toString(16), compute_msats: 300,
   }
 }
@@ -418,7 +418,7 @@ describe('cloud routes', () => {
     expect(ev.tags.find((t) => t[0] === 'A')?.[1]).toBe('sidestep')
     expect(ev.tags.find((t) => t[0] === 'proof')?.[1]).toBe(p.proofHash)
     expect(ev.tags.find((t) => t[0] === 'mr')?.[1]).toBe([p.merkleX, p.merkleY, p.merkleZ].map(bytesToHex).join(':'))
-    expect(ev.tags.find((t) => t[0] === 'mp')?.[1]).toBe([p.inclusionProofs.x.map(bytesToHex).join(''), '', ''].join(':'))
+    expect(ev.tags.find((t) => t[0] === 'mp')?.[1]).toBe([p.openings.x.map((q) => q.map(bytesToHex).join('')).join(''), '', ''].join(':'))
     expect(ev.tags.find((t) => t[0] === 'hx')?.[1]).toBe('13')
     await vi.waitFor(() => { expect(S().plan).toBeNull() })
 

--- a/src/store/movePlan.test.ts
+++ b/src/store/movePlan.test.ts
@@ -33,7 +33,7 @@ import { useCyberspace } from './useCyberspace'
 
 function done(req: (typeof posted)[number]) {
   const sidestep = req.mode === 'sidestep'
-    ? { merkleRoots: ['aa'.repeat(32), 'bb'.repeat(32), 'cc'.repeat(32)] as [string, string, string], inclusionProofs: ['', '', ''] as [string, string, string], lcaHeights: [1, 0, 0] as [number, number, number] }
+    ? { merkleRoots: ['aa'.repeat(32), 'bb'.repeat(32), 'cc'.repeat(32)] as [string, string, string], openings: ['', '', ''] as [string, string, string], lcaHeights: [1, 0, 0] as [number, number, number] }
     : undefined
   return { type: 'done' as const, id: req.id, mode: req.mode as 'hop' | 'sidestep', elapsedMs: 5, proofHash: 'dd'.repeat(32), terrainK: 3, lca: { x: 1, y: 0, z: 0 }, totalOps: 4, sidestep }
 }

--- a/src/workers/calibrate.worker.ts
+++ b/src/workers/calibrate.worker.ts
@@ -17,7 +17,7 @@
  * measurement that would have wedged this thread, not after.
  */
 
-import { AXIS_CENTER, computeAxisMerkleRoot, computeSubtreeCantor } from 'cyberspace-core'
+import { AXIS_CENTER, computeAxisMerkleRoot, computeSubtreeCantor, seedPrefix } from 'cyberspace-core'
 
 export interface CalibrateRequest {
   id: number
@@ -97,7 +97,8 @@ self.onmessage = async (event: MessageEvent<CalibrateRequest>) => {
     // 2^17 - 1 internal nodes.
     const SIDESTEP_HASHES = 2 ** 18 - 1
     const t0 = performance.now()
-    computeAxisMerkleRoot(AXIS_CENTER, AXIS_CENTER + (1n << 16n))
+    // Any seed will do for the rate; the openings add nine two-leaf rebuilds at this height.
+    computeAxisMerkleRoot(seedPrefix(new Uint8Array(32), 0), 0, AXIS_CENTER, AXIS_CENTER + (1n << 16n))
     const sidestepMs = Math.max(performance.now() - t0, 0.5)
     const sha256PerSec = SIDESTEP_HASHES / (sidestepMs / 1000)
 

--- a/src/workers/proof.worker.ts
+++ b/src/workers/proof.worker.ts
@@ -10,6 +10,7 @@
 import {
   computeHopProof,
   computeSidestepProof,
+  encodeOpenings,
   estimateHopCost,
   estimateSidestepCost,
   type Plane,
@@ -36,7 +37,8 @@ export interface ProofRequest {
  */
 export interface SidestepTags {
   merkleRoots: [string, string, string]
-  inclusionProofs: [string, string, string]
+  /** Per-axis mp segments (spec 8.5): every opening's siblings, leaf first, as hex. */
+  openings: [string, string, string]
   lcaHeights: [number, number, number]
 }
 
@@ -97,9 +99,6 @@ self.onmessage = (event: MessageEvent<ProofRequest>) => {
         prevEventId,
         onProgress,
       )
-      // §8.5: siblings concatenated leaf-first per axis, empty where the axis
-      // did not move.
-      const path = (siblings: Uint8Array[]): string => siblings.map(bytesToHex).join('')
       const response: ProofResponse = {
         type: 'done',
         id,
@@ -111,11 +110,8 @@ self.onmessage = (event: MessageEvent<ProofRequest>) => {
         totalOps: estimate.totalHashes,
         sidestep: {
           merkleRoots: [bytesToHex(proof.merkleX), bytesToHex(proof.merkleY), bytesToHex(proof.merkleZ)],
-          inclusionProofs: [
-            path(proof.inclusionProofs.x),
-            path(proof.inclusionProofs.y),
-            path(proof.inclusionProofs.z),
-          ],
+          // §8.5: every opening's siblings leaf first per axis, empty where the axis did not move.
+          openings: [encodeOpenings(proof.openings.x), encodeOpenings(proof.openings.y), encodeOpenings(proof.openings.z)],
           lcaHeights: proof.lcaHeights,
         },
       }


### PR DESCRIPTION
Takes `cyberspace-core` at the version 2 sidestep (arkin0x/cyberspace-cli-js#3, master 16584ec) and follows it through.

- **The proof worker** builds seeded trees and encodes the nine openings per moving axis into the `mp` segments (spec 8.5).
- **HOSAKA results** carry `openings` (per axis, nine lists of sibling hashes); `cloudProofResponse` joins them into the segments.
- **The verifier** between a cloud result and a signature checks each moving axis's openings against our own seed (spec 6.11): a tree built under someone else's chain position, or a v1 result with a single path, is refused before it is signed. The geometry, terrain, region and proof-hash checks are as before.
- **Calibration** seeds its timing tree with zeros; the rate it measures is the same.

tsc and the suite (525) are green. `cloudVerify.test.ts` now covers a flipped sibling inside a sampled opening, a v1-shaped result, and a result built under another seed.

**Do not merge before HOSAKA is deployed on the same construction** (hosaka-core#3, then hosaka-modal and hosaka-api): a v2 client refuses every v1 cloud result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz