### PR TITLE
Shard points on the gibsons' disc, and workshop handles that hold their size

### DIFF
--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -15,7 +15,6 @@ import { useEffect, useMemo, useRef } from 'react'
 import { useFrame, type ThreeEvent } from '@react-three/fiber'
 import {
   AddEquation,
-  AdditiveBlending,
   FrontSide,
   CustomBlending,
   OneFactor,
@@ -28,8 +27,8 @@ import {
 } from 'three'
 import { easeOutCubic, hash01, scrambleOffset, seedOf, SHARD_DECODE_MS } from '../lib/decode'
 import { flatten, ticksOf, toRender, type ShardModel } from '../lib/shards'
-import { glowTexture } from '../lib/glow'
 import { orientShard } from '../lib/orient'
+import { SHARD_DOTS, SHARD_POINTS, createDiscMaterial, sizeDisc, withDiscColors } from './pointDisc'
 
 interface Props {
   shard: ShardModel
@@ -86,7 +85,8 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
     const g = new BufferGeometry()
     g.setAttribute('position', posAttr)
     g.setAttribute('color', colAttr)
-    return g
+    // The same colours under the name the disc shader reads (scene/pointDisc).
+    return withDiscColors(g, colAttr)
   }, [posAttr, colAttr])
 
   const indexed = useMemo(() => {
@@ -113,6 +113,14 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
     g.setIndex(flipped)
     return g
   }, [posAttr, colAttr, index, lit])
+
+  // The points, drawn as the terrain field draws its gibsons: a feathered disc
+  // with a bright core for the bloom, sized in pixels between a floor and a cap.
+  const pointMaterial = useMemo(() => {
+    const seen = ghost ? 0.45 : 1
+    return createDiscMaterial(shard.mode === 'points' ? SHARD_POINTS : SHARD_DOTS, shard.mode === 'points' ? seen : seen * 0.55)
+  }, [shard.mode, ghost])
+  useEffect(() => () => pointMaterial.dispose(), [pointMaterial])
 
   const line = useMemo(() => {
     const l = new Line(plain, new LineBasicMaterial({ vertexColors: true, toneMapped: false, transparent: true, opacity: ghost ? 0.45 : 1 }))
@@ -151,7 +159,9 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
   const done = useRef(false)
   const frame = useRef(0)
 
-  useFrame(() => {
+  useFrame((state) => {
+    // The disc is sized in pixels, so it needs the canvas it is drawn on.
+    sizeDisc(pointMaterial, state.gl.getPixelRatio(), state.size.height)
     if (birth === undefined || noise === null || done.current) return
     const t = Math.min(1, (performance.now() - birth) / SHARD_DECODE_MS)
     const e = easeOutCubic(t)
@@ -171,7 +181,6 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
 
   if (shard.vertices.length === 0) return null
   const opacity = ghost ? 0.45 : 1
-  const glow = glowTexture()
 
   return (
     <group scale={scale}>
@@ -192,21 +201,7 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
       )}
       {shard.mode === 'lines' && shard.vertices.length > 1 && <primitive object={line} />}
       {(shard.mode === 'points' || shard.mode === 'solid' || shard.mode === 'lines') && (
-        <points geometry={plain} frustumCulled={false}>
-          {/* Small and glowing: a soft round sprite tinted by the vertex colour, added
-              to what is behind it, so a point reads as a light rather than a tile. */}
-          <pointsMaterial
-            vertexColors
-            size={shard.mode === 'points' ? 0.22 : 0.1}
-            sizeAttenuation
-            transparent
-            opacity={shard.mode === 'points' ? opacity : opacity * 0.9}
-            blending={AdditiveBlending}
-            depthWrite={false}
-            toneMapped={false}
-            {...(glow ? { map: glow, alphaTest: 0.02 } : {})}
-          />
-        </points>
+        <points geometry={plain} material={pointMaterial} frustumCulled={false} />
       )}
     </group>
   )

--- a/src/scene/pointDisc.ts
+++ b/src/scene/pointDisc.ts
@@ -1,0 +1,128 @@
+/**
+ * pointDisc.ts - the glowing disc the terrain field draws its gibsons with,
+ * lent to anything else that draws points.
+ *
+ * ShaderPointField earns its look two ways: the disc is computed from
+ * gl_PointCoord, solid to its rim with a couple of feathered pixels, so a dot
+ * is exactly the size it asked for and never a square; and it is sized in
+ * pixels, so it stays dust however near the camera comes. A shard's points
+ * want the same disc, but they are objects in a place rather than a field, so
+ * here the size keeps its perspective (near points larger, far ones smaller)
+ * between a floor and a ceiling in pixels. The ceiling is the whole point: a
+ * point a metre from the camera used to fill a tenth of the screen.
+ *
+ * The core is brightened above the colour it was given so the bloom pass has
+ * something to catch, which is the glow around a gibson.
+ */
+
+import { ShaderMaterial, type BufferAttribute, type BufferGeometry } from 'three'
+
+/** How a family of points looks. Sizes are diameters: world units, then CSS pixels. */
+export interface DiscProfile {
+  /** Diameter in world units at the distance perspective makes it exact. */
+  size: number
+  /** Never smaller than this on screen, so a distant shard is dust and not nothing. */
+  minPx: number
+  /** Never larger than this on screen, whatever the camera does. */
+  maxPx: number
+  /** How much brighter the core is than the colour given, for the bloom pass. */
+  glow: number
+}
+
+/** A shard drawn as points: its vertices are the shape, so they carry the size. */
+export const SHARD_POINTS: DiscProfile = { size: 0.3, minPx: 1.6, maxPx: 10, glow: 1.1 }
+
+/** The same vertices under a solid or wireframe shard: a hint that they are there,
+ * never a second shape competing with the faces. */
+export const SHARD_DOTS: DiscProfile = { size: 0.07, minPx: 0.7, maxPx: 2.4, glow: 0.25 }
+
+const vertexShader = /* glsl */ `
+  attribute vec3 aColor;
+
+  uniform float uSize;
+  uniform float uMinPx;
+  uniform float uMaxPx;
+  uniform float uDpr;
+  uniform float uBufferHeight;
+
+  varying vec3 vColor;
+  varying float vPx;
+
+  void main() {
+    vColor = aColor;
+    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+
+    // The perspective scale three's own attenuated points use, in drawing-buffer
+    // pixels: half the buffer's height times the projection's vertical scale,
+    // over the distance. Clamped at both ends, in CSS pixels times the device
+    // ratio, since gl_PointSize is in drawing-buffer pixels.
+    float attenuation = uBufferHeight * projectionMatrix[1][1] * 0.5 / max(-mv.z, 0.0001);
+    vPx = clamp(uSize * attenuation, uMinPx * uDpr, uMaxPx * uDpr);
+
+    gl_PointSize = vPx;
+    gl_Position = projectionMatrix * mv;
+  }
+`
+
+const fragmentShader = /* glsl */ `
+  uniform float uGlow;
+  uniform float uOpacity;
+
+  varying vec3 vColor;
+  varying float vPx;
+
+  void main() {
+    // 0 at the centre, 1 at the sprite's rim.
+    float d = length(gl_PointCoord - vec2(0.5)) * 2.0;
+
+    // Feather a constant couple of pixels, whatever the dot's size, so a small
+    // one is not all edge and a large one is not a hard-cut circle.
+    float edge = clamp(2.0 / max(vPx, 1.0), 0.04, 0.5);
+    float alpha = (1.0 - smoothstep(1.0 - edge, 1.0, d)) * uOpacity;
+    if (alpha < 0.02) discard;
+
+    // Brighter than the colour it was given, most at the centre: the bloom pass
+    // keys off brightness, so this is where the glow comes from.
+    vec3 color = vColor * (1.0 + uGlow * (1.0 - smoothstep(0.0, 0.8, d)));
+
+    gl_FragColor = vec4(color, alpha);
+  }
+`
+
+/**
+ * A material for one family of points. The geometry must carry `aColor`;
+ * `withDiscColors` puts it there beside the `color` every other material reads.
+ */
+export function createDiscMaterial(profile: DiscProfile, opacity: number): ShaderMaterial {
+  return new ShaderMaterial({
+    vertexShader,
+    fragmentShader,
+    uniforms: {
+      uSize: { value: profile.size },
+      uMinPx: { value: profile.minPx },
+      uMaxPx: { value: profile.maxPx },
+      uGlow: { value: profile.glow },
+      uOpacity: { value: opacity },
+      uDpr: { value: 1 },
+      uBufferHeight: { value: 1000 },
+    },
+    transparent: true,
+    depthWrite: false,
+  })
+}
+
+/**
+ * The colour attribute under the name the disc shader reads. The same
+ * BufferAttribute as `color`, so one upload serves both and an animation that
+ * writes the colours keeps writing to one place.
+ */
+export function withDiscColors(geometry: BufferGeometry, colors: BufferAttribute): BufferGeometry {
+  geometry.setAttribute('aColor', colors)
+  return geometry
+}
+
+/** The two uniforms that follow the canvas rather than the material. */
+export function sizeDisc(material: ShaderMaterial, dpr: number, cssHeight: number): void {
+  material.uniforms.uDpr.value = dpr
+  material.uniforms.uBufferHeight.value = cssHeight * dpr
+}

--- a/src/workshop/Bench.tsx
+++ b/src/workshop/Bench.tsx
@@ -18,7 +18,7 @@
 import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { useEffect, useMemo, useRef } from 'react'
-import { AdditiveBlending, BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, IcosahedronGeometry, Line, LineBasicMaterial, Vector3 } from 'three'
+import { AdditiveBlending, BufferGeometry, DoubleSide, EdgesGeometry, Float32BufferAttribute, Group, IcosahedronGeometry, Line, LineBasicMaterial, PerspectiveCamera, Vector3 } from 'three'
 import { ACCENT, BG, WARN } from '../lib/palette'
 import { glowTexture } from '../lib/glow'
 import { GRID_HALF, TICKS_PER_UNIT, centroid, pointKey, rgbToHex, ticksOf, toRender } from '../lib/shards'
@@ -187,18 +187,44 @@ function Ghost(): JSX.Element | null {
   )
 }
 
-/** Handle radii in bench units (a gibson at level 0): the dot, the selected dot, its halo's width. */
-const HANDLE = 0.07
-const HANDLE_ON = 0.11
-const HALO = 0.5
-/** Hit sphere radii: wide enough for a finger at a whole-gibson grid, and never
- * more than a share of the current step, so points a fifth of a gibson apart
- * each keep their own target; ADD and FACE take the narrow one, since there a
- * tap beside a point means the plane or the face. */
-const HIT = 0.3
-const HIT_NARROW = 0.16
-function hitRadiusFor(tool: Tool, stepUnits: number): number {
-  return Math.min(tool === 'add' || tool === 'face' ? HIT_NARROW : HIT, stepUnits * 0.45)
+/**
+ * Handle sizes in CSS pixels, not bench units.
+ *
+ * Each handle sits in a group scaled by its own distance from the camera
+ * (`ScreenScale`), so a radius of 1 draws one pixel across whatever the zoom.
+ * That is the whole point: a ball sized in the world is a good target when you
+ * are looking at the whole shard and a screenful when you lean in to place two
+ * points inside one gibson. Constant on screen, it is the same target at every
+ * zoom, and zooming in spreads the points apart underneath it, which is what
+ * makes close work possible.
+ */
+const DOT_R = 4.25
+const DOT_ON_R = 6
+const HALO_PX = 26
+const RING_R = 11
+const RING_OUT = 13
+/** The finger target: bigger than the dot, and smaller in ADD and FACE, where a
+ * tap beside a point means the plane or the face rather than the point. */
+const HIT_R = 10
+const HIT_NARROW_R = 5.5
+function hitRadiusFor(tool: Tool): number {
+  return tool === 'add' || tool === 'face' ? HIT_NARROW_R : HIT_R
+}
+
+/**
+ * A group that holds its size on screen: scaled by its distance from the camera
+ * and the view's pixels per world unit, so its children's units are CSS pixels.
+ */
+function ScreenScale({ position, children }: { position: [number, number, number]; children: React.ReactNode }): JSX.Element {
+  const ref = useRef<Group>(null)
+  useFrame((state) => {
+    const g = ref.current
+    if (!g) return
+    const cam = state.camera as PerspectiveCamera
+    const perPixel = 2 * Math.tan((cam.fov * Math.PI) / 360) / state.size.height
+    g.scale.setScalar(Math.max(1e-5, cam.position.distanceTo(g.position) * perPixel))
+  })
+  return <group ref={ref} position={position}>{children}</group>
 }
 
 /**
@@ -210,7 +236,6 @@ function Handles(): JSX.Element | null {
   const selection = useWorkshop((s) => s.selection)
   const facePick = useWorkshop((s) => s.facePick)
   const tool = useWorkshop((s) => s.tool)
-  const step = useWorkshop((s) => s.step())
   const chosen = useMemo(() => new Set(selection), [selection])
   const groups = useMemo(() => {
     const m = new Map<string, number[]>()
@@ -219,7 +244,7 @@ function Handles(): JSX.Element | null {
   }, [shard?.vertices])
   if (!shard) return null
   const glow = glowTexture()
-  const hitRadius = hitRadiusFor(tool, step / TICKS_PER_UNIT)
+  const hitRadius = hitRadiusFor(tool)
 
   const onClick = (first: number, isSel: boolean) => (e: ThreeEvent<MouseEvent>): void => {
     if (e.delta > TAP_SLOP) return
@@ -231,7 +256,9 @@ function Handles(): JSX.Element | null {
       // the ray passes farther from the corner than its drawn dot, the face wins.
       const centre = new Vector3(...UP(ticksOf(shard.vertices[first])))
       const face = e.intersections.find((i) => i.object.name === 'shard-faces')
-      if (face && face.faceIndex !== undefined && e.ray.distanceToPoint(centre) > HANDLE_ON) { w.selectFace(face.faceIndex); return }
+      // The dot's drawn radius in world units: its pixels times the group's own scale.
+      const drawn = DOT_ON_R * (e.object.parent?.scale.x ?? 1)
+      if (face && face.faceIndex !== undefined && e.ray.distanceToPoint(centre) > drawn) { w.selectFace(face.faceIndex); return }
       w.pickForFace(first)
     }
     // In SELECT a tap adds or removes the point; elsewhere it picks that point alone.
@@ -247,7 +274,7 @@ function Handles(): JSX.Element | null {
         const isSel = g.some((i) => chosen.has(i))
         const picked = facePick.some((i) => g.includes(i))
         return (
-          <group key={first} position={UP(ticksOf(v))}>
+          <ScreenScale key={first} position={UP(ticksOf(v))}>
             {/* An invisible hit target wider than the handle, narrower in ADD so a tap
                 beside a point lands on the plane and places another one near it. */}
             <mesh onClick={onClick(first, isSel)}>
@@ -255,22 +282,22 @@ function Handles(): JSX.Element | null {
               <meshBasicMaterial transparent opacity={0} depthWrite={false} />
             </mesh>
             <mesh>
-              <sphereGeometry args={[isSel || picked ? HANDLE_ON : HANDLE, 12, 12]} />
+              <sphereGeometry args={[isSel || picked ? DOT_ON_R : DOT_R, 12, 12]} />
               <meshBasicMaterial color={isSel ? WARN : picked ? ACCENT : rgbToHex(v.c)} toneMapped={false} />
             </mesh>
             {/* A halo, so a small selected handle still stands out. */}
             {(isSel || picked) && glow && (
-              <sprite scale={[HALO, HALO, 1]}>
+              <sprite scale={[HALO_PX, HALO_PX, 1]}>
                 <spriteMaterial map={glow} color={isSel ? WARN : ACCENT} transparent opacity={0.85} blending={AdditiveBlending} depthWrite={false} toneMapped={false} />
               </sprite>
             )}
             {picked && (
               <mesh>
-                <ringGeometry args={[0.2, 0.24, 24]} />
+                <ringGeometry args={[RING_R, RING_OUT, 24]} />
                 <meshBasicMaterial color={ACCENT} toneMapped={false} side={2} />
               </mesh>
             )}
-          </group>
+          </ScreenScale>
         )
       })}
     </>
@@ -333,9 +360,11 @@ function Aim(): null {
   const camera = useThree((s) => s.camera)
   const scene = useThree((s) => s.scene)
   useEffect(() => {
-    // The browser harness projects handle positions through the camera to click them, and reaches the lights through the scene.
-    if (import.meta.env.DEV) Object.assign(window as unknown as Record<string, unknown>, { __benchCamera: camera, __benchScene: scene })
-  }, [camera, scene])
+    // The browser harness projects handle positions through the camera to click them,
+    // reaches the lights through the scene, and dollies the view through the controls
+    // (setting the camera alone is undone on their next update).
+    if (import.meta.env.DEV) Object.assign(window as unknown as Record<string, unknown>, { __benchCamera: camera, __benchScene: scene, __benchControls: controls })
+  }, [camera, scene, controls])
   const target = useMemo(() => {
     const shard = useWorkshop.getState().current()
     return shard ? UP(centroid(shard)) : [0, 0, 0]


### PR DESCRIPTION
Three things from the phone: shard points looked like weirdly large squares, the dots under a solid shard were too loud, and the workshop's vertex balls were a good size from far away but a screenful when leaning in to work inside a gibson.

**`scene/pointDisc.ts`** lends out what makes a gibson look good. The disc is computed from `gl_PointCoord`, solid to its rim with a couple of feathered pixels, so a dot is never a square, and its core is brightened above the colour it was given so the bloom pass has something to catch. Unlike the terrain field, a shard's points keep their perspective (near ones larger) but between a floor and a ceiling in pixels.

| | before | now |
|---|---|---|
| POINTS mode | 0.22 world units, unbounded on screen | 1.6 to 10 CSS px, glow 1.1 |
| dots under SOLID and LINES | 0.1 world units, opacity 0.9 | 0.7 to 2.4 CSS px, glow 0.25, opacity 0.55 |

The ceiling is the fix: a point close to the camera used to fill a tenth of the screen. Ten pixels sits slightly above a gibson at the cursor (7.5) and well above the field's dust (1.3).

**The bench's handles** now sit in a `ScreenScale` group scaled by their own distance from the camera, so their radii are written in CSS pixels: the dot is 8.5 across at every zoom, the selected dot 12, the finger target 20, and 11 in ADD and FACE. Zooming in no longer grows the ball; it spreads the points apart underneath it, which is what makes work inside one gibson possible. The step-based hit cap from #105 is gone, since constant size does the same job at every zoom. The face-over-corner rule measures against the dot's drawn radius, so it follows the scale.

Also `__benchControls` beside the other DEV hooks: setting the camera alone is undone on the controls' next update, so a probe could not dolly the bench.

**Measured headless at 412 px wide, device ratio 2:**

| camera distance | point disc | handle group scale | handle dot |
|---|---|---|---|
| 40 | 4.5 px | | |
| 20 | | 0.0204 | 9 px |
| 12 | 9.5 px | | |
| 4 | | 0.0041 | 10 px |
| 2 | 10 px (capped) | | |
| 0.9 | | 0.0009 | 10 px |
| 0.8 | 10 px (capped) | | |

The disc fills 0.7 of its bounding box, where a circle is 0.79 and a square 1.0. Suite 569 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz