### PR TITLE
Workshop: face outlines for LINES, finer divisions, and the small things

### DIFF
--- a/src/lib/outline.test.ts
+++ b/src/lib/outline.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { faceEdges } from './outline'
+import { DIVISIONS, TICKS_PER_UNIT } from './shards'
+
+/** Edges as unordered pairs, so a test does not care which way one is written. */
+const pairs = (idx: number[]): string[] => {
+  const out: string[] = []
+  for (let i = 0; i < idx.length; i += 2) out.push([idx[i], idx[i + 1]].sort((a, b) => a - b).join('-'))
+  return out.sort()
+}
+
+describe('faceEdges', () => {
+  it('draws a triangle as its three edges', () => {
+    expect(pairs(faceEdges([[0, 1, 2]]))).toEqual(['0-1', '0-2', '1-2'])
+  })
+
+  it('draws a quad as four edges, with no diagonal', () => {
+    expect(pairs(faceEdges([[0, 1, 2, 3]]))).toEqual(['0-1', '0-3', '1-2', '2-3'])
+  })
+
+  it('draws an edge two faces share exactly once', () => {
+    // Two triangles meeting along 1-2: five edges, not six.
+    const e = faceEdges([[0, 1, 2], [1, 3, 2]])
+    expect(pairs(e)).toEqual(['0-1', '0-2', '1-2', '1-3', '2-3'])
+  })
+
+  it('a closed box has twelve edges however its faces were cut', () => {
+    const box = [
+      [0, 1, 3, 2], [4, 6, 7, 5], [0, 4, 5, 1],
+      [2, 3, 7, 6], [0, 2, 6, 4], [1, 5, 7, 3],
+    ]
+    expect(pairs(faceEdges(box))).toHaveLength(12)
+  })
+
+  it('ignores degenerate faces and repeated points', () => {
+    expect(faceEdges([])).toEqual([])
+    expect(faceEdges([[5]])).toEqual([])
+    expect(pairs(faceEdges([[0, 0, 1]]))).toEqual(['0-1'])
+    // A two-point face is one edge, not the same edge there and back.
+    expect(faceEdges([[2, 3]])).toEqual([2, 3])
+  })
+})
+
+describe('grid divisions', () => {
+  it('every division divides a unit into whole ticks', () => {
+    for (const d of DIVISIONS) {
+      expect(TICKS_PER_UNIT % d).toBe(0)
+      expect(Number.isInteger(TICKS_PER_UNIT / d)).toBe(true)
+    }
+  })
+
+  it('offers 6, 8 and 10 and not the ones that would land between ticks', () => {
+    expect([...DIVISIONS]).toEqual([1, 2, 3, 4, 5, 6, 8, 10])
+    expect(DIVISIONS).not.toContain(7 as never)
+    expect(DIVISIONS).not.toContain(9 as never)
+  })
+})

