### PR TITLE
Your own avatar: a shard published as kind 33331, drawn in the dodecahedron's cell

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { startSelfSync } from './lib/selfSync'
 import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
 import { useHyperspace } from './store/useHyperspace'
+import { useAvatars } from './store/useAvatars'
 import { setSyncPriority } from './lib/hyperspace/anchors'
 
 /** How long after the panels open the anchor sync goes full tilt. */
@@ -51,7 +52,7 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync() }, [])
+  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine() }, [])
   // A cloud job paid or computing when the tab last closed is picked up here,
   // if the chain head is still the one it was bound to. Also fetches the caps.
   useEffect(() => { void useCyberspace.getState().resumeCloudJob() }, [])

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { AVATAR_KIND, avatarFromEvent, avatarScale, avatarTemplate } from './avatar'
+import { newShard, ticksOf } from './shards'
+
+const built = () => {
+  const s = newShard('me')
+  s.name = 'Arches'
+  s.vertices = [{ p: [0, 0, 0], c: [0, 0.9, 1] }, { p: [1, 0, 0], c: [0, 0.9, 1] }, { p: [0, 1, 0], c: [0, 0.9, 1] }]
+  s.faces = [[0, 1, 2]]
+  s.mode = 'solid'
+  return s
+}
+
+describe('avatar events (kind 33331)', () => {
+  it('writes the shard as an addressable event and reads it back', () => {
+    const shard = built()
+    const t = avatarTemplate(shard, 1700000000)
+    expect(t.kind).toBe(AVATAR_KIND)
+    expect(t.tags).toEqual([['d', 'avatar'], ['name', 'Arches']])
+    const back = avatarFromEvent({ ...t, pubkey: 'ab'.repeat(32) })!
+    expect(back.name).toBe('Arches')
+    expect(back.vertices.map((v) => ticksOf(v).join())).toEqual(shard.vertices.map((v) => ticksOf(v).join()))
+    expect(back.faces).toEqual([[0, 1, 2]])
+    expect(back.id).toBe('avatar:' + 'ab'.repeat(32))
+  })
+  it('an empty content means the dodecahedron, and other kinds are not avatars', () => {
+    const none = avatarTemplate(null, 1)
+    expect(none.content).toBe('')
+    expect(avatarFromEvent({ ...none, pubkey: 'x' })).toBeNull()
+    expect(avatarFromEvent({ kind: 3330, pubkey: 'x', tags: [['d', 'avatar']], content: '{}' })).toBeNull()
+    expect(avatarFromEvent({ kind: AVATAR_KIND, pubkey: 'x', tags: [], content: 'not json' })).toBeNull()
+  })
+  it('fills the dodecahedron cell whatever the grid size', () => {
+    const shard = built()
+    shard.extent = 8
+    expect(avatarScale(shard)).toBe(0.0625)
+    shard.extent = 1
+    expect(avatarScale(shard)).toBe(0.5)
+  })
+})

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -30,11 +30,17 @@ describe('avatar events (kind 33331)', () => {
     expect(avatarFromEvent({ kind: 3330, pubkey: 'x', tags: [['d', 'avatar']], content: '{}' })).toBeNull()
     expect(avatarFromEvent({ kind: AVATAR_KIND, pubkey: 'x', tags: [], content: 'not json' })).toBeNull()
   })
-  it('fills the dodecahedron cell whatever the grid size', () => {
+  it('draws at true scale: a gibson on the bench is a cell, whatever the grid size', () => {
     const shard = built()
     shard.extent = 8
-    expect(avatarScale(shard)).toBe(0.0625)
-    shard.extent = 1
-    expect(avatarScale(shard)).toBe(0.5)
+    expect(avatarScale(shard)).toBe(1)
+    // A unit of four gibsons draws four cells wide per unit.
+    shard.unit = 2
+    expect(avatarScale(shard)).toBe(4)
+  })
+  it('shrinks a shard that would reach past four cells', () => {
+    const shard = built()
+    shard.vertices.push({ p: [16, 0, 0], c: [1, 1, 1] })
+    expect(avatarScale(shard)).toBe(0.25)
   })
 })

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -4,12 +4,12 @@
  * Kind 33331 (decided 2026-09-07), addressable with `d` = "avatar": one per
  * pubkey, the newest wins, and it changes without a respawn. The content is
  * a shard payload as the workshop writes it. Drawn in place of the wireframe
- * dodecahedron wherever an avatar is drawn: its grid, -extent..extent, fills
- * the cell the dodecahedron fills. An empty content puts the dodecahedron
- * back.
+ * dodecahedron wherever an avatar is drawn, at true scale: one gibson on the
+ * bench is one cell, the size the white avatar shows there. An empty content
+ * puts the dodecahedron back.
  */
 
-import { fromPayload, toPayload, type ShardModel } from './shards'
+import { TICKS_PER_UNIT, fromPayload, ticksOf, toPayload, type ShardModel } from './shards'
 
 export const AVATAR_KIND = 33331
 export const AVATAR_D = 'avatar'
@@ -38,7 +38,25 @@ export function avatarFromEvent(ev: { kind: number; pubkey: string; content: str
   }
 }
 
-/** Render units per model unit: the whole grid fills the dodecahedron's cell, radius one half. */
+/**
+ * Widest an avatar may reach from its centre, in cells: a shard built beyond
+ * this is shrunk to it, so nobody's avatar blots out the field.
+ */
+export const MAX_AVATAR_RADIUS = 4
+
+/**
+ * Render units per model unit: true scale. A model unit is 2^unit gibsons,
+ * and the dodecahedron's cell is one gibson at 2^0, so a shard built to the
+ * white avatar on the bench comes out exactly that size. The avatar keeps
+ * that size at every zoom, as the dodecahedron does.
+ */
 export function avatarScale(shard: ShardModel): number {
-  return 0.5 / Math.max(1, shard.extent)
+  const perUnit = 2 ** shard.unit
+  let reach = 0
+  for (const v of shard.vertices) {
+    const t = ticksOf(v)
+    reach = Math.max(reach, Math.abs(t[0]), Math.abs(t[1]), Math.abs(t[2]))
+  }
+  const radius = (reach / TICKS_PER_UNIT) * perUnit
+  return radius > MAX_AVATAR_RADIUS ? perUnit * (MAX_AVATAR_RADIUS / radius) : perUnit
 }

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,44 @@
+/**
+ * avatar.ts - the shape others see for you, as a shard.
+ *
+ * Kind 33331 (decided 2026-09-07), addressable with `d` = "avatar": one per
+ * pubkey, the newest wins, and it changes without a respawn. The content is
+ * a shard payload as the workshop writes it. Drawn in place of the wireframe
+ * dodecahedron wherever an avatar is drawn: its grid, -extent..extent, fills
+ * the cell the dodecahedron fills. An empty content puts the dodecahedron
+ * back.
+ */
+
+import { fromPayload, toPayload, type ShardModel } from './shards'
+
+export const AVATAR_KIND = 33331
+export const AVATAR_D = 'avatar'
+
+export interface AvatarTemplate { kind: number; created_at: number; tags: string[][]; content: string }
+
+/** The event to sign: this shard as the avatar, or none for the dodecahedron. */
+export function avatarTemplate(shard: ShardModel | null, createdAt: number): AvatarTemplate {
+  return {
+    kind: AVATAR_KIND,
+    created_at: createdAt,
+    tags: [['d', AVATAR_D], ...(shard ? [['name', shard.name]] : [])],
+    content: shard ? JSON.stringify(toPayload(shard)) : '',
+  }
+}
+
+/** The shard an avatar event carries, or null when it carries none or is not one. */
+export function avatarFromEvent(ev: { kind: number; pubkey: string; content: string; tags: string[][] }): ShardModel | null {
+  if (ev.kind !== AVATAR_KIND) return null
+  if (!ev.tags.some((t) => t[0] === 'd' && t[1] === AVATAR_D)) return null
+  if (!ev.content) return null
+  try {
+    return fromPayload(JSON.parse(ev.content), `avatar:${ev.pubkey}`)
+  } catch {
+    return null
+  }
+}
+
+/** Render units per model unit: the whole grid fills the dodecahedron's cell, radius one half. */
+export function avatarScale(shard: ShardModel): number {
+  return 0.5 / Math.max(1, shard.extent)
+}

--- a/src/lib/facing.test.ts
+++ b/src/lib/facing.test.ts
@@ -25,17 +25,18 @@ describe('moveDirection', () => {
 })
 
 describe('facingQuaternion', () => {
-  it('leaves a move along +X as it is, and turns the nose about for -X with the top still up', () => {
-    expect(turned(new Vector3(1, 0, 0), new Vector3(1, 0, 0))).toEqual([1, 0, 0])
-    expect(turned(new Vector3(-1, 0, 0), new Vector3(1, 0, 0))).toEqual([-1, 0, 0])
-    expect(turned(new Vector3(-1, 0, 0), new Vector3(0, 1, 0))).toEqual([0, 1, 0])
+  const NOSE = new Vector3(0, 0, -1) // model +Z, as the scene draws it
+  it('leaves a move along the nose as it is, and turns about for the opposite with the top still up', () => {
+    expect(turned(new Vector3(0, 0, -1), NOSE)).toEqual([0, 0, -1])
+    expect(turned(new Vector3(0, 0, 1), NOSE)).toEqual([0, 0, 1])
+    expect(turned(new Vector3(0, 0, 1), new Vector3(0, 1, 0))).toEqual([0, 1, 0])
   })
   it('points the nose along any direction, top up when it can be', () => {
-    for (const dir of [new Vector3(0, 0, 1), new Vector3(0, 0, -1), new Vector3(1, 0, 1).normalize(), new Vector3(0, 1, 0)]) {
-      const nose = turned(dir, new Vector3(1, 0, 0))
+    for (const dir of [new Vector3(1, 0, 0), new Vector3(-1, 0, 0), new Vector3(1, 0, 1).normalize(), new Vector3(0, 1, 0)]) {
+      const nose = turned(dir, NOSE)
       expect(nose.map((n, i) => Math.abs(n - +dir.toArray()[i].toFixed(3)) < 0.002).every(Boolean)).toBe(true)
     }
-    // Sideways along +Z: the top stays up.
-    expect(turned(new Vector3(0, 0, 1), new Vector3(0, 1, 0))).toEqual([0, 1, 0])
+    // Sideways along +X: the top stays up.
+    expect(turned(new Vector3(1, 0, 0), new Vector3(0, 1, 0))).toEqual([0, 1, 0])
   })
 })

--- a/src/lib/facing.test.ts
+++ b/src/lib/facing.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { Vector3 } from 'three'
+import { facingQuaternion, moveDirection } from './facing'
+import type { ViewAxes } from './space'
+
+const AXES: ViewAxes = { right: { axis: 'x', dir: 1 }, up: { axis: 'y', dir: 1 }, out: { axis: 'z', dir: 1 } }
+const at = (x: bigint, y: bigint, z: bigint) => ({ x, y, z })
+const turned = (dir: Vector3, v: Vector3): number[] => v.clone().applyQuaternion(facingQuaternion(dir)).toArray().map((n) => +n.toFixed(3))
+
+describe('moveDirection', () => {
+  it('reads a hop as a unit vector in the scene\'s frame, and nothing as null', () => {
+    expect(moveDirection(at(5n, 5n, 5n), at(9n, 5n, 5n), AXES)!.toArray()).toEqual([1, 0, 0])
+    expect(moveDirection(at(5n, 5n, 5n), at(5n, 5n, 1n), AXES)!.toArray()).toEqual([0, 0, -1])
+    expect(moveDirection(at(5n, 5n, 5n), at(5n, 5n, 5n), AXES)).toBeNull()
+  })
+  it('keeps the proportions of a diagonal move across astronomical distances', () => {
+    const d = moveDirection(at(0n, 0n, 0n), at(1n << 80n, 1n << 79n, 0n), AXES)!
+    expect(+d.x.toFixed(3)).toBe(0.894)
+    expect(+d.y.toFixed(3)).toBe(0.447)
+  })
+  it('follows the view\'s axes: with x pointing left on screen the move flips', () => {
+    const flipped: ViewAxes = { ...AXES, right: { axis: 'x', dir: -1 } }
+    expect(moveDirection(at(0n, 0n, 0n), at(3n, 0n, 0n), flipped)!.toArray()).toEqual([-1, 0, 0])
+  })
+})
+
+describe('facingQuaternion', () => {
+  it('leaves a move along +X as it is, and turns the nose about for -X with the top still up', () => {
+    expect(turned(new Vector3(1, 0, 0), new Vector3(1, 0, 0))).toEqual([1, 0, 0])
+    expect(turned(new Vector3(-1, 0, 0), new Vector3(1, 0, 0))).toEqual([-1, 0, 0])
+    expect(turned(new Vector3(-1, 0, 0), new Vector3(0, 1, 0))).toEqual([0, 1, 0])
+  })
+  it('points the nose along any direction, top up when it can be', () => {
+    for (const dir of [new Vector3(0, 0, 1), new Vector3(0, 0, -1), new Vector3(1, 0, 1).normalize(), new Vector3(0, 1, 0)]) {
+      const nose = turned(dir, new Vector3(1, 0, 0))
+      expect(nose.map((n, i) => Math.abs(n - +dir.toArray()[i].toFixed(3)) < 0.002).every(Boolean)).toBe(true)
+    }
+    // Sideways along +Z: the top stays up.
+    expect(turned(new Vector3(0, 0, 1), new Vector3(0, 1, 0))).toEqual([0, 1, 0])
+  })
+})

--- a/src/lib/facing.ts
+++ b/src/lib/facing.ts
@@ -1,0 +1,37 @@
+/**
+ * facing.ts - which way an avatar points.
+ *
+ * After a hop or a sidestep the avatar turns to face the way it went, so a
+ * shape with a front reads as going somewhere. A shard's front is +X, the
+ * way a stamp faces on the bench at FACING 0, and it turns about its own
+ * centre with its top kept up wherever the move allows.
+ */
+
+import { Matrix4, Quaternion, Vector3 } from 'three'
+import type { AxisDirection, Position, ViewAxes } from './space'
+
+/**
+ * The render-space direction of a move, under the view's axes (the same
+ * mapping the scene draws positions with); null when nothing moved.
+ */
+export function moveDirection(from: Position, to: Position, axes: ViewAxes): Vector3 | null {
+  const d = { x: to.x - from.x, y: to.y - from.y, z: to.z - from.z }
+  const abs = (n: bigint): bigint => (n < 0n ? -n : n)
+  const widest = [abs(d.x), abs(d.y), abs(d.z)].reduce((a, b) => (a > b ? a : b), 0n)
+  if (widest === 0n) return null
+  // Proportions survive the narrowing: each axis as a thousandth of the widest.
+  const part = (a: AxisDirection): number => Number((d[a.axis] * 1000n) / widest) / 1000 * a.dir
+  return new Vector3(part(axes.right), part(axes.up), part(axes.out)).normalize()
+}
+
+const UP = new Vector3(0, 1, 0)
+const OUT = new Vector3(0, 0, 1)
+
+/** The rotation that turns the nose, +X, along `dir`, with the top kept up where the move is not vertical. */
+export function facingQuaternion(dir: Vector3): Quaternion {
+  const x = dir.clone().normalize()
+  const hint = Math.abs(x.y) > 0.99 ? OUT : UP
+  const z = new Vector3().crossVectors(x, hint).normalize()
+  const y = new Vector3().crossVectors(z, x).normalize()
+  return new Quaternion().setFromRotationMatrix(new Matrix4().makeBasis(x, y, z))
+}

--- a/src/lib/facing.ts
+++ b/src/lib/facing.ts
@@ -2,9 +2,9 @@
  * facing.ts - which way an avatar points.
  *
  * After a hop or a sidestep the avatar turns to face the way it went, so a
- * shape with a front reads as going somewhere. A shard's front is +X, the
- * way a stamp faces on the bench at FACING 0, and it turns about its own
- * centre with its top kept up wherever the move allows.
+ * shape with a front reads as going somewhere. A shard's front is its +Z,
+ * which the scene draws as render -Z (shards.ts toRender), and it turns
+ * about its own centre with its top kept up wherever the move allows.
  */
 
 import { Matrix4, Quaternion, Vector3 } from 'three'
@@ -27,11 +27,14 @@ export function moveDirection(from: Position, to: Position, axes: ViewAxes): Vec
 const UP = new Vector3(0, 1, 0)
 const OUT = new Vector3(0, 0, 1)
 
-/** The rotation that turns the nose, +X, along `dir`, with the top kept up where the move is not vertical. */
+/**
+ * The rotation that turns the nose, model +Z and so render -Z, along `dir`,
+ * with the top kept up where the move is not vertical.
+ */
 export function facingQuaternion(dir: Vector3): Quaternion {
-  const x = dir.clone().normalize()
-  const hint = Math.abs(x.y) > 0.99 ? OUT : UP
-  const z = new Vector3().crossVectors(x, hint).normalize()
+  const z = dir.clone().normalize().negate()
+  const hint = Math.abs(z.y) > 0.99 ? OUT : UP
+  const x = new Vector3().crossVectors(hint, z).normalize()
   const y = new Vector3().crossVectors(z, x).normalize()
   return new Quaternion().setFromRotationMatrix(new Matrix4().makeBasis(x, y, z))
 }

--- a/src/scene/Avatar.tsx
+++ b/src/scene/Avatar.tsx
@@ -15,11 +15,12 @@
  * the coordinate.
  */
 
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
-import { IcosahedronGeometry, EdgesGeometry, Group } from 'three'
+import { Group } from 'three'
 import { travelOffset } from '../lib/travel'
 import { useCyberspace } from '../store/useCyberspace'
+import { AvatarShape } from './AvatarShape'
 
 export function Avatar(): JSX.Element | null {
   const group = useRef<Group>(null)
@@ -27,11 +28,8 @@ export function Avatar(): JSX.Element | null {
   // marker there would say you are standing on it. Spectating keeps the marker,
   // where it stands in for the avatar being watched.
   const focus = useCyberspace((s) => s.focus)
-
-  const avatarGeometry = useMemo(() => {
-    const geo = new IcosahedronGeometry(0.5, 1)
-    return new EdgesGeometry(geo)
-  }, [])
+  // Whose shape: yours, or the spectated avatar's, whose marker this is then.
+  const pubkey = useCyberspace((s) => s.focusPubkey())
 
   useFrame(() => {
     if (group.current) group.current.position.copy(travelOffset)
@@ -46,9 +44,7 @@ export function Avatar(): JSX.Element | null {
           cell, the icosahedron inscribes it exactly, and standing on your
           own destination erased you; now the red edges composite on top of
           whatever shares your gibson. */}
-      <lineSegments geometry={avatarGeometry} frustumCulled={false} renderOrder={10}>
-        <lineBasicMaterial color="#ff2323" toneMapped={false} depthTest={false} />
-      </lineSegments>
+      <AvatarShape pubkey={pubkey} color="#ff2323" renderOrder={10} depthTest={false} />
     </group>
   )
 }

--- a/src/scene/Avatar.tsx
+++ b/src/scene/Avatar.tsx
@@ -15,9 +15,10 @@
  * the coordinate.
  */
 
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Group } from 'three'
+import { facingQuaternion, moveDirection } from '../lib/facing'
 import { travelOffset } from '../lib/travel'
 import { useCyberspace } from '../store/useCyberspace'
 import { AvatarShape } from './AvatarShape'
@@ -30,9 +31,31 @@ export function Avatar(): JSX.Element | null {
   const focus = useCyberspace((s) => s.focus)
   // Whose shape: yours, or the spectated avatar's, whose marker this is then.
   const pubkey = useCyberspace((s) => s.focusPubkey())
+  // The last move on the chain drawn, as a key so a re-render costs nothing
+  // until the chain grows; the avatar turns to face the way it went.
+  const view = useCyberspace((s) => s.view)
+  const moveKey = useCyberspace((s) => {
+    const chain = s.focusChain()
+    const n = chain.length
+    if (n < 2) return null
+    const a = chain[n - 2].position, b = chain[n - 1].position
+    return `${a.x},${a.y},${a.z}>${b.x},${b.y},${b.z}`
+  })
+  const facing = useMemo(() => {
+    if (!moveKey) return null
+    const s = useCyberspace.getState()
+    const chain = s.focusChain()
+    const dir = moveDirection(chain[chain.length - 2].position, chain[chain.length - 1].position, s.axes())
+    return dir ? facingQuaternion(dir) : null
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [moveKey, view])
 
-  useFrame(() => {
-    if (group.current) group.current.position.copy(travelOffset)
+  useFrame((_, dt) => {
+    const g = group.current
+    if (!g) return
+    g.position.copy(travelOffset)
+    // Eases into the new heading over the same beat the travel animation takes.
+    if (facing) g.quaternion.slerp(facing, 1 - Math.exp(-dt / 0.15))
   })
 
   if (focus) return null

--- a/src/scene/AvatarShape.tsx
+++ b/src/scene/AvatarShape.tsx
@@ -1,0 +1,39 @@
+/**
+ * AvatarShape.tsx - what an avatar looks like: their shard, or the dodecahedron.
+ *
+ * Every place an avatar is drawn (you, a target, the one being spectated)
+ * asks useAvatars for the pubkey's shard and draws it in the dodecahedron's
+ * cell, unlit under the bloom as deployed shards are; without one, the
+ * wireframe icosahedron in the colour the caller gives.
+ */
+
+import { useMemo } from 'react'
+import { EdgesGeometry, IcosahedronGeometry } from 'three'
+import { avatarScale } from '../lib/avatar'
+import { useAvatarShard } from '../store/useAvatars'
+import { ShardMesh } from './ShardMesh'
+
+interface Props {
+  pubkey: string
+  color: string
+  renderOrder?: number
+  depthTest?: boolean
+}
+
+export function AvatarShape({ pubkey, color, renderOrder = 0, depthTest = true }: Props): JSX.Element {
+  const shard = useAvatarShard(pubkey)
+  const geometry = useMemo(() => new EdgesGeometry(new IcosahedronGeometry(0.5, 1)), [])
+  if (shard && shard.vertices.length > 0) {
+    const k = avatarScale(shard)
+    return (
+      <group scale={[k, k, k]}>
+        <ShardMesh shard={shard} world />
+      </group>
+    )
+  }
+  return (
+    <lineSegments geometry={geometry} frustumCulled={false} renderOrder={renderOrder}>
+      <lineBasicMaterial color={color} toneMapped={false} depthTest={depthTest} />
+    </lineSegments>
+  )
+}

--- a/src/scene/TargetAvatars.tsx
+++ b/src/scene/TargetAvatars.tsx
@@ -9,9 +9,9 @@
  */
 
 import { useMemo } from 'react'
-import { EdgesGeometry, IcosahedronGeometry } from 'three'
 import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { AvatarShape } from './AvatarShape'
 import { WorldLabel } from './WorldLabel'
 
 /** Same cull as Earth and the spawn marker. */
@@ -35,7 +35,6 @@ export function TargetAvatars({ axes }: Props): JSX.Element | null {
   const anchorPlane = useCyberspace((s) => s.anchorPlane)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const focus = useCyberspace((s) => s.focusPubkey())
-  const geometry = useMemo(() => new EdgesGeometry(new IcosahedronGeometry(0.5, 1)), [])
 
   const near = useMemo(() => {
     if (scaleExp >= AVATAR_SCALE_LIMIT) return []
@@ -56,9 +55,7 @@ export function TargetAvatars({ axes }: Props): JSX.Element | null {
     <>
       {near.map((t) => (
         <group key={t.id} position={t.centre}>
-          <lineSegments geometry={geometry} frustumCulled={false}>
-            <lineBasicMaterial color={t.color} toneMapped={false} />
-          </lineSegments>
+          <AvatarShape pubkey={t.id} color={t.color} />
           <WorldLabel text={t.label} color={t.color} at={[0, 0.9, 0]} align="center" px={11} opacity={0.9} />
         </group>
       ))}

--- a/src/store/useAvatars.test.ts
+++ b/src/store/useAvatars.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The store keeps your own avatar in localStorage; the test runs where there is none.
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+vi.mock('../lib/relay', () => ({
+  publish: vi.fn(async () => ({ ok: true })),
+  query: vi.fn(async () => []),
+}))
+
+import { publish, query } from '../lib/relay'
+import { AVATAR_KIND } from '../lib/avatar'
+import { newShard } from '../lib/shards'
+import { useCyberspace } from './useCyberspace'
+import { useAvatars } from './useAvatars'
+
+const built = () => {
+  const s = newShard('me')
+  s.name = 'Arches'
+  s.vertices = [{ p: [0, 0, 0], c: [1, 0, 0] }, { p: [1, 0, 0], c: [1, 0, 0] }, { p: [0, 1, 0], c: [1, 0, 0] }]
+  s.faces = [[0, 1, 2]]
+  s.mode = 'solid'
+  return s
+}
+
+describe('useAvatars', () => {
+  beforeEach(() => { useAvatars.setState({ shards: {}, asked: {} }); localStorage.clear(); vi.mocked(query).mockClear(); vi.mocked(publish).mockClear() })
+
+  it('adopting a shard signs a kind 33331 event with d=avatar, publishes it and keeps a copy', async () => {
+    const me = useCyberspace.getState().identity.pubkey
+    expect(await useAvatars.getState().adopt(built())).toBe(true)
+    const ev = vi.mocked(publish).mock.calls[0][0]
+    expect(ev.kind).toBe(AVATAR_KIND)
+    expect(ev.pubkey).toBe(me)
+    expect(ev.tags).toEqual([['d', 'avatar'], ['name', 'Arches']])
+    expect(useAvatars.getState().shards[me]?.name).toBe('Arches')
+    // Kept for the next load, before any relay answers.
+    useAvatars.setState({ shards: {} })
+    useAvatars.getState().loadMine()
+    expect(useAvatars.getState().shards[me]?.name).toBe('Arches')
+  })
+
+  it('adopting nothing puts the dodecahedron back', async () => {
+    const me = useCyberspace.getState().identity.pubkey
+    await useAvatars.getState().adopt(built())
+    expect(await useAvatars.getState().adopt(null)).toBe(true)
+    expect(vi.mocked(publish).mock.calls[1][0].content).toBe('')
+    expect(useAvatars.getState().shards[me]).toBeNull()
+  })
+
+  it('asks the relay once per pubkey and reads the newest event', async () => {
+    const pk = 'cd'.repeat(32)
+    const shard = built()
+    const { avatarTemplate } = await import('../lib/avatar')
+    vi.mocked(query).mockResolvedValueOnce([
+      { ...avatarTemplate(shard, 10), pubkey: pk, id: 'a', sig: '' } as never,
+      { ...avatarTemplate(null, 20), pubkey: pk, id: 'b', sig: '' } as never,
+    ])
+    useAvatars.getState().ensure(pk)
+    useAvatars.getState().ensure(pk)
+    await vi.waitFor(() => { expect(pk in useAvatars.getState().shards).toBe(true) })
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1)
+    // The newest (created_at 20) carries no shard: the dodecahedron.
+    expect(useAvatars.getState().shards[pk]).toBeNull()
+  })
+})

--- a/src/store/useAvatars.ts
+++ b/src/store/useAvatars.ts
@@ -1,0 +1,97 @@
+/**
+ * useAvatars.ts - who looks like what.
+ *
+ * Every avatar drawn asks here for its shape: the kind 33331 event of that
+ * pubkey (lib/avatar), fetched once and refreshed now and then, null meaning
+ * the dodecahedron. Your own is kept in localStorage as well, so it is on
+ * screen before the relay answers, and adopting a shard signs and publishes
+ * the event and keeps the copy.
+ */
+
+import { useEffect } from 'react'
+import { create } from 'zustand'
+import { AVATAR_D, AVATAR_KIND, avatarFromEvent, avatarTemplate } from '../lib/avatar'
+import { publish, query } from '../lib/relay'
+import { fromPayload, toPayload, type ShardModel } from '../lib/shards'
+import { useCyberspace } from './useCyberspace'
+
+const MINE_KEY = 'onosendai:avatar'
+const REFRESH_MS = 5 * 60_000
+
+interface AvatarsState {
+  /** By pubkey: the shard, null for the dodecahedron; absent until asked. */
+  shards: Record<string, ShardModel | null>
+  /** When each pubkey was last asked for, so the relay is not asked per frame. */
+  asked: Record<string, number>
+  /** Look a pubkey's avatar up, once per refresh window. */
+  ensure: (pubkey: string) => void
+  /** Publish this shard as your avatar (null for the dodecahedron); true when a relay took it. */
+  adopt: (shard: ShardModel | null) => Promise<boolean>
+  /** Your own from localStorage, before the relay answers. */
+  loadMine: () => void
+}
+
+export const useAvatars = create<AvatarsState>((set, get) => ({
+  shards: {},
+  asked: {},
+
+  ensure: (pubkey) => {
+    const now = Date.now()
+    const last = get().asked[pubkey] ?? 0
+    if (now - last < REFRESH_MS) return
+    set({ asked: { ...get().asked, [pubkey]: now } })
+    query({ kinds: [AVATAR_KIND], authors: [pubkey], '#d': [AVATAR_D] })
+      .then((events) => {
+        const newest = [...events].sort((a, b) => b.created_at - a.created_at)[0]
+        const shard = newest ? avatarFromEvent(newest) : null
+        set({ shards: { ...get().shards, [pubkey]: shard } })
+        if (pubkey === useCyberspace.getState().identity.pubkey) remember(shard)
+      })
+      .catch(() => { if (!(pubkey in get().shards)) set({ shards: { ...get().shards, [pubkey]: null } }) })
+  },
+
+  adopt: async (shard) => {
+    const cs = useCyberspace.getState()
+    const me = cs.identity.pubkey
+    let event
+    try {
+      event = await cs.signEvent(avatarTemplate(shard, Math.floor(Date.now() / 1000)))
+    } catch {
+      return false
+    }
+    const result = await publish(event)
+    if (!result.ok) return false
+    set({ shards: { ...get().shards, [me]: shard }, asked: { ...get().asked, [me]: Date.now() } })
+    remember(shard)
+    return true
+  },
+
+  loadMine: () => {
+    const me = useCyberspace.getState().identity.pubkey
+    try {
+      const raw = localStorage.getItem(MINE_KEY)
+      if (!raw) return
+      const kept = JSON.parse(raw) as { pubkey?: string; payload?: unknown }
+      if (kept.pubkey !== me) return
+      const shard = kept.payload ? fromPayload(kept.payload, `avatar:${me}`) : null
+      set({ shards: { ...get().shards, [me]: shard } })
+    } catch { /* nothing kept */ }
+  },
+}))
+
+function remember(shard: ShardModel | null): void {
+  try {
+    localStorage.setItem(MINE_KEY, JSON.stringify({ pubkey: useCyberspace.getState().identity.pubkey, payload: shard ? toPayload(shard) : null }))
+  } catch { /* private mode */ }
+}
+
+/** The shard a pubkey is drawn as, or null for the dodecahedron; asks the relay as needed. */
+export function useAvatarShard(pubkey: string): ShardModel | null {
+  const shard = useAvatars((s) => s.shards[pubkey])
+  useEffect(() => { if (pubkey) useAvatars.getState().ensure(pubkey) }, [pubkey])
+  return shard ?? null
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __avatars?: unknown }).__avatars = useAvatars
+}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -29,6 +29,8 @@ import { DIVISIONS, MAX_EXTENT, MIN_EXTENT, MODES, TICKS_PER_UNIT, hexToRgb, nee
 import { hsvToRgb, rgbToHsv, type Hsv } from '../lib/hsv'
 import { formatCellSize } from '../lib/scale'
 import { FACED, FACING_LABEL, FLOOR, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
+import { useAvatars } from '../store/useAvatars'
+import { useCyberspace } from '../store/useCyberspace'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
 import { Bench } from './Bench'
@@ -246,6 +248,8 @@ export function Workshop(): JSX.Element | null {
   const plane = useWorkshop((s) => s.plane)
   const division = useWorkshop((s) => s.division)
   const showAvatar = useWorkshop((s) => s.showAvatar)
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const myAvatar = useAvatars((s) => s.shards[me] ?? null)
   const color = useWorkshop((s) => s.color)
   const stampKind = useWorkshop((s) => s.stampKind)
   const stampSize = useWorkshop((s) => s.stampSize)
@@ -405,6 +409,21 @@ export function Workshop(): JSX.Element | null {
               <button className={`workshop__mode ${showAvatar ? 'is-on' : ''}`} aria-pressed={showAvatar} onClick={() => w().setShowAvatar(true)} title="Show the to-scale avatar at the grid's centre">SHOW</button>
               <button className={`workshop__mode ${!showAvatar ? 'is-on' : ''}`} aria-pressed={!showAvatar} onClick={() => w().setShowAvatar(false)} title="Hide it">HIDE</button>
             </div>
+          </div>
+          {/* The shape others see for you: this shard, published as kind 33331,
+              drawn in the dodecahedron's cell wherever you are drawn. */}
+          <div className="workshop__row" role="group" aria-label="My avatar">
+            <span className="workshop__label">MY AVATAR</span>
+            <span className="workshop__value workshop__value--wide">{myAvatar ? myAvatar.name : 'dodecahedron'}</span>
+            <button
+              className="workshop__btn"
+              disabled={shard.vertices.length === 0 || shard.faces.length === 0}
+              onClick={() => { void useAvatars.getState().adopt(shard).then((ok) => say(ok ? `"${shard.name}" is your avatar now.` : 'No relay took the avatar. Try again when one is reachable.')) }}
+              title="Publish this shard as the shape others see for you; its whole grid fills the cell the dodecahedron fills"
+            >USE THIS SHARD</button>
+            {myAvatar && (
+              <button className="workshop__btn" onClick={() => { void useAvatars.getState().adopt(null).then((ok) => say(ok ? 'The dodecahedron is your avatar again.' : 'No relay took the change.')) }} title="Back to the dodecahedron">DODECAHEDRON</button>
+            )}
           </div>
           <div className="ws__panel-title">SHARDS ({shards.length})</div>
           <div className="workshop__list-row">

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -419,7 +419,7 @@ export function Workshop(): JSX.Element | null {
               className="workshop__btn"
               disabled={shard.vertices.length === 0 || shard.faces.length === 0}
               onClick={() => { void useAvatars.getState().adopt(shard).then((ok) => say(ok ? `"${shard.name}" is your avatar now.` : 'No relay took the avatar. Try again when one is reachable.')) }}
-              title="Publish this shard as the shape others see for you; its whole grid fills the cell the dodecahedron fills"
+              title="Publish this shard as the shape others see for you, at true scale: the white avatar on the grid is the size of one cell"
             >USE THIS SHARD</button>
             {myAvatar && (
               <button className="workshop__btn" onClick={() => { void useAvatars.getState().adopt(null).then((ok) => say(ok ? 'The dodecahedron is your avatar again.' : 'No relay took the change.')) }} title="Back to the dodecahedron">DODECAHEDRON</button>


### PR DESCRIPTION
The shape others see for you is a shard from the workshop.

- **Event.** Kind 33331 (free in the NIP registry, and the spec uses only 33330), addressable with `d` = `avatar`: one per pubkey, the newest wins, it changes without a respawn. Content is the shard payload as the workshop writes it; a `name` tag carries the shard's name. Empty content means the dodecahedron.
- **Workshop.** MY AVATAR under the MENU shows what you are drawn as; USE THIS SHARD signs and publishes the current shard (needs at least one face); DODECAHEDRON publishes the empty event to go back.
- **Facing.** After a hop or a sidestep the avatar turns to face along its move: the front is the shard's +Z, drawn as render −Z, the direction comes from the last two positions of the chain being drawn (yours or the spectated one) mapped through the view's axes, and the turn eases in over the travel animation's beat with the top kept up. Targets keep their heading for now, since the tracker holds only their head.
- **Drawing.** `AvatarShape` replaces the icosahedron wherever an avatar is drawn: you, a target, the one being spectated. The pubkey's shard is fetched once (refreshed every five minutes) and drawn unlit under the bloom as deployed shards are, at true scale: a model unit is 2^unit gibsons and the cell is one gibson, so a shard built to the white avatar on the bench comes out exactly that size and keeps it at every zoom, as the dodecahedron does. A shard reaching past four cells from its centre is shrunk to four. The wireframe icosahedron in the caller's colour stands in until it arrives or when there is none. Your own is kept in localStorage so it is on screen before the relay answers.

Tests: the event's shape and round trip, the empty case, the scale; the store's adopt (signs, publishes, keeps a copy), the return to the dodecahedron, and a single relay ask per pubkey reading the newest event. Suite: 531 passing, build green. Headless: the arch adopted locally replaces the red dodecahedron at the origin and the MENU row reads Arches.

A spec note for kind 33331 can follow in the cyberspace repo once the shape settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz