### PR TITLE
Adopting an avatar: one signature, and a row that says where it is

### DIFF
--- a/src/lib/avatarMine.ts
+++ b/src/lib/avatarMine.ts
@@ -121,6 +121,11 @@ export function describeDuration(seconds: number): string {
   return `about ${Math.round(seconds / (365.25 * 86400))} years`
 }
 
+/** How long a mine took, for a sentence: "under a second" or m:ss. */
+export function minedIn(ms: number): string {
+  return ms < 1000 ? 'under a second' : clock(ms)
+}
+
 /** m:ss for an elapsed span. */
 export function clock(ms: number): string {
   const s = Math.floor(ms / 1000)

--- a/src/lib/relay.test.ts
+++ b/src/lib/relay.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A pool whose first publish fails the way a half-open socket does, and whose
+// second, over fresh sockets, is accepted.
+const calls: { publish: string[][]; closed: string[][] } = { publish: [], closed: [] }
+let answers: Array<'ok' | Error> = []
+vi.mock('nostr-tools/abstract-pool', () => ({
+  AbstractSimplePool: class {
+    ensureRelay(): Promise<object> { return Promise.resolve({}) }
+    publish(relays: string[]): Promise<string>[] {
+      calls.publish.push(relays)
+      const a = answers.shift() ?? 'ok'
+      return relays.map(() => (a === 'ok' ? Promise.resolve('ok') : Promise.reject(a)))
+    }
+    close(relays: string[]): void { calls.closed.push(relays) }
+    subscribe(): { close: () => void } { return { close: () => {} } }
+  },
+}))
+
+import { publishMany } from './relay'
+
+const event = { id: 'a', pubkey: 'b', created_at: 1, kind: 1, tags: [], content: '', sig: 'c' } as never
+
+describe('publishMany', () => {
+  beforeEach(() => { calls.publish = []; calls.closed = []; answers = [] })
+
+  it('drops the sockets and sends once more after a timeout', async () => {
+    answers = [new Error('publish timed out'), 'ok']
+    expect(await publishMany(['wss://one'], event)).toEqual({ ok: true })
+    expect(calls.publish).toHaveLength(2)
+    expect(calls.closed).toEqual([['wss://one']])
+  })
+
+  it('takes a relay refusal as final', async () => {
+    answers = [new Error('blocked: not welcome')]
+    expect(await publishMany(['wss://one'], event)).toEqual({ ok: false, reason: 'blocked: not welcome' })
+    expect(calls.publish).toHaveLength(1)
+    expect(calls.closed).toEqual([])
+  })
+
+  it('reports the second failure when fresh sockets do not help either', async () => {
+    answers = [new Error('publish timed out'), new Error('relay connection closed')]
+    expect(await publishMany(['wss://one'], event)).toEqual({ ok: false, reason: 'relay connection closed' })
+    expect(calls.publish).toHaveLength(2)
+  })
+})

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -106,9 +106,22 @@ export function relaySet(): string[] {
 
 export type PublishResult = { ok: true } | { ok: false; reason: string }
 
-/** Send to a set of relays; ok if any accepts, the last refusal otherwise. */
-export async function publishMany(relays: string[], event: NostrEvent): Promise<PublishResult> {
-  if (relays.length === 0) return { ok: false, reason: 'no relays configured' }
+/** A relay's own refusal (NIP-01 OK false prefixes): asking again would get the same answer. */
+const REFUSED = /^(blocked|invalid|duplicate|pow|rate-limited|restricted|error)\b/i
+
+/**
+ * Drop the sockets to these relays so the next operation opens fresh ones.
+ * A phone that was in another app (a wallet, a signer) comes back with its
+ * sockets half-open: nothing arrives on them and a publish waits its whole
+ * maxWait for an OK that never comes. Also forgets their auth, since a new
+ * connection brings a new challenge.
+ */
+export function dropRelays(relays: string[]): void {
+  try { getPool().close(relays) } catch { /* nothing open */ }
+  for (const url of relays) authedFor.delete(url)
+}
+
+async function publishOnce(relays: string[], event: NostrEvent): Promise<PublishResult> {
   // Protected events (the `-` tag) are only accepted from an authenticated
   // author, and the relay does not challenge on the EVENT itself, so we must
   // already be authed before publishing.
@@ -117,6 +130,20 @@ export async function publishMany(relays: string[], event: NostrEvent): Promise<
   if (results.some((r) => r.status === 'fulfilled')) return { ok: true }
   const reason = results.map((r) => (r.status === 'rejected' ? String(r.reason?.message ?? r.reason) : '')).find(Boolean)
   return { ok: false, reason: reason || 'no relay accepted it' }
+}
+
+/**
+ * Send to a set of relays; ok if any accepts, the last refusal otherwise. When
+ * every relay failed for a reason that is not a refusal (a timeout, a closed
+ * socket), the sockets are presumed dead: they are dropped and the event is
+ * sent once more over fresh ones.
+ */
+export async function publishMany(relays: string[], event: NostrEvent): Promise<PublishResult> {
+  if (relays.length === 0) return { ok: false, reason: 'no relays configured' }
+  const first = await publishOnce(relays, event)
+  if (first.ok || REFUSED.test(first.reason)) return first
+  dropRelays(relays)
+  return publishOnce(relays, event)
 }
 
 /** Send one event to every configured relay. */

--- a/src/store/useAvatars.test.ts
+++ b/src/store/useAvatars.test.ts
@@ -23,7 +23,7 @@ import { eventId, mineChunk, nonceTagged } from '../lib/avatarMine'
 import { MineCancelled, type AvatarMiner } from '../lib/avatarWorker'
 import { newShard } from '../lib/shards'
 import { useCyberspace } from './useCyberspace'
-import { setAvatarMiner, useAvatars } from './useAvatars'
+import { AVATAR_SIGN_PATIENCE_MS, setAvatarMiner, useAvatars } from './useAvatars'
 
 // The work, inline: the same loop the worker runs, with a hook to cancel.
 const inline: AvatarMiner = (template, target, onProgress) => {
@@ -51,7 +51,7 @@ const built = () => {
 }
 
 describe('useAvatars', () => {
-  beforeEach(() => { useAvatars.setState({ shards: {}, asked: {}, mining: null, adoptError: null }); localStorage.clear(); vi.mocked(query).mockClear(); vi.mocked(publish).mockClear() })
+  beforeEach(() => { useAvatars.setState({ shards: {}, asked: {}, mining: null, phase: null, minedMs: null, adoptError: null }); localStorage.clear(); vi.mocked(query).mockClear(); vi.mocked(publish).mockClear() })
 
   it('adopting a shard signs a kind 33331 event with d=avatar, publishes it and keeps a copy', async () => {
     const me = useCyberspace.getState().identity.pubkey
@@ -92,6 +92,34 @@ describe('useAvatars', () => {
     expect(useAvatars.getState().adoptError).toBeNull()
     expect(vi.mocked(publish)).not.toHaveBeenCalled()
     expect(me in useAvatars.getState().shards).toBe(false)
+  })
+
+  it('walks mining, signing and publishing, refusing a second adopt the whole way', async () => {
+    const original = useCyberspace.getState().signEvent
+    let release: (() => void) | null = null
+    const patience: number[] = []
+    useCyberspace.setState({
+      signEvent: (template, patienceMs) => new Promise((resolve) => {
+        patience.push(patienceMs ?? -1)
+        release = () => { void original(template).then(resolve) }
+      }),
+    })
+    try {
+      const pending = useAvatars.getState().adopt(built())
+      expect(useAvatars.getState().phase).toBe('mining')
+      await vi.waitFor(() => { expect(useAvatars.getState().phase).toBe('signing') })
+      expect(useAvatars.getState().mining).toBeNull()
+      expect(useAvatars.getState().minedMs).not.toBeNull()
+      // The signer's prompt is open: a second press must not mine and ask again.
+      expect(await useAvatars.getState().adopt(built())).toBe(false)
+      expect(patience).toEqual([AVATAR_SIGN_PATIENCE_MS])
+      release!()
+      expect(await pending).toBe(true)
+      expect(useAvatars.getState().phase).toBeNull()
+      expect(vi.mocked(publish)).toHaveBeenCalledTimes(1)
+    } finally {
+      useCyberspace.setState({ signEvent: original })
+    }
   })
 
   it('a second adopt while one is mining is refused', async () => {

--- a/src/store/useAvatars.test.ts
+++ b/src/store/useAvatars.test.ts
@@ -128,6 +128,24 @@ describe('useAvatars', () => {
     expect(await pending).toBe(true)
   })
 
+  it('an empty answer from the relay keeps a known avatar', async () => {
+    const me = useCyberspace.getState().identity.pubkey
+    await useAvatars.getState().adopt(built())
+    expect(useAvatars.getState().shards[me]?.name).toBe('Arches')
+    useAvatars.setState({ asked: {} })
+    vi.mocked(query).mockResolvedValueOnce([])
+    useAvatars.getState().ensure(me)
+    await vi.waitFor(() => { expect(vi.mocked(query)).toHaveBeenCalledTimes(1) })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(useAvatars.getState().shards[me]?.name).toBe('Arches')
+    // Never asked before and nothing there: the dodecahedron, as before.
+    const other = '12'.repeat(32)
+    vi.mocked(query).mockResolvedValueOnce([])
+    useAvatars.getState().ensure(other)
+    await vi.waitFor(() => { expect(other in useAvatars.getState().shards).toBe(true) })
+    expect(useAvatars.getState().shards[other]).toBeNull()
+  })
+
   it('an avatar that has not paid is the dodecahedron to everyone', async () => {
     const pk = 'ef'.repeat(32)
     const shard = built()

--- a/src/store/useAvatars.ts
+++ b/src/store/useAvatars.ts
@@ -84,7 +84,13 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
     query({ kinds: [AVATAR_KIND], authors: [pubkey], '#d': [AVATAR_D] })
       .then((events) => {
         const newest = [...events].sort((a, b) => b.created_at - a.created_at)[0]
-        const shard = newest ? paidShard(newest) : null
+        // An empty answer says nothing: a relay that is down, or has not seen
+        // the event yet, must not turn a known avatar back into the dodecahedron.
+        if (!newest) {
+          if (!(pubkey in get().shards)) set({ shards: { ...get().shards, [pubkey]: null } })
+          return
+        }
+        const shard = paidShard(newest)
         set({ shards: { ...get().shards, [pubkey]: shard } })
         if (pubkey === useCyberspace.getState().identity.pubkey) remember(shard)
       })

--- a/src/store/useAvatars.ts
+++ b/src/store/useAvatars.ts
@@ -7,8 +7,10 @@
  * 8.10, cyberspace-core's verifyAvatarWork); one that has not is the
  * dodecahedron to everyone. Your own is kept in localStorage as well, so it
  * is on screen before the relay answers, and adopting a shard prices it,
- * mines the nonce off the main thread with progress and cancel, signs and
- * publishes the event and keeps the copy.
+ * mines the nonce off the main thread with progress and cancel, signs (with
+ * a long patience, since a person is reading the prompt), publishes the
+ * event and keeps the copy. `phase` says which of those is happening, so the
+ * workshop can keep the button down and say where things are.
  */
 
 import { useEffect } from 'react'
@@ -37,6 +39,12 @@ export interface Mining {
   elapsedMs: number
 }
 
+/** Where an adopt is: the work, then the signer, then the relays. */
+export type AdoptPhase = 'mining' | 'signing' | 'publishing'
+
+/** How long to wait for a remote signer here: a person is reading the prompt, not a hop. */
+export const AVATAR_SIGN_PATIENCE_MS = 120_000
+
 interface AvatarsState {
   /** By pubkey: the shard, null for the dodecahedron; absent until asked. */
   shards: Record<string, ShardModel | null>
@@ -44,6 +52,10 @@ interface AvatarsState {
   asked: Record<string, number>
   /** The job in progress, for the workshop's row. */
   mining: Mining | null
+  /** What adopt is doing now, null when idle; the button stays down through all of it. */
+  phase: AdoptPhase | null
+  /** How long the last mine took, kept through signing and publishing for the row. */
+  minedMs: number | null
   /** Why the last adopt failed, for the notice; null when it succeeded or was cancelled. */
   adoptError: string | null
   /** Look a pubkey's avatar up, once per refresh window. */
@@ -60,6 +72,8 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
   shards: {},
   asked: {},
   mining: null,
+  phase: null,
+  minedMs: null,
   adoptError: null,
 
   ensure: (pubkey) => {
@@ -78,11 +92,13 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
   },
 
   adopt: async (shard) => {
-    if (get().mining) return false
+    // One adopt at a time, through mining, signing and publishing: a second
+    // press while the signer's prompt is open would mine and ask again.
+    if (get().phase) return false
     const cs = useCyberspace.getState()
     const me = cs.identity.pubkey
     let template = avatarTemplate(shard, Math.floor(Date.now() / 1000))
-    set({ adoptError: null })
+    set({ adoptError: null, minedMs: null })
     if (shard) {
       const required = avatarWork(toPayload(shard))
       const job = miner({ ...template, pubkey: me }, required, (p) => {
@@ -90,37 +106,40 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
         if (m) set({ mining: { ...m, tries: p.tries, elapsedMs: p.elapsedMs } })
       })
       current = job
-      set({ mining: { required, tries: 0, elapsedMs: 0 } })
+      set({ phase: 'mining', mining: { required, tries: 0, elapsedMs: 0 } })
       try {
         const found = await job.done
         template = nonceTagged(template, found.nonce, required)
+        set({ minedMs: found.elapsedMs })
       } catch (e) {
-        set({ mining: null, adoptError: e instanceof MineCancelled ? null : 'The mining failed on this device.' })
+        set({ phase: null, mining: null, adoptError: e instanceof MineCancelled ? null : 'The mining failed on this device.' })
         return false
       } finally {
         current = null
       }
       set({ mining: null })
     }
+    set({ phase: 'signing' })
     let event
     try {
-      event = await cs.signEvent(template)
+      event = await cs.signEvent(template, AVATAR_SIGN_PATIENCE_MS)
     } catch {
-      set({ adoptError: 'The signer did not sign the avatar.' })
+      set({ phase: null, adoptError: 'The signer did not sign the avatar.' })
       return false
     }
     // The signer must return the event as mined: a changed created_at or tag
     // list is a different id, and the work is gone with it.
     if (shard && !verifyAvatarWork(event).ok) {
-      set({ adoptError: 'The signer changed the event, so the work no longer covers it. Try again.' })
+      set({ phase: null, adoptError: 'The signer changed the event, so the work no longer covers it. Try again.' })
       return false
     }
+    set({ phase: 'publishing' })
     const result = await publish(event)
     if (!result.ok) {
-      set({ adoptError: 'No relay took the avatar. Try again when one is reachable.' })
+      set({ phase: null, adoptError: 'No relay took the avatar. Try again when one is reachable.' })
       return false
     }
-    set({ shards: { ...get().shards, [me]: shard }, asked: { ...get().asked, [me]: Date.now() } })
+    set({ phase: null, shards: { ...get().shards, [me]: shard }, asked: { ...get().asked, [me]: Date.now() } })
     remember(shard)
     return true
   },

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -485,7 +485,8 @@ export interface CyberspaceState {
   targetList: () => CyberTarget[]
   /** Sign a template with this identity's active signer. Async because an
    * extension or a bunker is genuinely remote. The only door to it outside this module. */
-  signEvent: (template: EventTemplate) => Promise<NostrEvent>
+  /** Sign as the current identity. `patienceMs` is how long to wait for a remote signer before asking again over fresh sockets; a human-in-the-loop signature (an avatar) deserves more than a hop's. */
+  signEvent: (template: EventTemplate, patienceMs?: number) => Promise<NostrEvent>
 
   /** How the current identity signs: a local key, an extension, or a bunker. */
   signerKind: SignerKind
@@ -741,11 +742,15 @@ function pickInitialSigner(): Signer {
  * and it is rebuilt once and asked again. A payment poll used to await this
  * forever, which left a paid invoice unrecognised until a reload.
  */
-async function signEvent(template: EventTemplate): Promise<NostrEvent> {
+/** Remote signatures in flight: while one waits, a wake must not drop the sockets its answer arrives on. */
+let pendingSigns = 0
+
+async function signEvent(template: EventTemplate, patienceMs?: number): Promise<NostrEvent> {
   const signer = currentSigner
   if (signer.kind === 'local') return signer.signEvent(template)
+  pendingSigns++
   try {
-    return await signWithin(signer, template)
+    return await signWithin(signer, template, patienceMs)
   } catch (err) {
     // A timeout, or a publish that gave up ("All promises were rejected"):
     // either way the signer's sockets are presumed dead. Drop them and ask
@@ -753,7 +758,9 @@ async function signEvent(template: EventTemplate): Promise<NostrEvent> {
     if (!signer.reconnect) throw err
     const fresh = await signer.reconnect()
     if (currentSigner === signer) currentSigner = fresh
-    return await signWithin(fresh, template)
+    return await signWithin(fresh, template, patienceMs)
+  } finally {
+    pendingSigns--
   }
 }
 
@@ -764,6 +771,11 @@ async function signEvent(template: EventTemplate): Promise<NostrEvent> {
  */
 function wakeSigner(): void {
   if (currentSigner.kind === 'local') return
+  // Back from the signer's own app with a signature still pending: the answer
+  // is on its way over these sockets. Dropping them now would lose it and ask
+  // again, which is the second prompt for the same event. If they really are
+  // dead, the pending request's timeout reconnects and asks again itself.
+  if (pendingSigns > 0) return
   void currentSigner.reconnect?.().then((fresh) => { if (currentSigner !== fresh && currentSigner.kind !== 'local') currentSigner = fresh })
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -5095,3 +5095,9 @@ kbd {
   font-variant-numeric: tabular-nums;
   line-height: 1.5;
 }
+
+/* The avatar adopt in progress, visible from the top row while MENU is closed. */
+.ws__chip.ws__chip--work {
+  color: var(--warn, #ffb347);
+  border-color: color-mix(in srgb, var(--warn, #ffb347) 50%, transparent);
+}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -258,6 +258,7 @@ export function Workshop(): JSX.Element | null {
   const mining = useAvatars((s) => s.mining)
   const phase = useAvatars((s) => s.phase)
   const minedMs = useAvatars((s) => s.minedMs)
+  const adoptError = useAvatars((s) => s.adoptError)
   // The moment the work is done: say so, because the signer's prompt may take a
   // while to appear and nothing else marks the end of the mining.
   const lastPhase = useRef<typeof phase>(null)
@@ -480,7 +481,7 @@ export function Workshop(): JSX.Element | null {
                     ? `MINED IN ${minedIn(minedMs ?? 0).toUpperCase()} · WAITING FOR YOUR SIGNER`
                     : phase === 'publishing'
                       ? `MINED IN ${minedIn(minedMs ?? 0).toUpperCase()} · SIGNED · PUBLISHING`
-                      : `WORK ${work.required} BITS · ${work.reach.toFixed(work.reach >= 10 ? 0 : 1)} GIBSON REACH · ${work.detail} VERTICES + FACES · ${sha256PerSec ? describeDuration(expectedTries(work.required) / triesPerSec(sha256PerSec, work.bytes, minerCount())).toUpperCase() + ' ON THIS DEVICE' : 'TIME UNKNOWN UNTIL CALIBRATED'}`}
+                      : `${adoptError ? `LAST ATTEMPT: ${adoptError.toUpperCase()} · ` : ''}WORK ${work.required} BITS · ${work.reach.toFixed(work.reach >= 10 ? 0 : 1)} GIBSON REACH · ${work.detail} VERTICES + FACES · ${sha256PerSec ? describeDuration(expectedTries(work.required) / triesPerSec(sha256PerSec, work.bytes, minerCount())).toUpperCase() + ' ON THIS DEVICE' : 'TIME UNKNOWN UNTIL CALIBRATED'}`}
               </span>
             )}
           </div>

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -21,7 +21,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Vector3 } from 'three'
 import { Compass3D } from '../scene/Compass3D'
-import { Eye, Grid3x3, Link, Menu, MousePointer2, Pipette, Plus, Redo2, RotateCcw, RotateCw, Stamp, Trash2, Triangle, Undo2, Wrench, X, type LucideIcon } from 'lucide-react'
+import { Eye, Grid3x3, Link, Menu, MousePointer2, Pickaxe, Pipette, Plus, Redo2, RotateCcw, RotateCw, Stamp, Trash2, Triangle, type LucideIcon, Undo2, Wrench, X } from 'lucide-react'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { ConfirmModal } from '../hud/ConfirmModal'
 import { Explanation } from '../hud/Explanation'
@@ -32,7 +32,7 @@ import { FACED, FACING_LABEL, FLOOR, MAX_SIZE, MIN_SIZE, STAMPS, STAMP_HELP, typ
 import { useAvatars } from '../store/useAvatars'
 import { avatarReach, avatarWork } from 'cyberspace-core'
 import { avatarTemplate } from '../lib/avatar'
-import { clock, describeDuration, expectedTries, serializeEvent, triesPerSec } from '../lib/avatarMine'
+import { clock, describeDuration, expectedTries, minedIn, serializeEvent, triesPerSec } from '../lib/avatarMine'
 import { minerCount } from '../lib/avatarWorker'
 import { useCalibration } from '../lib/calibration'
 import { useCyberspace } from '../store/useCyberspace'
@@ -256,6 +256,16 @@ export function Workshop(): JSX.Element | null {
   const me = useCyberspace((s) => s.identity.pubkey)
   const myAvatar = useAvatars((s) => s.shards[me] ?? null)
   const mining = useAvatars((s) => s.mining)
+  const phase = useAvatars((s) => s.phase)
+  const minedMs = useAvatars((s) => s.minedMs)
+  // The moment the work is done: say so, because the signer's prompt may take a
+  // while to appear and nothing else marks the end of the mining.
+  const lastPhase = useRef<typeof phase>(null)
+  useEffect(() => {
+    if (lastPhase.current === 'mining' && phase === 'signing') useWorkshop.setState({ notice: `Mined in ${minedIn(minedMs ?? 0)}. Sign the avatar event when your signer asks.` })
+    lastPhase.current = phase
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase])
   const sha256PerSec = useCalibration((s) => s.sha256PerSec)
   // The avatar's price (spec 8.10), memoised on the geometry; a hook, so it sits with the others.
   const buildable = shard !== null && shard.vertices.length > 0 && shard.faces.length > 0
@@ -400,6 +410,12 @@ export function Workshop(): JSX.Element | null {
         <button className={`chip ws__chip ${panel === 'grid' ? 'is-on' : ''}`} aria-pressed={panel === 'grid'} onClick={() => toggle('grid')}>
           <Grid3x3 size={12} strokeWidth={2.25} aria-hidden />GRID
         </button>
+        {phase && (
+          <button className="chip ws__chip ws__chip--work" onClick={() => { if (panel !== 'menu') toggle('menu') }} title="Your avatar: see MENU" aria-live="polite">
+            <Pickaxe size={12} strokeWidth={2.25} aria-hidden />
+            {phase === 'mining' ? `MINING ${mining ? clock(mining.elapsedMs) : ''}` : phase === 'signing' ? 'SIGN IT' : 'PUBLISHING'}
+          </button>
+        )}
         <span className="ws__history">
           <button className="chip ws__icon" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)" aria-label="Undo"><Undo2 size={20} strokeWidth={2.25} aria-hidden /></button>
           <button className="chip ws__icon" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)" aria-label="Redo"><Redo2 size={20} strokeWidth={2.25} aria-hidden /></button>
@@ -432,8 +448,10 @@ export function Workshop(): JSX.Element | null {
           <div className="workshop__row" role="group" aria-label="My avatar">
             <span className="workshop__label">MY AVATAR</span>
             <span className="workshop__value workshop__value--wide">{myAvatar ? myAvatar.name : 'dodecahedron'}</span>
-            {mining ? (
+            {phase === 'mining' ? (
               <button className="workshop__btn workshop__btn--danger" onClick={() => useAvatars.getState().cancelAdopt()} title="Stop mining; your avatar stays as it is">CANCEL</button>
+            ) : phase ? (
+              <button className="workshop__btn" disabled title={phase === 'signing' ? 'Waiting for your signer' : 'Publishing to the relays'}>{phase === 'signing' ? 'SIGNING' : 'PUBLISHING'}</button>
             ) : (
               <button
                 className="workshop__btn"
@@ -448,7 +466,7 @@ export function Workshop(): JSX.Element | null {
                 title="Publish this shard as the shape others see for you, at true scale: the white avatar on the grid is the size of one cell. Its size and detail are paid for in proof of work first."
               >USE THIS SHARD</button>
             )}
-            {myAvatar && !mining && (
+            {myAvatar && !phase && (
               <button className="workshop__btn" onClick={() => { void useAvatars.getState().adopt(null).then((ok) => say(ok ? 'The dodecahedron is your avatar again.' : useAvatars.getState().adoptError ?? 'No relay took the change.')) }} title="Back to the dodecahedron; it owes no work">DODECAHEDRON</button>
             )}
             {/* The price (spec 8.10): 16 bits for any avatar, 6 more per doubling of
@@ -458,7 +476,11 @@ export function Workshop(): JSX.Element | null {
               <span className="workshop__work" aria-live="polite">
                 {mining
                   ? `MINING ${mining.required} BITS · ${clock(mining.elapsedMs)} ELAPSED · ${mining.elapsedMs > 1000 ? describeDuration(expectedTries(mining.required) / (mining.tries / (mining.elapsedMs / 1000))).toUpperCase() + ' EXPECTED · ' : ''}${mining.elapsedMs > 1000 ? Math.round(mining.tries / (mining.elapsedMs / 1000) / 1000) + 'K TRIES/S' : 'MEASURING'}`
-                  : `WORK ${work.required} BITS · ${work.reach.toFixed(work.reach >= 10 ? 0 : 1)} GIBSON REACH · ${work.detail} VERTICES + FACES · ${sha256PerSec ? describeDuration(expectedTries(work.required) / triesPerSec(sha256PerSec, work.bytes, minerCount())).toUpperCase() + ' ON THIS DEVICE' : 'TIME UNKNOWN UNTIL CALIBRATED'}`}
+                  : phase === 'signing'
+                    ? `MINED IN ${minedIn(minedMs ?? 0).toUpperCase()} · WAITING FOR YOUR SIGNER`
+                    : phase === 'publishing'
+                      ? `MINED IN ${minedIn(minedMs ?? 0).toUpperCase()} · SIGNED · PUBLISHING`
+                      : `WORK ${work.required} BITS · ${work.reach.toFixed(work.reach >= 10 ? 0 : 1)} GIBSON REACH · ${work.detail} VERTICES + FACES · ${sha256PerSec ? describeDuration(expectedTries(work.required) / triesPerSec(sha256PerSec, work.bytes, minerCount())).toUpperCase() + ' ON THIS DEVICE' : 'TIME UNKNOWN UNTIL CALIBRATED'}`}
               </span>
             )}
           </div>


### PR DESCRIPTION
From the phone: two signing prompts for the same kind 33331 event, and nothing on screen between pressing USE THIS SHARD and the prompt.

**The second prompt.** Coming back from the signer's app fires `wakeSigner`, which dropped the remote signer's sockets while the signature's answer was arriving on them; the request then timed out at 15 s and was asked again over fresh sockets, so the same event was signed twice. Now a wake leaves the sockets alone while a signature is pending (`pendingSigns`); if they really are dead, the pending request's own timeout reconnects and asks again, as before. And `signEvent` takes a patience: the avatar signature waits 120 s for a person reading a prompt, instead of a hop's 15 s.

**The silence.** Mining cleared the row's state before signing began, so USE THIS SHARD came back up while the prompt was open, and a second press mined and asked again. `useAvatars.adopt` now has a `phase`: mining, signing, publishing. The button stays down through all three and names the phase (CANCEL only while mining). The row reads `MINED IN 0:42 · WAITING FOR YOUR SIGNER`, then `SIGNED · PUBLISHING`. A chip in the top row (`MINING 0:42`, `SIGN IT`, `PUBLISHING`) shows the phase while MENU is closed and opens it on tap. A notice marks the moment the work is done: "Mined in 0:42. Sign the avatar event when your signer asks."

Tests: the phase walk with a held signer, a second adopt refused during signing, the patience passed through. The wake-while-pending rule has no unit test, since the signer is module state; it is four lines and reviewed by eye. Suite 565 passing, tsc and build clean.

**Second commit: the avatar that never reached the relay.** The relay holds one kind 33331 for the identity, from the day before and without a nonce (so unpaid, the dodecahedron); today's adoption is not there. The publish came right after the signer's app, over sockets the phone had left half-open, waited its whole 8 s for an OK that never came, and the one-line notice went by unseen.
- `publishMany` drops the sockets (`dropRelays`) and sends once more when every relay failed for a reason that is not a refusal; NIP-01 OK prefixes (blocked, invalid, duplicate, pow, rate-limited, restricted, error) are final. Three tests with a mocked pool.
- `useAvatars.ensure` keeps a known avatar on an empty answer instead of resetting it to the dodecahedron; a relay that is down or has not seen the event yet says nothing.
- The row keeps `LAST ATTEMPT: …` with the reason until the next try.

Still open, noted for later: live subscriptions do not resubscribe after a socket dies; the wake handler only wakes the signer and the cloud poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz