### PR TITLE
The work an avatar owes, done in the workshop: mined, verified, drawn only when paid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,7 +2091,7 @@
     },
     "node_modules/cyberspace-core": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#35ae9fed9a7f026e7b8ae92fdf3a4a92e7a2d43d",
+      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#a82239b9ec18882bccfff5011429a6764c31b73e",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,7 +2091,7 @@
     },
     "node_modules/cyberspace-core": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#16584ec35faf25eb746d106cc5ece8afe2f0e270",
+      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#35ae9fed9a7f026e7b8ae92fdf3a4a92e7a2d43d",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,7 +2091,7 @@
     },
     "node_modules/cyberspace-core": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#a82239b9ec18882bccfff5011429a6764c31b73e",
+      "resolved": "git+ssh://git@github.com/arkin0x/cyberspace-cli-js.git#2cdb075196080fc7050b91debf5f0ca91120a314",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.6.0"

--- a/src/lib/avatarMine.test.ts
+++ b/src/lib/avatarMine.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { getEventHash } from 'nostr-tools/pure'
+import { avatarWork, verifyAvatarWork } from 'cyberspace-core'
+import { avatarTemplate } from './avatar'
+import { blocksOf, describeDuration, eventId, leadingZeros, mineChunk, nonceTagged, serializeEvent, triesPerSec } from './avatarMine'
+import { newShard, toPayload } from './shards'
+
+const me = 'ab'.repeat(32)
+const wedge = () => {
+  const s = newShard('me')
+  s.name = 'Wedge'
+  s.vertices = [{ p: [0, 0, 0], c: [1, 0, 0] }, { p: [1, 0, 0], c: [1, 0, 0] }, { p: [0, 1, 0], c: [1, 0, 0] }, { p: [0, 0, 1], c: [1, 0, 0] }]
+  s.faces = [[0, 1, 2], [0, 2, 3], [0, 3, 1], [1, 3, 2]]
+  s.mode = 'solid'
+  return s
+}
+const template = (nonce?: string, target = 16) => {
+  const t = { ...avatarTemplate(wedge(), 1_800_000_000), pubkey: me }
+  return nonce === undefined ? t : nonceTagged(t, nonce, target)
+}
+
+describe('avatarMine', () => {
+  it('serializes and hashes exactly as NIP-01 (nostr-tools agrees)', () => {
+    const t = template('42')
+    expect(JSON.parse(serializeEvent(t))).toEqual([0, me, 1_800_000_000, 33331, t.tags, t.content])
+    expect(eventId(t)).toBe(getEventHash({ ...t, id: '', sig: '' } as never))
+  })
+
+  it('counts leading zero bits', () => {
+    expect(leadingZeros(new Uint8Array([0, 0, 0x0f, 0xff]))).toBe(20)
+    expect(leadingZeros(new Uint8Array([0x80]))).toBe(0)
+    expect(leadingZeros(new Uint8Array([0x01]))).toBe(7)
+    expect(leadingZeros(new Uint8Array([0, 0]))).toBe(16)
+  })
+
+  it('nonceTagged replaces an earlier nonce and keeps the rest', () => {
+    const t = nonceTagged(nonceTagged(template(), '1', 16), '2', 20)
+    expect(t.tags.filter((x) => x[0] === 'nonce')).toEqual([['nonce', '2', '20']])
+    expect(t.tags[0]).toEqual(['d', 'avatar'])
+  })
+
+  it('mines the floor for a one-gibson wedge, and the verdict is paid', () => {
+    const t = template()
+    const required = avatarWork(toPayload(wedge()))
+    expect(required).toBe(16)
+    let found = null
+    for (let from = 0; found === null && from < 2 ** 22; from += 4096) found = mineChunk(t, required, from, 4096)
+    expect(found).not.toBeNull()
+    const mined = nonceTagged(t, found!.nonce, required)
+    expect(eventId(mined)).toBe(found!.id)
+    const verdict = verifyAvatarWork({ ...mined, id: found!.id })
+    expect(verdict).toMatchObject({ ok: true, required: 16, committed: 16 })
+    expect(verdict.zeros).toBeGreaterThanOrEqual(16)
+  })
+
+  it('the fast path and the plain path find the same nonce', () => {
+    const t = template()
+    const fast = mineChunk(t, 8, 0, 4096)
+    let plain = null
+    for (let n = 0; plain === null && n < 4096; n++) {
+      const c = nonceTagged(t, String(n), 8)
+      const id = eventId(c)
+      if (id.startsWith('00')) plain = { nonce: String(n), id }
+    }
+    expect(fast).toEqual(plain)
+  })
+
+  it('a stride walks its own residue: worker i of n finds the first nonce congruent to i', () => {
+    const t = template()
+    const first = mineChunk(t, 8, 0, 4096)!
+    const byStride = [0, 1, 2].map((i) => mineChunk(t, 8, i, 2048, 3)).filter((x) => x !== null)
+    expect(byStride.map((x) => Number(x!.nonce) % 3)).toEqual([...new Set(byStride.map((x) => Number(x!.nonce) % 3))])
+    expect(byStride.some((x) => x!.nonce === first.nonce)).toBe(true)
+    for (const x of byStride) expect(x!.id.startsWith('00')).toBe(true)
+  })
+
+  it('estimates: blocks, tries per second, wording', () => {
+    expect(blocksOf(55)).toBe(1)
+    expect(blocksOf(56)).toBe(2)
+    expect(blocksOf(602)).toBe(10)
+    expect(triesPerSec(100_000, 602)).toBeCloseTo(24_000, 0)
+    expect(triesPerSec(100_000, 602, 4)).toBeCloseTo(24_000 * 3.1, 0)
+    expect(describeDuration(0.3)).toBe('under a second')
+    expect(describeDuration(40)).toBe('about 40 s')
+    expect(describeDuration(200)).toBe('about 3 min')
+    expect(describeDuration(7200)).toBe('about 2 h')
+    expect(describeDuration(5 * 86400)).toBe('about 5 days')
+    expect(describeDuration(3 * 365.25 * 86400)).toBe('about 3 years')
+  })
+})

--- a/src/lib/avatarMine.ts
+++ b/src/lib/avatarMine.ts
@@ -1,0 +1,129 @@
+/**
+ * avatarMine.ts - the work an avatar owes, done.
+ *
+ * Spec 8.10: a kind 33331 avatar is paid for in NIP-13 work on the event
+ * itself, `required = ceil(16 + 6 log2(reach) + 3 log2(detail / 32))` bits,
+ * the target committed in the nonce tag before mining. This is the loop
+ * that finds the nonce: the NIP-01 serialization is built once around a
+ * marker, the nonce's decimal digits are written into a reusable buffer,
+ * and only the hash runs per try. cyberspace-core's `avatarWork` prices
+ * the shape and `verifyAvatarWork` judges the result; the worker
+ * (workers/avatar.worker.ts) runs this off the main thread in chunks so
+ * progress and cancel stay live.
+ */
+
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex } from './events'
+
+export interface MineTemplate {
+  pubkey: string
+  created_at: number
+  kind: number
+  tags: string[][]
+  content: string
+}
+
+export interface MineFound { nonce: string; id: string }
+
+const enc = new TextEncoder()
+const MARKER = 'ONOSENDAI-NONCE-MARKER-7f3a9c'
+
+/** NIP-01: the id is the SHA-256 of this JSON array. */
+export function serializeEvent(t: MineTemplate): string {
+  return JSON.stringify([0, t.pubkey, t.created_at, t.kind, t.tags, t.content])
+}
+
+export function eventId(t: MineTemplate): string {
+  return bytesToHex(sha256(enc.encode(serializeEvent(t))))
+}
+
+/** The template with its nonce tag set (replacing any earlier one), NIP-13 shape. */
+export function nonceTagged<T extends { tags: string[][] }>(t: T, nonce: string, target: number): T {
+  return { ...t, tags: [...t.tags.filter((tag) => tag[0] !== 'nonce'), ['nonce', nonce, String(target)]] }
+}
+
+/** Leading zero bits of a hash. */
+export function leadingZeros(hash: Uint8Array): number {
+  let n = 0
+  for (const b of hash) {
+    if (b === 0) { n += 8; continue }
+    n += Math.clz32(b) - 24
+    break
+  }
+  return n
+}
+
+/**
+ * Try `count` nonces from `from`, `stride` apart (one worker per residue
+ * when several mine at once); the first whose id carries `target` leading
+ * zero bits, or null. Deterministic, so a worker and a test find the same
+ * nonce for the same template.
+ */
+export function mineChunk(t: MineTemplate, target: number, from: number, count: number, stride: number = 1): MineFound | null {
+  const split = serializeEvent(nonceTagged(t, MARKER, target)).split(MARKER)
+  const last = from + count * stride
+  if (split.length !== 2) {
+    for (let n = from; n < last; n += stride) {
+      const nonce = String(n)
+      const hash = sha256(enc.encode(serializeEvent(nonceTagged(t, nonce, target))))
+      if (leadingZeros(hash) >= target) return { nonce, id: bytesToHex(hash) }
+    }
+    return null
+  }
+  const head = enc.encode(split[0])
+  const tail = enc.encode(split[1])
+  const buf = new Uint8Array(head.length + 20 + tail.length)
+  buf.set(head, 0)
+  let width = 0
+  for (let n = from; n < last; n += stride) {
+    const digits = String(n)
+    if (digits.length !== width) {
+      width = digits.length
+      buf.set(tail, head.length + width)
+    }
+    for (let i = 0; i < width; i++) buf[head.length + i] = digits.charCodeAt(i)
+    const hash = sha256(buf.subarray(0, head.length + width + tail.length))
+    if (leadingZeros(hash) >= target) return { nonce: digits, id: bytesToHex(hash) }
+  }
+  return null
+}
+
+/** SHA-256 blocks a serialized event of this many bytes takes: padding included. */
+export function blocksOf(bytes: number): number {
+  return Math.ceil((bytes + 9) / 64)
+}
+
+/**
+ * Tries per second this device can expect for an event of `bytes`, from the
+ * calibration's leaf-hash rate: a sidestep leaf costs about three SHA-256
+ * blocks (the leaf from its midstate and the fold above it), the per-try
+ * overhead beyond hashing is about a fifth (measured), and workers past the
+ * first add about seven tenths each, since half of them share a core.
+ */
+export function triesPerSec(sha256PerSec: number, bytes: number, workers: number = 1): number {
+  const one = (sha256PerSec * 3 / blocksOf(bytes)) * 0.8
+  return one * (1 + 0.7 * Math.max(0, workers - 1))
+}
+
+/** Expected tries for `bits` of work. */
+export function expectedTries(bits: number): number {
+  return 2 ** bits
+}
+
+/** "about 40 s", "about 3 min", "about 2 h", "about 5 days". */
+export function describeDuration(seconds: number): string {
+  if (!Number.isFinite(seconds)) return 'unknown'
+  if (seconds < 1) return 'under a second'
+  if (seconds < 90) return `about ${Math.round(seconds)} s`
+  if (seconds < 90 * 60) return `about ${Math.round(seconds / 60)} min`
+  if (seconds < 36 * 3600) return `about ${Math.round(seconds / 3600)} h`
+  if (seconds < 400 * 86400) return `about ${Math.round(seconds / 86400)} days`
+  return `about ${Math.round(seconds / (365.25 * 86400))} years`
+}
+
+/** m:ss for an elapsed span. */
+export function clock(ms: number): string {
+  const s = Math.floor(ms / 1000)
+  const m = Math.floor(s / 60)
+  return `${m}:${String(s % 60).padStart(2, '0')}`
+}

--- a/src/lib/avatarWorker.ts
+++ b/src/lib/avatarWorker.ts
@@ -1,0 +1,84 @@
+/**
+ * avatarWorker.ts - the main thread's handle on an avatar mining job.
+ *
+ * `mineInWorker` starts a worker per spare core, each on its own residue of
+ * the nonce, and resolves with the first find; cancel terminates them all and
+ * rejects. The store takes any AvatarMiner of this shape, so tests run the
+ * loop inline.
+ */
+
+import type { MineFound, MineTemplate } from './avatarMine'
+import type { MineRequest, MineResponse } from '../workers/avatar.worker'
+
+export interface MineProgress { tries: number; elapsedMs: number }
+
+export interface MineJob {
+  done: Promise<MineFound & MineProgress>
+  cancel: () => void
+}
+
+export type AvatarMiner = (template: MineTemplate, target: number, onProgress: (p: MineProgress) => void) => MineJob
+
+export class MineCancelled extends Error {
+  constructor() { super('mining cancelled') }
+}
+
+/** Workers per job: every core but one, so the page itself keeps breathing. */
+export function minerCount(): number {
+  const cores = typeof navigator !== 'undefined' ? navigator.hardwareConcurrency || 2 : 2
+  return Math.max(1, Math.min(16, cores - 1))
+}
+
+export const mineInWorker: AvatarMiner = (template, target, onProgress) => {
+  const workers: Worker[] = []
+  const tries: number[] = []
+  let elapsedMs = 0
+  let settled = false
+  let reject: (e: Error) => void = () => {}
+  const stopAll = () => { for (const w of workers) w.terminate(); workers.length = 0 }
+  const done = new Promise<MineFound & MineProgress>((resolve, rej) => {
+    reject = rej
+    const n = minerCount()
+    for (let i = 0; i < n; i++) {
+      let worker: Worker
+      try {
+        worker = new Worker(new URL('../workers/avatar.worker.ts', import.meta.url), { type: 'module' })
+      } catch (e) {
+        stopAll()
+        settled = true
+        rej(e instanceof Error ? e : new Error(String(e)))
+        return
+      }
+      workers.push(worker)
+      tries.push(0)
+      worker.onmessage = (event: MessageEvent<MineResponse>) => {
+        if (settled) return
+        const msg = event.data
+        tries[i] = msg.tries
+        elapsedMs = Math.max(elapsedMs, msg.elapsedMs)
+        const total = tries.reduce((a, b) => a + b, 0)
+        if (msg.type === 'progress') { onProgress({ tries: total, elapsedMs }); return }
+        settled = true
+        stopAll()
+        resolve({ ...msg.found, tries: total, elapsedMs })
+      }
+      worker.onerror = (e) => {
+        if (settled) return
+        settled = true
+        stopAll()
+        rej(new Error(e.message || 'mining failed'))
+      }
+      const request: MineRequest = { template, target, start: i, stride: n }
+      worker.postMessage(request)
+    }
+  })
+  return {
+    done,
+    cancel: () => {
+      if (settled) return
+      settled = true
+      stopAll()
+      reject(new MineCancelled())
+    },
+  }
+}

--- a/src/lib/calibration.ts
+++ b/src/lib/calibration.ts
@@ -160,6 +160,8 @@ interface CalibrationSnapshot {
   hopHeight: number
   /** Recommended sidestep ceiling: measured, else the default. */
   sidestepHeight: number
+  /** Measured SHA-256 leaf hashes per second; absent until measured or read from the cache. */
+  sha256PerSec?: number
 }
 
 /**
@@ -226,6 +228,7 @@ export function startCalibration(): void {
       status: 'cached',
       hopHeight: hopCeiling(cached.cantorMsByHeight),
       sidestepHeight: sidestepCeiling(cached.sha256PerSec),
+      sha256PerSec: cached.sha256PerSec,
     })
     return
   }
@@ -258,6 +261,7 @@ function runBenchmark(): void {
       status: 'measured',
       hopHeight: hopCeiling(msg.cantorMsByHeight),
       sidestepHeight: sidestepCeiling(msg.sha256PerSec),
+      sha256PerSec: msg.sha256PerSec,
     })
   }
   worker.onerror = () => worker.terminate()

--- a/src/store/useAvatars.test.ts
+++ b/src/store/useAvatars.test.ts
@@ -16,11 +16,30 @@ vi.mock('../lib/relay', () => ({
   query: vi.fn(async () => []),
 }))
 
+import { verifyAvatarWork } from 'cyberspace-core'
 import { publish, query } from '../lib/relay'
-import { AVATAR_KIND } from '../lib/avatar'
+import { AVATAR_KIND, avatarTemplate } from '../lib/avatar'
+import { eventId, mineChunk, nonceTagged } from '../lib/avatarMine'
+import { MineCancelled, type AvatarMiner } from '../lib/avatarWorker'
 import { newShard } from '../lib/shards'
 import { useCyberspace } from './useCyberspace'
-import { useAvatars } from './useAvatars'
+import { setAvatarMiner, useAvatars } from './useAvatars'
+
+// The work, inline: the same loop the worker runs, with a hook to cancel.
+const inline: AvatarMiner = (template, target, onProgress) => {
+  let cancelled = false
+  const done = new Promise<{ nonce: string; id: string; tries: number; elapsedMs: number }>((resolve, reject) => {
+    setTimeout(() => {
+      if (cancelled) { reject(new MineCancelled()); return }
+      let found = null
+      let from = 0
+      for (; found === null && from < 2 ** 24; from += 4096) { found = mineChunk(template, target, from, 4096); onProgress({ tries: from + 4096, elapsedMs: 1 }) }
+      resolve({ ...found!, tries: from, elapsedMs: 1 })
+    }, 0)
+  })
+  return { done, cancel: () => { cancelled = true } }
+}
+setAvatarMiner(inline)
 
 const built = () => {
   const s = newShard('me')
@@ -32,7 +51,7 @@ const built = () => {
 }
 
 describe('useAvatars', () => {
-  beforeEach(() => { useAvatars.setState({ shards: {}, asked: {} }); localStorage.clear(); vi.mocked(query).mockClear(); vi.mocked(publish).mockClear() })
+  beforeEach(() => { useAvatars.setState({ shards: {}, asked: {}, mining: null, adoptError: null }); localStorage.clear(); vi.mocked(query).mockClear(); vi.mocked(publish).mockClear() })
 
   it('adopting a shard signs a kind 33331 event with d=avatar, publishes it and keeps a copy', async () => {
     const me = useCyberspace.getState().identity.pubkey
@@ -40,7 +59,11 @@ describe('useAvatars', () => {
     const ev = vi.mocked(publish).mock.calls[0][0]
     expect(ev.kind).toBe(AVATAR_KIND)
     expect(ev.pubkey).toBe(me)
-    expect(ev.tags).toEqual([['d', 'avatar'], ['name', 'Arches']])
+    expect(ev.tags.slice(0, 2)).toEqual([['d', 'avatar'], ['name', 'Arches']])
+    // Paid: the floor for a one-gibson triangle, committed before mining and carried by the id.
+    expect(ev.tags[2]).toEqual(['nonce', expect.any(String), '16'])
+    expect(verifyAvatarWork(ev)).toMatchObject({ ok: true, required: 16, committed: 16 })
+    expect(useAvatars.getState().mining).toBeNull()
     expect(useAvatars.getState().shards[me]?.name).toBe('Arches')
     // Kept for the next load, before any relay answers.
     useAvatars.setState({ shards: {} })
@@ -52,8 +75,49 @@ describe('useAvatars', () => {
     const me = useCyberspace.getState().identity.pubkey
     await useAvatars.getState().adopt(built())
     expect(await useAvatars.getState().adopt(null)).toBe(true)
-    expect(vi.mocked(publish).mock.calls[1][0].content).toBe('')
+    const ev = vi.mocked(publish).mock.calls[1][0]
+    expect(ev.content).toBe('')
+    // The dodecahedron owes nothing: no nonce, no mining.
+    expect(ev.tags.some((t) => t[0] === 'nonce')).toBe(false)
     expect(useAvatars.getState().shards[me]).toBeNull()
+  })
+
+  it('cancelling the work leaves the avatar as it was, with no error', async () => {
+    const me = useCyberspace.getState().identity.pubkey
+    const pending = useAvatars.getState().adopt(built())
+    expect(useAvatars.getState().mining).toMatchObject({ required: 16, tries: 0 })
+    useAvatars.getState().cancelAdopt()
+    expect(await pending).toBe(false)
+    expect(useAvatars.getState().mining).toBeNull()
+    expect(useAvatars.getState().adoptError).toBeNull()
+    expect(vi.mocked(publish)).not.toHaveBeenCalled()
+    expect(me in useAvatars.getState().shards).toBe(false)
+  })
+
+  it('a second adopt while one is mining is refused', async () => {
+    const pending = useAvatars.getState().adopt(built())
+    expect(await useAvatars.getState().adopt(built())).toBe(false)
+    expect(await pending).toBe(true)
+  })
+
+  it('an avatar that has not paid is the dodecahedron to everyone', async () => {
+    const pk = 'ef'.repeat(32)
+    const shard = built()
+    const unpaid = { ...avatarTemplate(shard, 30), pubkey: pk, id: 'ff'.repeat(32), sig: '' }
+    vi.mocked(query).mockResolvedValueOnce([unpaid as never])
+    useAvatars.getState().ensure(pk)
+    await vi.waitFor(() => { expect(pk in useAvatars.getState().shards).toBe(true) })
+    expect(useAvatars.getState().shards[pk]).toBeNull()
+    // The same shape with its work done is drawn.
+    const t = { ...avatarTemplate(shard, 31), pubkey: pk }
+    let found = null
+    for (let from = 0; found === null; from += 4096) found = mineChunk(t, 16, from, 4096)
+    const paid = { ...nonceTagged(t, found!.nonce, 16), id: found!.id, sig: '' }
+    expect(eventId(paid)).toBe(paid.id)
+    useAvatars.setState({ asked: {} })
+    vi.mocked(query).mockResolvedValueOnce([paid as never])
+    useAvatars.getState().ensure(pk)
+    await vi.waitFor(() => { expect(useAvatars.getState().shards[pk]?.name).toBe('Arches') })
   })
 
   it('asks the relay once per pubkey and reads the newest event', async () => {

--- a/src/store/useAvatars.ts
+++ b/src/store/useAvatars.ts
@@ -3,14 +3,20 @@
  *
  * Every avatar drawn asks here for its shape: the kind 33331 event of that
  * pubkey (lib/avatar), fetched once and refreshed now and then, null meaning
- * the dodecahedron. Your own is kept in localStorage as well, so it is on
- * screen before the relay answers, and adopting a shard signs and publishes
- * the event and keeps the copy.
+ * the dodecahedron. An avatar is drawn only when it has paid its work (spec
+ * 8.10, cyberspace-core's verifyAvatarWork); one that has not is the
+ * dodecahedron to everyone. Your own is kept in localStorage as well, so it
+ * is on screen before the relay answers, and adopting a shard prices it,
+ * mines the nonce off the main thread with progress and cancel, signs and
+ * publishes the event and keeps the copy.
  */
 
 import { useEffect } from 'react'
 import { create } from 'zustand'
+import { avatarWork, verifyAvatarWork } from 'cyberspace-core'
 import { AVATAR_D, AVATAR_KIND, avatarFromEvent, avatarTemplate } from '../lib/avatar'
+import { nonceTagged } from '../lib/avatarMine'
+import { MineCancelled, mineInWorker, type AvatarMiner } from '../lib/avatarWorker'
 import { publish, query } from '../lib/relay'
 import { fromPayload, toPayload, type ShardModel } from '../lib/shards'
 import { useCyberspace } from './useCyberspace'
@@ -18,15 +24,34 @@ import { useCyberspace } from './useCyberspace'
 const MINE_KEY = 'onosendai:avatar'
 const REFRESH_MS = 5 * 60_000
 
+/** How the work is done; tests swap in an inline loop. */
+let miner: AvatarMiner = mineInWorker
+export function setAvatarMiner(m: AvatarMiner): void { miner = m }
+
+let current: { cancel: () => void } | null = null
+
+export interface Mining {
+  /** Bits the shape owes. */
+  required: number
+  tries: number
+  elapsedMs: number
+}
+
 interface AvatarsState {
   /** By pubkey: the shard, null for the dodecahedron; absent until asked. */
   shards: Record<string, ShardModel | null>
   /** When each pubkey was last asked for, so the relay is not asked per frame. */
   asked: Record<string, number>
+  /** The job in progress, for the workshop's row. */
+  mining: Mining | null
+  /** Why the last adopt failed, for the notice; null when it succeeded or was cancelled. */
+  adoptError: string | null
   /** Look a pubkey's avatar up, once per refresh window. */
   ensure: (pubkey: string) => void
   /** Publish this shard as your avatar (null for the dodecahedron); true when a relay took it. */
   adopt: (shard: ShardModel | null) => Promise<boolean>
+  /** Stop the mining in progress; adopt resolves false. */
+  cancelAdopt: () => void
   /** Your own from localStorage, before the relay answers. */
   loadMine: () => void
 }
@@ -34,6 +59,8 @@ interface AvatarsState {
 export const useAvatars = create<AvatarsState>((set, get) => ({
   shards: {},
   asked: {},
+  mining: null,
+  adoptError: null,
 
   ensure: (pubkey) => {
     const now = Date.now()
@@ -43,7 +70,7 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
     query({ kinds: [AVATAR_KIND], authors: [pubkey], '#d': [AVATAR_D] })
       .then((events) => {
         const newest = [...events].sort((a, b) => b.created_at - a.created_at)[0]
-        const shard = newest ? avatarFromEvent(newest) : null
+        const shard = newest ? paidShard(newest) : null
         set({ shards: { ...get().shards, [pubkey]: shard } })
         if (pubkey === useCyberspace.getState().identity.pubkey) remember(shard)
       })
@@ -51,20 +78,54 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
   },
 
   adopt: async (shard) => {
+    if (get().mining) return false
     const cs = useCyberspace.getState()
     const me = cs.identity.pubkey
+    let template = avatarTemplate(shard, Math.floor(Date.now() / 1000))
+    set({ adoptError: null })
+    if (shard) {
+      const required = avatarWork(toPayload(shard))
+      const job = miner({ ...template, pubkey: me }, required, (p) => {
+        const m = get().mining
+        if (m) set({ mining: { ...m, tries: p.tries, elapsedMs: p.elapsedMs } })
+      })
+      current = job
+      set({ mining: { required, tries: 0, elapsedMs: 0 } })
+      try {
+        const found = await job.done
+        template = nonceTagged(template, found.nonce, required)
+      } catch (e) {
+        set({ mining: null, adoptError: e instanceof MineCancelled ? null : 'The mining failed on this device.' })
+        return false
+      } finally {
+        current = null
+      }
+      set({ mining: null })
+    }
     let event
     try {
-      event = await cs.signEvent(avatarTemplate(shard, Math.floor(Date.now() / 1000)))
+      event = await cs.signEvent(template)
     } catch {
+      set({ adoptError: 'The signer did not sign the avatar.' })
+      return false
+    }
+    // The signer must return the event as mined: a changed created_at or tag
+    // list is a different id, and the work is gone with it.
+    if (shard && !verifyAvatarWork(event).ok) {
+      set({ adoptError: 'The signer changed the event, so the work no longer covers it. Try again.' })
       return false
     }
     const result = await publish(event)
-    if (!result.ok) return false
+    if (!result.ok) {
+      set({ adoptError: 'No relay took the avatar. Try again when one is reachable.' })
+      return false
+    }
     set({ shards: { ...get().shards, [me]: shard }, asked: { ...get().asked, [me]: Date.now() } })
     remember(shard)
     return true
   },
+
+  cancelAdopt: () => { current?.cancel() },
 
   loadMine: () => {
     const me = useCyberspace.getState().identity.pubkey
@@ -78,6 +139,16 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
     } catch { /* nothing kept */ }
   },
 }))
+
+/**
+ * The shard an event is drawn as: none for an empty content (the dodecahedron,
+ * which owes nothing), none for a shape that has not paid its work.
+ */
+export function paidShard(ev: { kind: number; pubkey: string; content: string; tags: string[][]; id: string }): ShardModel | null {
+  if (!ev.content) return null
+  if (!verifyAvatarWork(ev).ok) return null
+  return avatarFromEvent(ev)
+}
 
 function remember(shard: ShardModel | null): void {
   try {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5085,3 +5085,13 @@ kbd {
 .comments__row { display: flex; justify-content: flex-end; gap: 6px; }
 .comments__empty, .comments__note { margin: 4px 0 0; font-size: 10px; letter-spacing: 0.05em; color: var(--dim); line-height: 1.4; }
 .comments__error { margin: 4px 0 0; font-size: 10px; color: #ff6b6b; }
+
+/* The avatar's price and, while it is mined, the progress: one dim line under the row. */
+.workshop__work {
+  flex-basis: 100%;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  color: var(--dim);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.5;
+}

--- a/src/workers/avatar.worker.ts
+++ b/src/workers/avatar.worker.ts
@@ -1,0 +1,48 @@
+/**
+ * avatar.worker.ts - mines an avatar's nonce off the main thread.
+ *
+ * One request per worker: chunks of nonces between progress messages, so the
+ * elapsed time and the live rate are on screen while it runs. Several run at
+ * once on disjoint residues of the nonce; the main thread takes the first
+ * find and cancels by terminating them all (lib/avatarWorker.ts).
+ */
+
+import { mineChunk, type MineFound, type MineTemplate } from '../lib/avatarMine'
+
+export interface MineRequest {
+  template: MineTemplate
+  target: number
+  /** This worker's first nonce and the gap to its next: worker i of n takes i, i+n, i+2n... */
+  start: number
+  stride: number
+}
+
+export type MineResponse =
+  | { type: 'progress'; tries: number; elapsedMs: number }
+  | { type: 'done'; found: MineFound; tries: number; elapsedMs: number }
+
+const CHUNK = 1024
+const REPORT_MS = 200
+
+self.onmessage = (event: MessageEvent<MineRequest>) => {
+  const { template, target, start: first, stride } = event.data
+  const start = performance.now()
+  let tries = 0
+  let lastReport = start
+  for (;;) {
+    const found = mineChunk(template, target, first + tries * stride, CHUNK, stride)
+    if (found) {
+      tries += Math.floor((Number(found.nonce) - first) / stride) % CHUNK + 1
+      const done: MineResponse = { type: 'done', found, tries, elapsedMs: performance.now() - start }
+      self.postMessage(done)
+      return
+    }
+    tries += CHUNK
+    const now = performance.now()
+    if (now - lastReport >= REPORT_MS) {
+      lastReport = now
+      const progress: MineResponse = { type: 'progress', tries, elapsedMs: now - start }
+      self.postMessage(progress)
+    }
+  }
+}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -18,7 +18,7 @@
  * the bottom above the two corners.
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Vector3 } from 'three'
 import { Compass3D } from '../scene/Compass3D'
 import { Eye, Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, RotateCcw, RotateCw, Stamp, Trash2, Triangle, Undo2, Wrench, X, type LucideIcon } from 'lucide-react'
@@ -30,6 +30,11 @@ import { hsvToRgb, rgbToHsv, type Hsv } from '../lib/hsv'
 import { formatCellSize } from '../lib/scale'
 import { FACED, FACING_LABEL, FLOOR, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, type StampKind } from '../lib/stamps'
 import { useAvatars } from '../store/useAvatars'
+import { avatarReach, avatarWork } from 'cyberspace-core'
+import { avatarTemplate } from '../lib/avatar'
+import { clock, describeDuration, expectedTries, serializeEvent, triesPerSec } from '../lib/avatarMine'
+import { minerCount } from '../lib/avatarWorker'
+import { useCalibration } from '../lib/calibration'
 import { useCyberspace } from '../store/useCyberspace'
 import { useWorkshop, type Tool } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
@@ -250,6 +255,18 @@ export function Workshop(): JSX.Element | null {
   const showAvatar = useWorkshop((s) => s.showAvatar)
   const me = useCyberspace((s) => s.identity.pubkey)
   const myAvatar = useAvatars((s) => s.shards[me] ?? null)
+  const mining = useAvatars((s) => s.mining)
+  const sha256PerSec = useCalibration((s) => s.sha256PerSec)
+  // The avatar's price (spec 8.10), memoised on the geometry; a hook, so it sits with the others.
+  const buildable = shard !== null && shard.vertices.length > 0 && shard.faces.length > 0
+  const work = useMemo(() => {
+    if (!shard || !buildable) return { required: 0, reach: 0, detail: 0, bytes: 0 }
+    const payload = toPayload(shard)
+    // The bytes hashed per try: the serialized event with a nonce tag of typical width.
+    const bytes = new TextEncoder().encode(serializeEvent({ ...avatarTemplate(shard, 1_800_000_000), pubkey: me })).length + 40
+    return { required: avatarWork(payload), reach: Math.max(1, avatarReach(payload)), detail: shard.vertices.length + shard.faces.length, bytes }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buildable, shard?.vertices, shard?.faces, shard?.unit, shard?.name, me])
   const color = useWorkshop((s) => s.color)
   const stampKind = useWorkshop((s) => s.stampKind)
   const stampSize = useWorkshop((s) => s.stampSize)
@@ -415,14 +432,34 @@ export function Workshop(): JSX.Element | null {
           <div className="workshop__row" role="group" aria-label="My avatar">
             <span className="workshop__label">MY AVATAR</span>
             <span className="workshop__value workshop__value--wide">{myAvatar ? myAvatar.name : 'dodecahedron'}</span>
-            <button
-              className="workshop__btn"
-              disabled={shard.vertices.length === 0 || shard.faces.length === 0}
-              onClick={() => { void useAvatars.getState().adopt(shard).then((ok) => say(ok ? `"${shard.name}" is your avatar now.` : 'No relay took the avatar. Try again when one is reachable.')) }}
-              title="Publish this shard as the shape others see for you, at true scale: the white avatar on the grid is the size of one cell"
-            >USE THIS SHARD</button>
-            {myAvatar && (
-              <button className="workshop__btn" onClick={() => { void useAvatars.getState().adopt(null).then((ok) => say(ok ? 'The dodecahedron is your avatar again.' : 'No relay took the change.')) }} title="Back to the dodecahedron">DODECAHEDRON</button>
+            {mining ? (
+              <button className="workshop__btn workshop__btn--danger" onClick={() => useAvatars.getState().cancelAdopt()} title="Stop mining; your avatar stays as it is">CANCEL</button>
+            ) : (
+              <button
+                className="workshop__btn"
+                disabled={!buildable}
+                onClick={() => {
+                  const started = Date.now()
+                  void useAvatars.getState().adopt(shard).then((ok) => {
+                    const err = useAvatars.getState().adoptError
+                    say(ok ? `"${shard.name}" is your avatar now: ${work.required} bits of work in ${describeDuration((Date.now() - started) / 1000).replace('about ', '')}.` : err ?? 'Mining cancelled. Your avatar is as it was.')
+                  })
+                }}
+                title="Publish this shard as the shape others see for you, at true scale: the white avatar on the grid is the size of one cell. Its size and detail are paid for in proof of work first."
+              >USE THIS SHARD</button>
+            )}
+            {myAvatar && !mining && (
+              <button className="workshop__btn" onClick={() => { void useAvatars.getState().adopt(null).then((ok) => say(ok ? 'The dodecahedron is your avatar again.' : useAvatars.getState().adoptError ?? 'No relay took the change.')) }} title="Back to the dodecahedron; it owes no work">DODECAHEDRON</button>
+            )}
+            {/* The price (spec 8.10): 16 bits for any avatar, 6 more per doubling of
+                its reach in gibsons, 3 per doubling of vertices plus faces beyond 32;
+                the whole event is hashed per try, so bytes cost as well. */}
+            {buildable && (
+              <span className="workshop__work" aria-live="polite">
+                {mining
+                  ? `MINING ${mining.required} BITS · ${clock(mining.elapsedMs)} ELAPSED · ${mining.elapsedMs > 1000 ? describeDuration(expectedTries(mining.required) / (mining.tries / (mining.elapsedMs / 1000))).toUpperCase() + ' EXPECTED · ' : ''}${mining.elapsedMs > 1000 ? Math.round(mining.tries / (mining.elapsedMs / 1000) / 1000) + 'K TRIES/S' : 'MEASURING'}`
+                  : `WORK ${work.required} BITS · ${work.reach.toFixed(work.reach >= 10 ? 0 : 1)} GIBSON REACH · ${work.detail} VERTICES + FACES · ${sha256PerSec ? describeDuration(expectedTries(work.required) / triesPerSec(sha256PerSec, work.bytes, minerCount())).toUpperCase() + ' ON THIS DEVICE' : 'TIME UNKNOWN UNTIL CALIBRATED'}`}
+              </span>
             )}
           </div>
           <div className="ws__panel-title">SHARDS ({shards.length})</div>


### PR DESCRIPTION
The client side of spec 8.10 (cyberspace#24): a kind 33331 avatar is paid for in NIP-13 work on the event, and a client draws nothing that has not paid.

**The price** (cyberspace-core, cyberspace-cli-js#4): `required = ceil(16 + 2·log2(reach) + 3·log2(detail / 32))`, reach the farthest vertex from the build origin in gibsons at true scale, detail vertices plus faces. Bytes are charged besides, since every try hashes the whole event.

**Mining**
- `lib/avatarMine.ts`: the NIP-01 serialization built once around a marker, the nonce's digits written into a reusable buffer, one SHA-256 per try; a stride so workers walk disjoint residues. Its id agrees with nostr-tools' `getEventHash` (tested).
- `workers/avatar.worker.ts` runs chunks with progress every 200 ms; `lib/avatarWorker.ts` starts one worker per spare core, takes the first find, terminates the rest; cancel rejects with `MineCancelled`.
- `useAvatars.adopt`: prices the shard, mines, signs, checks the signer returned the event as mined (a changed `created_at` or tag list is a different id and the work is gone), publishes, and sets `adoptError` with the reason when it cannot. `cancelAdopt` stops the job; a second adopt while one runs is refused.
- `useAvatars.ensure`: an event is drawn only when `verifyAvatarWork` says it paid; empty content (the dodecahedron) owes nothing.

**The MENU row**: idle, it shows the price, the reach and detail behind it, and the expected time on this device from the calibration's hash rate (the snapshot now carries `sha256PerSec`). Mining, it shows elapsed, expected from the live rate, tries per second, and CANCEL in place of USE THIS SHARD.

**Measured in a headless browser on this machine** (16 threads, 15 workers):

| shape | reach | vertices + faces | bits | aggregate rate | time |
|---|---|---|---|---|---|
| one-gibson wedge | 1 | 8 | 16 | 428k tries/s | under a second |
| the arch | 5 | 72 | 25 | 428k tries/s | about 80 s |

Size settled at two bits per doubling on 2026-09-08 with the measured ladder in hand (it began at six, the arch at 34 bits and about 11 hours): cyberspace-cli-js#6, cyberspace-cli#21, spec 8.10 merged in cyberspace#24.

Suite 564 passing (13 new), tsc and build clean; core at 2cdb075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz