### PR TITLE
LOCAL means local, a bag left there can still be sent, and the head says LATEST

### DIFF
--- a/src/hud/ChainExplorer.tsx
+++ b/src/hud/ChainExplorer.tsx
@@ -12,8 +12,9 @@
  * space, not a fact you look up. Its heading is the chip that folds it away.
  *
  * Off the head the controls are withdrawn, because nothing in history is a
- * place you can move from; LIVE brings them back. Held buttons rapid-fire, and
- * [ ] Home End do the same from the keyboard.
+ * place you can move from; LATEST brings them back. It says LATEST, not LIVE,
+ * because LIVE is the publishing setting: this is the newest action on the
+ * chain, whether or not any of it has been sent to a relay.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -120,10 +121,10 @@ export function ChainExplorer(): JSX.Element {
             <span className={`explorer__type explorer__type--${action.type}`}>{action.type.toUpperCase()}</span>
             <span className="explorer__when" title={formatStamp(action.createdAt)}>{formatAgo(action.createdAt, now)}</span>
             {atHead ? (
-              <span className="explorer__live">{spectate ? 'THEIR HEAD' : 'LIVE'}</span>
+              <span className="explorer__live">{spectate ? 'THEIR HEAD' : 'LATEST'}</span>
             ) : (
               <button className="explorer__return" {...noCallout}
-                onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); go(null) }}>{spectate ? 'TO THEIR HEAD' : 'RETURN TO LIVE'}</button>
+                onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); go(null) }}>{spectate ? 'TO THEIR HEAD' : 'RETURN TO LATEST'}</button>
             )}
           </div>
 

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -37,6 +37,8 @@ function depName(d: MyDeployment): string {
 function DeployedRow({ d, viewing, onGo }: { d: MyDeployment; viewing: boolean; onGo: () => void }): JSX.Element {
   const cashu = useCashu(d.type === 'message' ? d.text : null)
   const coin = cashu.token !== null
+  const live = useCyberspace((s) => s.live)
+  const broadcasting = useShards((s) => s.broadcasting) === d.lookupId
   return (
     <li className={`shards__row shards__row--deployed ${viewing ? 'is-viewing' : ''}`}>
       <button className="shards__goto" onClick={onGo} title="Fly to it and see its wire record">
@@ -49,6 +51,15 @@ function DeployedRow({ d, viewing, onGo }: { d: MyDeployment; viewing: boolean; 
           {coin && <> · <span className={`shards__cashu shards__cashu--${cashu.state}`}>{cashuStateLabel(cashu.state)}</span></>}
         </span>
       </button>
+      {/* Deployed while LOCAL: signed and kept, never sent. This sends it. */}
+      {!d.published && live && (
+        <button
+          className="shards__broadcast"
+          disabled={broadcasting}
+          onClick={() => { void useShards.getState().broadcast(d.lookupId) }}
+          title="Send this region's bag to the relays now"
+        >{broadcasting ? 'SENDING' : 'BROADCAST'}</button>
+      )}
       <span className="shards__goto-hint" aria-hidden="true">▸</span>
     </li>
   )
@@ -66,6 +77,9 @@ export function ShardsPanel(): JSX.Element {
   const target = models.find((m) => m.id === deleteModel)
   const deployedCount = (id: string): number => mine.filter((d) => d.type === 'shard' && d.shard?.id === id).length
   const hiddenCount = mine.length
+  const live = useCyberspace((s) => s.live)
+  const broadcastError = useShards((s) => s.broadcastError)
+  const localCount = mine.filter((d) => !d.published).length
 
   const goTo = (d: MyDeployment): void => {
     useShards.getState().inspect(d.eventId)
@@ -136,6 +150,15 @@ export function ShardsPanel(): JSX.Element {
       {mine.length > 0 && (
         <div className="shards__section">
           <span className="legend__label">Deployed — hidden in cyberspace</span>
+          {/* Anything deployed while LOCAL was signed and kept but never sent.
+              It stays that way until it is broadcast, which needs LIVE. */}
+          {localCount > 0 && (
+            <span className="shards__note">
+              {localCount === 1 ? 'One thing is' : `${localCount} things are`} on this device only.{' '}
+              {live ? 'BROADCAST sends the region it is hidden in.' : 'Switch to LIVE to send them.'}
+            </span>
+          )}
+          {broadcastError && <span className="shards__note shards__note--warn">{broadcastError}</span>}
           <ul className="avatars__list">
             {mine.map((d) => (
               <DeployedRow key={d.eventId} d={d} viewing={inspecting === d.eventId} onGo={() => goTo(d)} />

--- a/src/store/broadcast.test.ts
+++ b/src/store/broadcast.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The store keeps deployments in localStorage; the test runs where there is none.
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+vi.mock('../lib/relay', () => ({
+  publishMany: vi.fn(async () => ({ ok: true })),
+  query: vi.fn(async () => []),
+  relaySet: () => ['wss://relay.test'],
+}))
+
+import { publishMany, query } from '../lib/relay'
+import { useCyberspace } from './useCyberspace'
+import { useShards, type MyDeployment } from './useShards'
+
+const LOOKUP = 'ab'.repeat(16)
+
+async function localDeployment(): Promise<MyDeployment> {
+  const inner = await useCyberspace.getState().signEvent({
+    kind: 30079,
+    created_at: 1_800_000_000,
+    content: 'hidden',
+    tags: [['d', 'inner']],
+  })
+  return {
+    eventId: inner.id,
+    inner,
+    bagId: 'ff'.repeat(32),
+    type: 'message',
+    text: 'hidden',
+    at: { x: '1', y: '2', z: '3' },
+    plane: 0,
+    height: 8,
+    lookupId: LOOKUP,
+    keyHex: '11'.repeat(32),
+    relays: [],
+    createdAt: 1_800_000_000,
+    published: false,
+  }
+}
+
+describe('broadcasting a bag left LOCAL', () => {
+  beforeEach(async () => {
+    useShards.setState({ mine: [await localDeployment()], broadcasting: null, broadcastError: null })
+    vi.mocked(publishMany).mockClear()
+    vi.mocked(query).mockClear()
+    useCyberspace.setState({ live: true })
+  })
+
+  it('sends the region and marks everything in it published', async () => {
+    expect(await useShards.getState().broadcast(LOOKUP)).toBe(true)
+    expect(vi.mocked(publishMany)).toHaveBeenCalledTimes(1)
+    const [relays, event] = vi.mocked(publishMany).mock.calls[0]
+    expect(relays).toEqual(['wss://relay.test'])
+    // A fresh bag, not the stale envelope the local deploy recorded.
+    expect(event.id).not.toBe('ff'.repeat(32))
+    const row = useShards.getState().mine[0]
+    expect(row.published).toBe(true)
+    expect(row.bagId).toBe(event.id)
+    expect(row.relays).toEqual(['wss://relay.test'])
+    expect(useShards.getState().broadcasting).toBeNull()
+  })
+
+  it('refuses while LOCAL, and says why', async () => {
+    useCyberspace.setState({ live: false })
+    expect(await useShards.getState().broadcast(LOOKUP)).toBe(false)
+    expect(vi.mocked(publishMany)).not.toHaveBeenCalled()
+    expect(useShards.getState().broadcastError).toMatch(/LOCAL/)
+    expect(useShards.getState().mine[0].published).toBe(false)
+  })
+
+  it('keeps the deployment local when no relay takes the bag', async () => {
+    vi.mocked(publishMany).mockResolvedValueOnce({ ok: false, reason: 'no relay accepted it' })
+    expect(await useShards.getState().broadcast(LOOKUP)).toBe(false)
+    expect(useShards.getState().mine[0].published).toBe(false)
+    expect(useShards.getState().broadcastError).toMatch(/No relay/)
+    expect(useShards.getState().broadcasting).toBeNull()
+  })
+
+  it('merges what the relay already holds for the region rather than overwriting it', async () => {
+    await useShards.getState().broadcast(LOOKUP)
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(query).mock.calls[0][0]).toMatchObject({ '#d': [LOOKUP] })
+  })
+})

--- a/src/store/useAvatars.test.ts
+++ b/src/store/useAvatars.test.ts
@@ -51,7 +51,7 @@ const built = () => {
 }
 
 describe('useAvatars', () => {
-  beforeEach(() => { useAvatars.setState({ shards: {}, asked: {}, mining: null, phase: null, minedMs: null, adoptError: null }); localStorage.clear(); vi.mocked(query).mockClear(); vi.mocked(publish).mockClear() })
+  beforeEach(() => { useAvatars.setState({ shards: {}, asked: {}, mining: null, phase: null, minedMs: null, adoptError: null, mineEvent: null, minePublished: false }); useCyberspace.setState({ live: true }); localStorage.clear(); vi.mocked(query).mockClear(); vi.mocked(publish).mockClear() })
 
   it('adopting a shard signs a kind 33331 event with d=avatar, publishes it and keeps a copy', async () => {
     const me = useCyberspace.getState().identity.pubkey
@@ -144,6 +144,36 @@ describe('useAvatars', () => {
     useAvatars.getState().ensure(other)
     await vi.waitFor(() => { expect(other in useAvatars.getState().shards).toBe(true) })
     expect(useAvatars.getState().shards[other]).toBeNull()
+  })
+
+  it('LOCAL keeps the avatar on this device, and BROADCAST sends that same event later', async () => {
+    const me = useCyberspace.getState().identity.pubkey
+    const wasLive = useCyberspace.getState().live
+    useCyberspace.setState({ live: false })
+    try {
+      expect(await useAvatars.getState().adopt(built())).toBe(true)
+      // Drawn for you, kept whole, and no relay heard about it.
+      expect(useAvatars.getState().shards[me]?.name).toBe('Arches')
+      expect(useAvatars.getState().minePublished).toBe(false)
+      expect(vi.mocked(publish)).not.toHaveBeenCalled()
+      const kept = useAvatars.getState().mineEvent
+      expect(kept).not.toBeNull()
+      expect(verifyAvatarWork(kept!)).toMatchObject({ ok: true })
+
+      // Broadcasting while still LOCAL refuses rather than publishing.
+      expect(await useAvatars.getState().broadcastMine()).toBe(false)
+      expect(vi.mocked(publish)).not.toHaveBeenCalled()
+      expect(useAvatars.getState().adoptError).toMatch(/LOCAL/)
+
+      // Live: the very event that was mined goes out, no second mine.
+      useCyberspace.setState({ live: true })
+      expect(await useAvatars.getState().broadcastMine()).toBe(true)
+      expect(vi.mocked(publish)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(publish).mock.calls[0][0].id).toBe(kept!.id)
+      expect(useAvatars.getState().minePublished).toBe(true)
+    } finally {
+      useCyberspace.setState({ live: wasLive })
+    }
   })
 
   it('an avatar that has not paid is the dodecahedron to everyone', async () => {

--- a/src/store/useAvatars.ts
+++ b/src/store/useAvatars.ts
@@ -9,7 +9,9 @@
  * is on screen before the relay answers, and adopting a shard prices it,
  * mines the nonce off the main thread with progress and cancel, signs (with
  * a long patience, since a person is reading the prompt), publishes the
- * event and keeps the copy. `phase` says which of those is happening, so the
+ * event unless you are LOCAL, and keeps the copy. An avatar adopted while
+ * LOCAL is kept whole, work and all, and `broadcastMine` sends that same
+ * event once you are LIVE. `phase` says which of those is happening, so the
  * workshop can keep the button down and say where things are.
  */
 
@@ -19,6 +21,7 @@ import { avatarWork, verifyAvatarWork } from 'cyberspace-core'
 import { AVATAR_D, AVATAR_KIND, avatarFromEvent, avatarTemplate } from '../lib/avatar'
 import { nonceTagged } from '../lib/avatarMine'
 import { MineCancelled, mineInWorker, type AvatarMiner } from '../lib/avatarWorker'
+import type { NostrEvent } from '../lib/events'
 import { publish, query } from '../lib/relay'
 import { fromPayload, toPayload, type ShardModel } from '../lib/shards'
 import { useCyberspace } from './useCyberspace'
@@ -52,6 +55,10 @@ interface AvatarsState {
   asked: Record<string, number>
   /** The job in progress, for the workshop's row. */
   mining: Mining | null
+  /** Your own avatar event, signed and kept, whether or not a relay has it. */
+  mineEvent: NostrEvent | null
+  /** Whether a relay took your avatar. False for one adopted while LOCAL. */
+  minePublished: boolean
   /** What adopt is doing now, null when idle; the button stays down through all of it. */
   phase: AdoptPhase | null
   /** How long the last mine took, kept through signing and publishing for the row. */
@@ -64,6 +71,8 @@ interface AvatarsState {
   adopt: (shard: ShardModel | null) => Promise<boolean>
   /** Stop the mining in progress; adopt resolves false. */
   cancelAdopt: () => void
+  /** Send the avatar you adopted while LOCAL to the relays now. */
+  broadcastMine: () => Promise<boolean>
   /** Your own from localStorage, before the relay answers. */
   loadMine: () => void
 }
@@ -72,6 +81,8 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
   shards: {},
   asked: {},
   mining: null,
+  mineEvent: null,
+  minePublished: false,
   phase: null,
   minedMs: null,
   adoptError: null,
@@ -92,7 +103,11 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
         }
         const shard = paidShard(newest)
         set({ shards: { ...get().shards, [pubkey]: shard } })
-        if (pubkey === useCyberspace.getState().identity.pubkey) remember(shard)
+        if (pubkey === useCyberspace.getState().identity.pubkey) {
+          // The relay has it, so it is published, whatever this device thought.
+          set({ minePublished: true })
+          remember(shard, get().mineEvent, true)
+        }
       })
       .catch(() => { if (!(pubkey in get().shards)) set({ shards: { ...get().shards, [pubkey]: null } }) })
   },
@@ -139,14 +154,44 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
       set({ phase: null, adoptError: 'The signer changed the event, so the work no longer covers it. Try again.' })
       return false
     }
+    // LOCAL means LOCAL. The avatar is signed, kept and drawn for you, and it
+    // goes out the moment you broadcast it or adopt again while LIVE; publishing
+    // it anyway would have been the one action that ignored the setting.
+    if (!cs.live) {
+      set({ phase: null, shards: { ...get().shards, [me]: shard }, asked: { ...get().asked, [me]: Date.now() }, mineEvent: event, minePublished: false })
+      remember(shard, event, false)
+      return true
+    }
     set({ phase: 'publishing' })
+    const result = await publish(event)
+    if (!result.ok) {
+      set({ phase: null, mineEvent: event, minePublished: false, adoptError: 'No relay took the avatar. Try again when one is reachable.' })
+      remember(shard, event, false)
+      return false
+    }
+    set({ phase: null, shards: { ...get().shards, [me]: shard }, asked: { ...get().asked, [me]: Date.now() }, mineEvent: event, minePublished: true })
+    remember(shard, event, true)
+    return true
+  },
+
+  broadcastMine: async () => {
+    const cs = useCyberspace.getState()
+    const event = get().mineEvent
+    if (!event) return false
+    if (!cs.live) {
+      set({ adoptError: 'Nothing is published while you are LOCAL. Switch to LIVE and try again.' })
+      return false
+    }
+    if (get().phase) return false
+    set({ phase: 'publishing', adoptError: null })
     const result = await publish(event)
     if (!result.ok) {
       set({ phase: null, adoptError: 'No relay took the avatar. Try again when one is reachable.' })
       return false
     }
-    set({ phase: null, shards: { ...get().shards, [me]: shard }, asked: { ...get().asked, [me]: Date.now() } })
-    remember(shard)
+    const shard = get().shards[cs.identity.pubkey] ?? null
+    set({ phase: null, minePublished: true, asked: { ...get().asked, [cs.identity.pubkey]: Date.now() } })
+    remember(shard, event, true)
     return true
   },
 
@@ -157,10 +202,15 @@ export const useAvatars = create<AvatarsState>((set, get) => ({
     try {
       const raw = localStorage.getItem(MINE_KEY)
       if (!raw) return
-      const kept = JSON.parse(raw) as { pubkey?: string; payload?: unknown }
+      const kept = JSON.parse(raw) as { pubkey?: string; payload?: unknown; event?: NostrEvent; published?: boolean }
       if (kept.pubkey !== me) return
       const shard = kept.payload ? fromPayload(kept.payload, `avatar:${me}`) : null
-      set({ shards: { ...get().shards, [me]: shard } })
+      set({
+        shards: { ...get().shards, [me]: shard },
+        mineEvent: kept.event ?? null,
+        // Anything kept before this field existed was published as it was adopted.
+        minePublished: kept.published ?? true,
+      })
     } catch { /* nothing kept */ }
   },
 }))
@@ -175,9 +225,16 @@ export function paidShard(ev: { kind: number; pubkey: string; content: string; t
   return avatarFromEvent(ev)
 }
 
-function remember(shard: ShardModel | null): void {
+function remember(shard: ShardModel | null, event: NostrEvent | null, published: boolean): void {
   try {
-    localStorage.setItem(MINE_KEY, JSON.stringify({ pubkey: useCyberspace.getState().identity.pubkey, payload: shard ? toPayload(shard) : null }))
+    localStorage.setItem(MINE_KEY, JSON.stringify({
+      pubkey: useCyberspace.getState().identity.pubkey,
+      payload: shard ? toPayload(shard) : null,
+      // Kept whole so an avatar adopted while LOCAL can be broadcast later
+      // without mining it again: the work is on this event.
+      event,
+      published,
+    }))
   } catch { /* private mode */ }
 }
 

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -92,6 +92,10 @@ interface ShardsState {
   deleted: Record<string, true>
   inspecting: string | null
   scanning: boolean
+  /** The region whose bag is being sent to the relays right now, by lookup id. */
+  broadcasting: string | null
+  /** Why the last broadcast failed, for the row that asked for it. */
+  broadcastError: string | null
   /** A world item clicked open, by its inner event id. */
   selectedSecret: string | null
 
@@ -101,6 +105,8 @@ interface ShardsState {
   cancelDeploy: () => void
   deploy: () => Promise<void>
   deleteInstance: (eventId: string) => Promise<void>
+  /** Send a region's bag to the relays now: what LOCAL deferred. */
+  broadcast: (lookupId: string) => Promise<boolean>
   inspect: (eventId: string | null) => void
   selectSecret: (eventId: string | null) => void
   addDiscovered: (items: Hidden[]) => void
@@ -203,6 +209,8 @@ export const useShards = create<ShardsState>((set, get) => {
     deleted: loadDeleted(),
     inspecting: null,
     scanning: false,
+    broadcasting: null,
+    broadcastError: null,
     selectedSecret: null,
 
     startDeployShard: (shardId) => set({ pending: { type: 'shard', shardId }, deployStatus: 'idle', deployError: null }),
@@ -268,6 +276,46 @@ export const useShards = create<ShardsState>((set, get) => {
         saveMine(mine)
       } catch (err) {
         set({ deployStatus: 'error', deployError: err instanceof Error ? err.message : String(err) })
+      }
+    },
+
+    /**
+     * Send a region's bag to the relays, with everything this device has for it.
+     *
+     * A deploy made while LOCAL is signed and kept but never sent, and going
+     * LIVE afterwards did nothing for it: the bag sat on the device with no way
+     * out. This is that way out. It rebuilds the region's bag exactly as a
+     * deploy does, from the relay's copy merged with every local item, so a
+     * region half published from another device comes back whole rather than
+     * being overwritten by this device's half.
+     */
+    broadcast: async (lookupId) => {
+      const cs = cyber()
+      if (!cs.live) {
+        set({ broadcastError: 'Nothing is published while you are LOCAL. Switch to LIVE and try again.' })
+        return false
+      }
+      if (get().broadcasting) return false
+      const items = get().mine.filter((d) => d.lookupId === lookupId)
+      if (items.length === 0) return false
+      set({ broadcasting: lookupId, broadcastError: null })
+      try {
+        const key = hexToBytes(items[0].keyHex)
+        const existing = await gatherInners(lookupId, key, true)
+        const allInners = mergeInners(existing, items.map((d) => d.inner))
+        const { event, published } = await publishBag(allInners, key, lookupId, items[0].height, true)
+        if (!published) {
+          set({ broadcasting: null, broadcastError: 'No relay took the bag. Try again when one is reachable.' })
+          return false
+        }
+        const relays = relaySet()
+        const mine = get().mine.map((d) => (d.lookupId === lookupId ? { ...d, bagId: event.id, published: true, relays } : d))
+        set({ mine, broadcasting: null })
+        saveMine(mine)
+        return true
+      } catch (err) {
+        set({ broadcasting: null, broadcastError: err instanceof Error ? err.message : String(err) })
+        return false
       }
     },
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -5101,3 +5101,36 @@ kbd {
   color: var(--warn, #ffb347);
   border-color: color-mix(in srgb, var(--warn, #ffb347) 50%, transparent);
 }
+
+/* Something deployed while LOCAL, and the button that sends it. */
+.shards__note {
+  display: block;
+  font-size: 9px;
+  line-height: 1.5;
+  color: var(--dim);
+  padding: 2px 0 4px;
+}
+
+.shards__note--warn { color: var(--warn); }
+
+.shards__broadcast {
+  flex: 0 0 auto;
+  align-self: center;
+  margin-left: 6px;
+  padding: 3px 7px;
+  font: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--warn);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, transparent);
+  border-radius: 3px;
+}
+
+.shards__broadcast:disabled { opacity: 0.5; }
+
+/* An avatar adopted while LOCAL, waiting to be sent. */
+.workshop__btn.workshop__btn--warn {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+}

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -259,6 +259,8 @@ export function Workshop(): JSX.Element | null {
   const phase = useAvatars((s) => s.phase)
   const minedMs = useAvatars((s) => s.minedMs)
   const adoptError = useAvatars((s) => s.adoptError)
+  const minePublished = useAvatars((s) => s.minePublished)
+  const live = useCyberspace((s) => s.live)
   // The moment the work is done: say so, because the signer's prompt may take a
   // while to appear and nothing else marks the end of the mining.
   const lastPhase = useRef<typeof phase>(null)
@@ -449,6 +451,12 @@ export function Workshop(): JSX.Element | null {
           <div className="workshop__row" role="group" aria-label="My avatar">
             <span className="workshop__label">MY AVATAR</span>
             <span className="workshop__value workshop__value--wide">{myAvatar ? myAvatar.name : 'dodecahedron'}</span>
+            {/* Adopted while LOCAL: signed and kept and drawn for you, but no relay has it. */}
+            {myAvatar && !minePublished && !phase && (
+              live
+                ? <button className="workshop__btn workshop__btn--warn" onClick={() => { void useAvatars.getState().broadcastMine().then((ok) => say(ok ? 'Your avatar is published.' : useAvatars.getState().adoptError ?? 'No relay took the avatar.')) }} title="Send the avatar you adopted while LOCAL to the relays">BROADCAST</button>
+                : <span className="workshop__value">LOCAL</span>
+            )}
             {phase === 'mining' ? (
               <button className="workshop__btn workshop__btn--danger" onClick={() => useAvatars.getState().cancelAdopt()} title="Stop mining; your avatar stays as it is">CANCEL</button>
             ) : phase ? (
@@ -460,8 +468,12 @@ export function Workshop(): JSX.Element | null {
                 onClick={() => {
                   const started = Date.now()
                   void useAvatars.getState().adopt(shard).then((ok) => {
-                    const err = useAvatars.getState().adoptError
-                    say(ok ? `"${shard.name}" is your avatar now: ${work.required} bits of work in ${describeDuration((Date.now() - started) / 1000).replace('about ', '')}.` : err ?? 'Mining cancelled. Your avatar is as it was.')
+                    const st = useAvatars.getState()
+                    const took = describeDuration((Date.now() - started) / 1000).replace('about ', '')
+                    if (!ok) { say(st.adoptError ?? 'Mining cancelled. Your avatar is as it was.'); return }
+                    say(st.minePublished
+                      ? `"${shard.name}" is your avatar now: ${work.required} bits of work in ${took}.`
+                      : `"${shard.name}" is your avatar on this device: ${work.required} bits of work in ${took}. You are LOCAL, so no relay has it. BROADCAST sends it when you go LIVE.`)
                   })
                 }}
                 title="Publish this shard as the shape others see for you, at true scale: the white avatar on the grid is the size of one cell. Its size and detail are paid for in proof of work first."


### PR DESCRIPTION
Three things from one sitting.

**A bag deployed while LOCAL was stuck there.** It is signed and kept, but never sent, and going LIVE afterwards did nothing for it. `useShards.broadcast(lookupId)` rebuilds that region's bag exactly as a deploy does, from the relay's copy merged with every local item, so a region half published from another device comes back whole rather than being overwritten by this device's half. The STASH now says how many things are on this device only, and each such row carries BROADCAST once you are LIVE. While LOCAL it says to switch first, and a refusal from the relays leaves the row local with the reason on screen.

**The avatar ignored the setting.** It went to the relays even while LOCAL, which is how you noticed. `adopt` now keeps the signed event when you are LOCAL, work and all, draws it for you, and the notice says no relay has it; `broadcastMine` sends that very event later, so the proof of work is never redone. An avatar the relay hands back is marked published whatever this device thought, and an avatar kept from before this change is treated as published, which it was.

**LIVE at the head was the wrong word**, since LIVE is also the publishing setting. The chain overlay now reads LATEST at the newest action, and RETURN TO LATEST off it. The setting keeps its LIVE and LOCAL names.

Tests: `broadcast.test.ts` (sends the region and marks it published, refuses while LOCAL, stays local when no relay takes it, merges what the relay holds) and one in `useAvatars.test.ts` (LOCAL keeps it, BROADCAST sends the same event id, refuses while LOCAL). Suite 574 passing, tsc and build clean. Verified in a browser: the row reads `Wedge LOCAL` while local and offers BROADCAST on live, the stash shows the note and the button, and the overlay reads LATEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz