### PR TITLE
Bitcoin in a message, the free view, and the provider's own mark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "https://creativecommons.org/licenses/by-sa/4.0/legalcode",
       "dependencies": {
         "@fontsource/monaspace-krypton": "^5.3.0",
+        "@noble/curves": "2.0.1",
         "@react-three/fiber": "^8.17.10",
         "cyberspace-core": "git+https://github.com/arkin0x/cyberspace-cli-js.git#master",
         "decimal.js": "^10.6.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@fontsource/monaspace-krypton": "^5.3.0",
+    "@noble/curves": "2.0.1",
     "@react-three/fiber": "^8.17.10",
     "cyberspace-core": "git+https://github.com/arkin0x/cyberspace-cli-js.git#master",
     "decimal.js": "^10.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,8 @@ export default function App(): JSX.Element {
   // VIEW from the position panel or a target: on a phone the panels cover the
   // scene, so the view they asked for closes them; RETURN is on the bar.
   const driving = useCyberspace((s) => s.focus?.drive === true)
-  useEffect(() => { if (driving && isMobile) setPanelsOpen(false) }, [driving, isMobile])
+  const stationView = useHyperspace((s) => s.viewOwned)
+  useEffect(() => { if ((driving || stationView) && isMobile) setPanelsOpen(false) }, [driving, stationView, isMobile])
 
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,10 @@ export default function App(): JSX.Element {
   // instruments and compass stay out of the way until it is placed or dropped.
   const deploying = useShards((s) => s.pending !== null)
   useEffect(() => { if (deploying) setPanelsOpen(false) }, [deploying])
+  // VIEW from the position panel or a target: on a phone the panels cover the
+  // scene, so the view they asked for closes them; RETURN is on the bar.
+  const driving = useCyberspace((s) => s.focus?.drive === true)
+  useEffect(() => { if (driving && isMobile) setPanelsOpen(false) }, [driving, isMobile])
 
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.

--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -48,6 +48,7 @@ const BALANCE_STALE_MS = 10 * 60 * 1000
 export function CloudPanel(): JSX.Element {
   const prefs = useCyberspace((s) => s.cloudPrefs)
   const cloud = useCyberspace((s) => s.cloud)
+  const provider = cloud.provider
   const [editingUrl, setEditingUrl] = useState(false)
   const [urlDraft, setUrlDraft] = useState(prefs.apiUrl)
   const store = useCyberspace.getState
@@ -88,7 +89,7 @@ export function CloudPanel(): JSX.Element {
       {/* The provider's mark, first thing under the title: this is the panel
           whose work happens on someone else's machine. HOSAKA's for now; the
           plan is for the connected provider to serve its own (hosaka-api #6). */}
-      <img className="cloud__mark" src="/hosaka-mark.png" alt="HOSAKA" width={308} height={334} decoding="async" />
+      <img className="cloud__mark" src={provider?.logo ?? '/hosaka-mark.png'} alt={provider?.name ?? 'HOSAKA'} width={308} height={334} decoding="async" />
 
       <div className="cloud__modes" role="radiogroup" aria-label="Cloud mode">
         {MODES.map(([mode, label]) => (

--- a/src/hud/FocusBar.tsx
+++ b/src/hud/FocusBar.tsx
@@ -18,7 +18,8 @@ import { useShards } from '../store/useShards'
 
 export function FocusBar(): JSX.Element | null {
   const focus = useCyberspace((s) => s.focus)
-  const anchor = useCyberspace((s) => s.anchor)
+  // The cursor, not the anchor: the anchor catches up after the presses settle.
+  const anchor = useCyberspace((s) => (s.focus?.drive ? s.cursor : s.anchor))
   const anchorPlane = useCyberspace((s) => s.anchorPlane)
   // A free view reads where it is now, and in which plane, since the pad moves it.
   const focusLabel = focus === null ? null : focus.drive

--- a/src/hud/FocusBar.tsx
+++ b/src/hud/FocusBar.tsx
@@ -11,12 +11,19 @@
  * RETURN puts the anchor back on your avatar at the zoom you left.
  */
 
+import { shortAxis } from '../lib/viewAt'
 import { useCyberspace } from '../store/useCyberspace'
 import { useHyperspace } from '../store/useHyperspace'
 import { useShards } from '../store/useShards'
 
 export function FocusBar(): JSX.Element | null {
-  const focusLabel = useCyberspace((s) => s.focus?.label ?? null)
+  const focus = useCyberspace((s) => s.focus)
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  // A free view reads where it is now, and in which plane, since the pad moves it.
+  const focusLabel = focus === null ? null : focus.drive
+    ? `${[anchor.x, anchor.y, anchor.z].map(shortAxis).join(', ')} · ${anchorPlane === 0 ? 'DATASPACE' : 'IDEASPACE'}`
+    : focus.label
   const spectating = useCyberspace((s) => s.spectate !== null)
   const viewOwned = useHyperspace((s) => s.viewOwned)
   const inspecting = useShards((s) => s.inspecting !== null)

--- a/src/hud/HosakaPulse.tsx
+++ b/src/hud/HosakaPulse.tsx
@@ -11,11 +11,12 @@ import { useCyberspace } from '../store/useCyberspace'
 
 export function HosakaPulse(): JSX.Element | null {
   const status = useCyberspace((s) => s.cloud.status)
+  const provider = useCyberspace((s) => s.cloud.provider)
   if (!jobInProgress(status)) return null
   return (
     <img
       className="hosaka-pulse"
-      src="/hosaka-mark.png"
+      src={provider?.logo ?? '/hosaka-mark.png'}
       alt="HOSAKA job in progress"
       role="status"
       width={308}

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -6,6 +6,7 @@
 import { useState } from 'react'
 import { formatBig, formatStep } from '../lib/space'
 import { formatCellSizeLong } from '../lib/scale'
+import { parseViewAt } from '../lib/viewAt'
 import { useCyberspace } from '../store/useCyberspace'
 import { shortHex } from '../lib/time'
 import { ProfilePic } from './ProfileBadge'
@@ -110,6 +111,8 @@ function PositionPanel(): JSX.Element {
   const coordHex = useCyberspace((s) => s.coordHex())
   const sector = useCyberspace((s) => s.sector())
   const [copied, copy] = useCopied()
+  const [viewText, setViewText] = useState('')
+  const [viewBad, setViewBad] = useState(false)
 
   // Every figure copies on a tap, raw: the grouping commas are for reading,
   // not for pasting into a filter or a script.
@@ -140,6 +143,32 @@ function PositionPanel(): JSX.Element {
         <span className={`hash__label ${copied === 'coord' ? 'is-copied' : ''}`}>{copied === 'coord' ? 'copied' : 'coord'}</span>
         <code>{coordHex}</code>
       </button>
+
+      {/* The free view: look at any place without walking there. Three axis
+          values, or a coordinate as the tags carry it; RETURN on the bar brings
+          the view home. */}
+      <form
+        className="avatars__add"
+        onSubmit={(e) => {
+          e.preventDefault()
+          const target = parseViewAt(viewText, plane)
+          if (!target) { setViewBad(true); return }
+          setViewBad(false)
+          useCyberspace.getState().focusOn(target.position, target.plane, target.label)
+        }}
+      >
+        <input
+          className={`avatars__input ${viewBad ? 'is-bad' : ''}`}
+          value={viewText}
+          onChange={(e) => { setViewText(e.target.value); setViewBad(false) }}
+          placeholder="x, y, z or a coordinate"
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="A place to view"
+          aria-invalid={viewBad}
+        />
+        <button className="avatars__go" type="submit" disabled={!viewText.trim()} title="Look at this place without moving">VIEW</button>
+      </form>
     </section>
   )
 }

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -109,7 +109,7 @@ const RECENT_KEY = 'onosendai:view-recent'
 function loadRecent(): RecentView[] {
   try {
     const v = JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]') as unknown
-    return Array.isArray(v) ? v.filter((r): r is RecentView => typeof r?.input === 'string' && typeof r?.label === 'string').slice(0, 3) : []
+    return Array.isArray(v) ? v.filter((r): r is RecentView => typeof r?.input === 'string' && typeof r?.label === 'string' && (r?.plane === 0 || r?.plane === 1)).slice(0, 3) : []
   } catch { return [] }
 }
 function saveRecent(list: RecentView[]): void {
@@ -119,6 +119,8 @@ function saveRecent(list: RecentView[]): void {
 function PositionPanel(): JSX.Element {
   const position = useCyberspace((s) => s.position)
   const plane = useCyberspace((s) => s.plane)
+  // Decimals go to the plane on show: yours at your head, the view's in a view.
+  const lookedPlane = useCyberspace((s) => (s.atHead() ? s.plane : s.anchorPlane))
   const coordHex = useCyberspace((s) => s.coordHex())
   const sector = useCyberspace((s) => s.sector())
   const [copied, copy] = useCopied()
@@ -128,7 +130,7 @@ function PositionPanel(): JSX.Element {
   const [recentOpen, setRecentOpen] = useState(false)
   const look = (typed: string, target: ViewTarget): void => {
     useCyberspace.getState().focusOn(target.position, target.plane, target.label, undefined, true)
-    const next = rememberView(recent, { input: canonicalViewAt(typed), label: target.label })
+    const next = rememberView(recent, { input: canonicalViewAt(typed), label: target.label, plane: target.plane })
     setRecent(next)
     saveRecent(next)
   }
@@ -173,7 +175,7 @@ function PositionPanel(): JSX.Element {
           className="avatars__find"
           onSubmit={(e) => {
             e.preventDefault()
-            const target = parseViewAt(viewText, plane)
+            const target = parseViewAt(viewText, lookedPlane)
             if (!target) { setViewBad(true); return }
             setViewBad(false)
             look(viewText, target)
@@ -198,7 +200,7 @@ function PositionPanel(): JSX.Element {
               <ul className="viewat__list">
                 {recent.map((r) => (
                   <li key={r.input}>
-                    <button className="viewat__item" onClick={() => { const target = parseViewAt(r.input, plane); if (target) { setViewText(r.input); look(r.input, target) } }} title={r.input}>{r.label}</button>
+                    <button className="viewat__item" onClick={() => { const target = parseViewAt(r.input, r.plane); if (target) { setViewText(r.input); look(r.input, target) } }} title={r.input}><span className={`plane plane--${r.plane} viewat__plane`}>{r.plane === 0 ? 'D' : 'I'}</span>{r.label}</button>
                   </li>
                 ))}
               </ul>

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -6,7 +6,7 @@
 import { useState } from 'react'
 import { formatBig, formatStep } from '../lib/space'
 import { formatCellSizeLong } from '../lib/scale'
-import { parseViewAt } from '../lib/viewAt'
+import { canonicalViewAt, parseViewAt, rememberView, type RecentView, type ViewTarget } from '../lib/viewAt'
 import { useCyberspace } from '../store/useCyberspace'
 import { shortHex } from '../lib/time'
 import { ProfilePic } from './ProfileBadge'
@@ -105,6 +105,17 @@ function IdentityPanel(): JSX.Element {
   )
 }
 
+const RECENT_KEY = 'onosendai:view-recent'
+function loadRecent(): RecentView[] {
+  try {
+    const v = JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]') as unknown
+    return Array.isArray(v) ? v.filter((r): r is RecentView => typeof r?.input === 'string' && typeof r?.label === 'string').slice(0, 3) : []
+  } catch { return [] }
+}
+function saveRecent(list: RecentView[]): void {
+  try { localStorage.setItem(RECENT_KEY, JSON.stringify(list)) } catch { /* private mode */ }
+}
+
 function PositionPanel(): JSX.Element {
   const position = useCyberspace((s) => s.position)
   const plane = useCyberspace((s) => s.plane)
@@ -113,6 +124,14 @@ function PositionPanel(): JSX.Element {
   const [copied, copy] = useCopied()
   const [viewText, setViewText] = useState('')
   const [viewBad, setViewBad] = useState(false)
+  const [recent, setRecent] = useState<RecentView[]>(() => loadRecent())
+  const [recentOpen, setRecentOpen] = useState(false)
+  const look = (typed: string, target: ViewTarget): void => {
+    useCyberspace.getState().focusOn(target.position, target.plane, target.label, undefined, true)
+    const next = rememberView(recent, { input: canonicalViewAt(typed), label: target.label })
+    setRecent(next)
+    saveRecent(next)
+  }
 
   // Every figure copies on a tap, raw: the grouping commas are for reading,
   // not for pasting into a filter or a script.
@@ -145,30 +164,48 @@ function PositionPanel(): JSX.Element {
       </button>
 
       {/* The free view: look at any place without walking there. Three axis
-          values, or a coordinate as the tags carry it; RETURN on the bar brings
-          the view home. */}
-      <form
-        className="avatars__add"
-        onSubmit={(e) => {
-          e.preventDefault()
-          const target = parseViewAt(viewText, plane)
-          if (!target) { setViewBad(true); return }
-          setViewBad(false)
-          useCyberspace.getState().focusOn(target.position, target.plane, target.label)
-        }}
-      >
-        <input
-          className={`avatars__input ${viewBad ? 'is-bad' : ''}`}
-          value={viewText}
-          onChange={(e) => { setViewText(e.target.value); setViewBad(false) }}
-          placeholder="x, y, z or a coordinate"
-          spellCheck={false}
-          autoComplete="off"
-          aria-label="A place to view"
-          aria-invalid={viewBad}
-        />
-        <button className="avatars__go" type="submit" disabled={!viewText.trim()} title="Look at this place without moving">VIEW</button>
-      </form>
+          values, or a coordinate as the tags carry it; the cursor comes along,
+          so the pad drives from there and RETURN on the bar brings the view
+          home. The last three places typed wait under RECENT. */}
+      <div className="viewat">
+        <span className="legend__label">View a coordinate</span>
+        <form
+          className="avatars__find"
+          onSubmit={(e) => {
+            e.preventDefault()
+            const target = parseViewAt(viewText, plane)
+            if (!target) { setViewBad(true); return }
+            setViewBad(false)
+            look(viewText, target)
+          }}
+        >
+          <input
+            className={`avatars__input ${viewBad ? 'is-bad' : ''}`}
+            value={viewText}
+            onChange={(e) => { setViewText(e.target.value); setViewBad(false) }}
+            placeholder="x, y, z or a coordinate"
+            spellCheck={false}
+            autoComplete="off"
+            aria-label="A place to view"
+            aria-invalid={viewBad}
+          />
+          <button className="avatars__go" type="submit" disabled={!viewText.trim()} title="Look at this place without moving">VIEW</button>
+        </form>
+        {recent.length > 0 && (
+          <div className="viewat__recent">
+            <button className="viewat__toggle" onClick={() => setRecentOpen((o) => !o)} aria-expanded={recentOpen}>RECENT {recentOpen ? '▴' : '▾'}</button>
+            {recentOpen && (
+              <ul className="viewat__list">
+                {recent.map((r) => (
+                  <li key={r.input}>
+                    <button className="viewat__item" onClick={() => { const target = parseViewAt(r.input, plane); if (target) { setViewText(r.input); look(r.input, target) } }} title={r.input}>{r.label}</button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
     </section>
   )
 }

--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -447,9 +447,9 @@ export function viewEarth(): void {
  * lattices are drawn: the view a hyperjump gives, held still. Stays in the
  * current plane; the lattices take that plane's colors.
  */
-export function viewCyberspace(): void {
+export function viewCyberspace(scaleExp = 82): void {
   ownHyperspaceView()
   markViewedStop(null)
   const plane = useCyberspace.getState().plane
-  useCyberspace.getState().focusOn({ x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }, plane, 'CYBERSPACE', 82)
+  useCyberspace.getState().focusOn({ x: 1n << 84n, y: 1n << 84n, z: 1n << 84n }, plane, 'CYBERSPACE', scaleExp)
 }

--- a/src/hud/LootDetail.tsx
+++ b/src/hud/LootDetail.tsx
@@ -10,6 +10,7 @@
  * VIEW button that flies the scene to each.
  */
 
+import { cashuLabel, decodeCashuToken, findCashuToken } from '../lib/cashu'
 import { nip19 } from 'nostr-tools'
 import type { Plane } from 'cyberspace-core'
 import { useState } from 'react'
@@ -37,6 +38,13 @@ interface OpenedItem {
   unit: number
   shard?: ShardModel
   text?: string
+}
+
+/** A message's preview, or what its Cashu token holds when it carries one. */
+function cashuOrPreview(text: string | undefined): string {
+  const raw = findCashuToken(text)
+  const token = raw ? decodeCashuToken(raw) : null
+  return token ? `₿ ${cashuLabel(token)} hidden here` : messagePreview(text ?? '', 48)
 }
 
 function safeNpub(pubkey: string): string {
@@ -67,7 +75,7 @@ function openedItems(item: LootItem, discovered: ReturnType<typeof useShards.get
     out.set(h.eventId, {
       eventId: h.eventId,
       type: h.type,
-      label: h.type === 'message' ? messagePreview(h.text ?? '', 48) : h.shard?.name ?? 'shard',
+      label: h.type === 'message' ? cashuOrPreview(h.text) : h.shard?.name ?? 'shard',
       at: h.at,
       plane: h.plane,
       unit: h.type === 'shard' ? h.shard?.unit ?? 0 : 0,
@@ -80,7 +88,7 @@ function openedItems(item: LootItem, discovered: ReturnType<typeof useShards.get
     out.set(d.eventId, {
       eventId: d.eventId,
       type: d.type,
-      label: d.type === 'message' ? messagePreview(d.text ?? '', 48) : d.shard?.name ?? 'shard',
+      label: d.type === 'message' ? cashuOrPreview(d.text) : d.shard?.name ?? 'shard',
       at: { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) },
       plane: d.plane,
       unit: d.type === 'shard' ? d.shard?.unit ?? 0 : 0,
@@ -164,7 +172,7 @@ export function LootDetail(): JSX.Element | null {
           <ul className="lootd__items">
             {opened.map((o) => (
               <li key={o.eventId} className="lootd__item">
-                <span className={`secret__badge secret__badge--${o.type}`}>{o.type === 'message' ? '✎' : '◇'}</span>
+                <span className={`secret__badge secret__badge--${o.type}`}>{o.type === 'message' ? (o.label.startsWith('₿') ? '₿' : '✎') : '◇'}</span>
                 <span className="lootd__item-label" title={o.label}>{o.label}</span>
                 <span className="lootd__acts">
                   <button className="secret__act lootd__view" onClick={() => view(o)}>VIEW</button>

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -11,6 +11,7 @@
  * that scrolls, so the menu column stays short.
  */
 
+import { findCashuToken } from '../lib/cashu'
 import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useLoot } from '../hooks/useLoot'
@@ -37,7 +38,7 @@ export function LootPanel(): JSX.Element {
     const by = new Map<string, { at: number; glyph: string }[]>()
     for (const h of Object.values(discovered)) {
       const list = by.get(h.bagId) ?? []
-      list.push({ at: h.createdAt, glyph: h.type === 'message' ? '✎' : '◇' })
+      list.push({ at: h.createdAt, glyph: h.type === 'message' ? (findCashuToken(h.text) ? '₿' : '✎') : '◇' })
       by.set(h.bagId, list)
     }
     const out = new Map<string, string>()

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -12,6 +12,8 @@
 
 import { useState } from 'react'
 import { formatCellSize } from '../lib/scale'
+import { cashuLabel } from '../lib/cashu'
+import { cashuStateLabel, useCashu } from './useCashu'
 import { messagePreview, MAX_MESSAGE_LENGTH } from '../lib/hidden'
 import { ConfirmModal } from './ConfirmModal'
 import { useCyberspace } from '../store/useCyberspace'
@@ -25,6 +27,31 @@ function positionOf(d: MyDeployment): { x: bigint; y: bigint; z: bigint } {
 
 function depName(d: MyDeployment): string {
   return d.type === 'message' ? messagePreview(d.text ?? '', 24) : d.shard?.name ?? 'shard'
+}
+
+/**
+ * One hidden thing in the STASH. A message carrying a Cashu token shows the
+ * coin instead of the pen, what it holds, and whether anyone has taken it:
+ * the mint says which proofs are spent (useCashu), so REDEEMED means found.
+ */
+function DeployedRow({ d, viewing, onGo }: { d: MyDeployment; viewing: boolean; onGo: () => void }): JSX.Element {
+  const cashu = useCashu(d.type === 'message' ? d.text : null)
+  const coin = cashu.token !== null
+  return (
+    <li className={`shards__row shards__row--deployed ${viewing ? 'is-viewing' : ''}`}>
+      <button className="shards__goto" onClick={onGo} title="Fly to it and see its wire record">
+        <span className="avatars__who">
+          <span className={`shards__type shards__type--${coin ? 'cashu' : d.type}`}>{coin ? '₿' : d.type === 'message' ? '✎' : '◇'}</span>
+          {coin && cashu.token ? cashuLabel(cashu.token) : depName(d)}
+        </span>
+        <span className="shards__meta">
+          {d.height === 0 ? 'exact gibson' : formatCellSize(d.height)} · {d.published ? 'LIVE' : 'LOCAL'}{d.plane === 1 ? ' · ideaspace' : ''}
+          {coin && <> · <span className={`shards__cashu shards__cashu--${cashu.state}`}>{cashuStateLabel(cashu.state)}</span></>}
+        </span>
+      </button>
+      <span className="shards__goto-hint" aria-hidden="true">▸</span>
+    </li>
+  )
 }
 
 export function ShardsPanel(): JSX.Element {
@@ -111,18 +138,7 @@ export function ShardsPanel(): JSX.Element {
           <span className="legend__label">Deployed — hidden in cyberspace</span>
           <ul className="avatars__list">
             {mine.map((d) => (
-              <li key={d.eventId} className={`shards__row shards__row--deployed ${inspecting === d.eventId ? 'is-viewing' : ''}`}>
-                <button className="shards__goto" onClick={() => goTo(d)} title="Fly to it and see its wire record">
-                  <span className="avatars__who">
-                    <span className={`shards__type shards__type--${d.type}`}>{d.type === 'message' ? '✎' : '◇'}</span>
-                    {depName(d)}
-                  </span>
-                  <span className="shards__meta">
-                    {d.height === 0 ? 'exact gibson' : formatCellSize(d.height)} · {d.published ? 'LIVE' : 'LOCAL'}{d.plane === 1 ? ' · ideaspace' : ''}
-                  </span>
-                </button>
-                <span className="shards__goto-hint" aria-hidden="true">▸</span>
-              </li>
+              <DeployedRow key={d.eventId} d={d} viewing={inspecting === d.eventId} onGo={() => goTo(d)} />
             ))}
           </ul>
         </div>

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -142,7 +142,7 @@ export function TargetsPanel(): JSX.Element {
                   : t.status === 'spawn' ? 'AT SPAWN'
                     : 'RELAY?'}
             </span>
-            <button className="avatars__spectate" onClick={() => useCyberspace.getState().focusOn(t.position, t.plane, t.name ?? `${t.npub.slice(0, 12)}…`)} title="Look at where they are, without walking there">VIEW</button>
+            <button className="avatars__spectate" onClick={() => useCyberspace.getState().focusOn(t.position, t.plane, t.name ?? `${t.npub.slice(0, 12)}…`, undefined, true)} title="Look at where they are, without walking there">VIEW</button>
             <button className="avatars__spectate" onClick={() => void spectate(t.pubkey)} title="Spectate">SPECTATE</button>
             <button className="targets__remove" onClick={() => useCyberspace.getState().removeTarget(t.pubkey)} aria-label="Remove target" title="Remove target">✕</button>
           </li>

--- a/src/hud/TargetsPanel.tsx
+++ b/src/hud/TargetsPanel.tsx
@@ -142,6 +142,7 @@ export function TargetsPanel(): JSX.Element {
                   : t.status === 'spawn' ? 'AT SPAWN'
                     : 'RELAY?'}
             </span>
+            <button className="avatars__spectate" onClick={() => useCyberspace.getState().focusOn(t.position, t.plane, t.name ?? `${t.npub.slice(0, 12)}…`)} title="Look at where they are, without walking there">VIEW</button>
             <button className="avatars__spectate" onClick={() => void spectate(t.pubkey)} title="Spectate">SPECTATE</button>
             <button className="targets__remove" onClick={() => useCyberspace.getState().removeTarget(t.pubkey)} aria-label="Remove target" title="Remove target">✕</button>
           </li>

--- a/src/hud/ToastChip.tsx
+++ b/src/hud/ToastChip.tsx
@@ -5,10 +5,12 @@
  * is still announced when the scene comes back. Tap to dismiss.
  */
 
+import { useCyberspace } from '../store/useCyberspace'
 import { useEffect } from 'react'
 import { TOAST_MS, useToast } from '../store/useToast'
 
 export function ToastChip(): JSX.Element | null {
+  const provider = useCyberspace((s) => s.cloud.provider)
   const toast = useToast((s) => s.toast)
 
   useEffect(() => {
@@ -20,7 +22,7 @@ export function ToastChip(): JSX.Element | null {
   if (!toast) return null
   return (
     <div className="hyperbar hyperbar--found hyperbar--toast" role="status" onClick={() => useToast.getState().dismiss()}>
-      <img className="hyperbar__mark" src="/hosaka-mark.png" alt="HOSAKA" width={308} height={334} decoding="async" />
+      <img className="hyperbar__mark" src={provider?.logo ?? '/hosaka-mark.png'} alt={provider?.name ?? 'HOSAKA'} width={308} height={334} decoding="async" />
       <span className="hyperbar__text">
         <span className="hyperbar__label">{toast.label}</span>
         <span className="hyperbar__meta">{toast.meta}</span>

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -43,6 +43,8 @@ export function TouchControls(): JSX.Element {
   // stays, at its own size and in its own place, with those cells emptied.
   // Hiding the whole pad instead left EARTH opening at 2^52 with no way down.
   const atHead = useCyberspace((s) => s.canDrive())
+  // The commit row is for a move of your own: only at your head.
+  const home = useCyberspace((s) => s.atHead())
 
   const computing = proof.status === 'computing'
   const armed = !(position.x === cursor.x && position.y === cursor.y && position.z === cursor.z)
@@ -137,7 +139,7 @@ export function TouchControls(): JSX.Element {
         >2^{scaleExp}</button>
       </div>
 
-      {atHead && <div className="touchops">
+      {home && <div className="touchops">
         <button
           className="touchops__cancel"
           title={computing ? 'Cancel proof (X)' : 'Recall cursor (X)'}

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -40,7 +40,7 @@ export function TouchControls(): JSX.Element {
   // of the line the field draws and which regime owns the frame, so the pad
   // stays, at its own size and in its own place, with those cells emptied.
   // Hiding the whole pad instead left EARTH opening at 2^52 with no way down.
-  const atHead = useCyberspace((s) => s.atHead())
+  const atHead = useCyberspace((s) => s.canDrive())
 
   const computing = proof.status === 'computing'
   const armed = !(position.x === cursor.x && position.y === cursor.y && position.z === cursor.z)

--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -15,7 +15,9 @@
  * way WASD does and the two can never disagree about which way is up.
  */
 
+import { Box } from 'lucide-react'
 import { useCyberspace } from '../store/useCyberspace'
+import { viewCyberspace } from './HyperspacePanel'
 import { moveDirection, type MoveName } from '../lib/moves'
 import { MAX_SCALE_EXP } from '../lib/space'
 import { useShards } from '../store/useShards'
@@ -94,7 +96,12 @@ export function TouchControls(): JSX.Element {
 
   return (
     <>
-      <div className="touchpad" role="group" aria-label="Move cursor and change scale">
+      <div className={`touchpad${atHead ? '' : ' touchpad--scale'}`} role="group" aria-label="Move cursor and change scale">
+        {/* The purple cube: all of cyberspace at once, 2^84, the camera on
+            the whole of it. On every pad, at your head or off it. */}
+        <button className="touchpad__key touchpad__key--cube" title="All of cyberspace at 2^84" aria-label="See all of cyberspace at 2^84" {...noCallout} onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); viewCyberspace(MAX_SCALE_EXP) }}>
+          <Box size={16} strokeWidth={2.25} aria-hidden />
+        </button>
         {pad.map((b) => (
           <button
             key={b.cell}

--- a/src/hud/ViewMenu.tsx
+++ b/src/hud/ViewMenu.tsx
@@ -23,7 +23,8 @@ interface Props {
 }
 
 export function ViewMenu({ onClose }: Props): JSX.Element {
-  const plane = useCyberspace((s) => s.plane)
+  // The plane on show: yours at your head, the view's in a view (D-SPACE flips that one).
+  const plane = useCyberspace((s) => (s.atHead() ? s.plane : s.anchorPlane))
   const canGoBack = useCyberspace((s) => s.viewHistory.length > 0)
 
   const press = (fn: () => void) => (e: React.PointerEvent) => {

--- a/src/hud/routePreview.ts
+++ b/src/hud/routePreview.ts
@@ -43,6 +43,9 @@ function summaryOf(steps: PlanStep[]): PlanSummary {
 
 /** The route from the avatar to the cursor, with this machine's ceilings and HOSAKA's caps as they stand. */
 export function useRoutePreview(): RoutePreview | null {
+  // Only at your head: in a free view the cursor is a thousand hops from the
+  // avatar, and planning that route on every press is what made the pad crawl.
+  const home = useCyberspace((s) => s.atHead())
   const position = useCyberspace((s) => s.position)
   const cursor = useCyberspace((s) => s.cursor)
   const plane = useCyberspace((s) => s.plane)
@@ -53,7 +56,7 @@ export function useRoutePreview(): RoutePreview | null {
   const cloudHop = limits?.max_hop_height ?? 0
   const cloudSidestep = limits?.max_sidestep_height ?? 0
   return useMemo(() => {
-    if (samePosition(position, cursor)) return null
+    if (!home || samePosition(position, cursor)) return null
     const hop = estimateHopCost(position.x, position.y, position.z, cursor.x, cursor.y, cursor.z, plane, ceiling)
     if (!hop.exceedsLimit) return { hop, route: null, steps: null, needsCloud: false }
     // HOSAKA's caps whatever the cloud mode: what a move needs does not
@@ -63,7 +66,7 @@ export function useRoutePreview(): RoutePreview | null {
     try { steps = buildMovePlan(position, cursor, ceilings, PREVIEW_STEPS_MAX) } catch { steps = null }
     const route = steps ? summaryOf(steps) : planSummary(position, cursor, ceilings, PREVIEW_STEPS_MAX)
     return { hop, route, steps, needsCloud: route.cloudSteps > 0 }
-  }, [position, cursor, plane, ceiling, sidestepCeil, cloudHop, cloudSidestep])
+  }, [home, position, cursor, plane, ceiling, sidestepCeil, cloudHop, cloudSidestep])
 }
 
 export interface PreviewRow { index: number; kind: string; height: string; state: string; label: string }

--- a/src/hud/useCashu.ts
+++ b/src/hud/useCashu.ts
@@ -1,0 +1,51 @@
+/**
+ * useCashu.ts - what a message's Cashu token holds, and whether it is still there.
+ *
+ * The STASH and the loot list ask this per message. The token is read once
+ * per text; the mint is asked once a minute at most, shared across every
+ * place the same token shows.
+ */
+
+import { useEffect, useState } from 'react'
+import { checkCashuState, decodeCashuToken, findCashuToken, type CashuState, type CashuToken } from '../lib/cashu'
+
+const RECHECK_MS = 60_000
+const cache = new Map<string, { state: CashuState; at: number; pending: Promise<CashuState> | null }>()
+
+export interface CashuView {
+  token: CashuToken | null
+  state: CashuState | 'checking'
+}
+
+/** Ask the mint, no more than once a minute per token. */
+function stateOf(raw: string, token: CashuToken): Promise<CashuState> {
+  const now = Date.now()
+  const c = cache.get(raw)
+  if (c?.pending) return c.pending
+  if (c && now - c.at < RECHECK_MS) return Promise.resolve(c.state)
+  const pending = checkCashuState(token).then((state) => { cache.set(raw, { state, at: Date.now(), pending: null }); return state })
+  cache.set(raw, { state: c?.state ?? 'unknown', at: c?.at ?? 0, pending })
+  return pending
+}
+
+export function useCashu(text: string | null | undefined): CashuView {
+  const raw = findCashuToken(text)
+  const [state, setState] = useState<CashuState | 'checking'>('checking')
+  useEffect(() => {
+    if (!raw) return
+    const token = decodeCashuToken(raw)
+    if (!token) { setState('unknown'); return }
+    let live = true
+    const cached = cache.get(raw)
+    if (cached && cached.at > 0) setState(cached.state)
+    void stateOf(raw, token).then((s) => { if (live) setState(s) })
+    return () => { live = false }
+  }, [raw])
+  if (!raw) return { token: null, state: 'unknown' }
+  return { token: decodeCashuToken(raw), state }
+}
+
+/** UNCLAIMED, REDEEMED, PENDING, CHECKING, or nothing to say. */
+export function cashuStateLabel(state: CashuView['state']): string {
+  return state === 'unclaimed' ? 'UNCLAIMED' : state === 'redeemed' ? 'REDEEMED' : state === 'pending' ? 'PENDING' : state === 'checking' ? 'CHECKING' : 'MINT?'
+}

--- a/src/lib/cashu.test.ts
+++ b/src/lib/cashu.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { bytesToHex, hexToBytes } from 'cyberspace-core'
+import { cashuLabel, checkCashuState, decodeCashuToken, decodeCbor, findCashuToken, hashToCurve } from './cashu'
+
+const b64url = (bytes: Uint8Array): string => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+// A small CBOR encoder for the test's own fixtures.
+function encodeCbor(v: unknown): Uint8Array {
+  const head = (major: number, n: number): number[] => n < 24 ? [(major << 5) | n] : n < 256 ? [(major << 5) | 24, n] : [(major << 5) | 25, n >> 8, n & 255]
+  if (typeof v === 'number') return new Uint8Array(head(0, v))
+  if (typeof v === 'string') { const b = new TextEncoder().encode(v); return new Uint8Array([...head(3, b.length), ...b]) }
+  if (v instanceof Uint8Array) return new Uint8Array([...head(2, v.length), ...v])
+  if (Array.isArray(v)) return new Uint8Array([...head(4, v.length), ...v.flatMap((x) => [...encodeCbor(x)])])
+  if (v && typeof v === 'object') { const e = Object.entries(v as Record<string, unknown>); return new Uint8Array([...head(5, e.length), ...e.flatMap(([k, x]) => [...encodeCbor(k), ...encodeCbor(x)])]) }
+  throw new Error('unsupported')
+}
+
+const V3 = 'cashuA' + b64url(new TextEncoder().encode(JSON.stringify({ token: [{ mint: 'https://mint.example', proofs: [{ id: '00ad', amount: 16, secret: 'a', C: '02aa' }, { id: '00ad', amount: 5, secret: 'b', C: '02bb' }] }], unit: 'sat', memo: 'find me' })))
+const V4 = 'cashuB' + b64url(encodeCbor({ m: 'https://mint.example', u: 'sat', d: 'chest', t: [{ i: new Uint8Array([0, 0xad]), p: [{ a: 8, s: 'x', c: new Uint8Array([2, 1]) }, { a: 1, s: 'y', c: new Uint8Array([2, 2]) }] }] }))
+
+describe('findCashuToken', () => {
+  it('finds a token inside a message and ignores the rest', () => {
+    expect(findCashuToken(`Congratulations, take it: ${V3} and say hi`)).toBe(V3)
+    expect(findCashuToken('nothing here')).toBeNull()
+    expect(findCashuToken(null)).toBeNull()
+  })
+})
+
+describe('decodeCashuToken', () => {
+  it('reads a v3 token: mint, amount, unit, memo, proofs', () => {
+    const t = decodeCashuToken(V3)!
+    expect(t.version).toBe(3)
+    expect(t.mint).toBe('https://mint.example')
+    expect(t.amount).toBe(21)
+    expect(t.memo).toBe('find me')
+    expect(t.proofs.map((p) => p.secret)).toEqual(['a', 'b'])
+    expect(cashuLabel(t)).toBe('21 sats')
+  })
+  it('reads a v4 token from CBOR', () => {
+    const t = decodeCashuToken(V4)!
+    expect(t.version).toBe(4)
+    expect(t.mint).toBe('https://mint.example')
+    expect(t.amount).toBe(9)
+    expect(t.memo).toBe('chest')
+  })
+  it('returns null for junk', () => {
+    expect(decodeCashuToken('cashuAnotbase64!!')).toBeNull()
+    expect(decodeCashuToken('cashuB' + b64url(encodeCbor([1, 2])))).toBeNull()
+  })
+})
+
+describe('decodeCbor', () => {
+  it('round-trips the slice a token uses', () => {
+    const v = { a: 1, b: 'two', c: new Uint8Array([3]), d: [4, 5], e: 300 }
+    const out = decodeCbor(encodeCbor(v)) as Record<string, unknown>
+    expect(out.a).toBe(1); expect(out.b).toBe('two'); expect(out.d).toEqual([4, 5]); expect(out.e).toBe(300)
+    expect(bytesToHex(out.c as Uint8Array)).toBe('03')
+  })
+})
+
+describe('hashToCurve (NUT-00)', () => {
+  it('matches the published vectors', () => {
+    // NUT-00 test vectors: the secrets 0, 1 and 2 as 32-byte values.
+    expect(bytesToHex(hashToCurve(hexToBytes('0000000000000000000000000000000000000000000000000000000000000000')))).toBe('024cce997d3b518f739663b757deaec95bcd9473c30a14ac2fd04023a739d1a725')
+    expect(bytesToHex(hashToCurve(hexToBytes('0000000000000000000000000000000000000000000000000000000000000001')))).toBe('022e7158e11c9506f1aa4248bf531298daa7febd6194f003edcd9b93ade6253acf')
+    expect(bytesToHex(hashToCurve(hexToBytes('0000000000000000000000000000000000000000000000000000000000000002')))).toBe('026cdbe15362df59cd1dd3c9c11de8aedac2106eca69236ecd9fbe117af897be4f')
+  })
+})
+
+describe('checkCashuState (NUT-07)', () => {
+  const token = decodeCashuToken(V3)!
+  const mint = (states: string[]): typeof fetch => (async (url: string | URL | Request, init?: RequestInit) => {
+    expect(String(url)).toBe('https://mint.example/v1/checkstate')
+    const body = JSON.parse(String(init?.body)) as { Ys: string[] }
+    expect(body.Ys).toHaveLength(2)
+    expect(body.Ys.every((y) => /^0[23][0-9a-f]{64}$/.test(y))).toBe(true)
+    return new Response(JSON.stringify({ states: body.Ys.map((Y, i) => ({ Y, state: states[i] })) }), { status: 200 })
+  }) as typeof fetch
+  it('reads unclaimed, redeemed and pending off the mint', async () => {
+    expect(await checkCashuState(token, mint(['UNSPENT', 'UNSPENT']))).toBe('unclaimed')
+    expect(await checkCashuState(token, mint(['SPENT', 'SPENT']))).toBe('redeemed')
+    expect(await checkCashuState(token, mint(['PENDING', 'UNSPENT']))).toBe('pending')
+  })
+  it('is unknown when the mint is down', async () => {
+    expect(await checkCashuState(token, (async () => { throw new Error('down') }) as unknown as typeof fetch)).toBe('unknown')
+  })
+})

--- a/src/lib/cashu.ts
+++ b/src/lib/cashu.ts
@@ -1,0 +1,177 @@
+/**
+ * cashu.ts - a Cashu token hidden in a message, and whether it has been taken.
+ *
+ * Bitcoin hidden in cyberspace is a Cashu token in a message (decided
+ * 2026-09-07): a bearer thing, like a coin in a chest, and the mint decides
+ * who was first. This file finds a token in a message's text, reads what it
+ * holds (v3 JSON and v4 CBOR tokens, NUT-00), and asks the mint whether the
+ * proofs are still unspent (NUT-07), which is the STASH's claimed or
+ * unclaimed. Nothing here spends anything.
+ */
+
+import { secp256k1 } from '@noble/curves/secp256k1.js'
+import { bytesToHex, sha256 } from 'cyberspace-core'
+
+export interface CashuProof { amount: number; secret: string }
+export interface CashuToken {
+  /** The mint's URL, as written in the token. */
+  mint: string
+  unit: string
+  memo: string | null
+  amount: number
+  proofs: CashuProof[]
+  version: 3 | 4
+}
+export type CashuState = 'unclaimed' | 'redeemed' | 'pending' | 'unknown'
+
+const TOKEN = /cashu[AB][A-Za-z0-9_\-+/=]{16,}/
+
+/** The first Cashu token in a text, or null. */
+export function findCashuToken(text: string | null | undefined): string | null {
+  if (!text) return null
+  const m = TOKEN.exec(text)
+  return m ? m[0].replace(/=+$/, '') : null
+}
+
+function base64ToBytes(s: string): Uint8Array {
+  const std = s.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = std + '='.repeat((4 - (std.length % 4)) % 4)
+  const bin = atob(padded)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// The slice of CBOR a v4 token uses: unsigned ints, bytes, text, arrays, maps,
+// and the simple values. No floats, no tags, no indefinite lengths.
+// ---------------------------------------------------------------------------
+type Cbor = number | bigint | string | Uint8Array | boolean | null | Cbor[] | { [k: string]: Cbor }
+
+export function decodeCbor(bytes: Uint8Array): Cbor {
+  let at = 0
+  const need = (n: number): void => { if (at + n > bytes.length) throw new Error('cbor: short') }
+  const length = (info: number): number => {
+    if (info < 24) return info
+    if (info === 24) { need(1); return bytes[at++] }
+    if (info === 25) { need(2); const v = (bytes[at] << 8) | bytes[at + 1]; at += 2; return v }
+    if (info === 26) { need(4); const v = ((bytes[at] << 24) >>> 0) + (bytes[at + 1] << 16) + (bytes[at + 2] << 8) + bytes[at + 3]; at += 4; return v }
+    if (info === 27) { need(8); let v = 0n; for (let i = 0; i < 8; i++) v = (v << 8n) | BigInt(bytes[at + i]); at += 8; if (v > BigInt(Number.MAX_SAFE_INTEGER)) throw new Error('cbor: too large'); return Number(v) }
+    throw new Error('cbor: indefinite length')
+  }
+  const item = (): Cbor => {
+    need(1)
+    const head = bytes[at++]
+    const major = head >> 5, info = head & 31
+    switch (major) {
+      case 0: return length(info)
+      case 1: return -1 - length(info)
+      case 2: { const n = length(info); need(n); const v = bytes.slice(at, at + n); at += n; return v }
+      case 3: { const n = length(info); need(n); const v = new TextDecoder().decode(bytes.slice(at, at + n)); at += n; return v }
+      case 4: { const n = length(info); const out: Cbor[] = []; for (let i = 0; i < n; i++) out.push(item()); return out }
+      case 5: { const n = length(info); const out: { [k: string]: Cbor } = {}; for (let i = 0; i < n; i++) { const k = item(); const v = item(); out[typeof k === 'string' ? k : String(k)] = v } return out }
+      case 7:
+        if (info === 20) return false
+        if (info === 21) return true
+        if (info === 22) return null
+        throw new Error('cbor: unsupported simple value')
+      default: throw new Error('cbor: unsupported type')
+    }
+  }
+  const v = item()
+  if (at !== bytes.length) throw new Error('cbor: trailing bytes')
+  return v
+}
+
+/** What a token holds, or null when it is not one this reader understands. */
+export function decodeCashuToken(token: string): CashuToken | null {
+  try {
+    if (token.startsWith('cashuA')) {
+      const json = JSON.parse(new TextDecoder().decode(base64ToBytes(token.slice(6)))) as { token?: Array<{ mint?: string; proofs?: Array<{ amount?: number; secret?: string }> }>; unit?: string; memo?: string }
+      const entries = Array.isArray(json.token) ? json.token : []
+      const mint = entries.find((e) => typeof e.mint === 'string')?.mint
+      if (!mint) return null
+      const proofs: CashuProof[] = []
+      for (const e of entries) for (const p of e.proofs ?? []) if (typeof p.amount === 'number' && typeof p.secret === 'string') proofs.push({ amount: p.amount, secret: p.secret })
+      return { mint, unit: json.unit ?? 'sat', memo: json.memo ?? null, amount: proofs.reduce((a, p) => a + p.amount, 0), proofs, version: 3 }
+    }
+    if (token.startsWith('cashuB')) {
+      const v = decodeCbor(base64ToBytes(token.slice(6))) as { m?: Cbor; u?: Cbor; d?: Cbor; t?: Cbor }
+      if (typeof v.m !== 'string' || !Array.isArray(v.t)) return null
+      const proofs: CashuProof[] = []
+      for (const keyset of v.t as Array<{ p?: Cbor }>) {
+        for (const p of (Array.isArray(keyset.p) ? keyset.p : []) as Array<{ a?: Cbor; s?: Cbor }>) {
+          if (typeof p.a === 'number' && typeof p.s === 'string') proofs.push({ amount: p.a, secret: p.s })
+        }
+      }
+      return { mint: v.m, unit: typeof v.u === 'string' ? v.u : 'sat', memo: typeof v.d === 'string' ? v.d : null, amount: proofs.reduce((a, p) => a + p.amount, 0), proofs, version: 4 }
+    }
+  } catch { /* not a token this reader understands */ }
+  return null
+}
+
+const DOMAIN = new TextEncoder().encode('Secp256k1_HashToCurve_Cashu_')
+
+/**
+ * NUT-00 hash_to_curve: the curve point Y a secret stands for, which is what
+ * the mint indexes spent proofs by. The counter is four bytes little endian.
+ */
+export function hashToCurve(secret: Uint8Array): Uint8Array {
+  const msg = sha256(concat(DOMAIN, secret))
+  const counter = new Uint8Array(4)
+  for (let i = 0; i < 2 ** 16; i++) {
+    counter[0] = i & 0xff; counter[1] = (i >> 8) & 0xff; counter[2] = (i >> 16) & 0xff; counter[3] = (i >>> 24) & 0xff
+    const x = sha256(concat(msg, counter))
+    const candidate = new Uint8Array(33)
+    candidate[0] = 2
+    candidate.set(x, 1)
+    try {
+      return secp256k1.Point.fromHex(bytesToHex(candidate)).toBytes(true)
+    } catch { /* not on the curve: next counter */ }
+  }
+  throw new Error('hash_to_curve: no point found')
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length)
+  out.set(a, 0)
+  out.set(b, a.length)
+  return out
+}
+
+/** The Y of each proof, hex, for NUT-07 checkstate. */
+export function proofYs(token: CashuToken): string[] {
+  return token.proofs.map((p) => bytesToHex(hashToCurve(new TextEncoder().encode(p.secret))))
+}
+
+/**
+ * NUT-07: ask the mint whether the proofs are still unspent. Redeemed when
+ * every proof is spent, pending while any is in flight, unclaimed when all
+ * are unspent, unknown when the mint cannot be reached or answers oddly.
+ */
+export async function checkCashuState(token: CashuToken, fetchFn: typeof fetch = fetch): Promise<CashuState> {
+  if (token.proofs.length === 0) return 'unknown'
+  try {
+    const r = await fetchFn(`${token.mint.replace(/\/+$/, '')}/v1/checkstate`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ Ys: proofYs(token) }),
+    })
+    if (!r.ok) return 'unknown'
+    const body = (await r.json()) as { states?: Array<{ state?: string }> }
+    const states = (body.states ?? []).map((s) => s.state)
+    if (states.length !== token.proofs.length) return 'unknown'
+    if (states.every((s) => s === 'SPENT')) return 'redeemed'
+    if (states.some((s) => s === 'PENDING')) return 'pending'
+    if (states.every((s) => s === 'UNSPENT')) return 'unclaimed'
+    return states.some((s) => s === 'SPENT') ? 'redeemed' : 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+/** "21 sats" or "1 sat", in the token's unit. */
+export function cashuLabel(token: CashuToken): string {
+  const unit = token.unit === 'sat' ? (token.amount === 1 ? 'sat' : 'sats') : token.unit
+  return `${token.amount.toLocaleString('en-US')} ${unit}`
+}

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -64,6 +64,25 @@ export interface HosakaCoord {
   plane: Plane
 }
 
+/**
+ * GET /api/v1/provider (hosaka-api#6): how the provider presents itself.
+ * Read once per URL next to /limits; absent on providers that predate it,
+ * when the built-in HOSAKA presentation stands in.
+ */
+export interface HosakaProvider {
+  version: number
+  name: string
+  tagline?: string
+  homepage?: string
+  /** A URL or data URI for the mark shown at the head of the cloud panel, in toasts and as the pulse. */
+  logo?: string
+  services?: Array<{ type: string; max_height: number; min_msats?: number }>
+  pricing?: { reference?: boolean; hop?: Array<{ max_height: number; sats: number; est_time: string }>; sidestep?: Array<{ max_height: number; sats: number; est_time: string }> }
+  payments?: { methods?: string[]; deposit_min_msats?: number; deposit_max_msats?: number; invoice_ttl_seconds?: number }
+  contact?: string
+  terms?: string
+}
+
 /** GET /api/v1/limits. Clients never hardcode a cap. */
 export interface HosakaLimits {
   max_hop_height: number
@@ -313,6 +332,8 @@ export interface HosakaClientOptions {
 export interface HosakaClient {
   readonly apiUrl: string
   limits: (signal?: AbortSignal) => Promise<HosakaLimits>
+  /** Absent on a client built before providers presented themselves. */
+  provider?: (signal?: AbortSignal) => Promise<HosakaProvider>
   quote: (action: HosakaAction, v1: HosakaCoord, v2: HosakaCoord, signal?: AbortSignal) => Promise<HosakaQuote>
   submitHop: (v1: HosakaCoord, v2: HosakaCoord, previousEventId: string, signal?: AbortSignal) => Promise<HosakaJob>
   submitSidestep: (v1: HosakaCoord, v2: HosakaCoord, previousEventId: string, signal?: AbortSignal) => Promise<HosakaJob>
@@ -438,6 +459,7 @@ export function createHosaka(opts: HosakaClientOptions): HosakaClient {
   const client: HosakaClient = {
     apiUrl,
     limits: (signal) => request<HosakaLimits>('/api/v1/limits', { method: 'GET', signal }),
+    provider: (signal) => request<HosakaProvider>('/api/v1/provider', { method: 'GET', signal }),
     quote: (action, v1, v2, signal) =>
       request<HosakaQuote>('/api/v1/quote', { method: 'POST', body: { action, v1, v2 }, signal }),
     submitHop: (v1, v2, previousEventId, signal) => submit('hop', v1, v2, previousEventId, signal),

--- a/src/lib/viewAt.test.ts
+++ b/src/lib/viewAt.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { xyzToCoord } from 'cyberspace-core'
+import { parseViewAt } from './viewAt'
+
+describe('parseViewAt', () => {
+  it('reads three decimal axis values', () => {
+    const v = parseViewAt('19342813102987152433021963, 19342813150131325755198912 19342813074366675019965142', 0)!
+    expect(v.position.x).toBe(19342813102987152433021963n)
+    expect(v.position.z).toBe(19342813074366675019965142n)
+    expect(v.plane).toBe(0)
+    expect(v.label).toBe('19342…21963, 19342…98912, 19342…65142')
+  })
+  it('reads a 64-hex coordinate with its plane', () => {
+    const coord = xyzToCoord(5n, 6n, 7n, 1).toString(16).padStart(64, '0')
+    const v = parseViewAt(coord, 0)!
+    expect(v.position).toEqual({ x: 5n, y: 6n, z: 7n })
+    expect(v.plane).toBe(1)
+  })
+  it('refuses anything else', () => {
+    expect(parseViewAt('1, 2', 0)).toBeNull()
+    expect(parseViewAt('a, b, c', 0)).toBeNull()
+    expect(parseViewAt(`${(1n << 85n).toString()}, 0, 0`, 0)).toBeNull()
+  })
+})

--- a/src/lib/viewAt.test.ts
+++ b/src/lib/viewAt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { xyzToCoord } from 'cyberspace-core'
-import { parseViewAt } from './viewAt'
+import { canonicalViewAt, parseViewAt, rememberView } from './viewAt'
 
 describe('parseViewAt', () => {
   it('reads three decimal axis values', () => {
@@ -20,5 +20,25 @@ describe('parseViewAt', () => {
     expect(parseViewAt('1, 2', 0)).toBeNull()
     expect(parseViewAt('a, b, c', 0)).toBeNull()
     expect(parseViewAt(`${(1n << 85n).toString()}, 0, 0`, 0)).toBeNull()
+  })
+})
+
+describe('rememberView', () => {
+  const at = (input: string): { input: string; label: string } => ({ input: canonicalViewAt(input), label: input.slice(0, 8) })
+  it('keeps three, newest first, and collapses a place typed again', () => {
+    let list = rememberView([], at('1, 2, 3'))
+    list = rememberView(list, at('4 5 6'))
+    list = rememberView(list, at('7,8,9'))
+    expect(list.map((r) => r.input)).toEqual(['7, 8, 9', '4, 5, 6', '1, 2, 3'])
+    list = rememberView(list, at('1,2,3'))
+    expect(list.map((r) => r.input)).toEqual(['1, 2, 3', '7, 8, 9', '4, 5, 6'])
+    list = rememberView(list, at('10, 11, 12'))
+    expect(list).toHaveLength(3)
+    expect(list.map((r) => r.input)).toEqual(['10, 11, 12', '1, 2, 3', '7, 8, 9'])
+  })
+  it('treats a coordinate the same whatever its case', () => {
+    const hex = 'AB'.repeat(32)
+    expect(canonicalViewAt(hex)).toBe('ab'.repeat(32))
+    expect(rememberView([at(hex)], at(hex.toLowerCase()))).toHaveLength(1)
   })
 })

--- a/src/lib/viewAt.test.ts
+++ b/src/lib/viewAt.test.ts
@@ -24,7 +24,7 @@ describe('parseViewAt', () => {
 })
 
 describe('rememberView', () => {
-  const at = (input: string): { input: string; label: string } => ({ input: canonicalViewAt(input), label: input.slice(0, 8) })
+  const at = (input: string, plane: 0 | 1 = 0): { input: string; label: string; plane: 0 | 1 } => ({ input: canonicalViewAt(input), label: input.slice(0, 8), plane })
   it('keeps three, newest first, and collapses a place typed again', () => {
     let list = rememberView([], at('1, 2, 3'))
     list = rememberView(list, at('4 5 6'))
@@ -40,5 +40,7 @@ describe('rememberView', () => {
     const hex = 'AB'.repeat(32)
     expect(canonicalViewAt(hex)).toBe('ab'.repeat(32))
     expect(rememberView([at(hex)], at(hex.toLowerCase()))).toHaveLength(1)
+    // The same place in the other plane is another place.
+    expect(rememberView([at('1, 2, 3', 0)], at('1, 2, 3', 1))).toHaveLength(2)
   })
 })

--- a/src/lib/viewAt.ts
+++ b/src/lib/viewAt.ts
@@ -1,0 +1,33 @@
+/**
+ * viewAt.ts - a place to look at, typed in.
+ *
+ * The free view (arkinox, 2026-09-07): move the view anywhere in cyberspace
+ * without the chain line and the grid coming along, which is what focusing
+ * does. This reads what a person types into the POSITION panel: three
+ * decimal axis values separated by commas or spaces, or a 64-hex coordinate
+ * as the c and C tags carry it.
+ */
+
+import { AXIS_MAX, coordToXyz, type Plane } from 'cyberspace-core'
+import type { Position } from './space'
+
+export interface ViewTarget { position: Position; plane: Plane; label: string }
+
+/** The place a typed string names, or null when it names nothing. */
+export function parseViewAt(text: string, plane: Plane): ViewTarget | null {
+  const t = text.trim()
+  if (/^[0-9a-f]{64}$/i.test(t)) {
+    const c = coordToXyz(BigInt('0x' + t))
+    return { position: { x: c.x, y: c.y, z: c.z }, plane: c.plane, label: `${t.slice(0, 8)}…${t.slice(-4)}` }
+  }
+  const parts = t.split(/[\s,]+/).filter(Boolean)
+  if (parts.length !== 3 || !parts.every((p) => /^\d+$/.test(p))) return null
+  const [x, y, z] = parts.map((p) => BigInt(p))
+  if ([x, y, z].some((v) => v > AXIS_MAX)) return null
+  return { position: { x, y, z }, plane, label: parts.map(short).join(', ') }
+}
+
+/** "19342813102987152433021963" reads as "19342…21963". */
+function short(n: string): string {
+  return n.length > 12 ? `${n.slice(0, 5)}…${n.slice(-5)}` : n
+}

--- a/src/lib/viewAt.ts
+++ b/src/lib/viewAt.ts
@@ -31,3 +31,18 @@ export function parseViewAt(text: string, plane: Plane): ViewTarget | null {
 function short(n: string): string {
   return n.length > 12 ? `${n.slice(0, 5)}…${n.slice(-5)}` : n
 }
+
+/** A remembered place: what was typed, canonically, and how it is shown. */
+export interface RecentView { input: string; label: string }
+
+/** The same place typed two ways is one entry: decimals become "x, y, z", a coordinate its lowercase hex. */
+export function canonicalViewAt(text: string): string {
+  const t = text.trim()
+  if (/^[0-9a-f]{64}$/i.test(t)) return t.toLowerCase()
+  return t.split(/[\s,]+/).filter(Boolean).join(', ')
+}
+
+/** The list with `entry` at the front, its earlier copy gone, three at most. */
+export function rememberView(list: RecentView[], entry: RecentView): RecentView[] {
+  return [entry, ...list.filter((r) => r.input !== entry.input)].slice(0, 3)
+}

--- a/src/lib/viewAt.ts
+++ b/src/lib/viewAt.ts
@@ -32,8 +32,13 @@ function short(n: string): string {
   return n.length > 12 ? `${n.slice(0, 5)}…${n.slice(-5)}` : n
 }
 
+/** An axis value, shortened the same way. */
+export function shortAxis(n: bigint): string {
+  return short(n.toString())
+}
+
 /** A remembered place: what was typed, canonically, and how it is shown. */
-export interface RecentView { input: string; label: string }
+export interface RecentView { input: string; label: string; plane: Plane }
 
 /** The same place typed two ways is one entry: decimals become "x, y, z", a coordinate its lowercase hex. */
 export function canonicalViewAt(text: string): string {
@@ -44,5 +49,5 @@ export function canonicalViewAt(text: string): string {
 
 /** The list with `entry` at the front, its earlier copy gone, three at most. */
 export function rememberView(list: RecentView[], entry: RecentView): RecentView[] {
-  return [entry, ...list.filter((r) => r.input !== entry.input)].slice(0, 3)
+  return [entry, ...list.filter((r) => r.input !== entry.input || r.plane !== entry.plane)].slice(0, 3)
 }

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -150,7 +150,8 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const pendingTarget = useCyberspace((s) => s.pendingTarget)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const anchor = useCyberspace((s) => s.anchor)
-  const atHead = useCyberspace((s) => s.atHead())
+  const atHead = useCyberspace((s) => s.canDrive())
+  const home = useCyberspace((s) => s.atHead())
   // Looking at a focus the cursor cannot be used, so its size label would
   // just hang in the middle of the view.
   const focused = useCyberspace((s) => s.focus !== null)
@@ -158,7 +159,9 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   // In history there is no move being lined up, so no tether and no target
   // cell. The scale label stays, riding the anchor instead of the cursor.
   const target = atHead ? (pendingTarget ?? cursor) : anchor
-  const active = atHead && !samePosition(position, target)
+  // A plan, and its legs, only from your own head: in a free view the avatar
+  // is astronomically far from the anchor and a leg to it would be nonsense.
+  const active = home && !samePosition(position, target)
 
   // The one action the next commit takes, exactly as the button names it
   // (useOffer): where it lands is where the ghost stands and where the tether
@@ -260,7 +263,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const ghost = useRef<LineSegments>(null)
   useFrame(() => {
     const s = useCyberspace.getState()
-    const live = s.atHead() ? (s.pendingTarget ?? s.cursor) : s.anchor
+    const live = s.canDrive() ? (s.pendingTarget ?? s.cursor) : s.anchor
     const b = cellCentre(live, alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes)
     if (outline.current) outline.current.position.set(b[0], b[1], b[2])
     if (ghost.current && points.ghostOnCursor) ghost.current.position.set(b[0], b[1], b[2])
@@ -278,7 +281,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
         the SCALE panel already answers "how big is a gibson here" at rest.
         Off your own head it stays up, since nothing else there names the size.
       */}
-      {!focused && (!atHead || active) && <WorldLabel
+      {!focused && (!home || active) && <WorldLabel
         text={formatCellSize(scaleExp)}
         color={active ? targetColor : ACCENT}
         offset={[1.5, 0.7, 0]}
@@ -286,7 +289,7 @@ export function Cursor({ axes }: Props): JSX.Element | null {
         follow={() => {
           const s = useCyberspace.getState()
           return cellCentre(
-            s.atHead() ? (s.pendingTarget ?? s.cursor) : s.anchor,
+            s.canDrive() ? (s.pendingTarget ?? s.cursor) : s.anchor,
             alignedOrigin(s.anchor, s.scaleExp), s.scaleExp, axes,
           )
         }}

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -315,6 +315,13 @@ export function Cursor({ axes }: Props): JSX.Element | null {
           </lineSegments>
         </>
       )}
+      {/* The free view's own marker: the yellow cube on the cell you are
+          looking at, which the pad moves with the view. */}
+      {!home && atHead && !active && (
+        <lineSegments ref={outline} name="cursor-cell" geometry={cellOutline} position={points.targetCell} frustumCulled={false} renderOrder={10}>
+          <lineBasicMaterial color={WARN} toneMapped={false} transparent opacity={0.85} depthTest={false} />
+        </lineSegments>
+      )}
     </group>
   )
 }

--- a/src/scene/StopField.tsx
+++ b/src/scene/StopField.tsx
@@ -105,7 +105,10 @@ const REBUILD_GROWTH_FRACTION = 0.15
 // Landfalls read as embers of bitcoin orange on the globe; the old EARTH
 // blue made scrubbed stops look selected when nothing was.
 const LANDFALL_COLOR = new Color('#b06f14')
-const PORT_COLOR = new Color(SIDESTEP)
+// Half the sidestep purple: ports are pixel-sized and unlit under a bloom that
+// treats anything bright as a light, and a field of thousands at full purple
+// blew the whole ideaspace view out.
+const PORT_COLOR = new Color(SIDESTEP).multiplyScalar(0.45)
 
 interface Props {
   axes: ViewAxes
@@ -480,7 +483,7 @@ export function StopField({ axes }: Props): JSX.Element | null {
         */}
         <pointsMaterial
           vertexColors
-          size={portView ? 6 : 0.24}
+          size={portView ? 3 : 0.24}
           sizeAttenuation={!portView}
           transparent
           opacity={0.95}

--- a/src/store/freeView.test.ts
+++ b/src/store/freeView.test.ts
@@ -16,7 +16,24 @@ describe('the free view', () => {
     expect(S().anchor).toEqual(there)
     S().moveCursor({ axis: 'x', dir: 1 })
     expect(S().cursor.x).toBeGreaterThan(there.x)
+    // The pad moves the view itself: the anchor and the focus go with the cursor.
+    expect(S().anchor).toEqual(S().cursor)
+    expect(S().focus?.position).toEqual(S().cursor)
     expect(S().position).toEqual(home)
+  })
+
+  it('shows and flips the plane it looks at, keeping the cursor', () => {
+    S().focusOn({ x: 5n, y: 5n, z: 5n }, 1, 'there', undefined, true)
+    expect(S().anchorPlane).toBe(1)
+    const mine = S().plane
+    S().togglePlane()
+    expect(S().anchorPlane).toBe(0)
+    expect(S().focus?.plane).toBe(0)
+    expect(S().cursor).toEqual({ x: 5n, y: 5n, z: 5n })
+    // The flip is the view's alone; home is still in your own plane.
+    expect(S().plane).toBe(mine)
+    S().clearFocus()
+    expect(S().anchorPlane).toBe(mine)
   })
 
   it('leaves the cursor where it was for a plain focus, which cannot be driven', () => {

--- a/src/store/freeView.test.ts
+++ b/src/store/freeView.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useCyberspace } from './useCyberspace'
+
+const S = () => useCyberspace.getState()
+
+describe('the free view', () => {
+  beforeEach(() => { S().clearFocus() })
+
+  it('brings the cursor along and lets the pad drive it there', () => {
+    const home = { ...S().position }
+    const there = { x: home.x + 1000n, y: home.y, z: home.z + 5n }
+    S().focusOn(there, S().plane, 'there', undefined, true)
+    expect(S().atHead()).toBe(false)
+    expect(S().canDrive()).toBe(true)
+    expect(S().cursor).toEqual(there)
+    expect(S().anchor).toEqual(there)
+    S().moveCursor({ axis: 'x', dir: 1 })
+    expect(S().cursor.x).toBeGreaterThan(there.x)
+    expect(S().position).toEqual(home)
+  })
+
+  it('leaves the cursor where it was for a plain focus, which cannot be driven', () => {
+    const before = { ...S().cursor }
+    S().focusOn({ x: 7n, y: 7n, z: 7n }, 0, 'a shard')
+    expect(S().canDrive()).toBe(false)
+    expect(S().cursor).toEqual(before)
+    S().moveCursor({ axis: 'x', dir: 1 })
+    expect(S().cursor).toEqual(before)
+  })
+
+  it('RETURN puts the anchor home and the pad back on your head', () => {
+    S().focusOn({ x: 9n, y: 9n, z: 9n }, 0, 'there', undefined, true)
+    S().clearFocus()
+    expect(S().atHead()).toBe(true)
+    expect(S().anchor).toEqual(S().position)
+    expect(S().cursor).toEqual(S().position)
+  })
+})

--- a/src/store/freeView.test.ts
+++ b/src/store/freeView.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { useCyberspace } from './useCyberspace'
 
 const S = () => useCyberspace.getState()
@@ -14,44 +14,22 @@ describe('the free view', () => {
     expect(S().canDrive()).toBe(true)
     expect(S().cursor).toEqual(there)
     expect(S().anchor).toEqual(there)
-    vi.useFakeTimers()
-    try {
-      S().moveCursor({ axis: 'x', dir: 1 })
-      S().moveCursor({ axis: 'x', dir: 1 })
-      expect(S().cursor.x).toBeGreaterThan(there.x)
-      // The cursor moves at once; the view catches up once the presses settle.
-      expect(S().anchor).toEqual(there)
-      vi.advanceTimersByTime(300)
-      expect(S().anchor).toEqual(S().cursor)
-      expect(S().focus?.position).toEqual(S().cursor)
-      expect(S().position).toEqual(home)
-    } finally { vi.useRealTimers() }
+    S().moveCursor({ axis: 'x', dir: 1 })
+    S().moveCursor({ axis: 'x', dir: 1 })
+    expect(S().cursor.x).toBe(there.x + 2n)
+    // Within the field the anchor stays: the camera follows the cursor, nothing re-anchors.
+    expect(S().anchor).toEqual(there)
+    expect(S().position).toEqual(home)
   })
 
-  it('does not catch up after RETURN', () => {
-    vi.useFakeTimers()
-    try {
-      S().focusOn({ x: 20n, y: 20n, z: 20n }, 0, 'there', undefined, true)
-      S().moveCursor({ axis: 'y', dir: 1 })
-      S().clearFocus()
-      vi.advanceTimersByTime(300)
-      expect(S().anchor).toEqual(S().position)
-      expect(S().focus).toBeNull()
-    } finally { vi.useRealTimers() }
-  })
-
-  it('shows and flips the plane it looks at, keeping the cursor', () => {
-    S().focusOn({ x: 5n, y: 5n, z: 5n }, 1, 'there', undefined, true)
-    expect(S().anchorPlane).toBe(1)
-    const mine = S().plane
-    S().togglePlane()
-    expect(S().anchorPlane).toBe(0)
-    expect(S().focus?.plane).toBe(0)
-    expect(S().cursor).toEqual({ x: 5n, y: 5n, z: 5n })
-    // The flip is the view's alone; home is still in your own plane.
-    expect(S().plane).toBe(mine)
-    S().clearFocus()
-    expect(S().anchorPlane).toBe(mine)
+  it('jumps the view to the cursor once it leaves the field', () => {
+    const there = { x: 1000n, y: 1000n, z: 1000n }
+    S().focusOn(there, S().plane, 'there', undefined, true)
+    for (let i = 0; i < 24; i++) S().moveCursor({ axis: 'z', dir: 1 })
+    expect(S().anchor).toEqual(there)
+    S().moveCursor({ axis: 'z', dir: 1 })
+    expect(S().anchor).toEqual(S().cursor)
+    expect(S().focus?.position).toEqual(S().cursor)
   })
 
   it('leaves the cursor where it was for a plain focus, which cannot be driven', () => {

--- a/src/store/freeView.test.ts
+++ b/src/store/freeView.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useCyberspace } from './useCyberspace'
 
 const S = () => useCyberspace.getState()
@@ -14,12 +14,30 @@ describe('the free view', () => {
     expect(S().canDrive()).toBe(true)
     expect(S().cursor).toEqual(there)
     expect(S().anchor).toEqual(there)
-    S().moveCursor({ axis: 'x', dir: 1 })
-    expect(S().cursor.x).toBeGreaterThan(there.x)
-    // The pad moves the view itself: the anchor and the focus go with the cursor.
-    expect(S().anchor).toEqual(S().cursor)
-    expect(S().focus?.position).toEqual(S().cursor)
-    expect(S().position).toEqual(home)
+    vi.useFakeTimers()
+    try {
+      S().moveCursor({ axis: 'x', dir: 1 })
+      S().moveCursor({ axis: 'x', dir: 1 })
+      expect(S().cursor.x).toBeGreaterThan(there.x)
+      // The cursor moves at once; the view catches up once the presses settle.
+      expect(S().anchor).toEqual(there)
+      vi.advanceTimersByTime(300)
+      expect(S().anchor).toEqual(S().cursor)
+      expect(S().focus?.position).toEqual(S().cursor)
+      expect(S().position).toEqual(home)
+    } finally { vi.useRealTimers() }
+  })
+
+  it('does not catch up after RETURN', () => {
+    vi.useFakeTimers()
+    try {
+      S().focusOn({ x: 20n, y: 20n, z: 20n }, 0, 'there', undefined, true)
+      S().moveCursor({ axis: 'y', dir: 1 })
+      S().clearFocus()
+      vi.advanceTimersByTime(300)
+      expect(S().anchor).toEqual(S().position)
+      expect(S().focus).toBeNull()
+    } finally { vi.useRealTimers() }
   })
 
   it('shows and flips the plane it looks at, keeping the cursor', () => {

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -46,8 +46,10 @@ import {
   xyzToSectorId,
   type Plane,
 } from 'cyberspace-core'
-import { OCCUPANCY_SCALE_MAX,
+import {
+  GRID_RADIUS,
   MAX_SCALE_EXP,
+  OCCUPANCY_SCALE_MAX,
   alignTo,
   canonicalQuaternion,
   cellDelta,
@@ -134,9 +136,6 @@ function parsedChain(events: NostrEvent[]): ActionEvent[] {
 
 /** Matches cyberspace-core's DEFAULT_MAX_COMPUTE_HEIGHT. */
 export const MAX_COMPUTE_HEIGHT = 20
-/** How long the pad rests before a free view re-anchors on its cursor. */
-const FOLLOW_MS = 220
-let followTimer: ReturnType<typeof setTimeout> | null = null
 
 /**
  * Another avatar, followed. Their chain is the focus chain while this is set:
@@ -1337,20 +1336,18 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   }
 
   /**
-   * A free view follows its cursor, but not per press: re-anchoring is a
-   * change of frame that a dozen scene parts redraw for, and doing it on
-   * every step made the pad feel half a second slow. The cursor moves at
-   * once; the anchor catches it up when the presses have settled.
+   * A free view keeps its anchor where VIEW put it and lets the cursor roam
+   * the field, exactly as at your head: the camera follows the cursor, and
+   * nothing re-anchors per press. Only when the cursor leaves the field's
+   * reach does the view jump to it, the way a commit re-anchors on the avatar,
+   * so a long walk costs one re-anchor every field width rather than one
+   * per step.
    */
-  const followView = (): void => {
-    if (followTimer !== null) clearTimeout(followTimer)
-    followTimer = setTimeout(() => {
-      followTimer = null
-      const focus = get().focus
-      if (!focus?.drive || get().atHead()) return
-      const at = { ...get().cursor }
-      set({ anchor: at, focus: { ...focus, position: { ...at } } })
-    }, FOLLOW_MS)
+  const rideView = (next: Position): void => {
+    const { anchor, scaleExp, focus } = get()
+    if (!focus?.drive || get().atHead()) return
+    const far = (['x', 'y', 'z'] as const).some((axis) => Math.abs(cellDelta(next[axis], anchor[axis], scaleExp)) > GRID_RADIUS)
+    if (far) set({ anchor: { ...next }, focus: { ...focus, position: { ...next } } })
   }
 
   return {
@@ -1388,10 +1385,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
     // Clamped against the axis wall: nowhere to go.
     if (next[dir.axis] === cursor[dir.axis]) return
-    // In a free view the cursor is the view: the cursor moves now and the
-    // anchor catches it up once the presses settle (followView).
     set({ cursor: next })
-    if (!get().atHead() && get().focus?.drive) followView()
+    rideView(next)
   },
 
   setCursorAtCell: (row, col) => {
@@ -1416,7 +1411,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     // Depth axis stays at avatar's position (clicking doesn't move into/out of screen).
 
     set({ cursor: next })
-    if (viewing) followView()
+    if (viewing) rideView(next)
   },
 
   commit: async () => {
@@ -1906,7 +1901,6 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     // Home is your position in the plane you have lined up, which is what
     // the scene showed before the focus began.
     const { position, plane, focusReturnScale, scaleExp, focus } = get()
-    if (followTimer !== null) { clearTimeout(followTimer); followTimer = null }
     set({
       focus: null,
       anchor: position,
@@ -2398,7 +2392,9 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     // its cell, put the viewed block up-and-right of screen centre by the
     // sub-cell fraction (always positive, so always the same corner). Frame
     // the point itself, with the same continuous math it is drawn with.
-    if (focus !== null) {
+    // A driven focus (the free view) frames its cursor like your head does,
+    // so the camera follows the pad; a plain focus frames the viewed point.
+    if (focus !== null && !focus.drive) {
       // Same policy as markerCentre: at occupancy zooms the marker snaps to
       // its cell, whose cube centre is the aligned origin itself.
       if (scaleExp <= OCCUPANCY_SCALE_MAX) return [0, 0, 0]
@@ -2407,8 +2403,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         (a) => (cellDelta(anchor[a.axis], focusOrigin[a.axis], scaleExp) - 0.5) * a.dir,
       ) as [number, number, number]
     }
-    // Off your own head there is no cursor to frame; the camera sits on the anchor.
-    if (!get().atHead()) return [0, 0, 0]
+    // With no cursor to drive (spectating, history, a plain focus) the camera sits on the anchor.
+    if (!get().canDrive()) return [0, 0, 0]
     const axes = viewAxes(view)
     const origin = alignedOrigin(anchor, scaleExp)
     // Cell CENTRES, the same convention the cursor cube, the avatar and the path

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -1368,11 +1368,18 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
     // Clamped against the axis wall: nowhere to go.
     if (next[dir.axis] === cursor[dir.axis]) return
+    // In a free view the cursor is the view: the pad moves the anchor with it.
+    const focus = get().focus
+    if (!get().atHead() && focus?.drive) { set({ cursor: next, anchor: { ...next }, focus: { ...focus, position: { ...next } } }); return }
     set({ cursor: next })
   },
 
   setCursorAtCell: (row, col) => {
-    const { position, scaleExp, view } = get()
+    const { scaleExp, view } = get()
+    const focus = get().focus
+    const viewing = !get().atHead() && focus?.drive === true
+    // Cells are counted from the field's origin: your head, or the view's anchor.
+    const position = viewing ? get().anchor : get().position
     const axes = viewAxes(view)
     const origin = alignedOrigin(position, scaleExp)
     const step = stepFor(scaleExp)
@@ -1388,6 +1395,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     )
     // Depth axis stays at avatar's position (clicking doesn't move into/out of screen).
 
+    if (viewing && focus) { set({ cursor: next, anchor: { ...next }, focus: { ...focus, position: { ...next } } }); return }
     set({ cursor: next })
   },
 
@@ -1593,18 +1601,23 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     if (get().proof.status === 'computing') return
     // Someone else's plane is theirs; the terrain follows their chain.
     if (get().spectate) return
-    if (get().plane === plane) return
+    if (get().plane === plane && get().anchorPlane === plane) return
     // The view follows the lined-up plane the way it follows the cursor: at
     // your own head, or in a focus view such as EARTH, the scene switches
     // planes now, so the planet, the landfalls, other avatars and everything
     // else of the other plane disappear at once. Only history keeps its own
     // plane, because each action there records the plane it was in.
+    // In a free view the flip is the view's alone: the plane you have lined
+    // up at your head is untouched, and RETURN puts the scene back in it.
+    const focus = get().focus
+    if (focus?.drive && get().exploreIndex === null) { set({ anchorPlane: plane, focus: { ...focus, plane } }); return }
     const next: Partial<CyberspaceState> = { plane, proof: IDLE_PROOF }
     if (get().exploreIndex === null) next.anchorPlane = plane
     set(next)
   },
 
-  togglePlane: () => { get().setPlane(get().plane === 0 ? 1 : 0) },
+  // The plane on show flips: yours at your head, the view's in a view.
+  togglePlane: () => { const shown = get().atHead() ? get().plane : get().anchorPlane; get().setPlane(shown === 0 ? 1 : 0) },
 
   applyProofMessage: async (msg) => {
     // Stale responses from a cancelled commit must not overwrite fresh state.

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -134,6 +134,9 @@ function parsedChain(events: NostrEvent[]): ActionEvent[] {
 
 /** Matches cyberspace-core's DEFAULT_MAX_COMPUTE_HEIGHT. */
 export const MAX_COMPUTE_HEIGHT = 20
+/** How long the pad rests before a free view re-anchors on its cursor. */
+const FOLLOW_MS = 220
+let followTimer: ReturnType<typeof setTimeout> | null = null
 
 /**
  * Another avatar, followed. Their chain is the focus chain while this is set:
@@ -1333,6 +1336,23 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     void get().resumeCloudJob()
   }
 
+  /**
+   * A free view follows its cursor, but not per press: re-anchoring is a
+   * change of frame that a dozen scene parts redraw for, and doing it on
+   * every step made the pad feel half a second slow. The cursor moves at
+   * once; the anchor catches it up when the presses have settled.
+   */
+  const followView = (): void => {
+    if (followTimer !== null) clearTimeout(followTimer)
+    followTimer = setTimeout(() => {
+      followTimer = null
+      const focus = get().focus
+      if (!focus?.drive || get().atHead()) return
+      const at = { ...get().cursor }
+      set({ anchor: at, focus: { ...focus, position: { ...at } } })
+    }, FOLLOW_MS)
+  }
+
   return {
   identity: { pubkey: pubkeyHex, npub: nip19.npubEncode(pubkeyHex) },
   ...initial,
@@ -1368,10 +1388,10 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
     // Clamped against the axis wall: nowhere to go.
     if (next[dir.axis] === cursor[dir.axis]) return
-    // In a free view the cursor is the view: the pad moves the anchor with it.
-    const focus = get().focus
-    if (!get().atHead() && focus?.drive) { set({ cursor: next, anchor: { ...next }, focus: { ...focus, position: { ...next } } }); return }
+    // In a free view the cursor is the view: the cursor moves now and the
+    // anchor catches it up once the presses settle (followView).
     set({ cursor: next })
+    if (!get().atHead() && get().focus?.drive) followView()
   },
 
   setCursorAtCell: (row, col) => {
@@ -1395,8 +1415,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     )
     // Depth axis stays at avatar's position (clicking doesn't move into/out of screen).
 
-    if (viewing && focus) { set({ cursor: next, anchor: { ...next }, focus: { ...focus, position: { ...next } } }); return }
     set({ cursor: next })
+    if (viewing) followView()
   },
 
   commit: async () => {
@@ -1886,6 +1906,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     // Home is your position in the plane you have lined up, which is what
     // the scene showed before the focus began.
     const { position, plane, focusReturnScale, scaleExp, focus } = get()
+    if (followTimer !== null) { clearTimeout(followTimer); followTimer = null }
     set({
       focus: null,
       anchor: position,

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -84,8 +84,7 @@ import {
   type HosakaClient,
   type HosakaJob,
   type HosakaLimits,
-  type Waker,
-} from '../lib/hosaka'
+  type Waker, type HosakaProvider } from '../lib/hosaka'
 import {
   clearCloudJob,
   cloudProofResponse,
@@ -273,6 +272,8 @@ export interface CloudState {
   message: string | null
   /** GET /limits, fetched once per API URL; null until it answers, which means no cloud route. */
   limits: HosakaLimits | null
+  /** GET /provider, fetched with the limits; null on a provider that does not serve it, when the built-in HOSAKA presentation stands in. */
+  provider: HosakaProvider | null
   /** Date.now() when this flow began, for the elapsed line. */
   startedAt: number | null
   /** The last cloud proof that landed, for the panel. */
@@ -300,6 +301,7 @@ const IDLE_CLOUD: CloudState = {
   progress: null,
   message: null,
   limits: null,
+  provider: null,
   startedAt: null,
   last: null,
   checking: false,
@@ -937,6 +939,10 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       .then((limits) => {
         // The URL may have changed while this was out; a stale answer is dropped.
         if (get().cloudPrefs.apiUrl === url) set({ cloud: { ...get().cloud, limits } })
+        // The provider's own presentation rides along, and is never required.
+        void cloudClient(url).provider?.()
+          .then((provider) => { if (get().cloudPrefs.apiUrl === url) set({ cloud: { ...get().cloud, provider } }) })
+          .catch(() => { if (get().cloudPrefs.apiUrl === url) set({ cloud: { ...get().cloud, provider: null } }) })
         return limits
       })
       .catch(() => null)
@@ -2259,7 +2265,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     saveCloudPrefs(next)
     const urlChanged = next.apiUrl !== prev.apiUrl
     if (urlChanged) limitsInFlight = null
-    set({ cloudPrefs: next, ...(urlChanged ? { cloud: { ...get().cloud, limits: null } } : {}) })
+    set({ cloudPrefs: next, ...(urlChanged ? { cloud: { ...get().cloud, limits: null, provider: null } } : {}) })
     if (next.mode !== 'off' && get().cloud.limits === null) void ensureCloudLimits()
   },
 

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -406,7 +406,7 @@ export interface CyberspaceState {
    * is somewhere you are not. Exclusive with spectating in practice, because
    * the panel it is reached from is hidden while spectating.
    */
-  focus: { position: Position; plane: Plane; label: string } | null
+  focus: { position: Position; plane: Plane; label: string; /** The cursor came along (VIEW): the pad drives it here. */ drive?: boolean } | null
   /** The zoom before the standing focus began, restored by clearFocus. */
   focusReturnScale: number | null
   /** Pubkeys being pointed at, keyed by pubkey. Persisted. */
@@ -459,7 +459,8 @@ export interface CyberspaceState {
   /** Back to your own head. */
   endSpectate: () => void
   /** Look at a fixed coordinate (a deployed shard), optionally jumping the scale. */
-  focusOn: (position: Position, plane: Plane, label: string, scaleExp?: number) => void
+  /** Look at a place. With `drive` the cursor comes along: the free view, driven from the pad. */
+  focusOn: (position: Position, plane: Plane, label: string, scaleExp?: number, drive?: boolean) => void
   /** Stop looking; the scene returns to your avatar. */
   clearFocus: () => void
   /** Hyperspace transit: non-null from boarding until arrival (DECK-0001 v3). */
@@ -552,6 +553,8 @@ export interface CyberspaceState {
   actions: () => ActionEvent[]
   /** True when the scene is anchored on YOUR live head, where the controls apply. */
   atHead: () => boolean
+  /** The cursor can be driven: at your head, or in a free view that brought it along. Never while spectating or exploring history. */
+  canDrive: () => boolean
   /** The chain the scene is anchored on: the spectated avatar's, else yours. */
   focusChain: () => ActionEvent[]
   /** Whose chain that is. */
@@ -1357,7 +1360,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
   moveCursor: (dir) => {
     const { cursor, scaleExp } = get()
-    if (!get().atHead()) return
+    if (!get().canDrive()) return
     const step = stepFor(scaleExp) * BigInt(dir.dir)
 
     const next: Position = { ...cursor }
@@ -1849,9 +1852,12 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: plane })
   },
 
-  focusOn: (position, plane, label, scaleExp) => {
+  focusOn: (position, plane, label, scaleExp, drive = false) => {
     const next: Partial<CyberspaceState> = {
-      focus: { position: { ...position }, plane, label },
+      focus: { position: { ...position }, plane, label, drive },
+      // A free view brings the cursor along, so the pad moves it there and a
+      // message or a shard placed from the view lands there, not at your head.
+      ...(drive ? { cursor: { ...position } } : {}),
       // Remember the zoom once, at the first focus; later focus changes keep it.
       focusReturnScale: get().focus === null ? get().scaleExp : get().focusReturnScale,
       spectate: null,
@@ -1866,11 +1872,13 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   clearFocus: () => {
     // Home is your position in the plane you have lined up, which is what
     // the scene showed before the focus began.
-    const { position, plane, focusReturnScale, scaleExp } = get()
+    const { position, plane, focusReturnScale, scaleExp, focus } = get()
     set({
       focus: null,
       anchor: position,
       anchorPlane: plane,
+      // A cursor that went out with the view comes home with it.
+      ...(focus?.drive ? { cursor: { ...position } } : {}),
       // Back at the zoom the user left, not whatever the viewed thing chose.
       scaleExp: focusReturnScale ?? scaleExp,
       focusReturnScale: null,
@@ -2308,6 +2316,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
   actions: () => parsedChain(get().events),
 
+  canDrive: () => get().atHead() || (get().focus?.drive === true && get().spectate === null && get().exploreIndex === null),
   atHead: () =>
     get().exploreIndex === null &&
     get().spectate === null &&

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -53,6 +53,8 @@ const cursorKeyOf = (c: { x: bigint; y: bigint; z: bigint }, plane: number): str
 /** What the lined-up move needs, or null when this machine can do it. Not a hook: for the keyboard. */
 export function offerNeed(): OfferView | null {
   const s = useCyberspace.getState()
+  // Only a move from your head is anyone's to make; a free view plans nothing.
+  if (!s.atHead()) return null
   const cal = useCalibration.getState()
   const machineCeiling = Math.min(MAX_COMPUTE_HEIGHT, cal.hopHeight)
   const verdict = offerVerdict(s.position, s.cursor, s.plane, {
@@ -66,6 +68,7 @@ export function offerNeed(): OfferView | null {
 
 /** The same, for a component: recomputed as the cursor, the caps or the ceilings change. */
 export function useOfferNeed(): OfferView | null {
+  const home = useCyberspace((s) => s.atHead())
   const position = useCyberspace((s) => s.position)
   const cursor = useCyberspace((s) => s.cursor)
   const plane = useCyberspace((s) => s.plane)
@@ -73,7 +76,7 @@ export function useOfferNeed(): OfferView | null {
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const machineCeiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
-  const verdict = offerVerdict(position, cursor, plane, {
+  const verdict = !home ? null : offerVerdict(position, cursor, plane, {
     hop: machineCeiling,
     sidestep: sidestepCeil,
     cloudHop: limits?.max_hop_height ?? 0,
@@ -132,19 +135,22 @@ export function nextActionFor(position: Position, cursor: Position, plane: numbe
 /** The next action, read from the stores. Not a hook: for the keyboard. */
 export function nextAction(): NextActionView | null {
   const s = useCyberspace.getState()
+  if (!s.atHead()) return null
   const cal = useCalibration.getState()
   return nextActionFor(s.position, s.cursor, s.plane, cal.hopHeight, cal.sidestepHeight, s.cloud.limits)
 }
 
 /** The same, for a component. */
 export function useNextAction(): NextActionView | null {
+  // A move is yours to make only from your head; a free view plans nothing.
+  const home = useCyberspace((s) => s.atHead())
   const position = useCyberspace((s) => s.position)
   const cursor = useCyberspace((s) => s.cursor)
   const plane = useCyberspace((s) => s.plane)
   const limits = useCyberspace((s) => s.cloud.limits)
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
-  return nextActionFor(position, cursor, plane, hopCeil, sidestepCeil, limits)
+  return home ? nextActionFor(position, cursor, plane, hopCeil, sidestepCeil, limits) : null
 }
 
 /** What the COMMIT button says for each next action. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -3237,26 +3237,26 @@ kbd {
   grid-template-rows: repeat(3, 38px);
   gap: 4px;
   grid-template-areas:
-    "away    up   toward cube"
-    "left    hub  right  ."
-    "zoomout down zoomin .";
+    "cube away    up   toward"
+    ".    left    hub  right"
+    ".    zoomout down zoomin";
 }
 /* Off your own head only scale is left to drive, so the pad folds to one
  * row: coarser, the readout, finer, and the cube. The direction cells leave
  * the grid rather than standing empty in it. */
 .touchpad--scale {
   grid-template-rows: 38px;
-  grid-template-areas: "zoomout hub zoomin cube";
+  grid-template-areas: "cube zoomout hub zoomin";
 }
 .touchpad--scale .is-standdown { display: none; }
 /* The purple cube: all of cyberspace at once. */
 .touchpad__key--cube {
   grid-area: cube;
-  color: #e6d2ff;
-  background: rgba(150, 80, 255, 0.28);
-  border-color: rgba(192, 125, 255, 0.75);
+  color: #dcc2ff;
+  background: rgba(124, 58, 237, 0.62);
+  border-color: rgba(200, 150, 255, 0.9);
 }
-.touchpad__key--cube:active { background: rgba(192, 125, 255, 0.5); border-color: #e6d2ff; }
+.touchpad__key--cube:active { background: rgba(160, 100, 255, 0.85); border-color: #f0e6ff; }
 
 .touchpad__key {
   display: flex;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3233,14 +3233,30 @@ kbd {
 .touchpad {
   bottom: 92px;
   display: grid;
-  grid-template-columns: repeat(3, 38px);
+  grid-template-columns: repeat(4, 38px);
   grid-template-rows: repeat(3, 38px);
   gap: 4px;
   grid-template-areas:
-    "away  up    toward"
-    "left  hub   right"
-    "zoomout down zoomin";
+    "away    up   toward cube"
+    "left    hub  right  ."
+    "zoomout down zoomin .";
 }
+/* Off your own head only scale is left to drive, so the pad folds to one
+ * row: coarser, the readout, finer, and the cube. The direction cells leave
+ * the grid rather than standing empty in it. */
+.touchpad--scale {
+  grid-template-rows: 38px;
+  grid-template-areas: "zoomout hub zoomin cube";
+}
+.touchpad--scale .is-standdown { display: none; }
+/* The purple cube: all of cyberspace at once. */
+.touchpad__key--cube {
+  grid-area: cube;
+  color: #e6d2ff;
+  background: rgba(150, 80, 255, 0.28);
+  border-color: rgba(192, 125, 255, 0.75);
+}
+.touchpad__key--cube:active { background: rgba(192, 125, 255, 0.5); border-color: #e6d2ff; }
 
 .touchpad__key {
   display: flex;

--- a/src/styles.css
+++ b/src/styles.css
@@ -895,6 +895,44 @@ body {
   margin-bottom: 10px;
 }
 
+/* VIEW A COORDINATE under the position readouts, with its RECENT list. */
+.viewat {
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border, #1d3547);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.viewat__recent { display: flex; flex-direction: column; gap: 4px; }
+.viewat__toggle {
+  align-self: flex-start;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+  background: none;
+  border: 0;
+  padding: 2px 0;
+  cursor: pointer;
+}
+.viewat__toggle:hover { color: var(--fg); }
+.viewat__list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
+.viewat__item {
+  width: 100%;
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--fg);
+  background: rgba(0, 229, 255, 0.06);
+  border: 1px solid var(--border, #1d3547);
+  border-radius: 6px;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+.viewat__item:hover { border-color: var(--accent, #00e5ff); }
+
 .legend__label {
   display: block;
   font-size: 9px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1727,6 +1727,10 @@ kbd {
 }
 
 .shards__type--message { color: #ffd27d; }
+.shards__type--cashu { color: #f7931a; }
+.shards__cashu--unclaimed { color: #52e39f; }
+.shards__cashu--redeemed { color: #f7931a; }
+.shards__cashu--pending, .shards__cashu--checking, .shards__cashu--unknown { opacity: 0.7; }
 
 .shards__compose {
   display: flex;

--- a/src/styles.css
+++ b/src/styles.css
@@ -932,6 +932,7 @@ body {
   cursor: pointer;
 }
 .viewat__item:hover { border-color: var(--accent, #00e5ff); }
+.viewat__plane { display: inline-block; margin-right: 8px; padding: 1px 5px; font-size: 8px; }
 
 .legend__label {
   display: block;


### PR DESCRIPTION
Three small pieces from the agenda, plus the free-view feedback and the pad.

- **Bitcoin in a message.** A Cashu token hidden in a message (no new type, as decided): the STASH shows the coin instead of the pen, what the token holds, and UNCLAIMED, REDEEMED or PENDING from the mint, which is what decides who was first. The loot list and the detail show the coin and the amount for a bag that carries one. `cashu.ts` reads v3 (JSON) and v4 (CBOR) tokens, computes each proof's point per NUT-00 hash_to_curve, checked against the published vectors, and asks the mint's checkstate (NUT-07) at most once a minute per token. Nothing spends anything. Adds `@noble/curves` as a direct dependency (already installed through nostr-tools).
- **The free view.** VIEW A COORDINATE under the POSITION panel takes three axis values or a 64-hex coordinate, and VIEW on a target looks at where they are. In a free view the cursor roams the field as it does at your head, the camera following it, with nothing planned or re-anchored per press: the route preview, the offer card and the next-action readout stand down off your head (they were planning a thousand-hop route on every press), and the view jumps to the cursor only when it leaves the field's reach. The bar reads where the cursor is and in which plane; the cell wears the yellow cube; a message or a shard placed from the view lands there; RETURN brings the anchor and the cursor home at the zoom you left. The plane on the view controls is the one you are looking at (a hex coordinate brings its own, decimals go to the plane on show), and D-SPACE / I-SPACE flips the view's plane alone. A plain focus (flying to a shard) leaves the cursor where it was, as before. Legs, ghosts and the commit row are only at your head. On a phone, VIEW and VIEW STATION close the panels, every time, including a recent place tapped while already viewing. RECENT under the field holds the last three places, newest first, with their plane; a place typed again in other spacing or case folds onto its entry.
- **The pad.** Off your head (a block, Earth, the cube) the pad folds to one row: coarser, the readout, finer, instead of the readout a row above two keys with a gap. The purple cube joins every pad at its left end, the top corner at your head and the first cell off it: one press takes the scale straight to 2^84, all of cyberspace in a cell, without moving the view.
- **Ideaspace ports.** Drawn at three pixels instead of six, in the sidestep purple at less than half strength, so a field of thousands no longer blows the view out under the bloom on a phone.
- **The provider's own mark.** hosaka-api#8's `GET /api/v1/provider` is read once per API URL alongside `/limits`; the cloud panel's head, the job-complete toast and the pulse show the provider's logo and name from it, falling back to the built-in HOSAKA mark on a provider that does not serve it. Never required.

Verified headless on a phone viewport: the pad's cells at your head and off it, the cube taking the scale to 2^84 with the CYBERSPACE focus; the free view's cursor and anchor moving together with the yellow cube on the cell and the bar following; the plane flip from the compass menu; RETURN recalling everything; RECENT folding duplicates. tsc, the suite (542) and the build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz