### PR TITLE
The stash stops listing models, and the loot list stops reloading

### DIFF
--- a/src/hooks/useLoot.test.ts
+++ b/src/hooks/useLoot.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const events: Array<Record<string, unknown>> = []
+let queryCalls = 0
+let subscribeCalls = 0
+let closed = 0
+
+vi.mock('../lib/relay', () => ({
+  query: vi.fn(async () => { queryCalls++; return events }),
+  subscribe: vi.fn(() => { subscribeCalls++; return () => { closed++ } }),
+}))
+
+vi.mock('../lib/loot', async () => {
+  const actual = await vi.importActual<typeof import('../lib/loot')>('../lib/loot')
+  return { ...actual, summarizeBag: (ev: { id: string }) => ({ key: ev.id, bagId: ev.id, at: 1, bytes: 10 } as never) }
+})
+
+import { ensureLoot, useLootStore } from './useLoot'
+
+describe('the loot list outlives the panel', () => {
+  beforeEach(() => {
+    events.length = 0
+    queryCalls = 0; subscribeCalls = 0; closed = 0
+    useLootStore.setState({ items: [], status: 'loading', source: '' })
+  })
+
+  it('reads the relay once for a relay set, however often the panel opens', async () => {
+    events.push({ id: 'a' }, { id: 'b' })
+    ensureLoot(['wss://one'])
+    await vi.waitFor(() => { expect(useLootStore.getState().status).toBe('ready') })
+    expect(useLootStore.getState().items).toHaveLength(2)
+
+    // The panel closing and opening again asks, and is answered from memory.
+    ensureLoot(['wss://one'])
+    ensureLoot(['wss://one'])
+    expect(queryCalls).toBe(1)
+    expect(subscribeCalls).toBe(1)
+    expect(useLootStore.getState().items).toHaveLength(2)
+  })
+
+  it('a new relay set is read again, without emptying the list first', async () => {
+    events.push({ id: 'a' })
+    ensureLoot(['wss://one'])
+    await vi.waitFor(() => { expect(useLootStore.getState().status).toBe('ready') })
+
+    events.push({ id: 'c' })
+    ensureLoot(['wss://one', 'wss://two'])
+    // Still showing what it had, and not back to LOADING.
+    expect(useLootStore.getState().status).toBe('ready')
+    expect(useLootStore.getState().items.length).toBeGreaterThan(0)
+    // At least this run's own subscription; the previous test's closer is
+    // module state and may be flushed here too.
+    expect(closed).toBeGreaterThanOrEqual(1)
+    await vi.waitFor(() => { expect(useLootStore.getState().items).toHaveLength(2) })
+    expect(queryCalls).toBe(2)
+  })
+
+  it('loads with nothing to show only when there is nothing to show', async () => {
+    ensureLoot(['wss://one'])
+    expect(useLootStore.getState().status).toBe('loading')
+    await vi.waitFor(() => { expect(useLootStore.getState().status).toBe('ready') })
+  })
+})

--- a/src/hooks/useLoot.ts
+++ b/src/hooks/useLoot.ts
@@ -1,14 +1,21 @@
 /**
- * useLoot.ts — the relay's bags, fetched once and kept live.
+ * useLoot.ts — the relay's bags, fetched once and kept for the session.
  *
- * Same shape as useRecentAvatars: one backfill query for every kind:33330
- * envelope, one live subscription for new or rewritten ones, merged by bag key
- * so a republished bag replaces its older self instead of appearing twice.
- * Re-runs when the relay set changes, so a relay added in the Relays panel is
- * searched for loot without a reload.
+ * One backfill query for every kind:33330 envelope and one live subscription
+ * for new or rewritten ones, merged by bag key so a republished bag replaces
+ * its older self instead of appearing twice.
+ *
+ * The list lives outside React. It used to live in the panel's own state, so
+ * closing the menu threw it away and opening it again showed LOADING, then an
+ * empty list, then everything at once: the panel jumped every time. Now the
+ * fetch runs once per relay set, the subscription stays open for the session,
+ * and reopening the panel shows what is already known. A relay added in the
+ * Relays panel starts a fresh backfill, and the rows already on screen stay
+ * there while it runs.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
+import { create } from 'zustand'
 import { HIDDEN_KIND } from '../lib/hidden'
 import { mergeLoot, summarizeBag, type LootItem } from '../lib/loot'
 import { query, subscribe } from '../lib/relay'
@@ -22,30 +29,52 @@ export interface Loot {
 /** The relay holds a few dozen bags today; this leaves room without paging. */
 export const LOOT_BACKFILL = 500
 
+interface LootState extends Loot {
+  /** The relay set the current subscription and backfill belong to. */
+  source: string
+}
+
+export const useLootStore = create<LootState>(() => ({ items: [], status: 'loading', source: '' }))
+
+let close: (() => void) | null = null
+
+/** Start (or restart, for a new relay set) the backfill and the subscription. */
+export function ensureLoot(relays: string[]): void {
+  const source = relays.join(',')
+  if (useLootStore.getState().source === source) return
+  close?.()
+
+  const known = useLootStore.getState().items
+  // Anything already known stays on screen while the new relays are read, so
+  // the panel never blinks back to nothing.
+  useLootStore.setState({ source, status: known.length > 0 ? 'ready' : 'loading' })
+
+  const since = Math.floor(Date.now() / 1000) - 60
+  close = subscribe({ kinds: [HIDDEN_KIND], since }, (ev) => {
+    const item = summarizeBag(ev)
+    if (item && useLootStore.getState().source === source) {
+      useLootStore.setState((s) => ({ items: mergeLoot(s.items, [item]) }))
+    }
+  })
+
+  query({ kinds: [HIDDEN_KIND], limit: LOOT_BACKFILL }).then(
+    (events) => {
+      if (useLootStore.getState().source !== source) return
+      const found = events.map(summarizeBag).filter((x): x is LootItem => x !== null)
+      useLootStore.setState((s) => ({ items: mergeLoot(s.items, found), status: 'ready' }))
+    },
+    () => {
+      if (useLootStore.getState().source !== source) return
+      // A failed read leaves whatever is already known standing.
+      useLootStore.setState((s) => ({ status: s.items.length > 0 ? 'ready' : 'error' }))
+    },
+  )
+}
+
 export function useLoot(): Loot {
-  const [items, setItems] = useState<LootItem[]>([])
-  const [status, setStatus] = useState<Loot['status']>('loading')
   const relays = useRelays((s) => s.relays)
-
-  useEffect(() => {
-    let alive = true
-    setStatus('loading')
-    const since = Math.floor(Date.now() / 1000) - 60
-    const close = subscribe({ kinds: [HIDDEN_KIND], since }, (ev) => {
-      const item = summarizeBag(ev)
-      if (alive && item) setItems((prev) => mergeLoot(prev, [item]))
-    })
-    query({ kinds: [HIDDEN_KIND], limit: LOOT_BACKFILL }).then(
-      (events) => {
-        if (!alive) return
-        const found = events.map(summarizeBag).filter((x): x is LootItem => x !== null)
-        setItems((prev) => mergeLoot(prev, found))
-        setStatus('ready')
-      },
-      () => { if (alive) setStatus('error') },
-    )
-    return () => { alive = false; close() }
-  }, [relays])
-
+  const items = useLootStore((s) => s.items)
+  const status = useLootStore((s) => s.status)
+  useEffect(() => { ensureLoot(relays) }, [relays])
   return { items, status }
 }

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -15,7 +15,6 @@ import { formatCellSize } from '../lib/scale'
 import { cashuLabel } from '../lib/cashu'
 import { cashuStateLabel, useCashu } from './useCashu'
 import { messagePreview, MAX_MESSAGE_LENGTH } from '../lib/hidden'
-import { ConfirmModal } from './ConfirmModal'
 import { useCyberspace } from '../store/useCyberspace'
 import { useShards, type MyDeployment } from '../store/useShards'
 import { useWorkshop } from '../store/useWorkshop'
@@ -66,16 +65,12 @@ function DeployedRow({ d, viewing, onGo }: { d: MyDeployment; viewing: boolean; 
 }
 
 export function ShardsPanel(): JSX.Element {
-  const models = useWorkshop((s) => s.shards)
   const mine = useShards((s) => s.mine)
   const inspecting = useShards((s) => s.inspecting)
   const scanning = useShards((s) => s.scanning)
-  const [deleteModel, setDeleteModel] = useState<string | null>(null)
   const [composing, setComposing] = useState(false)
   const [message, setMessage] = useState('')
 
-  const target = models.find((m) => m.id === deleteModel)
-  const deployedCount = (id: string): number => mine.filter((d) => d.type === 'shard' && d.shard?.id === id).length
   const hiddenCount = mine.length
   const live = useCyberspace((s) => s.live)
   const broadcastError = useShards((s) => s.broadcastError)
@@ -102,23 +97,11 @@ export function ShardsPanel(): JSX.Element {
         <span className={`tag ${scanning ? 'tag--scan' : ''}`}>{scanning ? 'SCANNING' : hiddenCount === 0 ? 'NOTHING HIDDEN' : `${hiddenCount} HIDDEN`}</span>
       </header>
 
+      {/* The models themselves live in the workshop, which is where they are
+          made, named and deleted. Listing them here grew a second scrolling
+          box inside a scrolling panel, and the panel could not be scrolled
+          past it. What the stash is for is what is hidden. */}
       <div className="shards__section">
-        <span className="legend__label">Models — shard designs on this device</span>
-        <ul className="avatars__list shards__list">
-          {models.map((m) => {
-            const n = deployedCount(m.id)
-            return (
-              <li key={m.id} className="shards__row">
-                <button className="shards__open" onClick={() => useWorkshop.getState().openWorkshop(m.id)} title="Open in the workshop">
-                  <span className="avatars__who">{m.name}</span>
-                  <span className="shards__meta">{m.vertices.length} v · {m.faces.length} f · {m.mode.toUpperCase()} · 2^{m.unit}{n > 0 ? ` · ${n} deployed` : ''}</span>
-                </button>
-                <button className="targets__remove" onClick={() => setDeleteModel(m.id)} aria-label="Delete model" title="Delete this model">✕</button>
-              </li>
-            )
-          })}
-          {models.length === 0 && <li className="avatars__empty">Nothing built yet.</li>}
-        </ul>
         <div className="shards__actions">
           <button className="avatars__go" onClick={() => useWorkshop.getState().openWorkshop()}>OPEN WORKSHOP</button>
           <button className="avatars__go" onClick={() => { useWorkshop.getState().create(); useWorkshop.getState().openWorkshop() }}>NEW MODEL</button>
@@ -171,16 +154,6 @@ export function ShardsPanel(): JSX.Element {
         Build 3D objects (shards), messages, and encrypt them at a location in
         cyberspace for others to find.
       </Explanation>
-
-      {target && (
-        <ConfirmModal
-          title={`Delete the model "${target.name}"?`}
-          body={`This removes the model and its ${target.vertices.length} vertices from this device for good — it is not the same as removing a deployed copy. ${deployedCount(target.id) > 0 ? `Its ${deployedCount(target.id)} deployed instance${deployedCount(target.id) === 1 ? ' stays' : 's stay'} in cyberspace; delete those from the Deployed list.` : 'It has no deployed instances.'}`}
-          confirmLabel="DELETE MODEL"
-          onConfirm={() => { useWorkshop.getState().remove(target.id); setDeleteModel(null) }}
-          onCancel={() => setDeleteModel(null)}
-        />
-      )}
     </section>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5180,3 +5180,10 @@ kbd {
   line-height: 1.55;
   color: var(--dim);
 }
+
+/* The stash's hidden list scrolls with the panel, not inside its own box: a
+   scroller within a scroller ate the drag that was meant for the panel. */
+.shards__section .avatars__list {
+  max-height: none;
+  overflow-y: visible;
+}


### PR DESCRIPTION
Two panels that fought the hand.

**The stash no longer lists models.** They sat in a box 190px tall with its own scrollbar, inside a panel that also scrolls, so past a few models the drag meant for the panel was eaten by the box. OPEN WORKSHOP and NEW MODEL stay; the workshop is where a model is named, edited and deleted anyway, so the delete-a-model confirmation went with the list. The deployed list stays, and now scrolls with the panel rather than inside itself.

Measured with six models on the device: no nested scrollers left in the panel, and it stands 178px tall instead of filling the column.

**The loot list is kept for the session.** It lived in the panel's own state, so closing the menu threw it away and reopening showed LOADING, then an empty list, then two dozen rows at once, with everything below jumping. It now lives outside React: one backfill per relay set, the subscription open for the session, so reopening shows what is already known. A relay added in the Relays panel starts a fresh backfill and the rows on screen stay while it runs; a failed read leaves them standing rather than clearing to an error.

Verified in a browser: the panel reads `26 HIDDEN` immediately on reopen, with no LOADING pass. Three new tests, 603 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