--- a/src/lib/outline.ts
+++ b/src/lib/outline.ts
@@ -1,0 +1,29 @@
+/**
+ * outline.ts - the edges of a shard's faces, each one once.
+ *
+ * LINES mode draws a shard as a wireframe of its faces. The edges come from
+ * the faces as they were made, not from the triangles they are cut into for
+ * drawing: a polygon's outline is its own edges, and the diagonals the
+ * triangulation added are not part of the shape. An edge two faces share is
+ * drawn once, so a closed solid costs one line per edge rather than two.
+ */
+
+/** Index pairs for every distinct edge of these faces, ready for a LineSegments index. */
+export function faceEdges(faces: number[][]): number[] {
+  const seen = new Set<string>()
+  const edges: number[] = []
+  for (const face of faces) {
+    if (face.length < 2) continue
+    for (let i = 0; i < face.length; i++) {
+      const a = face[i]
+      const b = face[(i + 1) % face.length]
+      // A face of two points is one edge, not the same edge there and back.
+      if (a === b || (face.length === 2 && i === 1)) continue
+      const key = a < b ? `${a}:${b}` : `${b}:${a}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      edges.push(a, b)
+    }
+  }
+  return edges
+}

--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -33,7 +33,16 @@ export interface ShardVertex {
  * 120 is divisible by every division the workshop offers and by eighths.
  */
 export const TICKS_PER_UNIT = 120
-export const DIVISIONS = [1, 2, 3, 4, 5] as const
+/**
+ * The grid divisions offered, all of them exact.
+ *
+ * A vertex is stored in 120ths of a unit (TICKS_PER_UNIT), so a division is
+ * only offered when it divides 120 without a remainder: sevenths and ninths
+ * would land vertices between ticks and could not be written to the wire.
+ * That leaves 6, 8 and 10 as the next steps after 5; 12, 15, 20, 24, 30, 40
+ * and 60 are exact too if finer work ever wants them.
+ */
+export const DIVISIONS = [1, 2, 3, 4, 5, 6, 8, 10] as const
 export type Division = typeof DIVISIONS[number]
 
 export interface ShardModel {

--- a/src/scene/ShardMesh.tsx
+++ b/src/scene/ShardMesh.tsx
@@ -3,6 +3,9 @@
  *
  * SOLID draws the indexed triangles, LINES the vertex order as one line, and
  * every mode draws the vertices as points so a shard is visible at any size.
+ * LINES draws every edge of every face once, so a shape reads as a wireframe;
+ * with no faces there are no edges, and it falls back to one line through the
+ * points in the order they were made.
  * The two geometries share one pair of attribute buffers.
  *
  * With a `birth`, the shard is one this client has just found, and it does not
@@ -28,6 +31,7 @@ import {
 import { easeOutCubic, hash01, scrambleOffset, seedOf, SHARD_DECODE_MS } from '../lib/decode'
 import { flatten, ticksOf, toRender, type ShardModel } from '../lib/shards'
 import { orientShard } from '../lib/orient'
+import { faceEdges } from '../lib/outline'
 import { SHARD_DOTS, SHARD_POINTS, createDiscMaterial, sizeDisc, withDiscColors } from './pointDisc'
 
 interface Props {
@@ -122,6 +126,26 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
   }, [shard.mode, ghost])
   useEffect(() => () => pointMaterial.dispose(), [pointMaterial])
 
+  /**
+   * LINES mode: every edge of every face, each drawn once.
+   *
+   * Built from the shard's own faces rather than the triangulated index, so a
+   * polygon shows its outline and not the diagonals its triangles were cut
+   * along, and an edge two faces share is drawn once rather than twice.
+   */
+  const outline = useMemo(() => {
+    if (shard.faces.length === 0) return null
+    const idx = faceEdges(shard.faces)
+    if (idx.length === 0) return null
+    const g = new BufferGeometry()
+    g.setAttribute('position', posAttr)
+    g.setAttribute('color', colAttr)
+    g.setIndex(idx)
+    return g
+  }, [posAttr, colAttr, shard.faces])
+
+  useEffect(() => () => { outline?.dispose() }, [outline])
+
   const line = useMemo(() => {
     const l = new Line(plain, new LineBasicMaterial({ vertexColors: true, toneMapped: false, transparent: true, opacity: ghost ? 0.45 : 1 }))
     l.frustumCulled = false
@@ -199,7 +223,14 @@ export function ShardMesh({ shard, scale = 1, ghost = false, birth, onFaceClick,
           )}
         </group>
       )}
-      {shard.mode === 'lines' && shard.vertices.length > 1 && <primitive object={line} />}
+      {/* Faces as outlines. A shard with no faces has no edges to draw, so it
+          keeps the old single line through its points, which is all there is. */}
+      {shard.mode === 'lines' && outline && (
+        <lineSegments geometry={outline} frustumCulled={false}>
+          <lineBasicMaterial vertexColors toneMapped={false} transparent opacity={opacity} />
+        </lineSegments>
+      )}
+      {shard.mode === 'lines' && !outline && shard.vertices.length > 1 && <primitive object={line} />}
       {(shard.mode === 'points' || shard.mode === 'solid' || shard.mode === 'lines') && (
         <points geometry={plain} material={pointMaterial} frustumCulled={false} />
       )}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5134,3 +5134,25 @@ kbd {
   color: var(--warn);
   border-color: color-mix(in srgb, var(--warn) 45%, transparent);
 }
+
+/* The workshop's panels hover over the compass and its pad, which share the
+   top-right corner: the panel is what you are reading, so it wins. */
+.ws__top { z-index: 5; }
+
+/* A rule between the controls in MENU and GRID, so a row reads as one control. */
+.ws__panel .workshop__row {
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding-top: 8px;
+}
+
+.ws__panel .workshop__row:first-child { border-top: none; padding-top: 0; }
+
+/* With undo and redo out of the way, the open panel sits right under its chip. */
+.ws__top--open { gap: 5px; }
+
+/* The delete X, big enough to hit and to read. */
+.workshop__mini--x {
+  font-size: 20px;
+  line-height: 1;
+  padding-bottom: 2px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5136,8 +5136,16 @@ kbd {
 }
 
 /* The workshop's panels hover over the compass and its pad, which share the
-   top-right corner: the panel is what you are reading, so it wins. */
-.ws__top { z-index: 5; }
+   top-right corner: the panel is what you are reading, so it wins. The compass
+   drops a layer rather than the panels rising one, because DEPLOY and the way
+   out share the top edge with the chips and must stay pressable above all of it.
+   The chip row also reserves 124px on its right for those two buttons, and that
+   strip must let a press through rather than swallow it. */
+.ws__view { z-index: 2; }
+
+.ws__chips { pointer-events: none; }
+
+.ws__chips > * { pointer-events: auto; }
 
 /* A rule between the controls in MENU and GRID, so a row reads as one control. */
 .ws__panel .workshop__row {

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -234,7 +234,7 @@ function BenchViewMenu(): JSX.Element {
         <button className="viewmenu__key viewmenu__key--down" {...noCallout} onPointerDown={press(turn('tip'))} aria-label="Tip the grid down">▼</button>
       </div>
       <div className="viewmenu__row">
-        <button className="viewmenu__op" {...noCallout} onPointerDown={press(() => { w().setPlane(FLOOR); requestView({ kind: 'home' }) })} title="The grid back on the floor, the view back where the bench opens">SUN</button>
+        <button className="viewmenu__op" {...noCallout} onPointerDown={press(() => { w().setPlane(FLOOR); requestView({ kind: 'home' }) })} title="The grid back on the floor, the view back where the bench opens">RESET</button>
       </div>
     </div>
   )
@@ -405,7 +405,7 @@ export function Workshop(): JSX.Element | null {
 
       {/* Top left: the three chips and the history in one row, wrapping on a phone,
           and the open panel under whatever the row wrapped to. */}
-      <div className="ws__top">
+      <div className={`ws__top ${panel ? 'ws__top--open' : ''}`}>
       <div className="ws__chips">
         <button className={`chip ws__chip ${panel === 'menu' ? 'is-on' : ''}`} aria-pressed={panel === 'menu'} onClick={() => toggle('menu')}>
           <Menu size={12} strokeWidth={2.25} aria-hidden />MENU
@@ -419,10 +419,14 @@ export function Workshop(): JSX.Element | null {
             {phase === 'mining' ? `MINING ${mining ? clock(mining.elapsedMs) : ''}` : phase === 'signing' ? 'SIGN IT' : 'PUBLISHING'}
           </button>
         )}
-        <span className="ws__history">
-          <button className="chip ws__icon" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)" aria-label="Undo"><Undo2 size={20} strokeWidth={2.25} aria-hidden /></button>
-          <button className="chip ws__icon" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)" aria-label="Redo"><Redo2 size={20} strokeWidth={2.25} aria-hidden /></button>
-        </span>
+        {/* Out of the way while a panel is open: on a phone they wrapped the chip
+            row onto a second line and pushed the panel down with it. */}
+        {!panel && (
+          <span className="ws__history">
+            <button className="chip ws__icon" disabled={!canUndo} onClick={() => w().undo()} title="Undo (Ctrl+Z)" aria-label="Undo"><Undo2 size={20} strokeWidth={2.25} aria-hidden /></button>
+            <button className="chip ws__icon" disabled={!canRedo} onClick={() => w().redo()} title="Redo (Ctrl+Shift+Z)" aria-label="Redo"><Redo2 size={20} strokeWidth={2.25} aria-hidden /></button>
+          </span>
+        )}
       </div>
       {panel === 'menu' && shard && (
         <div className="ws__panel" role="region" aria-label="Menu">
@@ -439,8 +443,8 @@ export function Workshop(): JSX.Element | null {
               ))}
             </div>
           </div>
-          <div className="workshop__row" role="group" aria-label="Scale avatar">
-            <span className="workshop__label">AVATAR</span>
+          <div className="workshop__row" role="group" aria-label="Default avatar ghost">
+            <span className="workshop__label">DEFAULT AVATAR GHOST</span>
             <div className="workshop__modes">
               <button className={`workshop__mode ${showAvatar ? 'is-on' : ''}`} aria-pressed={showAvatar} onClick={() => w().setShowAvatar(true)} title="Show the to-scale avatar at the grid's centre">SHOW</button>
               <button className={`workshop__mode ${!showAvatar ? 'is-on' : ''}`} aria-pressed={!showAvatar} onClick={() => w().setShowAvatar(false)} title="Hide it">HIDE</button>
@@ -520,12 +524,12 @@ export function Workshop(): JSX.Element | null {
                 </button>
                 <button className="workshop__mini" title="Duplicate" onClick={() => w().duplicate(s.id)}>⧉</button>
                 <button className="workshop__mini workshop__mini--wide" title="Copy to the clipboard" onClick={() => copy(s.id)}>COPY</button>
-                <button className="workshop__mini workshop__mini--danger" title="Delete" onClick={() => { if (window.confirm(`Delete "${s.name}"? This cannot be undone.`)) w().remove(s.id) }}>×</button>
+                <button className="workshop__mini workshop__mini--danger workshop__mini--x" title="Delete" aria-label={`Delete ${s.name}`} onClick={() => { if (window.confirm(`Delete "${s.name}"? This cannot be undone.`)) w().remove(s.id) }}>×</button>
               </li>
             ))}
           </ul>
           <div className="workshop__row">
-            <button className="workshop__btn workshop__btn--danger" disabled={shard.vertices.length === 0} onClick={() => { if (window.confirm('Clear every vertex and face of this shard?')) w().clearShard() }} title="Empty this shard (undoable)">CLEAR SHARD</button>
+            <button className="workshop__btn workshop__btn--danger" disabled={shard.vertices.length === 0} onClick={() => { if (window.confirm('Delete all vertices and faces in the scene?')) w().clearShard() }} title="Empty this scene (undoable)">CLEAR THIS SCENE</button>
             <span className="workshop__gap" />
             <Explanation>
               A shard is colored points on a grid of whole units, drawn SOLID (faces, colors blending


### PR DESCRIPTION
Your list, in one pass.

**LINES draws the faces now.** It drew one line through the points in the order they were made, which is a shape's history rather than its shape. It now draws every edge of every face, once each, built from the faces as they were made (`lib/outline.ts`), so a polygon shows its outline and not the diagonals its triangles were cut along, and an edge two faces share is one line rather than two. A shard with no faces has no edges and keeps the old single line, which is all there is to draw. Verified in the bench: a six-quad box renders exactly 12 edges.

**DIVISION goes to 1/10**, as 1/6, 1/8 and 1/10. Sevenths and ninths are not there and cannot be: a vertex is stored in 120ths of a unit, and 120 does not divide by 7 or 9, so those would land vertices between ticks and could not be written to the wire. 12, 15, 20, 24, 30, 40 and 60 are exact if you ever want finer.

**The rest**

| Asked | Done |
|---|---|
| "Avatar" in the menu | DEFAULT AVATAR GHOST |
| the delete X is tiny | 20px, was the body text's size |
| the menu is covered by the 3-axis preview | the panels sit above it, z-index 5 over 3 |
| clear shard wording | CLEAR THIS SCENE, asking whether to delete all vertices and faces in the scene |
| a rule between controls | a rule above each row in MENU and GRID |
| SUN in the rotation panel | RESET |
| undo and redo in the way | hidden while a panel is open, so the chip row stops wrapping on a phone and the panel sits right under its chip |

Seven new tests: the edge builder (triangle, quad without its diagonal, a shared edge once, a box's twelve, degenerate faces) and that every offered division divides a unit into whole ticks. Suite 581 passing, tsc and build clean.

**Fix after review on the branch:** raising the panels over the compass raised the chip row with them, and that row reserves 124px on its right for DEPLOY and the way out, so the empty strip swallowed both presses. The compass drops a layer instead, which does the same job for the panels and leaves the top edge alone, and the chip row's reserved strip now passes presses through. Hit-tested with MENU open: DEPLOY receives its press, the way out receives its press and closes the workshop, and the compass under the panel is the panel.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
