### PR TITLE
Points that glow and handles that get out of the way

### DIFF
--- a/src/lib/glow.ts
+++ b/src/lib/glow.ts
@@ -1,0 +1,34 @@
+/**
+ * glow.ts - one soft round sprite for points that should read as light.
+ *
+ * A radial falloff from a white core to nothing, drawn once on a small canvas
+ * and shared by every points material and halo sprite that asks. Tinted by
+ * the material's colour, blended additively, it turns a square point into a
+ * small glow. Null where there is no document (tests, workers), and callers
+ * draw plain points then.
+ */
+
+import { CanvasTexture, SRGBColorSpace, type Texture } from 'three'
+
+let cached: Texture | null | undefined
+
+export function glowTexture(): Texture | null {
+  if (cached !== undefined) return cached
+  if (typeof document === 'undefined') return (cached = null)
+  const size = 64
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return (cached = null)
+  const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2)
+  g.addColorStop(0, 'rgba(255,255,255,1)')
+  g.addColorStop(0.18, 'rgba(255,255,255,0.9)')
+  g.addColorStop(0.45, 'rgba(255,255,255,0.28)')
+  g.addColorStop(1, 'rgba(255,255,255,0)')
+  ctx.fillStyle = g
+  ctx.fillRect(0, 0, size, size)
+  const tex = new CanvasTexture(canvas)
+  tex.colorSpace = SRGBColorSpace
+  return (cached = tex)
+}

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -28,6 +28,7 @@ import {
 } from 'three'
 import { easeOutCubic, hash01, scrambleOffset, seedOf, SHARD_DECODE_MS } from '../lib/decode'
 import { flatten, ticksOf, toRender, type ShardModel } from '../lib/shards'
+import { glowTexture } from '../lib/glow'
 import { orientShard } from '../lib/orient'
 
 interface Props {
@@ -170,6 +171,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
 
   if (shard.vertices.length === 0) return null
   const opacity = ghost ? 0.45 : 1
+  const glow = glowTexture()
 
   return (
     <group scale={scale}>
@@ -191,15 +193,18 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
       {shard.mode === 'lines' && shard.vertices.length > 1 && <primitive object={line} />}
       {(shard.mode === 'points' || shard.mode === 'solid' || shard.mode === 'lines') && (
         <points geometry={plain} frustumCulled={false}>
+          {/* Small and glowing: a soft round sprite tinted by the vertex colour, added
+              to what is behind it, so a point reads as a light rather than a tile. */}
           <pointsMaterial
             vertexColors
-            size={shard.mode === 'points' ? 0.6 : 0.16}
+            size={shard.mode === 'points' ? 0.22 : 0.1}
             sizeAttenuation
             transparent
             opacity={shard.mode === 'points' ? opacity : opacity * 0.9}
             blending={AdditiveBlending}
             depthWrite={false}
             toneMapped={false}
+            {...(glow ? { map: glow, alphaTest: 0.02 } : {})}
           />
         </points>
       )}

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -177,7 +177,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
     <group scale={scale}>
       {shard.mode === 'solid' && index.length > 0 && (
         <group>
-          <mesh geometry={indexed} frustumCulled={false} {...(onFaceClick ? { onClick: onFaceClick } : {})}>
+          <mesh name="shard-faces" geometry={indexed} frustumCulled={false} {...(onFaceClick ? { onClick: onFaceClick } : {})}>
             {lit
               ? <meshLambertMaterial vertexColors flatShading side={FrontSide} transparent opacity={opacity} />
               : <meshBasicMaterial vertexColors side={DoubleSide} toneMapped={false} transparent opacity={opacity} {...(world && !ghost ? TAG_BLEND : {})} />}

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -18,8 +18,9 @@
 import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
-import { BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
+import { AdditiveBlending, BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
+import { glowTexture } from '../lib/glow'
 import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, ticksOf, toRender } from '../lib/shards'
 import { benchAxes, benchPose, nudgeFor, planeAfter, sameAxes, useBenchView, type NudgeName } from './benchAxes'
 import { landing, preview, type WorkPlane } from '../lib/stamps'
@@ -173,7 +174,7 @@ function Ghost(): JSX.Element | null {
   if (tool === 'add') {
     return (
       <mesh position={UP(aim)}>
-        <sphereGeometry args={[0.2, 12, 12]} />
+        <sphereGeometry args={[0.1, 12, 12]} />
         <meshBasicMaterial color={rgbToHex(color)} transparent opacity={0.5} toneMapped={false} depthWrite={false} />
       </mesh>
     )
@@ -185,6 +186,15 @@ function Ghost(): JSX.Element | null {
     </group>
   )
 }
+
+/** Handle radii in bench units (a gibson at level 0): the dot, the selected dot, its halo's width. */
+const HANDLE = 0.07
+const HANDLE_ON = 0.11
+const HALO = 0.5
+/** Hit sphere radii: wide enough for a finger, and in ADD narrow enough that two
+ * points a fifth of a gibson apart can both be placed and picked. */
+const HIT = 0.3
+const HIT_ADD = 0.16
 
 /**
  * One handle per point. Several vertices can share a point once stamps have
@@ -202,6 +212,8 @@ function Handles(): JSX.Element | null {
     return [...m.values()]
   }, [shard?.vertices])
   if (!shard) return null
+  const glow = glowTexture()
+  const hitRadius = tool === 'add' ? HIT_ADD : HIT
 
   const onClick = (first: number, isSel: boolean) => (e: ThreeEvent<MouseEvent>): void => {
     if (e.delta > TAP_SLOP) return
@@ -222,18 +234,25 @@ function Handles(): JSX.Element | null {
         const picked = facePick.some((i) => g.includes(i))
         return (
           <group key={first} position={UP(ticksOf(v))}>
-            {/* A generous invisible hit target; the visible handle is small. */}
+            {/* An invisible hit target wider than the handle, narrower in ADD so a tap
+                beside a point lands on the plane and places another one near it. */}
             <mesh onClick={onClick(first, isSel)}>
-              <sphereGeometry args={[0.42, 10, 10]} />
+              <sphereGeometry args={[hitRadius, 10, 10]} />
               <meshBasicMaterial transparent opacity={0} depthWrite={false} />
             </mesh>
             <mesh>
-              <sphereGeometry args={[isSel || picked ? 0.2 : 0.12, 12, 12]} />
+              <sphereGeometry args={[isSel || picked ? HANDLE_ON : HANDLE, 12, 12]} />
               <meshBasicMaterial color={isSel ? WARN : picked ? ACCENT : rgbToHex(v.c)} toneMapped={false} />
             </mesh>
+            {/* A halo, so a small selected handle still stands out. */}
+            {(isSel || picked) && glow && (
+              <sprite scale={[HALO, HALO, 1]}>
+                <spriteMaterial map={glow} color={isSel ? WARN : ACCENT} transparent opacity={0.85} blending={AdditiveBlending} depthWrite={false} toneMapped={false} />
+              </sprite>
+            )}
             {picked && (
               <mesh>
-                <ringGeometry args={[0.3, 0.36, 24]} />
+                <ringGeometry args={[0.2, 0.24, 24]} />
                 <meshBasicMaterial color={ACCENT} toneMapped={false} side={2} />
               </mesh>
             )}

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -25,7 +25,7 @@ import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, ticksOf, toRen
 import { benchAxes, benchPose, nudgeFor, planeAfter, sameAxes, useBenchView, type NudgeName } from './benchAxes'
 import { landing, preview, type WorkPlane } from '../lib/stamps'
 import { ShardMesh } from '../scene/ShardMesh'
-import { useWorkshop } from '../store/useWorkshop'
+import { useWorkshop, type Tool } from '../store/useWorkshop'
 
 /** A press that travels further than this is an orbit, not a tap. */
 const TAP_SLOP = 8
@@ -191,10 +191,15 @@ function Ghost(): JSX.Element | null {
 const HANDLE = 0.07
 const HANDLE_ON = 0.11
 const HALO = 0.5
-/** Hit sphere radii: wide enough for a finger, and in ADD narrow enough that two
- * points a fifth of a gibson apart can both be placed and picked. */
+/** Hit sphere radii: wide enough for a finger at a whole-gibson grid, and never
+ * more than a share of the current step, so points a fifth of a gibson apart
+ * each keep their own target; ADD and FACE take the narrow one, since there a
+ * tap beside a point means the plane or the face. */
 const HIT = 0.3
-const HIT_ADD = 0.16
+const HIT_NARROW = 0.16
+function hitRadiusFor(tool: Tool, stepUnits: number): number {
+  return Math.min(tool === 'add' || tool === 'face' ? HIT_NARROW : HIT, stepUnits * 0.45)
+}
 
 /**
  * One handle per point. Several vertices can share a point once stamps have
@@ -205,6 +210,7 @@ function Handles(): JSX.Element | null {
   const selection = useWorkshop((s) => s.selection)
   const facePick = useWorkshop((s) => s.facePick)
   const tool = useWorkshop((s) => s.tool)
+  const step = useWorkshop((s) => s.step())
   const chosen = useMemo(() => new Set(selection), [selection])
   const groups = useMemo(() => {
     const m = new Map<string, number[]>()
@@ -213,13 +219,21 @@ function Handles(): JSX.Element | null {
   }, [shard?.vertices])
   if (!shard) return null
   const glow = glowTexture()
-  const hitRadius = tool === 'add' ? HIT_ADD : HIT
+  const hitRadius = hitRadiusFor(tool, step / TICKS_PER_UNIT)
 
   const onClick = (first: number, isSel: boolean) => (e: ThreeEvent<MouseEvent>): void => {
     if (e.delta > TAP_SLOP) return
     e.stopPropagation()
     const w = useWorkshop.getState()
-    if (tool === 'face') w.pickForFace(first)
+    if (tool === 'face') {
+      // The sphere stands proud of the faces, so it meets the ray first even when
+      // the tap was on a face beside the corner. If a face is under the tap and
+      // the ray passes farther from the corner than its drawn dot, the face wins.
+      const centre = new Vector3(...UP(ticksOf(shard.vertices[first])))
+      const face = e.intersections.find((i) => i.object.name === 'shard-faces')
+      if (face && face.faceIndex !== undefined && e.ray.distanceToPoint(centre) > HANDLE_ON) { w.selectFace(face.faceIndex); return }
+      w.pickForFace(first)
+    }
     // In SELECT a tap adds or removes the point; elsewhere it picks that point alone.
     else if (tool === 'select') w.toggleVertex(first)
     else w.selectVertex(isSel ? null : first)
@@ -537,8 +551,9 @@ export function Bench(): JSX.Element {
       <directionalLight position={[-9, 2, -3]} intensity={0.6} />
       {/* One finger or left drag orbits, except in SELECT where that drag is the
           marquee's. Two fingers, or the right button, pan the view in the screen
-          plane; pinch or the wheel dollies. These are the controls' own bindings. */}
-      <OrbitControls makeDefault enablePan screenSpacePanning panSpeed={0.9} enableRotate={tool !== 'select'} minDistance={3} maxDistance={60} dampingFactor={0.12} />
+          plane; pinch or the wheel dollies, in to 0.6 of a gibson so a fifth-gibson
+          step fills a good share of a phone's screen. These are the controls' own bindings. */}
+      <OrbitControls makeDefault enablePan screenSpacePanning panSpeed={0.9} enableRotate={tool !== 'select'} minDistance={0.6} maxDistance={60} dampingFactor={0.12} />
       <Marquee />
       <Aim />
       <Keys />


### PR DESCRIPTION
From the phone: POINTS mode drew each vertex as a tile half a cell wide, the handles were as big, and their hit spheres made it hard to place two points within one gibson.

- `lib/glow.ts`: one soft round sprite (radial falloff on a small canvas), shared. The shard points material maps it, additive, so a point reads as a small light instead of a tile.
- Point size 0.6 to 0.22 in POINTS mode, 0.16 to 0.1 for the vertex dots in SOLID and LINES.
- Handles 0.12 to 0.07; selected and face-picked 0.2 to 0.11, with a halo sprite (WARN or ACCENT) so a small selected handle still stands out; the pick ring 0.3 to 0.2; the ADD ghost 0.2 to 0.1.
- Hit spheres 0.42 to 0.3, and 0.16 in ADD, so a tap a fifth of a gibson from a point lands on the plane and places another one there. Verified at phone size (412 px wide, one cell about 47 px): the tap placed a point where it selected the neighbour before; in SELECT, a tap 0.22 from a point still picks it.

Suite 564 passing, tsc and build clean. Headless glow is subtler than a phone's; the sizes are what to judge from the sheet.

**Second commit, from the next round on the phone: faces, steps, zoom.**
- In FACE mode, taps on a face beside a corner kept picking the corner, because the corner's sphere stands proud of the face and meets the ray first. The handle now reads `e.intersections`: when a face is under the tap and the ray passes farther from the corner than its drawn dot (0.11), the face wins. A tap on the dot itself still picks the corner.
- Hit spheres are capped at 0.45 of the current grid step (`hitRadiusFor`), so at division 5 each point keeps its own 0.09 target and the face between two points is reachable; at division 1 they are as above.
- The bench dollies in to 0.6 of a gibson (was 3), so a fifth-gibson step can fill a good share of a phone screen.

Tested at phone size: on the face 0.13 from a corner selects the face at divisions 1 and 5; 0.05 from the corner picks the corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz