### PR TITLE
The cube key changes the scale and nothing else, beside the key it belongs to

### DIFF
--- a/src/hud/TouchControls.tsx
+++ b/src/hud/TouchControls.tsx
@@ -17,7 +17,6 @@
 
 import { Box } from 'lucide-react'
 import { useCyberspace } from '../store/useCyberspace'
-import { viewCyberspace } from './HyperspacePanel'
 import { moveDirection, type MoveName } from '../lib/moves'
 import { MAX_SCALE_EXP } from '../lib/space'
 import { useShards } from '../store/useShards'
@@ -99,9 +98,13 @@ export function TouchControls(): JSX.Element {
   return (
     <>
       <div className={`touchpad${atHead ? '' : ' touchpad--scale'}`} role="group" aria-label="Move cursor and change scale">
-        {/* The purple cube: all of cyberspace at once, 2^84, the camera on
-            the whole of it. On every pad, at your head or off it. */}
-        <button className="touchpad__key touchpad__key--cube" title="All of cyberspace at 2^84" aria-label="See all of cyberspace at 2^84" {...noCallout} onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); viewCyberspace(MAX_SCALE_EXP) }}>
+        {/* The purple cube: the scale key taken to its end, 2^84, in one press.
+            It changes the scale and nothing else, so whatever you are looking
+            at stays what you are looking at, only seen from the top of the
+            ladder. Viewing cyberspace itself is the CYBERSPACE button in the
+            view menu, which is a different thing and stays where it is.
+            On every pad, at your head or off it. */}
+        <button className="touchpad__key touchpad__key--cube" title="Zoom all the way out (2^84)" aria-label="Zoom out to 2^84" {...noCallout} onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); useCyberspace.getState().adjustScale(MAX_SCALE_EXP) }}>
           <Box size={16} strokeWidth={2.25} aria-hidden />
         </button>
         {pad.map((b) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -3237,9 +3237,9 @@ kbd {
   grid-template-rows: repeat(3, 38px);
   gap: 4px;
   grid-template-areas:
-    "cube away    up   toward"
+    ".    away    up   toward"
     ".    left    hub  right"
-    ".    zoomout down zoomin";
+    "cube zoomout down zoomin";
 }
 /* Off your own head only scale is left to drive, so the pad folds to one
  * row: coarser, the readout, finer, and the cube. The direction cells leave
@@ -3249,7 +3249,8 @@ kbd {
   grid-template-areas: "cube zoomout hub zoomin";
 }
 .touchpad--scale .is-standdown { display: none; }
-/* The purple cube: all of cyberspace at once. */
+/* The purple cube: the scale keys' own end of the ladder, so it sits with them,
+   directly left of the coarser key rather than up in the direction cells. */
 .touchpad__key--cube {
   grid-area: cube;
   color: #dcc2ff;


### PR DESCRIPTION
The cube key called `viewCyberspace`, the same helper behind the view menu's CYBERSPACE button, which re-targets the view on the centre of the cube at 2^84 and labels it CYBERSPACE. It was only ever meant to take the scale to its end. It now calls `adjustScale` to the maximum and does nothing else, so whatever you were looking at stays what you are looking at, seen from the top of the ladder. Viewing cyberspace itself is still the CYBERSPACE button in the view menu, untouched.

It also moves on the pad, from the top-left cell beside FAR to the bottom-left, directly left of the coarser key, since that is the key it finishes. Off your head, where the pad folds to one row, it was already beside the scale keys.

Checked in a browser:

| | before the press | after |
|---|---|---|
| at your head | scale 0, no focus, plane 1 | scale 84, no focus, plane 1 |
| in a driven view | scale 0, focus A COORDINATE, plane 1 | scale 84, focus A COORDINATE, plane 1 |

And measured on the pad: the cube's box ends 4px before the coarser key's, on the same row.

Suite 581 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
