### PR TITLE
UNLOCK or BYPASS a wall, and one press or the whole route

### DIFF
--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -16,9 +16,11 @@ import { HOSAKA_DEFAULT_URL } from '../lib/hosaka'
 import { shortHex } from '../lib/time'
 import { useNow } from '../hooks/useNow'
 import { useCyberspace } from '../store/useCyberspace'
+import type { RouteProfile } from '../lib/movePlan'
 import { Explanation } from './Explanation'
 
 const MODES: Array<[CloudMode, string]> = [['auto', 'AUTO'], ['ask', 'ASK'], ['off', 'OFF']]
+const PROFILES: Array<[RouteProfile, string]> = [['fastest', 'FASTEST'], ['cheapest', 'CHEAPEST']]
 
 const STAGE_LABEL: Record<string, string> = {
   awaiting_payment: 'AWAITING PAYMENT',
@@ -103,6 +105,31 @@ export function CloudPanel(): JSX.Element {
           >{label}</button>
         ))}
       </div>
+
+      {/* Which step to prefer where both this machine and HOSAKA have one.
+          Not a spending limit: AUTO and ASK still decide what gets paid. */}
+      {prefs.mode !== 'off' && (
+        <div className="cloud__profile">
+          <span className="login__label">Route profile</span>
+          <div className="cloud__modes" role="radiogroup" aria-label="Route profile">
+            {PROFILES.map(([profile, label]) => (
+              <button
+                key={profile}
+                type="button"
+                role="radio"
+                aria-checked={prefs.profile === profile}
+                className={`secret__act cloud__mode ${prefs.profile === profile ? 'is-on' : ''}`}
+                onClick={() => store().setCloudPrefs({ profile })}
+              >{label}</button>
+            ))}
+          </div>
+          <span className="cloud__profile-note">
+            {prefs.profile === 'fastest'
+              ? 'HOSAKA hops the boundaries this machine could only sidestep across: one paid step in place of a walk to the wall, a sidestep, and a walk on.'
+              : 'This machine takes every boundary it can, sidestepping across the ones above its hop ceiling, however many steps that walk takes. HOSAKA is used only where this machine cannot go at all.'}
+          </span>
+        </div>
+      )}
 
       {prefs.mode === 'auto' && (
         <label className="cloud__budget">

--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -22,7 +22,7 @@ import { useCalibration } from '../lib/calibration'
 import { Explanation } from './Explanation'
 
 const MODES: Array<[CloudMode, string]> = [['auto', 'AUTO'], ['ask', 'ASK'], ['off', 'OFF']]
-const PROFILES: Array<[RouteProfile, string]> = [['fastest', 'FASTEST'], ['cheapest', 'CHEAPEST']]
+const PROFILES: Array<[RouteProfile, string]> = [['unlock', 'UNLOCK'], ['bypass', 'BYPASS']]
 
 const STAGE_LABEL: Record<string, string> = {
   awaiting_payment: 'AWAITING PAYMENT',
@@ -81,7 +81,7 @@ export function CloudPanel(): JSX.Element {
 
   // Where the paid hop starts winning, measured (lib/crossover): the setting
   // explains itself with the number rather than a promise.
-  const crossover = offloadFrom('fastest', {
+  const crossover = offloadFrom('unlock', {
     hopCeiling: hopCeil,
     sidestepCeiling: sidestepCeil,
     cloudHop: cloud.limits?.max_hop_height ?? 0,
@@ -125,12 +125,12 @@ export function CloudPanel(): JSX.Element {
         ))}
       </div>
 
-      {/* Which step to prefer where both this machine and HOSAKA have one.
-          Not a spending limit: AUTO and ASK still decide what gets paid. */}
+      {/* How to get past a wall this machine cannot hop. Not a spending limit:
+          AUTO and ASK still decide what actually gets paid. */}
       {prefs.mode !== 'off' && (
         <div className="cloud__profile">
-          <span className="login__label">Route profile</span>
-          <div className="cloud__modes" role="radiogroup" aria-label="Route profile">
+          <span className="login__label">Crossing a wall</span>
+          <div className="cloud__modes" role="radiogroup" aria-label="Crossing a wall">
             {PROFILES.map(([profile, label]) => (
               <button
                 key={profile}
@@ -143,11 +143,11 @@ export function CloudPanel(): JSX.Element {
             ))}
           </div>
           <span className="cloud__profile-note">
-            {prefs.profile === 'cheapest'
-              ? 'This machine takes every boundary it can, sidestepping across the ones above its hop ceiling, however many steps that walk takes. HOSAKA is used only where this machine cannot go at all.'
+            {prefs.profile === 'bypass'
+              ? 'Sidestep around every wall this machine can, however many steps that walk takes, and pay nothing. You arrive without the region’s Cantor root, so anything hidden along the way stays shut. HOSAKA is used only where this machine cannot cross at all.'
               : Number.isFinite(crossover)
-                ? `HOSAKA takes the crossings from 2^${crossover} up, where the walk across costs this machine more time than the paid hop does. Below that this machine is quicker as well as free, so nothing is bought.`
-                : 'Measured against HOSAKA’s own published times, this machine is quicker at every crossing it can make, so nothing is bought. HOSAKA still takes the boundaries this machine cannot cross at all.'}
+                ? `Buy the hop from 2^${crossover} up, where the walk also costs more time than the hop does, and arrive holding the region’s Cantor root. Below that this machine is quicker as well as free, so nothing is bought.`
+                : 'Measured against HOSAKA’s own published times, this machine crosses faster than HOSAKA everywhere it can reach, so nothing is bought here. HOSAKA still takes the walls this machine cannot cross at all, and those arrive with the region’s root.'}
           </span>
         </div>
       )}

--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -17,6 +17,8 @@ import { shortHex } from '../lib/time'
 import { useNow } from '../hooks/useNow'
 import { useCyberspace } from '../store/useCyberspace'
 import type { RouteProfile } from '../lib/movePlan'
+import { offloadFrom } from '../lib/crossover'
+import { useCalibration } from '../lib/calibration'
 import { Explanation } from './Explanation'
 
 const MODES: Array<[CloudMode, string]> = [['auto', 'AUTO'], ['ask', 'ASK'], ['off', 'OFF']]
@@ -72,6 +74,23 @@ export function CloudPanel(): JSX.Element {
     const known = st.cloud.balance
     if (signerKind === 'local' && st.cloud.limits !== null && st.cloudPrefs.mode !== 'off' && (known === null || Date.now() - known.at > BALANCE_STALE_MS)) void st.refreshBalance()
   }, [pubkey, signerKind, cloud.limits !== null])
+  const hopCeil = useCalibration((st) => st.hopHeight)
+  const sidestepCeil = useCalibration((st) => st.sidestepHeight)
+  const cantorMsByHeight = useCalibration((st) => st.cantorMsByHeight)
+  const sha256PerSec = useCalibration((st) => st.sha256PerSec)
+
+  // Where the paid hop starts winning, measured (lib/crossover): the setting
+  // explains itself with the number rather than a promise.
+  const crossover = offloadFrom('fastest', {
+    hopCeiling: hopCeil,
+    sidestepCeiling: sidestepCeil,
+    cloudHop: cloud.limits?.max_hop_height ?? 0,
+    provider: cloud.provider ?? null,
+    signerKind,
+    cantorMsByHeight,
+    sha256PerSec,
+  })
+
   const tag = prefs.mode === 'off' ? 'OFF' : active || cloud.status === 'error' ? STATUS_LABEL[cloud.status] : prefs.mode.toUpperCase()
 
   const setUrl = (): void => {
@@ -124,9 +143,11 @@ export function CloudPanel(): JSX.Element {
             ))}
           </div>
           <span className="cloud__profile-note">
-            {prefs.profile === 'fastest'
-              ? 'HOSAKA hops the boundaries this machine could only sidestep across: one paid step in place of a walk to the wall, a sidestep, and a walk on.'
-              : 'This machine takes every boundary it can, sidestepping across the ones above its hop ceiling, however many steps that walk takes. HOSAKA is used only where this machine cannot go at all.'}
+            {prefs.profile === 'cheapest'
+              ? 'This machine takes every boundary it can, sidestepping across the ones above its hop ceiling, however many steps that walk takes. HOSAKA is used only where this machine cannot go at all.'
+              : Number.isFinite(crossover)
+                ? `HOSAKA takes the crossings from 2^${crossover} up, where the walk across costs this machine more time than the paid hop does. Below that this machine is quicker as well as free, so nothing is bought.`
+                : 'Measured against HOSAKA’s own published times, this machine is quicker at every crossing it can make, so nothing is bought. HOSAKA still takes the boundaries this machine cannot cross at all.'}
           </span>
         </div>
       )}

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -14,7 +14,12 @@ import { useCalibration } from '../lib/calibration'
 import { satsOf } from '../lib/cloud'
 import { previewWindow, routeLabel, useRoutePreview } from './routePreview'
 import { formatMs, formatOps } from '../lib/space'
-import { MAX_COMPUTE_HEIGHT, useCyberspace, type CloudState, type MovePlan } from '../store/useCyberspace'
+import { MAX_COMPUTE_HEIGHT, useCyberspace, type CloudState, type MovePlan, type MoveMode } from '../store/useCyberspace'
+
+const MOVE_MODES: Array<[MoveMode, string, string]> = [
+  ['single', 'SINGLE ACTION', 'One action per press'],
+  ['auto', 'AUTOMATIC', 'The whole route, in order'],
+]
 
 function StatusLabel({ status }: { status: string }): JSX.Element {
   const label: Record<string, string> = {
@@ -46,6 +51,7 @@ export function ProofPanel(): JSX.Element {
   // defaults until the quiet benchmark lands, then the line updates in place.
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
+  const moveMode = useCyberspace((s) => s.moveMode)
   // This machine's hop ceiling as the commit attempts it: the protocol cap,
   // lowered to what calibration measured (the preview hook uses the same).
   const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
@@ -218,6 +224,29 @@ export function ProofPanel(): JSX.Element {
           {proof.message && <p className="notice">{proof.message}</p>}
         </>
       )}
+
+      {/* What COMMIT does with a route: its first step, or all of them. */}
+      <div className="proof__mode" role="radiogroup" aria-label="What commit runs">
+        <span className="login__label">Commit runs</span>
+        <div className="cloud__modes">
+          {MOVE_MODES.map(([mode, label, title]) => (
+            <button
+              key={mode}
+              type="button"
+              role="radio"
+              aria-checked={moveMode === mode}
+              title={title}
+              className={`secret__act cloud__mode ${moveMode === mode ? 'is-on' : ''}`}
+              onClick={() => useCyberspace.getState().setMoveMode(mode)}
+            >{label}</button>
+          ))}
+        </div>
+        <span className="cloud__profile-note">
+          {moveMode === 'auto'
+            ? 'Every step of the route in order, stopping only if a signature is declined or a step fails.'
+            : 'One step per press: the one the button names. The cursor stays where it is, so the next press takes the next step.'}
+        </span>
+      </div>
 
       <p className="legend__note">
         THIS MACHINE BENCHMARK

--- a/src/hud/routePreview.ts
+++ b/src/hud/routePreview.ts
@@ -12,6 +12,7 @@
 import { useMemo } from 'react'
 import { estimateHopCost } from 'cyberspace-core'
 import { useCalibration } from '../lib/calibration'
+import { offloadFrom } from '../lib/crossover'
 import { buildMovePlan, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { MAX_COMPUTE_HEIGHT, samePosition, useCyberspace } from '../store/useCyberspace'
 
@@ -53,21 +54,26 @@ export function useRoutePreview(): RoutePreview | null {
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
-  const profile = useCyberspace((st) => st.cloudPrefs.profile)
   const cloudHop = limits?.max_hop_height ?? 0
   const cloudSidestep = limits?.max_sidestep_height ?? 0
+  const profile = useCyberspace((st) => st.cloudPrefs.profile)
+  const provider = useCyberspace((st) => st.cloud.provider)
+  const signerKind = useCyberspace((st) => st.signerKind)
+  const cantorMsByHeight = useCalibration((st) => st.cantorMsByHeight)
+  const sha256PerSec = useCalibration((st) => st.sha256PerSec)
+  const from = offloadFrom(profile, { hopCeiling: ceiling, sidestepCeiling: sidestepCeil, cloudHop, provider: provider ?? null, signerKind, cantorMsByHeight, sha256PerSec })
   return useMemo(() => {
     if (!home || samePosition(position, cursor)) return null
     const hop = estimateHopCost(position.x, position.y, position.z, cursor.x, cursor.y, cursor.z, plane, ceiling)
     if (!hop.exceedsLimit) return { hop, route: null, steps: null, needsCloud: false }
     // HOSAKA's caps whatever the cloud mode: what a move needs does not
     // depend on a setting, and the button (useOffer) reads it the same way.
-    const ceilings: Ceilings = { hop: ceiling, sidestep: sidestepCeil, cloudHop, cloudSidestep, profile }
+    const ceilings: Ceilings = { hop: ceiling, sidestep: sidestepCeil, cloudHop, cloudSidestep, offloadFrom: from }
     let steps: PlanStep[] | null = null
     try { steps = buildMovePlan(position, cursor, ceilings, PREVIEW_STEPS_MAX) } catch { steps = null }
     const route = steps ? summaryOf(steps) : planSummary(position, cursor, ceilings, PREVIEW_STEPS_MAX)
     return { hop, route, steps, needsCloud: route.cloudSteps > 0 }
-  }, [home, position, cursor, plane, ceiling, sidestepCeil, cloudHop, cloudSidestep, profile])
+  }, [home, position, cursor, plane, ceiling, sidestepCeil, cloudHop, cloudSidestep, from])
 }
 
 export interface PreviewRow { index: number; kind: string; height: string; state: string; label: string }

--- a/src/hud/routePreview.ts
+++ b/src/hud/routePreview.ts
@@ -53,6 +53,7 @@ export function useRoutePreview(): RoutePreview | null {
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
+  const profile = useCyberspace((st) => st.cloudPrefs.profile)
   const cloudHop = limits?.max_hop_height ?? 0
   const cloudSidestep = limits?.max_sidestep_height ?? 0
   return useMemo(() => {
@@ -61,12 +62,12 @@ export function useRoutePreview(): RoutePreview | null {
     if (!hop.exceedsLimit) return { hop, route: null, steps: null, needsCloud: false }
     // HOSAKA's caps whatever the cloud mode: what a move needs does not
     // depend on a setting, and the button (useOffer) reads it the same way.
-    const ceilings: Ceilings = { hop: ceiling, sidestep: sidestepCeil, cloudHop, cloudSidestep }
+    const ceilings: Ceilings = { hop: ceiling, sidestep: sidestepCeil, cloudHop, cloudSidestep, profile }
     let steps: PlanStep[] | null = null
     try { steps = buildMovePlan(position, cursor, ceilings, PREVIEW_STEPS_MAX) } catch { steps = null }
     const route = steps ? summaryOf(steps) : planSummary(position, cursor, ceilings, PREVIEW_STEPS_MAX)
     return { hop, route, steps, needsCloud: route.cloudSteps > 0 }
-  }, [home, position, cursor, plane, ceiling, sidestepCeil, cloudHop, cloudSidestep])
+  }, [home, position, cursor, plane, ceiling, sidestepCeil, cloudHop, cloudSidestep, profile])
 }
 
 export interface PreviewRow { index: number; kind: string; height: string; state: string; label: string }

--- a/src/lib/calibration.ts
+++ b/src/lib/calibration.ts
@@ -162,6 +162,8 @@ interface CalibrationSnapshot {
   sidestepHeight: number
   /** Measured SHA-256 leaf hashes per second; absent until measured or read from the cache. */
   sha256PerSec?: number
+  /** Measured milliseconds per Cantor axis at each height; absent until measured. */
+  cantorMsByHeight?: Record<number, number>
 }
 
 /**
@@ -229,6 +231,7 @@ export function startCalibration(): void {
       hopHeight: hopCeiling(cached.cantorMsByHeight),
       sidestepHeight: sidestepCeiling(cached.sha256PerSec),
       sha256PerSec: cached.sha256PerSec,
+      cantorMsByHeight: cached.cantorMsByHeight,
     })
     return
   }
@@ -262,6 +265,7 @@ function runBenchmark(): void {
       hopHeight: hopCeiling(msg.cantorMsByHeight),
       sidestepHeight: sidestepCeiling(msg.sha256PerSec),
       sha256PerSec: msg.sha256PerSec,
+      cantorMsByHeight: msg.cantorMsByHeight,
     })
   }
   worker.onerror = () => worker.terminate()

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -107,9 +107,9 @@ describe('persistence', () => {
 
   it('defaults prefs, round-trips them, and refuses junk', () => {
     expect(loadCloudPrefs()).toEqual(defaultCloudPrefs())
-    saveCloudPrefs({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765/' })
+    saveCloudPrefs({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765/', profile: 'cheapest' })
     // A trailing slash is dropped on the way back in, so paths never double it.
-    expect(loadCloudPrefs()).toEqual({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765' })
+    expect(loadCloudPrefs()).toEqual({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765', profile: 'cheapest' })
     localStorage.setItem('onosendai:cloud', JSON.stringify({ mode: 'yes', autoMaxSats: -4, apiUrl: 'ftp://x' }))
     expect(loadCloudPrefs()).toEqual(defaultCloudPrefs())
     localStorage.setItem('onosendai:cloud', '{not json')

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -107,9 +107,9 @@ describe('persistence', () => {
 
   it('defaults prefs, round-trips them, and refuses junk', () => {
     expect(loadCloudPrefs()).toEqual(defaultCloudPrefs())
-    saveCloudPrefs({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765/', profile: 'cheapest' })
+    saveCloudPrefs({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765/', profile: 'bypass' })
     // A trailing slash is dropped on the way back in, so paths never double it.
-    expect(loadCloudPrefs()).toEqual({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765', profile: 'cheapest' })
+    expect(loadCloudPrefs()).toEqual({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765', profile: 'bypass' })
     localStorage.setItem('onosendai:cloud', JSON.stringify({ mode: 'yes', autoMaxSats: -4, apiUrl: 'ftp://x' }))
     expect(loadCloudPrefs()).toEqual(defaultCloudPrefs())
     localStorage.setItem('onosendai:cloud', '{not json')

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -49,14 +49,15 @@ export interface CloudPrefs {
   mode: CloudMode
   autoMaxSats: number
   apiUrl: string
-  /** Which step to prefer where both this machine and HOSAKA have one. */
+  /** How to get past a wall this machine cannot hop: unlock it, or bypass it. */
   profile: RouteProfile
 }
 
 export function defaultCloudPrefs(): CloudPrefs {
-  // Fastest by default: the walk this machine can make across a high boundary
-  // is dozens of signed events, and one paid hop replaces all of them.
-  return { mode: 'auto', autoMaxSats: 0, apiUrl: defaultHosakaUrl(), profile: 'fastest' }
+  // Unlock by default: the walk across a high boundary is dozens of signed
+  // events and arrives blind, and one paid hop replaces all of them with the
+  // region's key in hand.
+  return { mode: 'auto', autoMaxSats: 0, apiUrl: defaultHosakaUrl(), profile: 'unlock' }
 }
 
 const PREFS_KEY = 'onosendai:cloud'
@@ -68,14 +69,18 @@ export function loadCloudPrefs(): CloudPrefs {
   try {
     const raw = localStorage.getItem(PREFS_KEY)
     if (!raw) return d
-    const p = JSON.parse(raw) as Partial<CloudPrefs>
+    const p = JSON.parse(raw) as Omit<Partial<CloudPrefs>, 'profile'> & { profile?: string }
     return {
       mode: p.mode === 'auto' || p.mode === 'ask' || p.mode === 'off' ? p.mode : d.mode,
       autoMaxSats: typeof p.autoMaxSats === 'number' && Number.isFinite(p.autoMaxSats) && p.autoMaxSats >= 0
         ? Math.floor(p.autoMaxSats)
         : d.autoMaxSats,
       apiUrl: typeof p.apiUrl === 'string' && /^https?:\/\/\S+$/.test(p.apiUrl) ? p.apiUrl.replace(/\/+$/, '') : d.apiUrl,
-      profile: p.profile === 'cheapest' || p.profile === 'fastest' ? p.profile : d.profile,
+      // The pair was briefly called fastest and cheapest; anything kept under
+      // those names still reads.
+      profile: p.profile === 'bypass' || p.profile === 'cheapest' ? 'bypass'
+        : p.profile === 'unlock' || p.profile === 'fastest' ? 'unlock'
+        : d.profile,
     }
   } catch {
     return d

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -43,14 +43,20 @@ export type CloudMode = 'auto' | 'ask' | 'off'
  * Auto never means auto-pay: the client has no wallet, so it means the
  * invoice is shown at once.
  */
+import type { RouteProfile } from './movePlan'
+
 export interface CloudPrefs {
   mode: CloudMode
   autoMaxSats: number
   apiUrl: string
+  /** Which step to prefer where both this machine and HOSAKA have one. */
+  profile: RouteProfile
 }
 
 export function defaultCloudPrefs(): CloudPrefs {
-  return { mode: 'auto', autoMaxSats: 0, apiUrl: defaultHosakaUrl() }
+  // Fastest by default: the walk this machine can make across a high boundary
+  // is dozens of signed events, and one paid hop replaces all of them.
+  return { mode: 'auto', autoMaxSats: 0, apiUrl: defaultHosakaUrl(), profile: 'fastest' }
 }
 
 const PREFS_KEY = 'onosendai:cloud'
@@ -69,6 +75,7 @@ export function loadCloudPrefs(): CloudPrefs {
         ? Math.floor(p.autoMaxSats)
         : d.autoMaxSats,
       apiUrl: typeof p.apiUrl === 'string' && /^https?:\/\/\S+$/.test(p.apiUrl) ? p.apiUrl.replace(/\/+$/, '') : d.apiUrl,
+      profile: p.profile === 'cheapest' || p.profile === 'fastest' ? p.profile : d.profile,
     }
   } catch {
     return d

--- a/src/lib/crossover.test.ts
+++ b/src/lib/crossover.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { EVENT_SECONDS, PAYMENT_SECONDS, cloudSeconds, crossoverHeight, parseEstTime, walkSeconds, type CrossoverInputs } from './crossover'
+
+/** HOSAKA's real published ladder, as the live provider gives it. */
+const LADDER = [
+  { max_height: 18, sats: 9, est_seconds: 97 },
+  { max_height: 20, sats: 10, est_seconds: 103 },
+  { max_height: 22, sats: 13, est_seconds: 136 },
+  { max_height: 24, sats: 41, est_seconds: 277 },
+  { max_height: 25, sats: 79, est_seconds: 474 },
+  { max_height: 27, sats: 609, est_seconds: 1730 },
+]
+
+/** A phone: hops to 2^17, hashes 559k a second, so it sidesteps to 2^24. */
+const phone = (signerKind: CrossoverInputs['signerKind'] = 'local'): CrossoverInputs => ({
+  hopCeiling: 17,
+  sidestepCeiling: 24,
+  cloudHop: 27,
+  cantorMsByHeight: { 14: 300, 15: 700, 16: 1600, 17: 3800 },
+  sha256PerSec: 559_000,
+  ladder: LADDER,
+  signerKind,
+})
+
+describe('reading the provider', () => {
+  it('takes the seconds it publishes, by band', () => {
+    expect(cloudSeconds(18, LADDER)).toBe(97)
+    expect(cloudSeconds(21, LADDER)).toBe(136)
+    expect(cloudSeconds(27, LADDER)).toBe(1730)
+  })
+
+  it('falls back to the words when the seconds are missing', () => {
+    expect(parseEstTime('about 5 min')).toBe(300)
+    expect(parseEstTime('under 10 sec')).toBe(10)
+    expect(parseEstTime('about 1.5 hr')).toBe(5400)
+    expect(parseEstTime('rejected, use a sidestep')).toBeNull()
+    expect(cloudSeconds(24, [{ max_height: 24, est_time: 'about 5 min' }])).toBe(300)
+  })
+
+  it('says nothing when the height is past the ladder', () => {
+    expect(cloudSeconds(40, LADDER)).toBeNull()
+  })
+})
+
+describe('the walk', () => {
+  it('grows by the step count, not by the sidestep', () => {
+    const p = phone()
+    const low = walkSeconds(18, p)
+    const high = walkSeconds(24, p)
+    // Four steps against 256: two orders of magnitude, not one crossing's worth.
+    expect(high / low).toBeGreaterThan(50)
+  })
+
+  it('counts the signature on every event', () => {
+    const withKey = walkSeconds(22, phone('local'))
+    const withBunker = walkSeconds(22, phone('nip46'))
+    expect(withBunker).toBeGreaterThan(withKey)
+    expect(EVENT_SECONDS.nip46).toBeGreaterThan(EVENT_SECONDS.local)
+  })
+
+  it('is out of the question above this machine’s sidestep ceiling', () => {
+    expect(walkSeconds(26, phone())).toBe(Infinity)
+  })
+})
+
+describe('the crossover', () => {
+  it('leaves the small crossings to this machine', () => {
+    const h = crossoverHeight(phone())
+    expect(h).toBeGreaterThan(17)
+    // A 2^18 crossing is four steps and a few seconds: never worth 9 sats.
+    expect(walkSeconds(18, phone())).toBeLessThan(cloudSeconds(18, LADDER)! + PAYMENT_SECONDS)
+    expect(h).toBeGreaterThan(18)
+  })
+
+  it('hands over once the walk is longer than the hop', () => {
+    const p = phone()
+    const h = crossoverHeight(p)
+    expect(Number.isFinite(h)).toBe(true)
+    expect(walkSeconds(h, p)).toBeGreaterThan(cloudSeconds(h, LADDER)! + PAYMENT_SECONDS)
+    expect(walkSeconds(h - 1, p)).toBeLessThanOrEqual(cloudSeconds(h - 1, LADDER)! + PAYMENT_SECONDS)
+  })
+
+  it('hands over sooner when every event costs a bunker round trip', () => {
+    expect(crossoverHeight(phone('nip46'))).toBeLessThanOrEqual(crossoverHeight(phone('local')))
+  })
+
+  it('never hands over when the provider says nothing about its times', () => {
+    expect(crossoverHeight({ ...phone(), ladder: null })).toBe(Infinity)
+    expect(crossoverHeight({ ...phone(), ladder: [{ max_height: 27 }] })).toBe(Infinity)
+  })
+
+  it('never hands over when the cloud reaches no further than this machine', () => {
+    expect(crossoverHeight({ ...phone(), cloudHop: 17 })).toBe(Infinity)
+  })
+})

--- a/src/lib/crossover.ts
+++ b/src/lib/crossover.ts
@@ -1,8 +1,8 @@
 /**
  * crossover.ts - the wall height where buying the hop beats walking it.
  *
- * The route profile used to be structural: under `fastest` any boundary above
- * this machine's hop ceiling went to HOSAKA. Measured, that is wrong at the
+ * The choice used to be structural: under UNLOCK any boundary above this
+ * machine's hop ceiling went to HOSAKA. Measured, that is wrong at the
  * bottom of the range. A single sidestep is one hash chain and this machine
  * beats HOSAKA at every height it can reach at all: a 2^20 crossing is four
  * seconds here against about two and a half minutes there.
@@ -20,7 +20,7 @@
  * one number.
  */
 
-import { buildMovePlan, localOnly } from './movePlan'
+import { buildMovePlan, localOnly, type RouteProfile } from './movePlan'
 import { projectCantorMs } from './calibration'
 import type { SignerKind } from './signers'
 
@@ -134,8 +134,8 @@ export function crossoverHeight(inputs: CrossoverInputs): number {
 let cached: { key: string; value: number } | null = null
 
 /** The same, memoised: the inputs change rarely and the answer is asked per cursor move. */
-export function crossoverFor(profile: 'fastest' | 'cheapest', inputs: CrossoverInputs): number {
-  if (profile !== 'fastest') return Infinity
+export function crossoverFor(profile: RouteProfile, inputs: CrossoverInputs): number {
+  if (profile !== 'unlock') return Infinity
   const key = [
     inputs.hopCeiling, inputs.sidestepCeiling, inputs.cloudHop, inputs.signerKind,
     Math.round(inputs.sha256PerSec ?? 0),
@@ -154,7 +154,7 @@ export function crossoverFor(profile: 'fastest' | 'cheapest', inputs: CrossoverI
  * cannot disagree about where HOSAKA takes over.
  */
 export function offloadFrom(
-  profile: 'fastest' | 'cheapest',
+  profile: RouteProfile,
   opts: {
     hopCeiling: number
     sidestepCeiling: number

--- a/src/lib/crossover.ts
+++ b/src/lib/crossover.ts
@@ -1,0 +1,177 @@
+/**
+ * crossover.ts - the wall height where buying the hop beats walking it.
+ *
+ * The route profile used to be structural: under `fastest` any boundary above
+ * this machine's hop ceiling went to HOSAKA. Measured, that is wrong at the
+ * bottom of the range. A single sidestep is one hash chain and this machine
+ * beats HOSAKA at every height it can reach at all: a 2^20 crossing is four
+ * seconds here against about two and a half minutes there.
+ *
+ * What the cloud actually replaces is not one sidestep but the walk. Crossing
+ * a wall at height h with a hop ceiling of c takes about 2^(h-c) steps, each
+ * one a signed, published event, and that is what grows out of hand: 4 steps
+ * at 2^18, 128 at 2^23, 256 at 2^24. So the honest question is not "is there a
+ * wall" but "does the walk cost more than the hop", and the answer moves with
+ * the machine, with the signer, and with what the provider charges in time.
+ *
+ * This module answers it in seconds, from what is already known: the walk from
+ * the planner and the calibration, the hop from the provider's own published
+ * ladder. The planner is left pure and quick: it takes the resulting height as
+ * one number.
+ */
+
+import { buildMovePlan, localOnly } from './movePlan'
+import { projectCantorMs } from './calibration'
+import type { SignerKind } from './signers'
+
+/**
+ * What one event costs beyond its computation: the signature and the publish.
+ *
+ * A local key signs in a millisecond. An extension asks the browser. A bunker
+ * is a round trip to another device over a relay, which is the case that turns
+ * a 256-step walk into an afternoon.
+ */
+export const EVENT_SECONDS: Record<SignerKind, number> = {
+  local: 0.5,
+  nip07: 1.2,
+  nip46: 4,
+}
+
+/** Quote, submit and the queue before HOSAKA's own clock starts, when the balance covers it. */
+export const PAYMENT_SECONDS = 30
+
+/** Longer walks than this are not costed step by step; they have already lost. */
+const WALK_STEPS_MAX = 4096
+
+export interface CrossoverInputs {
+  /** This machine's ceilings, from the calibration. */
+  hopCeiling: number
+  sidestepCeiling: number
+  /** The provider's hop cap; 0 when the cloud is off or unknown. */
+  cloudHop: number
+  cantorMsByHeight: Record<number, number> | null
+  sha256PerSec: number | null
+  /** The provider's published hop ladder. */
+  ladder: Array<{ max_height: number; est_seconds?: number; est_time?: string }> | null
+  signerKind: SignerKind
+}
+
+/** "about 5 min", "under 10 sec", "about 1.5 hr" as seconds; null when it is none of those. */
+export function parseEstTime(text: string | undefined): number | null {
+  if (!text) return null
+  const m = /(\d+(?:\.\d+)?)\s*(sec|min|hr|hour)/i.exec(text)
+  if (!m) return null
+  const n = Number(m[1])
+  if (!Number.isFinite(n)) return null
+  const unit = m[2].toLowerCase()
+  return unit === 'sec' ? n : unit === 'min' ? n * 60 : n * 3600
+}
+
+/** Seconds HOSAKA says a hop at this height takes, from its own ladder. */
+export function cloudSeconds(height: number, ladder: CrossoverInputs['ladder']): number | null {
+  if (!ladder || ladder.length === 0) return null
+  const band = [...ladder].sort((a, b) => a.max_height - b.max_height).find((b) => height <= b.max_height)
+  if (!band) return null
+  if (typeof band.est_seconds === 'number' && band.est_seconds > 0) return band.est_seconds
+  return parseEstTime(band.est_time)
+}
+
+/** Seconds one step of a walk costs this machine: its computation and its event. */
+export function stepSeconds(
+  kind: 'hop' | 'sidestep',
+  height: number,
+  inputs: CrossoverInputs,
+): number {
+  const event = EVENT_SECONDS[inputs.signerKind] ?? EVENT_SECONDS.local
+  if (kind === 'sidestep') {
+    const rate = inputs.sha256PerSec && inputs.sha256PerSec > 0 ? inputs.sha256PerSec : 500_000
+    return (2 ** (height + 1)) / rate + event
+  }
+  const ms = inputs.cantorMsByHeight ? projectCantorMs(inputs.cantorMsByHeight, height) : NaN
+  // Three axes may move in one hop, and the worker runs them one after another.
+  return (Number.isFinite(ms) ? (ms * 3) / 1000 : 0.2) + event
+}
+
+/**
+ * Seconds this machine needs to cross a wall at `height`, the whole walk: the
+ * hops to the leaf touching it, the sidestep across, and the hops on the far
+ * side, each with its signature.
+ */
+export function walkSeconds(height: number, inputs: CrossoverInputs): number {
+  if (height > inputs.sidestepCeiling) return Infinity
+  // A crossing whose LCA height is exactly `height`: from the origin to the
+  // block boundary below it, which is the canonical wall of that height with a
+  // full block to walk on the far side. (0 to 2^k has LCA k+1, not k.)
+  const from = { x: 0n, y: 0n, z: 0n }
+  const to = { x: 1n << BigInt(height - 1), y: 0n, z: 0n }
+  let steps
+  try {
+    steps = buildMovePlan(from, to, localOnly(inputs.hopCeiling, inputs.sidestepCeiling), WALK_STEPS_MAX)
+  } catch {
+    return Infinity
+  }
+  let total = 0
+  for (const s of steps) total += stepSeconds(s.kind, s.maxHeight, inputs)
+  return total
+}
+
+/**
+ * The lowest wall height at which the paid hop is the faster way across.
+ *
+ * Below it the walk is quicker and free, so nothing is bought. Infinity when
+ * the walk always wins, or when the provider says nothing about its own times.
+ */
+export function crossoverHeight(inputs: CrossoverInputs): number {
+  if (inputs.cloudHop <= inputs.hopCeiling) return Infinity
+  for (let h = inputs.hopCeiling + 1; h <= inputs.cloudHop; h++) {
+    const cloud = cloudSeconds(h, inputs.ladder)
+    if (cloud === null) return Infinity
+    if (walkSeconds(h, inputs) > cloud + PAYMENT_SECONDS) return h
+  }
+  return Infinity
+}
+
+let cached: { key: string; value: number } | null = null
+
+/** The same, memoised: the inputs change rarely and the answer is asked per cursor move. */
+export function crossoverFor(profile: 'fastest' | 'cheapest', inputs: CrossoverInputs): number {
+  if (profile !== 'fastest') return Infinity
+  const key = [
+    inputs.hopCeiling, inputs.sidestepCeiling, inputs.cloudHop, inputs.signerKind,
+    Math.round(inputs.sha256PerSec ?? 0),
+    inputs.ladder ? inputs.ladder.map((b) => `${b.max_height}:${b.est_seconds ?? b.est_time ?? ''}`).join(',') : '',
+    inputs.cantorMsByHeight ? Object.keys(inputs.cantorMsByHeight).length : 0,
+  ].join('|')
+  if (cached && cached.key === key) return cached.value
+  const value = crossoverHeight(inputs)
+  cached = { key, value }
+  return value
+}
+
+/**
+ * The height for the profile and the state of the world, ready for a Ceilings.
+ * The one place the three planners (preview, button, commit) ask, so they
+ * cannot disagree about where HOSAKA takes over.
+ */
+export function offloadFrom(
+  profile: 'fastest' | 'cheapest',
+  opts: {
+    hopCeiling: number
+    sidestepCeiling: number
+    cloudHop: number
+    provider: { pricing?: { hop?: Array<{ max_height: number; est_seconds?: number; est_time?: string }> } } | null
+    signerKind: SignerKind
+    cantorMsByHeight?: Record<number, number> | null
+    sha256PerSec?: number | null
+  },
+): number {
+  return crossoverFor(profile, {
+    hopCeiling: opts.hopCeiling,
+    sidestepCeiling: opts.sidestepCeiling,
+    cloudHop: opts.cloudHop,
+    cantorMsByHeight: opts.cantorMsByHeight ?? null,
+    sha256PerSec: opts.sha256PerSec ?? null,
+    ladder: opts.provider?.pricing?.hop ?? null,
+    signerKind: opts.signerKind,
+  })
+}

--- a/src/lib/movePlan.ts
+++ b/src/lib/movePlan.ts
@@ -51,7 +51,24 @@ export interface Ceilings {
   sidestep: number
   cloudHop: number
   cloudSidestep: number
+  /** Which step to prefer where both this machine and HOSAKA have one. */
+  profile?: RouteProfile
 }
+
+/**
+ * Which step to prefer where both this machine and HOSAKA can move you.
+ *
+ * `cheapest` spends nothing it does not have to: a boundary above the hop
+ * ceiling is crossed by this machine's own sidestep, and the walk to the wall
+ * and on from it is however many hops that takes. Nothing is paid for until
+ * a boundary neither ceiling reaches.
+ *
+ * `fastest` pays to skip that walk. Wherever this machine would have to
+ * sidestep and HOSAKA could hop the whole boundary instead, the paid hop is
+ * taken: one event, one wait, in place of a walk to the wall, a sidestep, and
+ * a walk on. A hop this machine can make is still never paid for.
+ */
+export type RouteProfile = 'fastest' | 'cheapest'
 
 export function localOnly(hop: number, sidestep: number = hop): Ceilings {
   return { hop, sidestep, cloudHop: 0, cloudSidestep: 0 }
@@ -59,6 +76,22 @@ export function localOnly(hop: number, sidestep: number = hop): Ceilings {
 
 function asCeilings(c: number | Ceilings): Ceilings {
   return typeof c === 'number' ? localOnly(c, Number.MAX_SAFE_INTEGER) : c
+}
+
+/**
+ * Whether the paid hop wins from here, under `fastest`.
+ *
+ * The question is about the crossing, not the step in hand. This machine's
+ * own first step toward a distant wall is an ordinary hop, and taking it
+ * because it is local would walk the whole way to the wall before the choice
+ * came up at all. So the tallest boundary between here and the target decides:
+ * if this machine would have to sidestep across it somewhere on the way, and
+ * HOSAKA can hop it outright, HOSAKA hops it now and the walk never happens.
+ */
+function cloudIsFaster(from: Position, to: Position, c: Ceilings): boolean {
+  if (c.profile !== 'fastest') return false
+  const h = Math.max(findLcaHeight(from.x, to.x), findLcaHeight(from.y, to.y), findLcaHeight(from.z, to.z))
+  return h > c.hop && h <= c.cloudHop
 }
 
 function sourceOf(kind: PlanStepKind, h: number, c: Ceilings): StepSource {
@@ -89,7 +122,11 @@ export function routeFeasible(from: Position, to: Position, ceilings: number | C
 export function routeNeedsCloud(from: Position, to: Position, ceilings: number | Ceilings): boolean {
   const c = asCeilings(ceilings)
   const h = Math.max(findLcaHeight(from.x, to.x), findLcaHeight(from.y, to.y), findLcaHeight(from.z, to.z))
-  return h > c.hop && h > c.sidestep
+  if (h <= c.hop) return false
+  // Under `fastest` a boundary HOSAKA can hop is HOSAKA's, even though this
+  // machine could have sidestepped its way across.
+  if (c.profile === 'fastest' && h <= c.cloudHop) return true
+  return h > c.sidestep
 }
 
 export type AxisMove =
@@ -158,7 +195,8 @@ export function nextStep(cur: Position, to: Position, ceilings: number | Ceiling
   // none, so a walk this machine can make is never a paid hop.
   if (c.cloudHop > 0 || c.cloudSidestep > 0) {
     const mine = nextStep(cur, to, localOnly(c.hop, c.sidestep))
-    if (mine === null || mine.source === 'local') return mine
+    if (mine === null) return null
+    if (mine.source === 'local' && !cloudIsFaster(cur, to, c)) return mine
   }
   const walk = Math.max(c.hop, c.cloudHop)
   if (walk < 1) throw new Error('ceiling must be at least 1')

--- a/src/lib/movePlan.ts
+++ b/src/lib/movePlan.ts
@@ -51,8 +51,12 @@ export interface Ceilings {
   sidestep: number
   cloudHop: number
   cloudSidestep: number
-  /** Which step to prefer where both this machine and HOSAKA have one. */
-  profile?: RouteProfile
+  /**
+   * The lowest wall height HOSAKA takes over at, when it can hop it. Infinity
+   * (or absent) means it never does unless this machine cannot cross at all,
+   * which is the cheapest profile; lib/crossover.ts measures the rest.
+   */
+  offloadFrom?: number
 }
 
 /**
@@ -63,10 +67,11 @@ export interface Ceilings {
  * and on from it is however many hops that takes. Nothing is paid for until
  * a boundary neither ceiling reaches.
  *
- * `fastest` pays to skip that walk. Wherever this machine would have to
- * sidestep and HOSAKA could hop the whole boundary instead, the paid hop is
- * taken: one event, one wait, in place of a walk to the wall, a sidestep, and
- * a walk on. A hop this machine can make is still never paid for.
+ * `fastest` pays to skip that walk, but only from the height where the walk
+ * actually costs more than the hop. That height is measured, not assumed
+ * (lib/crossover.ts): below it this machine is quicker as well as free, since
+ * one sidestep is one hash chain and a paid hop is a queue and a payment.
+ * A hop this machine can make is never paid for under either.
  */
 export type RouteProfile = 'fastest' | 'cheapest'
 
@@ -89,9 +94,10 @@ function asCeilings(c: number | Ceilings): Ceilings {
  * HOSAKA can hop it outright, HOSAKA hops it now and the walk never happens.
  */
 function cloudIsFaster(from: Position, to: Position, c: Ceilings): boolean {
-  if (c.profile !== 'fastest') return false
+  const from_ = c.offloadFrom ?? Infinity
+  if (!Number.isFinite(from_)) return false
   const h = Math.max(findLcaHeight(from.x, to.x), findLcaHeight(from.y, to.y), findLcaHeight(from.z, to.z))
-  return h > c.hop && h <= c.cloudHop
+  return h >= from_ && h > c.hop && h <= c.cloudHop
 }
 
 function sourceOf(kind: PlanStepKind, h: number, c: Ceilings): StepSource {
@@ -125,7 +131,7 @@ export function routeNeedsCloud(from: Position, to: Position, ceilings: number |
   if (h <= c.hop) return false
   // Under `fastest` a boundary HOSAKA can hop is HOSAKA's, even though this
   // machine could have sidestepped its way across.
-  if (c.profile === 'fastest' && h <= c.cloudHop) return true
+  if (h >= (c.offloadFrom ?? Infinity) && h <= c.cloudHop) return true
   return h > c.sidestep
 }
 

--- a/src/lib/movePlan.ts
+++ b/src/lib/movePlan.ts
@@ -54,26 +54,26 @@ export interface Ceilings {
   /**
    * The lowest wall height HOSAKA takes over at, when it can hop it. Infinity
    * (or absent) means it never does unless this machine cannot cross at all,
-   * which is the cheapest profile; lib/crossover.ts measures the rest.
+   * which is BYPASS; lib/crossover.ts measures where UNLOCK takes over.
    */
   offloadFrom?: number
 }
 
 /**
- * Which step to prefer where both this machine and HOSAKA can move you.
+ * How to get past a wall this machine cannot hop.
  *
- * `cheapest` spends nothing it does not have to: a boundary above the hop
- * ceiling is crossed by this machine's own sidestep, and the walk to the wall
- * and on from it is however many hops that takes. Nothing is paid for until
- * a boundary neither ceiling reaches.
+ * `bypass` goes around it. A sidestep crosses one gibson of the boundary and
+ * costs nothing, and the walk to the wall and on from it is however many hops
+ * that takes. You arrive without the Cantor root of the regions you crossed,
+ * so nothing hidden in them will open for you.
  *
- * `fastest` pays to skip that walk, but only from the height where the walk
- * actually costs more than the hop. That height is measured, not assumed
- * (lib/crossover.ts): below it this machine is quicker as well as free, since
- * one sidestep is one hash chain and a paid hop is a queue and a payment.
- * A hop this machine can make is never paid for under either.
+ * `unlock` buys the hop. One event instead of the walk, and you arrive holding
+ * the region's root, which is the key to whatever is hidden there. It is taken
+ * only from the height where it is also the quicker way across, measured
+ * rather than assumed (lib/crossover.ts): below that this machine is faster as
+ * well as free. A hop this machine can make is never paid for under either.
  */
-export type RouteProfile = 'fastest' | 'cheapest'
+export type RouteProfile = 'unlock' | 'bypass'
 
 export function localOnly(hop: number, sidestep: number = hop): Ceilings {
   return { hop, sidestep, cloudHop: 0, cloudSidestep: 0 }

--- a/src/lib/routeProfile.test.ts
+++ b/src/lib/routeProfile.test.ts
@@ -3,8 +3,9 @@ import { buildMovePlan, nextStep, planSummary, routeNeedsCloud, type Ceilings } 
 
 /** This machine hops to 2^18 and sidesteps to 2^23; HOSAKA hops to 2^27. */
 const base = { hop: 18, sidestep: 23, cloudHop: 27, cloudSidestep: 29 }
-const cheapest: Ceilings = { ...base, profile: 'cheapest' }
-const fastest: Ceilings = { ...base, profile: 'fastest' }
+const cheapest: Ceilings = { ...base, offloadFrom: Infinity }
+// Measured for this machine and this provider (lib/crossover): from h21 up.
+const fastest: Ceilings = { ...base, offloadFrom: 21 }
 
 const at = (x: bigint): { x: bigint; y: bigint; z: bigint } => ({ x, y: 1n << 84n, z: 1n << 84n })
 
@@ -54,7 +55,7 @@ describe('the route profile', () => {
   })
 
   it('with no cloud, the profile changes nothing', () => {
-    const alone: Ceilings = { hop: 18, sidestep: 23, cloudHop: 0, cloudSidestep: 0, profile: 'fastest' }
+    const alone: Ceilings = { hop: 18, sidestep: 23, cloudHop: 0, cloudSidestep: 0, offloadFrom: 21 }
     const step = nextStep(from, to, alone)
     expect(step?.source).toBe('local')
     expect(routeNeedsCloud(from, to, alone)).toBe(false)

--- a/src/lib/routeProfile.test.ts
+++ b/src/lib/routeProfile.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { buildMovePlan, nextStep, planSummary, routeNeedsCloud, type Ceilings } from './movePlan'
+
+/** This machine hops to 2^18 and sidesteps to 2^23; HOSAKA hops to 2^27. */
+const base = { hop: 18, sidestep: 23, cloudHop: 27, cloudSidestep: 29 }
+const cheapest: Ceilings = { ...base, profile: 'cheapest' }
+const fastest: Ceilings = { ...base, profile: 'fastest' }
+
+const at = (x: bigint): { x: bigint; y: bigint; z: bigint } => ({ x, y: 1n << 84n, z: 1n << 84n })
+
+// A crossing this machine can only sidestep: above its hop ceiling, inside
+// its sidestep ceiling, and inside HOSAKA's hop cap.
+const from = at(1n << 84n)
+const to = at((1n << 84n) ^ (1n << 21n))
+
+describe('the route profile', () => {
+  it('cheapest walks it: this machine sidesteps across, and pays nothing', () => {
+    const step = nextStep(from, to, cheapest)
+    expect(step?.source).toBe('local')
+    expect(routeNeedsCloud(from, to, cheapest)).toBe(false)
+    expect(planSummary(from, to, cheapest).cloudSteps).toBe(0)
+  })
+
+  it('fastest buys it: one paid hop instead of the walk', () => {
+    const step = nextStep(from, to, fastest)
+    expect(step?.source).toBe('cloud')
+    expect(step?.kind).toBe('hop')
+    expect(routeNeedsCloud(from, to, fastest)).toBe(true)
+    // And it is the whole crossing in one step, not a step toward a wall.
+    expect(step?.to.x).toBe(to.x)
+  })
+
+  it('fastest is fewer steps for the same journey', () => {
+    const walked = buildMovePlan(from, to, cheapest).length
+    const bought = buildMovePlan(from, to, fastest).length
+    expect(walked).toBeGreaterThan(bought)
+    expect(bought).toBe(1)
+  })
+
+  it('neither profile pays for a hop this machine can make', () => {
+    const near = at((1n << 84n) ^ (1n << 12n))
+    for (const c of [cheapest, fastest]) {
+      const step = nextStep(from, near, c)
+      expect(step?.source).toBe('local')
+      expect(step?.kind).toBe('hop')
+    }
+  })
+
+  it('a boundary above every cloud cap is nobody’s, under either profile', () => {
+    const far = at((1n << 84n) ^ (1n << 40n))
+    for (const c of [cheapest, fastest]) {
+      expect(nextStep(far, from, c)?.source).toBe('infeasible')
+    }
+  })
+
+  it('with no cloud, the profile changes nothing', () => {
+    const alone: Ceilings = { hop: 18, sidestep: 23, cloudHop: 0, cloudSidestep: 0, profile: 'fastest' }
+    const step = nextStep(from, to, alone)
+    expect(step?.source).toBe('local')
+    expect(routeNeedsCloud(from, to, alone)).toBe(false)
+  })
+
+  it('a boundary above HOSAKA’s hop is walked to and sidestepped across, either way', () => {
+    // h28: past this machine entirely and past HOSAKA's hop cap of 27, so no
+    // one can hop it. Both profiles walk to the wall and pay for the crossing.
+    const over = at((1n << 84n) ^ (1n << 28n))
+    for (const c of [cheapest, fastest]) {
+      expect(nextStep(from, over, c)?.source).toBe('local')
+      const summary = planSummary(from, over, c)
+      expect(summary.cloudSteps).toBeGreaterThan(0)
+    }
+  })
+
+  it('fastest decides on the crossing, not on the step in hand', () => {
+    // The first step toward the wall is an ordinary local hop; taking it
+    // because it is local would walk the whole way there before the choice
+    // ever came up. Under fastest the paid hop is offered immediately.
+    expect(nextStep(from, to, cheapest)?.kind).toBe('hop')
+    expect(nextStep(from, to, cheapest)?.source).toBe('local')
+    expect(nextStep(from, to, fastest)?.source).toBe('cloud')
+  })
+})

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -28,6 +28,7 @@ import {
   LineSegments,
   BoxGeometry,
 } from 'three'
+import { offloadFrom } from '../lib/crossover'
 import { useCalibration } from '../lib/calibration'
 import { nextActionFor } from '../store/useOffer'
 import { ACCENT, DANGER, SIDESTEP, WARN } from '../lib/palette'
@@ -172,9 +173,14 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const limits = useCyberspace((s) => s.cloud.limits)
   const profile = useCyberspace((s) => s.cloudPrefs.profile)
+  const provider = useCyberspace((s) => s.cloud.provider)
+  const signerKind = useCyberspace((s) => s.signerKind)
+  const cantorMsByHeight = useCalibration((s) => s.cantorMsByHeight)
+  const sha256PerSec = useCalibration((s) => s.sha256PerSec)
+  const from = offloadFrom(profile, { hopCeiling: hopCeil, sidestepCeiling: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, provider: provider ?? null, signerKind, cantorMsByHeight, sha256PerSec })
   const next = useMemo(
-    () => (active ? nextActionFor(position, target, plane, hopCeil, sidestepCeil, limits, profile) : null),
-    [active, position, target, plane, hopCeil, sidestepCeil, limits, profile],
+    () => (active ? nextActionFor(position, target, plane, hopCeil, sidestepCeil, limits, from) : null),
+    [active, position, target, plane, hopCeil, sidestepCeil, limits, from],
   )
 
   // Screen-space endpoints, at cell CENTRES.

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -171,9 +171,10 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const limits = useCyberspace((s) => s.cloud.limits)
+  const profile = useCyberspace((s) => s.cloudPrefs.profile)
   const next = useMemo(
-    () => (active ? nextActionFor(position, target, plane, hopCeil, sidestepCeil, limits) : null),
-    [active, position, target, plane, hopCeil, sidestepCeil, limits],
+    () => (active ? nextActionFor(position, target, plane, hopCeil, sidestepCeil, limits, profile) : null),
+    [active, position, target, plane, hopCeil, sidestepCeil, limits, profile],
   )
 
   // Screen-space endpoints, at cell CENTRES.

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -123,7 +123,7 @@ describe('cloud routes', () => {
     // This machine stops at h12 for hops AND sidesteps, so an h13 move has no local way and is
     // the cloud's (HOSAKA is used only when needed); the caps are already known.
     useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
-    useCyberspace.setState({ cloud: { ...S().cloud, limits: LIMITS, status: 'idle', job: null, message: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://fake' }, plan: null })
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: LIMITS, status: 'idle', job: null, message: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://fake', profile: 'cheapest' }, plan: null })
     for (const fn of Object.values(fake)) if (typeof fn === 'function' && 'mockReset' in fn) fn.mockReset()
     fake.limits.mockResolvedValue(LIMITS)
     fake.balance.mockResolvedValue({ pubkey: S().identity.pubkey, balance_msats: 5000, ledger: [] })
@@ -517,7 +517,7 @@ describe('cloud routes', () => {
   it('a caps request out for another API URL is not reused: the current URL gets its own (#69)', async () => {
     const old = deferred<HosakaLimits>()
     fake.limits.mockReturnValueOnce(old.promise).mockResolvedValueOnce(LIMITS)
-    useCyberspace.setState({ cloud: { ...S().cloud, limits: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://old' } })
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://old', profile: 'cheapest' } })
     const first = S().resumeCloudJob()
     await vi.waitFor(() => expect(fake.limits).toHaveBeenCalledTimes(1))
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, apiUrl: 'http://fake' } })

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -123,7 +123,7 @@ describe('cloud routes', () => {
     // This machine stops at h12 for hops AND sidesteps, so an h13 move has no local way and is
     // the cloud's (HOSAKA is used only when needed); the caps are already known.
     useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
-    useCyberspace.setState({ cloud: { ...S().cloud, limits: LIMITS, status: 'idle', job: null, message: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://fake', profile: 'cheapest' }, plan: null })
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: LIMITS, status: 'idle', job: null, message: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://fake', profile: 'bypass' }, plan: null })
     for (const fn of Object.values(fake)) if (typeof fn === 'function' && 'mockReset' in fn) fn.mockReset()
     fake.limits.mockResolvedValue(LIMITS)
     fake.balance.mockResolvedValue({ pubkey: S().identity.pubkey, balance_msats: 5000, ledger: [] })
@@ -517,7 +517,7 @@ describe('cloud routes', () => {
   it('a caps request out for another API URL is not reused: the current URL gets its own (#69)', async () => {
     const old = deferred<HosakaLimits>()
     fake.limits.mockReturnValueOnce(old.promise).mockResolvedValueOnce(LIMITS)
-    useCyberspace.setState({ cloud: { ...S().cloud, limits: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://old', profile: 'cheapest' } })
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://old', profile: 'bypass' } })
     const first = S().resumeCloudJob()
     await vi.waitFor(() => expect(fake.limits).toHaveBeenCalledTimes(1))
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, apiUrl: 'http://fake' } })

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -77,7 +77,8 @@ import {
   hyperjumpTemplate,
 } from '../lib/events'
 import { cancelProof, postProof, type ProofMode, type ProofResponse } from '../lib/workers'
-import { recommendedHopHeight, recommendedSidestepHeight } from '../lib/calibration'
+import { offloadFrom } from '../lib/crossover'
+import { recommendedHopHeight, recommendedSidestepHeight, useCalibration } from '../lib/calibration'
 import {
   createHosaka,
   createWaker,
@@ -996,7 +997,15 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       sidestep: recommendedSidestepHeight(),
       cloudHop: on && cloud.limits ? cloud.limits.max_hop_height : 0,
       cloudSidestep: on && cloud.limits ? cloud.limits.max_sidestep_height : 0,
-      profile: cloudPrefs.profile,
+      offloadFrom: offloadFrom(cloudPrefs.profile, {
+        hopCeiling: Math.min(MAX_COMPUTE_HEIGHT, recommendedHopHeight()),
+        sidestepCeiling: recommendedSidestepHeight(),
+        cloudHop: on && cloud.limits ? cloud.limits.max_hop_height : 0,
+        provider: cloud.provider ?? null,
+        signerKind: get().signerKind,
+        cantorMsByHeight: useCalibration.getState().cantorMsByHeight,
+        sha256PerSec: useCalibration.getState().sha256PerSec,
+      }),
     }
   }
 

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -425,6 +425,9 @@ export interface CyberspaceState {
   moveCursor: (dir: AxisDirection) => void
   setCursorAtCell: (row: number, col: number) => void
   commit: () => Promise<void>
+  /** Whether COMMIT runs one step of the route or all of them in order. */
+  moveMode: MoveMode
+  setMoveMode: (mode: MoveMode) => void
   cancel: () => void
   /** Continue a paused route: ask for the pending signature again, or restart the step. */
   resumePlan: () => void
@@ -592,6 +595,22 @@ function chainKeyFor(pubkey: string): string {
   return `${CHAIN_KEY}:${pubkey}`
 }
 const LIVE_KEY = 'onosendai:live'
+const MOVE_MODE_KEY = 'onosendai:moveMode'
+
+/** One action per commit, or the whole route in order. */
+export type MoveMode = 'single' | 'auto'
+
+function loadMoveMode(): MoveMode {
+  try {
+    return localStorage.getItem(MOVE_MODE_KEY) === 'auto' ? 'auto' : 'single'
+  } catch {
+    return 'single'
+  }
+}
+
+function saveMoveMode(mode: MoveMode): void {
+  try { localStorage.setItem(MOVE_MODE_KEY, mode) } catch { /* private mode */ }
+}
 const TARGETS_KEY = 'onosendai:targets'
 
 /**
@@ -977,6 +996,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       sidestep: recommendedSidestepHeight(),
       cloudHop: on && cloud.limits ? cloud.limits.max_hop_height : 0,
       cloudSidestep: on && cloud.limits ? cloud.limits.max_sidestep_height : 0,
+      profile: cloudPrefs.profile,
     }
   }
 
@@ -1521,14 +1541,16 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       })
       return
     }
-    // One action per commit. The cursor may sit any distance away; this
-    // commit executes only the first step of the way there, the one the
+    // SINGLE: one action per commit. The cursor may sit any distance away;
+    // the commit executes only the first step of the way there, the one the
     // button named (a hop to the cursor, a hop to the boundary, a sidestep
     // through it, or HOSAKA's version of either), and lands where that step
-    // lands. The cursor stays, so the next commit names the next step. The
-    // whole path is shown, never run: a route that signs step after step in
-    // the background was harder to follow than to walk.
-    const target = { ...step.to }
+    // lands. The cursor stays, so the next commit names the next step.
+    //
+    // AUTOMATIC: the whole route, its steps run in order, pausing only for a
+    // declined signature or a step that fails. A long walk is dozens of
+    // identical presses otherwise, which is what this is for.
+    const target = get().moveMode === 'auto' ? { ...cursor } : { ...step.to }
     const one = planSummary(position, target, ceilings)
     const funded = one.cloudSteps === 0
     set({
@@ -1546,6 +1568,12 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     })
     if (funded) startPlanStep()
     else await quoteRoute(++requestId)
+  },
+
+  setMoveMode: (mode) => {
+    if (mode === get().moveMode) return
+    saveMoveMode(mode)
+    set({ moveMode: mode })
   },
 
   resumePlan: () => {
@@ -2155,6 +2183,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
   cloud: IDLE_CLOUD,
   cloudPrefs: loadCloudPrefs(),
+  moveMode: loadMoveMode(),
 
   approveCloud: () => {
     const { cloud } = get()

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -13,7 +13,7 @@
 
 import { create } from 'zustand'
 import { useCalibration } from '../lib/calibration'
-import { localOnly, nextStep, routeFeasible, routeNeedsCloud, type Ceilings, type PlanStep } from '../lib/movePlan'
+import { localOnly, nextStep, routeFeasible, routeNeedsCloud, type Ceilings, type PlanStep, type RouteProfile } from '../lib/movePlan'
 import { offerVerdict, type OfferVerdict } from '../lib/offer'
 import type { Position } from '../lib/space'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
@@ -109,7 +109,7 @@ export interface NextActionView {
   cursorKey: string
 }
 
-export function nextActionFor(position: Position, cursor: Position, plane: number, hopCeil: number, sidestepCeil: number, limits: { max_hop_height: number; max_sidestep_height: number } | null): NextActionView | null {
+export function nextActionFor(position: Position, cursor: Position, plane: number, hopCeil: number, sidestepCeil: number, limits: { max_hop_height: number; max_sidestep_height: number } | null, profile: RouteProfile = 'cheapest'): NextActionView | null {
   if (position.x === cursor.x && position.y === cursor.y && position.z === cursor.z) return null
   const machineCeiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
   const cursorKey = cursorKeyOf(cursor, plane)
@@ -118,7 +118,7 @@ export function nextActionFor(position: Position, cursor: Position, plane: numbe
   // cross, which is when it is actually needed; a route with such a boundary
   // anywhere on it reads OFFLOAD from the start. A cursor no one reaches is
   // TOO FAR as soon as HOSAKA's caps are known; until they are, OFFLOAD asks.
-  const ceilings: Ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0 }
+  const ceilings: Ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0, profile }
   if (limits !== null && !routeFeasible(position, cursor, ceilings)) return { action: 'too-far', step: null, cursorKey }
   const step = nextStep(position, cursor, ceilings)
   if (!step) return null
@@ -137,7 +137,7 @@ export function nextAction(): NextActionView | null {
   const s = useCyberspace.getState()
   if (!s.atHead()) return null
   const cal = useCalibration.getState()
-  return nextActionFor(s.position, s.cursor, s.plane, cal.hopHeight, cal.sidestepHeight, s.cloud.limits)
+  return nextActionFor(s.position, s.cursor, s.plane, cal.hopHeight, cal.sidestepHeight, s.cloud.limits, s.cloudPrefs.profile)
 }
 
 /** The same, for a component. */
@@ -150,7 +150,8 @@ export function useNextAction(): NextActionView | null {
   const limits = useCyberspace((s) => s.cloud.limits)
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
-  return home ? nextActionFor(position, cursor, plane, hopCeil, sidestepCeil, limits) : null
+  const profile = useCyberspace((s) => s.cloudPrefs.profile)
+  return home ? nextActionFor(position, cursor, plane, hopCeil, sidestepCeil, limits, profile) : null
 }
 
 /** What the COMMIT button says for each next action. */

--- a/src/store/useOffer.ts
+++ b/src/store/useOffer.ts
@@ -13,7 +13,8 @@
 
 import { create } from 'zustand'
 import { useCalibration } from '../lib/calibration'
-import { localOnly, nextStep, routeFeasible, routeNeedsCloud, type Ceilings, type PlanStep, type RouteProfile } from '../lib/movePlan'
+import { offloadFrom } from '../lib/crossover'
+import { localOnly, nextStep, routeFeasible, routeNeedsCloud, type Ceilings, type PlanStep } from '../lib/movePlan'
 import { offerVerdict, type OfferVerdict } from '../lib/offer'
 import type { Position } from '../lib/space'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from './useCyberspace'
@@ -109,7 +110,7 @@ export interface NextActionView {
   cursorKey: string
 }
 
-export function nextActionFor(position: Position, cursor: Position, plane: number, hopCeil: number, sidestepCeil: number, limits: { max_hop_height: number; max_sidestep_height: number } | null, profile: RouteProfile = 'cheapest'): NextActionView | null {
+export function nextActionFor(position: Position, cursor: Position, plane: number, hopCeil: number, sidestepCeil: number, limits: { max_hop_height: number; max_sidestep_height: number } | null, offloadFromHeight: number = Infinity): NextActionView | null {
   if (position.x === cursor.x && position.y === cursor.y && position.z === cursor.z) return null
   const machineCeiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
   const cursorKey = cursorKeyOf(cursor, plane)
@@ -118,7 +119,7 @@ export function nextActionFor(position: Position, cursor: Position, plane: numbe
   // cross, which is when it is actually needed; a route with such a boundary
   // anywhere on it reads OFFLOAD from the start. A cursor no one reaches is
   // TOO FAR as soon as HOSAKA's caps are known; until they are, OFFLOAD asks.
-  const ceilings: Ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0, profile }
+  const ceilings: Ceilings = { hop: machineCeiling, sidestep: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, cloudSidestep: limits?.max_sidestep_height ?? 0, offloadFrom: offloadFromHeight }
   if (limits !== null && !routeFeasible(position, cursor, ceilings)) return { action: 'too-far', step: null, cursorKey }
   const step = nextStep(position, cursor, ceilings)
   if (!step) return null
@@ -137,7 +138,12 @@ export function nextAction(): NextActionView | null {
   const s = useCyberspace.getState()
   if (!s.atHead()) return null
   const cal = useCalibration.getState()
-  return nextActionFor(s.position, s.cursor, s.plane, cal.hopHeight, cal.sidestepHeight, s.cloud.limits, s.cloudPrefs.profile)
+  const from = offloadFrom(s.cloudPrefs.profile, {
+    hopCeiling: cal.hopHeight, sidestepCeiling: cal.sidestepHeight,
+    cloudHop: s.cloud.limits?.max_hop_height ?? 0, provider: s.cloud.provider ?? null,
+    signerKind: s.signerKind, cantorMsByHeight: cal.cantorMsByHeight, sha256PerSec: cal.sha256PerSec,
+  })
+  return nextActionFor(s.position, s.cursor, s.plane, cal.hopHeight, cal.sidestepHeight, s.cloud.limits, from)
 }
 
 /** The same, for a component. */
@@ -151,7 +157,12 @@ export function useNextAction(): NextActionView | null {
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const profile = useCyberspace((s) => s.cloudPrefs.profile)
-  return home ? nextActionFor(position, cursor, plane, hopCeil, sidestepCeil, limits, profile) : null
+  const provider = useCyberspace((s) => s.cloud.provider)
+  const signerKind = useCyberspace((s) => s.signerKind)
+  const cantorMsByHeight = useCalibration((s) => s.cantorMsByHeight)
+  const sha256PerSec = useCalibration((s) => s.sha256PerSec)
+  const from = offloadFrom(profile, { hopCeiling: hopCeil, sidestepCeiling: sidestepCeil, cloudHop: limits?.max_hop_height ?? 0, provider: provider ?? null, signerKind, cantorMsByHeight, sha256PerSec })
+  return home ? nextActionFor(position, cursor, plane, hopCeil, sidestepCeil, limits, from) : null
 }
 
 /** What the COMMIT button says for each next action. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -5165,3 +5165,18 @@ kbd {
   line-height: 1;
   padding-bottom: 2px;
 }
+
+/* The route profile and what a commit runs: a radio row with a line saying
+   what the choice means, since both change where your movement is computed. */
+.cloud__profile,
+.proof__mode {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.cloud__profile-note {
+  font-size: 9px;
+  line-height: 1.55;
+  color: var(--dim);
+}


### PR DESCRIPTION
Two settings, as asked.

**Route profile** (Cloud compute panel, **fastest** by default)

| | what it does |
|---|---|
| **cheapest** | What the planner has always done. This machine takes every boundary it can, sidestepping across the ones above its hop ceiling, however many steps that walk takes. HOSAKA is used only where this machine cannot go at all. |
| **fastest** | Pays to skip the walk. Wherever this machine would have to sidestep across a boundary and HOSAKA can hop it outright, the paid hop is taken: one event in place of a walk to the wall, a sidestep, and a walk on. |

A hop this machine can make is never paid for under either, and a boundary above HOSAKA's hop cap is walked to and sidestepped across under both, because nobody can hop it.

The choice is made on the **crossing**, not on the step in hand. This machine's first step toward a distant wall is an ordinary local hop, and taking it because it is local would walk the whole way there before the question came up; so the tallest boundary between here and the cursor decides. That is the same figure `routeNeedsCloud` and the button already read, so the preview, the ghost, the COMMIT label and the commit itself all agree.

Measured in a browser against a cursor across an h21 boundary, with this machine at hop 2^17 / sidestep 2^24 and HOSAKA at hop 2^27: the button reads **OFFLOAD** under fastest and **HOP TO BOUNDARY** under cheapest.

**Commit runs** (Movement proof panel, **single** by default)

Single is one action per press, as now. Automatic runs every step of the route in order, pausing only for a declined signature or a failed step. The plan machinery already did this before one-action-per-commit was put in front of it, so the change is the target: the cursor rather than the first step's landing.

Both settings persist. 8 new tests on the profile, 589 passing, tsc and build clean.

**Deployed while this was written:** hosaka-modal#4 (sidestep workers 600s to 1800s) and hosaka-api#10 (axis waits from the cost model, progress from the quote) are both live in production.

---

**Second commit: fastest is measured now.** The rule above was structural, and measured it is wrong at the bottom of the range: one sidestep is one hash chain, and this machine beats HOSAKA at every height it can reach at all. A 2^20 crossing is four seconds here against about two and a half minutes there.

What the cloud replaces is the **walk**, not the sidestep: crossing a wall at height h with a hop ceiling of c costs about 2^(h−c) signed events. `lib/crossover.ts` measures both sides in seconds (the walk from the planner and the calibration, with the signature counted per event; the hop from the provider's own published ladder plus the quote and queue) and returns the height where buying starts winning. The planner takes it as one number, `offloadFrom`.

**Measured against the live ladder:**

| machine | signer | offloads from |
|---|---|---|
| phone, hops 2^17, 560k hashes/s | local key | 2^22 |
| phone | extension | 2^22 |
| phone | bunker | 2^21 |
| desktop, hops 2^20, 3M hashes/s | local key | never |
| desktop | bunker | never |

The phone, height by height: 2^18 walk 13 s vs hop 127 s; 2^21 walk 118 s vs 166 s; 2^22 walk 243 s vs 166 s; 2^24 walk 1034 s vs 307 s.

The desktop result is the interesting one: its walk beats HOSAKA right up to its own sidestep ceiling, above which the cloud was already the only option. **On a desktop, fastest and cheapest are the same setting.** That is worth settling before either name is kept: HOSAKA's pitch is not speed, it is one event instead of hundreds and the region's Cantor root on arrival.

The cloud panel now states which case you are in, with the number. 11 new tests, 600 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
