### PR TITLE
Region keys: the regions you hold, listed, drawn and marked on the chain

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ import { startSelfSync } from './lib/selfSync'
 import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
 import { useHyperspace } from './store/useHyperspace'
-import { useSecrets } from './store/useSecrets'
+import { useSecrets, watchFocus } from './store/useSecrets'
 import { useAvatars } from './store/useAvatars'
 import { setSyncPriority } from './lib/hyperspace/anchors'
 
@@ -53,7 +53,7 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load() }, [])
+  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load(); watchFocus() }, [])
   // A cloud job paid or computing when the tab last closed is picked up here,
   // if the chain head is still the one it was bound to. Also fetches the caps.
   useEffect(() => { void useCyberspace.getState().resumeCloudJob() }, [])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,7 +110,10 @@ export default function App(): JSX.Element {
   // scene, so the view they asked for closes them; RETURN is on the bar.
   const driving = useCyberspace((s) => s.focus?.drive === true)
   const stationView = useHyperspace((s) => s.viewOwned)
-  useEffect(() => { if ((driving || stationView) && isMobile) setPanelsOpen(false) }, [driving, stationView, isMobile])
+  // A region tapped in the Secrets list is the same kind of asking: the panels
+  // are what you were reading, and the region is what you asked to see.
+  const viewingSecret = useSecrets((s) => s.focused !== null)
+  useEffect(() => { if ((driving || stationView || viewingSecret) && isMobile) setPanelsOpen(false) }, [driving, stationView, viewingSecret, isMobile])
 
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import { startSelfSync } from './lib/selfSync'
 import { startTracker } from './lib/tracker'
 import { useCyberspace } from './store/useCyberspace'
 import { useHyperspace } from './store/useHyperspace'
+import { useSecrets } from './store/useSecrets'
 import { useAvatars } from './store/useAvatars'
 import { setSyncPriority } from './lib/hyperspace/anchors'
 
@@ -52,7 +53,7 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine() }, [])
+  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load() }, [])
   // A cloud job paid or computing when the tab last closed is picked up here,
   // if the chain head is still the one it was bound to. Also fetches the caps.
   useEffect(() => { void useCyberspace.getState().resumeCloudJob() }, [])

--- a/src/hooks/useDiscovery.ts
+++ b/src/hooks/useDiscovery.ts
@@ -19,6 +19,7 @@ import { hexToBytes } from '../lib/events'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from '../store/useCyberspace'
 import { useCeremony } from '../store/useCeremony'
 import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
+import { useSecrets } from '../store/useSecrets'
 import type { RegionRequest, RegionResponse } from '../workers/region.worker'
 
 /** The aligned base of a value at a height: what decides "same region". */
@@ -35,13 +36,24 @@ function regionSignature(x: bigint, y: bigint, z: bigint): string {
 
 export function useDiscovery(): void {
   const anchor = useCyberspace((s) => s.anchor)
+  const plane = useCyberspace((s) => s.anchorPlane)
   const worker = useRef<Worker | null>(null)
   const lastSig = useRef<string | null>(null)
   const reqId = useRef(0)
 
   useEffect(() => {
     worker.current = new Worker(new URL('../workers/region.worker.ts', import.meta.url), { type: 'module' })
-    return () => { worker.current?.terminate(); worker.current = null }
+    return () => {
+      worker.current?.terminate()
+      worker.current = null
+      // The scan below skips a region it has already asked about. A terminated
+      // worker never answered, so the memory of having asked has to go with it,
+      // or the next worker is never asked anything. In development React mounts
+      // effects twice, which is exactly this: the first worker was killed
+      // mid-scan and the second sat idle, so nothing was ever found.
+      lastSig.current = null
+      useShards.getState().setScanning(false)
+    }
   }, [])
 
   useEffect(() => {
@@ -63,11 +75,30 @@ export function useDiscovery(): void {
       if (msg.id !== id) return
       if (msg.type === 'key') {
         keys.set(msg.key.lookupId, msg.key.keyHex)
+        // The key is the region: hold it, so the Secrets list is what you can
+        // open rather than what happened to be open when you walked past.
+        useSecrets.getState().hold([{
+          lookupId: msg.key.lookupId,
+          keyHex: msg.key.keyHex,
+          height: msg.key.height,
+          base: { x: String(base(anchor.x, msg.key.height)), y: String(base(anchor.y, msg.key.height)), z: String(base(anchor.z, msg.key.height)) },
+          plane,
+          source: 'scan',
+          at: Math.floor(Date.now() / 1000),
+        }])
+        return
+      }
+      if (msg.type === 'error') {
+        // A scan that dies took SCANNING with it; leaving the tag lit forever
+        // said the machine was still looking when it had stopped.
+        w.removeEventListener('message', onMessage)
+        useShards.getState().setScanning(false)
+        console.warn('[discovery] region worker failed:', msg.message)
         return
       }
       if (msg.type !== 'done') return
       w.removeEventListener('message', onMessage)
-      if (keys.size === 0) return
+      if (keys.size === 0) { useShards.getState().setScanning(false); return }
 
       // A superseded scan must not write stale finds.
       const events = await query({ kinds: [HIDDEN_KIND], '#d': [...keys.keys()] })

--- a/src/hooks/useDiscovery.ts
+++ b/src/hooks/useDiscovery.ts
@@ -68,6 +68,7 @@ export function useDiscovery(): void {
 
     // Collect this scan's keys, then query the relay once for all of them.
     const keys = new Map<string, string>() // lookupId -> keyHex
+    const heights = new Map<string, number>() // lookupId -> the cube's height
 
     const onMessage = (e: MessageEvent<RegionResponse>): void => { void handle(e) }
     const handle = async (e: MessageEvent<RegionResponse>): Promise<void> => {
@@ -75,17 +76,7 @@ export function useDiscovery(): void {
       if (msg.id !== id) return
       if (msg.type === 'key') {
         keys.set(msg.key.lookupId, msg.key.keyHex)
-        // The key is the region: hold it, so the Secrets list is what you can
-        // open rather than what happened to be open when you walked past.
-        useSecrets.getState().hold([{
-          lookupId: msg.key.lookupId,
-          keyHex: msg.key.keyHex,
-          height: msg.key.height,
-          base: { x: String(base(anchor.x, msg.key.height)), y: String(base(anchor.y, msg.key.height)), z: String(base(anchor.z, msg.key.height)) },
-          plane,
-          source: 'scan',
-          at: Math.floor(Date.now() / 1000),
-        }])
+        heights.set(msg.key.lookupId, msg.key.height)
         return
       }
       if (msg.type === 'error') {
@@ -105,12 +96,46 @@ export function useDiscovery(): void {
       if (id !== reqId.current) return
 
       const found = []
+      const opened: string[] = []
       for (const ev of events) {
         const region = ev.tags.find((t) => t[0] === 'd')?.[1]
         const keyHex = region ? keys.get(region) : undefined
-        if (!keyHex) continue
+        if (!keyHex || !region) continue
         // One envelope holds a bag; unbag flattens it to items.
-        found.push(...await unbag(ev, hexToBytes(keyHex)))
+        const items = await unbag(ev, hexToBytes(keyHex))
+        if (items.length > 0) opened.push(region)
+        found.push(...items)
+      }
+
+      /*
+       * Which keys are worth keeping.
+       *
+       * Every position is inside thirteen cubes, and this machine computes all
+       * thirteen every time you cross into a new one, so holding them all made
+       * the Secrets list a record of where the camera had been. Worse, the scan
+       * runs at the anchor, and the anchor follows exploring, spectating and
+       * the free view: regions were being marked as yours because you had
+       * looked at them.
+       *
+       * A key is kept when it opened something. That is the one that means
+       * anything: it says there is something here and you can read it. The
+       * rest cost milliseconds to compute again the moment you stand there.
+       */
+      if (opened.length > 0 && useCyberspace.getState().atHead()) {
+        const now = Math.floor(Date.now() / 1000)
+        useSecrets.getState().hold(opened.map((region) => ({
+          lookupId: region,
+          keyHex: keys.get(region)!,
+          height: heights.get(region) ?? 0,
+          base: {
+            x: String(base(anchor.x, heights.get(region) ?? 0)),
+            y: String(base(anchor.y, heights.get(region) ?? 0)),
+            z: String(base(anchor.z, heights.get(region) ?? 0)),
+          },
+          plane,
+          source: 'scan' as const,
+          at: now,
+        })))
       }
       if (id === reqId.current) {
         const known = useShards.getState().discovered

--- a/src/hooks/useLoot.test.ts
+++ b/src/hooks/useLoot.test.ts
@@ -1,5 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
 const events: Array<Record<string, unknown>> = []
 let queryCalls = 0
 let subscribeCalls = 0
@@ -59,5 +69,23 @@ describe('the loot list outlives the panel', () => {
     ensureLoot(['wss://one'])
     expect(useLootStore.getState().status).toBe('loading')
     await vi.waitFor(() => { expect(useLootStore.getState().status).toBe('ready') })
+  })
+})
+
+describe('the list survives a reload', () => {
+  it('writes what it learns, so the next visit opens with rows', async () => {
+    events.push({ id: 'a' }, { id: 'b' })
+    useLootStore.setState({ items: [], status: 'loading', source: '' })
+    ensureLoot(['wss://one'])
+    await vi.waitFor(() => { expect(useLootStore.getState().status).toBe('ready') })
+
+    const kept = JSON.parse(localStorage.getItem('onosendai:loot') ?? '[]')
+    expect(kept).toHaveLength(2)
+  })
+
+  it('a list already on screen is not a loading state', () => {
+    // What the store looks like when it was built from a cache.
+    useLootStore.setState({ items: [{ key: 'a' } as never], status: 'ready', source: '' })
+    expect(useLootStore.getState().status).toBe('ready')
   })
 })

--- a/src/hooks/useLoot.ts
+++ b/src/hooks/useLoot.ts
@@ -34,7 +34,42 @@ interface LootState extends Loot {
   source: string
 }
 
-export const useLootStore = create<LootState>(() => ({ items: [], status: 'loading', source: '' }))
+const CACHE_KEY = 'onosendai:loot'
+/** How many rows are kept for the next visit. The panel shows a handful. */
+const CACHE_MAX = 120
+
+/**
+ * The last list, kept for the next visit.
+ *
+ * Holding it outside React stopped the panel blinking when the menu closed,
+ * but a reload still opened on LOADING and an empty list and then dropped two
+ * dozen rows in at once, moving everything under them. The rows are small and
+ * they do not spoil: a bag that has been rewritten comes back in the same
+ * backfill and replaces itself.
+ */
+function readCache(): LootItem[] {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return []
+    const list = JSON.parse(raw) as unknown
+    return Array.isArray(list) ? (list as LootItem[]).filter((i) => i && typeof i.key === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function writeCache(items: LootItem[]): void {
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify(items.slice(0, CACHE_MAX))) } catch { /* private mode */ }
+}
+
+const cached = readCache()
+
+export const useLootStore = create<LootState>(() => ({
+  items: cached,
+  // Rows already on screen are not a loading state, whatever the relay is doing.
+  status: cached.length > 0 ? 'ready' : 'loading',
+  source: '',
+}))
 
 let close: (() => void) | null = null
 
@@ -53,7 +88,11 @@ export function ensureLoot(relays: string[]): void {
   close = subscribe({ kinds: [HIDDEN_KIND], since }, (ev) => {
     const item = summarizeBag(ev)
     if (item && useLootStore.getState().source === source) {
-      useLootStore.setState((s) => ({ items: mergeLoot(s.items, [item]) }))
+      useLootStore.setState((s) => {
+        const items = mergeLoot(s.items, [item])
+        writeCache(items)
+        return { items }
+      })
     }
   })
 
@@ -61,7 +100,11 @@ export function ensureLoot(relays: string[]): void {
     (events) => {
       if (useLootStore.getState().source !== source) return
       const found = events.map(summarizeBag).filter((x): x is LootItem => x !== null)
-      useLootStore.setState((s) => ({ items: mergeLoot(s.items, found), status: 'ready' }))
+      useLootStore.setState((s) => {
+        const items = mergeLoot(s.items, found)
+        writeCache(items)
+        return { items, status: 'ready' }
+      })
     },
     () => {
       if (useLootStore.getState().source !== source) return

--- a/src/hud/ChainExplorer.tsx
+++ b/src/hud/ChainExplorer.tsx
@@ -18,6 +18,9 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { KeyRound } from 'lucide-react'
+import { findLcaHeight } from 'cyberspace-core'
+import { keyStateForAction, useSecrets } from '../store/useSecrets'
 import { noCallout, useRepeatable } from '../hooks/useRepeatable'
 import { formatAgo, formatStamp, shortHex } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
@@ -35,6 +38,11 @@ export function ChainExplorer(): JSX.Element {
   const index = exploreIndex ?? last
   const action = actions[index]
   const atHead = exploreIndex === null
+  const secretKeys = useSecrets((s) => s.keys)
+  const key = useMemo(
+    () => (action ? keyStateForAction(action, actions[index - 1] ?? null, secretKeys, findLcaHeight) : { state: 'none' as const, height: null }),
+    [action, actions, index, secretKeys],
+  )
 
   // Minimized by default: the chip alone reads "CHAIN n/N", and the panel
   // opens on a tap when you actually want to walk the chain.
@@ -120,6 +128,18 @@ export function ChainExplorer(): JSX.Element {
           <div className="explorer__meta">
             <span className={`explorer__type explorer__type--${action.type}`}>{action.type.toUpperCase()}</span>
             <span className="explorer__when" title={formatStamp(action.createdAt)}>{formatAgo(action.createdAt, now)}</span>
+            {/* A hop computes the region's Cantor root, which is the key to what
+                is hidden there; a sidestep computes no root at all. */}
+            {key.state !== 'none' && (
+              <span
+                className={`explorer__root ${key.state === 'gone' ? 'is-gone' : ''}`}
+                title={key.state === 'held'
+                  ? `This hop yielded the key to its 2^${key.height} region, and you still hold it.`
+                  : `This hop yielded the key to its 2^${key.height} region. It is not in your Secrets list.`}
+              >
+                <KeyRound size={11} strokeWidth={2.25} aria-hidden />2^{key.height}
+              </span>
+            )}
             {atHead ? (
               <span className="explorer__live">{spectate ? 'THEIR HEAD' : 'LATEST'}</span>
             ) : (

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -230,10 +230,10 @@ export function ProofPanel(): JSX.Element {
         </>
       )}
 
-      {/* Every region you can open, and what it cost to get there. */}
+      {/* Every region you hold the key to, and what it cost to get there. */}
       <div className="proof__secrets">
         <button className="avatars__go" onClick={() => useSecrets.getState().setOpen(true)}>
-          <KeyRound size={12} strokeWidth={2.25} aria-hidden /> SECRETS{heldCount > 0 ? ` (${heldCount})` : ''}
+          <KeyRound size={12} strokeWidth={2.25} aria-hidden /> REGION KEYS{heldCount > 0 ? ` (${heldCount})` : ''}
         </button>
       </div>
       {secrets && <SecretsModal onClose={() => useSecrets.getState().setOpen(false)} />}

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -8,7 +8,6 @@
  * the real computation.
  */
 
-import { useState } from 'react'
 import { CloudUpload, Footprints, KeyRound, OctagonAlert } from 'lucide-react'
 import { Explanation } from './Explanation'
 import { SecretsModal } from './SecretsModal'
@@ -56,7 +55,8 @@ export function ProofPanel(): JSX.Element {
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const moveMode = useCyberspace((s) => s.moveMode)
   const heldCount = useSecrets((s) => Object.keys(s.keys).length)
-  const [secrets, setSecrets] = useState(false)
+  // In the store, so RETURN from a region can bring the list back.
+  const secrets = useSecrets((s) => s.open)
   // This machine's hop ceiling as the commit attempts it: the protocol cap,
   // lowered to what calibration measured (the preview hook uses the same).
   const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
@@ -232,11 +232,11 @@ export function ProofPanel(): JSX.Element {
 
       {/* Every region you can open, and what it cost to get there. */}
       <div className="proof__secrets">
-        <button className="avatars__go" onClick={() => setSecrets(true)}>
+        <button className="avatars__go" onClick={() => useSecrets.getState().setOpen(true)}>
           <KeyRound size={12} strokeWidth={2.25} aria-hidden /> SECRETS{heldCount > 0 ? ` (${heldCount})` : ''}
         </button>
       </div>
-      {secrets && <SecretsModal onClose={() => setSecrets(false)} />}
+      {secrets && <SecretsModal onClose={() => useSecrets.getState().setOpen(false)} />}
 
       {/* What COMMIT does with a route: its first step, or all of them. */}
       <div className="proof__mode" role="radiogroup" aria-label="What commit runs">

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -240,7 +240,7 @@ export function ProofPanel(): JSX.Element {
 
       {/* What COMMIT does with a route: its first step, or all of them. */}
       <div className="proof__mode" role="radiogroup" aria-label="What commit runs">
-        <span className="login__label">Commit runs</span>
+        <span className="login__label">COMMIT BUTTON ACTION:</span>
         <div className="cloud__modes">
           {MOVE_MODES.map(([mode, label, title]) => (
             <button
@@ -260,6 +260,8 @@ export function ProofPanel(): JSX.Element {
             : 'One step per press: the one the button names. The cursor stays where it is, so the next press takes the next step.'}
         </span>
       </div>
+
+      <hr className="proof__rule" />
 
       <p className="legend__note">
         THIS MACHINE BENCHMARK

--- a/src/hud/ProofPanel.tsx
+++ b/src/hud/ProofPanel.tsx
@@ -8,8 +8,11 @@
  * the real computation.
  */
 
-import { CloudUpload, Footprints, OctagonAlert } from 'lucide-react'
+import { useState } from 'react'
+import { CloudUpload, Footprints, KeyRound, OctagonAlert } from 'lucide-react'
 import { Explanation } from './Explanation'
+import { SecretsModal } from './SecretsModal'
+import { useSecrets } from '../store/useSecrets'
 import { useCalibration } from '../lib/calibration'
 import { satsOf } from '../lib/cloud'
 import { previewWindow, routeLabel, useRoutePreview } from './routePreview'
@@ -52,6 +55,8 @@ export function ProofPanel(): JSX.Element {
   const hopCeil = useCalibration((s) => s.hopHeight)
   const sidestepCeil = useCalibration((s) => s.sidestepHeight)
   const moveMode = useCyberspace((s) => s.moveMode)
+  const heldCount = useSecrets((s) => Object.keys(s.keys).length)
+  const [secrets, setSecrets] = useState(false)
   // This machine's hop ceiling as the commit attempts it: the protocol cap,
   // lowered to what calibration measured (the preview hook uses the same).
   const ceiling = Math.min(MAX_COMPUTE_HEIGHT, hopCeil)
@@ -224,6 +229,14 @@ export function ProofPanel(): JSX.Element {
           {proof.message && <p className="notice">{proof.message}</p>}
         </>
       )}
+
+      {/* Every region you can open, and what it cost to get there. */}
+      <div className="proof__secrets">
+        <button className="avatars__go" onClick={() => setSecrets(true)}>
+          <KeyRound size={12} strokeWidth={2.25} aria-hidden /> SECRETS{heldCount > 0 ? ` (${heldCount})` : ''}
+        </button>
+      </div>
+      {secrets && <SecretsModal onClose={() => setSecrets(false)} />}
 
       {/* What COMMIT does with a route: its first step, or all of them. */}
       <div className="proof__mode" role="radiogroup" aria-label="What commit runs">

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -1,0 +1,146 @@
+/**
+ * SecretsModal.tsx — every region you can open.
+ *
+ * A key is a number you computed, not a password you were given: the Cantor
+ * root of one aligned region, hashed for the key and again for the lookup id
+ * the relay knows it by (spec §7.2). This is the list of those, what each one
+ * covers, where it came from, and what it costs to keep.
+ *
+ * Keys are not hierarchical: holding a region a mile wide says nothing about
+ * the block inside it. So the list is flat, and forgetting one is not a loss
+ * you cannot undo, since standing there again recomputes it. Anything a key
+ * has already opened stays in the Stash whatever happens here.
+ */
+
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { KeyRound } from 'lucide-react'
+import { formatCellSize } from '../lib/scale'
+import { formatAgo } from '../lib/time'
+import { useCyberspace } from '../store/useCyberspace'
+import { useSecrets, bytesOf, heldList, type HeldKey } from '../store/useSecrets'
+import { useShards } from '../store/useShards'
+import { ConfirmModal } from './ConfirmModal'
+import { Explanation } from './Explanation'
+
+/** The green of "found here", as everywhere else keys are drawn. */
+export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element {
+  const keys = useSecrets((s) => s.keys)
+  const discovered = useShards((s) => s.discovered)
+  const showSecrets = useCyberspace((s) => s.showSecrets)
+  const [forgetAll, setForgetAll] = useState(false)
+
+  const list = useMemo(() => heldList(keys), [keys])
+  const bytes = useMemo(() => list.reduce((n, k) => n + bytesOf(k), 0), [list])
+  const now = Math.floor(Date.now() / 1000)
+
+  // What each region has actually yielded, so a key that opened something says so.
+  const opened = useMemo(() => {
+    const by = new Map<string, number>()
+    for (const h of Object.values(discovered)) {
+      if (!h.lookupId) continue
+      by.set(h.lookupId, (by.get(h.lookupId) ?? 0) + 1)
+    }
+    return by
+  }, [discovered])
+
+  const go = (k: HeldKey): void => {
+    // The region's own corner, in its own plane, at a scale where it fits.
+    const at = { x: BigInt(k.base.x), y: BigInt(k.base.y), z: BigInt(k.base.z) }
+    onClose()
+    useCyberspace.getState().focusOn(at, k.plane, `REGION 2^${k.height}`, Math.max(0, k.height - 4))
+  }
+
+  return createPortal(
+    <div className="modal" role="dialog" aria-label="Secrets" aria-modal="true" onPointerDown={onClose}>
+      <div className="modal__card secrets__box" onPointerDown={(e) => e.stopPropagation()}>
+        <header className="panel__head">
+          <h2><KeyRound size={14} strokeWidth={2.25} aria-hidden /> Secrets</h2>
+          <span className="tag">{list.length === 0 ? 'NO KEYS' : `${list.length} REGION${list.length === 1 ? '' : 'S'}`}</span>
+        </header>
+
+        <div className="secrets__summary">
+          <span>{formatBytes(bytes)} on this device</span>
+          <label className="secrets__toggle">
+            <input
+              type="checkbox"
+              checked={showSecrets}
+              onChange={(e) => useCyberspace.getState().setShowSecrets(e.target.checked)}
+            />
+            Draw them in the scene
+          </label>
+        </div>
+
+        <ul className="secrets__list">
+          {list.map((k) => {
+            const found = opened.get(k.lookupId) ?? 0
+            return (
+              <li key={k.lookupId} className="secrets__row">
+                <button className="secrets__go" onClick={() => go(k)} title="Look at this region">
+                  <span className="secrets__where">
+                    <KeyRound size={11} strokeWidth={2.25} aria-hidden />
+                    2^{k.height} · {formatCellSize(k.height)}
+                  </span>
+                  <span className="secrets__meta">
+                    {k.plane === 1 ? 'ideaspace' : 'dataspace'} · {k.source === 'cloud' ? 'HOSAKA' : 'scanned'} · {formatAgo(k.at, now)}
+                    {found > 0 && <span className="secrets__found"> · {found} found</span>}
+                  </span>
+                  <span className="secrets__id">{k.lookupId.slice(0, 16)}…</span>
+                </button>
+                <button
+                  className="secrets__scan"
+                  onClick={() => { void useShards.getState().rescan(k.lookupId, k.keyHex) }}
+                  title="Ask the relay what is hidden in this region now"
+                >SCAN</button>
+                <button
+                  className="targets__remove"
+                  onClick={() => useSecrets.getState().forget(k.lookupId)}
+                  aria-label="Forget this key"
+                  title="Forget this key. Standing there again computes it back."
+                >✕</button>
+              </li>
+            )
+          })}
+          {list.length === 0 && (
+            <li className="avatars__empty">
+              No keys yet. Moving through cyberspace computes the regions you pass, and each one you compute is a region you can open.
+            </li>
+          )}
+        </ul>
+
+        <Explanation>
+          A region key is the Cantor root of one aligned cube, hashed once for the
+          key and twice for the address the relay files it under. Holding it lets
+          you ask what is hidden there and read the answer, and it opens that cube
+          alone: a key to a large region says nothing about the blocks inside it,
+          because each has its own root. Your machine computes the small ones as
+          you move; the large ones are what HOSAKA sells, since a cube of side
+          2^20 is a million pairings per axis and one of side 2^27 is a hundred
+          and thirty million.
+        </Explanation>
+
+        <div className="modal__actions">
+          {list.length > 0 && <button className="avatars__go" onClick={() => setForgetAll(true)}>FORGET ALL</button>}
+          <button className="avatars__go" onClick={onClose}>CLOSE</button>
+        </div>
+      </div>
+
+      {forgetAll && (
+        <ConfirmModal
+          title={`Forget all ${list.length} keys?`}
+          body="Anything they have already opened stays in your Stash. The keys themselves come back by standing in those regions again, except the ones HOSAKA computed, which would have to be bought again."
+          confirmLabel="FORGET ALL"
+          onConfirm={() => { useSecrets.getState().forgetAll(); setForgetAll(false) }}
+          onCancel={() => setForgetAll(false)}
+        />
+      )}
+    </div>,
+    document.body,
+  )
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -19,6 +19,7 @@ import { formatCellSize } from '../lib/scale'
 import { formatAgo } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
 import { useSecrets, bytesOf, heldList, type HeldKey } from '../store/useSecrets'
+import { sizeLabel } from '../scene/SecretRegions'
 import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
 import { ConfirmModal } from './ConfirmModal'
 import { Explanation } from './Explanation'
@@ -29,6 +30,8 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
   const discovered = useShards((s) => s.discovered)
   const showSecrets = useCyberspace((s) => s.showSecrets)
   const [forgetAll, setForgetAll] = useState(false)
+  const [scanning, setScanning] = useState<string | null>(null)
+  const [scanned, setScanned] = useState<Record<string, number>>({})
 
   const anchor = useCyberspace((s) => s.anchor)
   const anchorPlane = useCyberspace((s) => s.anchorPlane)
@@ -65,22 +68,32 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
   }, [discovered])
 
   const go = (k: HeldKey): void => {
-    // The region's own corner, in its own plane, at a scale where it fits.
-    const at = { x: BigInt(k.base.x), y: BigInt(k.base.y), z: BigInt(k.base.z) }
+    // The middle of the region, not its corner: looking at a corner puts the
+    // thing you asked about at the edge of the screen and everything else in
+    // the middle. Half a side along each axis, per axis, because a movement's
+    // region is a box.
+    const mid = (axis: 'x' | 'y' | 'z'): bigint => {
+      const h = BigInt(k.heights ? k.heights[axis] : k.height)
+      return BigInt(k.base[axis]) + (1n << h) / 2n
+    }
     onClose()
-    useCyberspace.getState().focusOn(at, k.plane, `REGION 2^${k.height}`, Math.max(0, k.height - 4))
+    useSecrets.getState().focus(k.lookupId)
+    useCyberspace.getState().focusOn({ x: mid('x'), y: mid('y'), z: mid('z') }, k.plane, `REGION ${sizeLabel(k)}`, Math.max(0, k.height - 3))
   }
 
   return createPortal(
     <div className="modal" role="dialog" aria-label="Secrets" aria-modal="true" onPointerDown={onClose}>
       <div className="modal__card secrets__box" onPointerDown={(e) => e.stopPropagation()}>
-        <header className="panel__head">
+        <header className="panel__head secrets__head">
           <h2><KeyRound size={14} strokeWidth={2.25} aria-hidden /> Secrets</h2>
           <span className="tag">{list.length === 0 ? 'NO KEYS' : `${list.length} REGION${list.length === 1 ? '' : 'S'}`}</span>
+          <button className="targets__remove secrets__close" onClick={onClose} aria-label="Close" title="Close">✕</button>
         </header>
 
         <div className="secrets__summary">
           <span>{formatBytes(bytes)} on this device</span>
+          {list.length > 0 && <button className="secrets__forget-all" onClick={() => setForgetAll(true)}>FORGET ALL</button>}
+          <span className="secrets__gap" />
           <label className="secrets__toggle">
             <input
               type="checkbox"
@@ -123,10 +136,11 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
                 <button className="secrets__go" onClick={() => go(k)} title="Look at this region">
                   <span className="secrets__where">
                     <KeyRound size={11} strokeWidth={2.25} aria-hidden />
-                    {k.heights && !(k.heights.x === k.heights.y && k.heights.y === k.heights.z)
-                      ? `2^${k.heights.x} × 2^${k.heights.y} × 2^${k.heights.z}`
-                      : `2^${k.height} · ${formatCellSize(k.height)}`}
+                    {sizeLabel(k)}
                   </span>
+                  {/* Every side, in real units: a region is a volume and one
+                      number could only ever be one of its edges. */}
+                  <span className="secrets__dims">{physicalSize(k)}</span>
                   <span className="secrets__meta">
                     {k.plane === 1 ? 'ideaspace' : 'dataspace'} · {k.source === 'cloud' ? 'bought' : k.source === 'hop' ? 'crossed' : 'opened'} · {formatAgo(k.at, now)}
                     {found > 0 && <span className="secrets__found"> · {found} found</span>}
@@ -135,9 +149,17 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
                 </button>
                 <button
                   className="secrets__scan"
-                  onClick={() => { void useShards.getState().rescan(k.lookupId, k.keyHex) }}
+                  disabled={scanning === k.lookupId}
+                  onClick={() => {
+                    setScanning(k.lookupId)
+                    void useShards.getState().rescan(k.lookupId, k.keyHex).then((n) => {
+                      setScanning(null)
+                      setScanned((prev) => ({ ...prev, [k.lookupId]: n }))
+                      window.setTimeout(() => setScanned((prev) => { const next = { ...prev }; delete next[k.lookupId]; return next }), 6000)
+                    })
+                  }}
                   title="Ask the relay what is hidden in this region now"
-                >SCAN</button>
+                >{scanning === k.lookupId ? '…' : scanned[k.lookupId] !== undefined ? (scanned[k.lookupId] > 0 ? `+${scanned[k.lookupId]}` : 'NONE') : 'SCAN'}</button>
                 <button
                   className="targets__remove"
                   onClick={() => useSecrets.getState().forget(k.lookupId)}
@@ -166,10 +188,7 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
           and one of side 2^27 is a hundred and thirty million.
         </Explanation>
 
-        <div className="modal__actions">
-          {list.length > 0 && <button className="avatars__go" onClick={() => setForgetAll(true)}>FORGET ALL</button>}
-          <button className="avatars__go" onClick={onClose}>CLOSE</button>
-        </div>
+
       </div>
 
       {forgetAll && (
@@ -184,6 +203,14 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
     </div>,
     document.body,
   )
+}
+
+/** Every side of the region in real units, so "how big" has a whole answer. */
+function physicalSize(k: HeldKey): string {
+  if (!k.heights || (k.heights.x === k.heights.y && k.heights.y === k.heights.z)) {
+    return `${formatCellSize(k.height)} on every side`
+  }
+  return `${formatCellSize(k.heights.x)} × ${formatCellSize(k.heights.y)} × ${formatCellSize(k.heights.z)}`
 }
 
 function formatBytes(n: number): string {

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -123,10 +123,12 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
                 <button className="secrets__go" onClick={() => go(k)} title="Look at this region">
                   <span className="secrets__where">
                     <KeyRound size={11} strokeWidth={2.25} aria-hidden />
-                    2^{k.height} · {formatCellSize(k.height)}
+                    {k.heights && !(k.heights.x === k.heights.y && k.heights.y === k.heights.z)
+                      ? `2^${k.heights.x} × 2^${k.heights.y} × 2^${k.heights.z}`
+                      : `2^${k.height} · ${formatCellSize(k.height)}`}
                   </span>
                   <span className="secrets__meta">
-                    {k.plane === 1 ? 'ideaspace' : 'dataspace'} · {k.source === 'cloud' ? 'HOSAKA' : 'scanned'} · {formatAgo(k.at, now)}
+                    {k.plane === 1 ? 'ideaspace' : 'dataspace'} · {k.source === 'cloud' ? 'bought' : k.source === 'hop' ? 'crossed' : 'opened'} · {formatAgo(k.at, now)}
                     {found > 0 && <span className="secrets__found"> · {found} found</span>}
                   </span>
                   <span className="secrets__id">{k.lookupId.slice(0, 16)}…</span>

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -19,7 +19,7 @@ import { formatCellSize } from '../lib/scale'
 import { formatAgo } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
 import { useSecrets, bytesOf, heldList, type HeldKey } from '../store/useSecrets'
-import { useShards } from '../store/useShards'
+import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
 import { ConfirmModal } from './ConfirmModal'
 import { Explanation } from './Explanation'
 
@@ -29,6 +29,26 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
   const discovered = useShards((s) => s.discovered)
   const showSecrets = useCyberspace((s) => s.showSecrets)
   const [forgetAll, setForgetAll] = useState(false)
+
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const limits = useCyberspace((s) => s.cloud.limits)
+  const provider = useCyberspace((s) => s.cloud.provider)
+  const cloudOff = useCyberspace((s) => s.cloudPrefs.mode === 'off')
+  const buying = useSecrets((s) => s.buying)
+  const buyError = useSecrets((s) => s.buyError)
+
+  // Above what this machine sweeps for itself, up to what HOSAKA computes.
+  const lowest = SCAN_MAX_HEIGHT + 1
+  const highest = limits?.max_hop_height ?? lowest
+  const canBuy = !cloudOff && highest >= lowest
+  const [buyHeight, setBuyHeight] = useState(Math.min(highest, lowest + 4))
+  const price = useMemo(() => {
+    const ladder = provider?.pricing?.hop
+    if (!ladder) return null
+    const band = [...ladder].sort((a, b) => a.max_height - b.max_height).find((x) => buyHeight <= x.max_height)
+    return band?.sats ?? null
+  }, [provider, buyHeight])
 
   const list = useMemo(() => heldList(keys), [keys])
   const bytes = useMemo(() => list.reduce((n, k) => n + bytesOf(k), 0), [list])
@@ -70,6 +90,30 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
             Draw them in the scene
           </label>
         </div>
+
+        {/* The heights this machine cannot reach for itself. A cube of side
+            2^12 it computes as you walk; 2^20 is a million pairings an axis. */}
+        {canBuy && (
+          <div className="secrets__buy">
+            <span className="login__label">Buy a key where you stand</span>
+            <div className="secrets__buy-row">
+              <button className="secrets__step" disabled={!!buying || buyHeight <= lowest} onClick={() => setBuyHeight((h) => Math.max(lowest, h - 1))} aria-label="Smaller region">−</button>
+              <span className="secrets__buy-size">2^{buyHeight} · {formatCellSize(buyHeight)}</span>
+              <button className="secrets__step" disabled={!!buying || buyHeight >= highest} onClick={() => setBuyHeight((h) => Math.min(highest, h + 1))} aria-label="Larger region">+</button>
+              <button
+                className="avatars__go secrets__buy-go"
+                disabled={!!buying}
+                onClick={() => { void useSecrets.getState().buy(anchor, anchorPlane, buyHeight) }}
+              >{buying ? (buying.status === 'submitting' ? 'ASKING' : 'COMPUTING') : `BUY${price !== null ? ` · ${price} SATS` : ''}`}</button>
+            </div>
+            <span className="cloud__profile-note">
+              {buying
+                ? `HOSAKA is computing the 2^${buying.height} cube around you. It lands in this list when it is done.`
+                : `Three axis trees at 2^${buyHeight}, which is a hop's work at that height and is priced as one. Paid from your HOSAKA balance.`}
+            </span>
+            {buyError && <span className="secrets__error">{buyError}</span>}
+          </div>
+        )}
 
         <ul className="secrets__list">
           {list.map((k) => {

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -147,7 +147,7 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
           })}
           {list.length === 0 && (
             <li className="avatars__empty">
-              No keys yet. Moving through cyberspace computes the regions you pass, and each one you compute is a region you can open.
+              Nothing opened yet. A key is kept when it opens something where you stand, or when you buy one; the regions you merely pass through cost milliseconds to compute again and are not listed.
             </li>
           )}
         </ul>
@@ -157,10 +157,11 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
           key and twice for the address the relay files it under. Holding it lets
           you ask what is hidden there and read the answer, and it opens that cube
           alone: a key to a large region says nothing about the blocks inside it,
-          because each has its own root. Your machine computes the small ones as
-          you move; the large ones are what HOSAKA sells, since a cube of side
-          2^20 is a million pairings per axis and one of side 2^27 is a hundred
-          and thirty million.
+          because each has its own root. Your machine computes the small cubes
+          around you as you move, so those are not kept; a key earns its place
+          here by opening something, or by being bought. The large ones are what
+          HOSAKA sells, since a cube of side 2^20 is a million pairings per axis
+          and one of side 2^27 is a hundred and thirty million.
         </Explanation>
 
         <div className="modal__actions">

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -76,7 +76,7 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
       const h = BigInt(k.heights ? k.heights[axis] : k.height)
       return BigInt(k.base[axis]) + (1n << h) / 2n
     }
-    onClose()
+    useSecrets.getState().setOpen(false)
     useSecrets.getState().focus(k.lookupId)
     useCyberspace.getState().focusOn({ x: mid('x'), y: mid('y'), z: mid('z') }, k.plane, `REGION ${sizeLabel(k)}`, Math.max(0, k.height - 3))
   }

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -1,5 +1,5 @@
 /**
- * SecretsModal.tsx — every region you can open.
+ * SecretsModal.tsx — REGION KEYS: every region you can open.
  *
  * A key is a number you computed, not a password you were given: the Cantor
  * root of one aligned region, hashed for the key and again for the lookup id
@@ -85,10 +85,10 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
   }
 
   return createPortal(
-    <div className="modal" role="dialog" aria-label="Secrets" aria-modal="true" onPointerDown={onClose}>
+    <div className="modal" role="dialog" aria-label="Region keys" aria-modal="true" onPointerDown={onClose}>
       <div className="modal__card secrets__box" onPointerDown={(e) => e.stopPropagation()}>
         <header className="panel__head secrets__head">
-          <h2><KeyRound size={14} strokeWidth={2.25} aria-hidden /> Secrets</h2>
+          <h2><KeyRound size={14} strokeWidth={2.25} aria-hidden /> Region keys</h2>
           <span className="tag">{list.length === 0 ? 'NO KEYS' : `${list.length} REGION${list.length === 1 ? '' : 'S'}`}</span>
           <button className="targets__remove secrets__close" onClick={onClose} aria-label="Close" title="Close">✕</button>
         </header>
@@ -196,15 +196,11 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
         </ul>
 
         <Explanation>
-          A region key is the Cantor root of one aligned cube, hashed once for the
-          key and twice for the address the relay files it under. Holding it lets
-          you ask what is hidden there and read the answer, and it opens that cube
-          alone: a key to a large region says nothing about the blocks inside it,
-          because each has its own root. Your machine computes the small cubes
-          around you as you move, so those are not kept; a key earns its place
-          here by opening something, or by being bought. The large ones are what
-          HOSAKA sells, since a cube of side 2^20 is a million pairings per axis
-          and one of side 2^27 is a hundred and thirty million.
+          A region key is the Cantor root of one aligned volume containing your
+          hop origin and destination. The key is used for your movement proof,
+          but it can also decrypt location-encrypted content anchored to that
+          same region. Your action chain already holds the proofs independently
+          of these keys, so they can be deleted and recalculated later.
         </Explanation>
 
 

--- a/src/hud/SecretsModal.tsx
+++ b/src/hud/SecretsModal.tsx
@@ -18,11 +18,13 @@ import { KeyRound } from 'lucide-react'
 import { formatCellSize } from '../lib/scale'
 import { formatAgo } from '../lib/time'
 import { useCyberspace } from '../store/useCyberspace'
-import { useSecrets, bytesOf, heldList, type HeldKey } from '../store/useSecrets'
+import { useSecrets, bytesOf, heldList, type HeldKey, type SecretsSort } from '../store/useSecrets'
 import { sizeLabel } from '../scene/SecretRegions'
 import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
 import { ConfirmModal } from './ConfirmModal'
 import { Explanation } from './Explanation'
+
+const SORTS: Array<[SecretsSort, string]> = [['recent', 'MOST RECENT'], ['volume', 'LARGEST']]
 
 /** The green of "found here", as everywhere else keys are drawn. */
 export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element {
@@ -53,7 +55,8 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
     return band?.sats ?? null
   }, [provider, buyHeight])
 
-  const list = useMemo(() => heldList(keys), [keys])
+  const sort = useSecrets((s) => s.sort)
+  const list = useMemo(() => heldList(keys, sort), [keys, sort])
   const bytes = useMemo(() => list.reduce((n, k) => n + bytesOf(k), 0), [list])
   const now = Math.floor(Date.now() / 1000)
 
@@ -125,6 +128,22 @@ export function SecretsModal({ onClose }: { onClose: () => void }): JSX.Element 
                 : `Three axis trees at 2^${buyHeight}, which is a hop's work at that height and is priced as one. Paid from your HOSAKA balance.`}
             </span>
             {buyError && <span className="secrets__error">{buyError}</span>}
+          </div>
+        )}
+
+        {list.length > 1 && (
+          <div className="secrets__sort" role="radiogroup" aria-label="Order">
+            <span className="login__label">Order</span>
+            {SORTS.map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={sort === value}
+                className={`secret__act cloud__mode ${sort === value ? 'is-on' : ''}`}
+                onClick={() => useSecrets.getState().setSort(value)}
+              >{label}</button>
+            ))}
           </div>
         )}
 

--- a/src/lib/cashu.test.ts
+++ b/src/lib/cashu.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { bytesToHex, hexToBytes } from 'cyberspace-core'
-import { cashuLabel, checkCashuState, decodeCashuToken, decodeCbor, findCashuToken, hashToCurve } from './cashu'
+import { cashuLabel, checkCashuState, decodeCashuToken, decodeCbor, findCashuToken, hashToCurve, textWithoutToken } from './cashu'
 
 const b64url = (bytes: Uint8Array): string => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 
@@ -83,5 +83,30 @@ describe('checkCashuState (NUT-07)', () => {
   })
   it('is unknown when the mint is down', async () => {
     expect(await checkCashuState(token, (async () => { throw new Error('down') }) as unknown as typeof fetch)).toBe('unknown')
+  })
+})
+
+describe('a token among words', () => {
+  const token = 'cashuBo2FteCJodHRwczovL21pbnQubWluaWJpdHMuY2FzaCIsInVuaXQiOiJzYXQiLCJwcm9vZnMi' + 'A'.repeat(200)
+
+  it('is found wherever it sits in the message', () => {
+    expect(findCashuToken(`for the drinks ${token}`)).toBeTruthy()
+    expect(findCashuToken(`${token} enjoy`)).toBeTruthy()
+    expect(findCashuToken(`before ${token} after`)).toBeTruthy()
+  })
+
+  it('leaves the words behind when it is taken out', () => {
+    expect(textWithoutToken(`for the drinks ${token}`)).toBe('for the drinks')
+    expect(textWithoutToken(`${token} enjoy`)).toBe('enjoy')
+    expect(textWithoutToken(`before ${token} after`)).toBe('before after')
+  })
+
+  it('is nothing but a token when there are no words', () => {
+    expect(textWithoutToken(token)).toBe('')
+  })
+
+  it('leaves an ordinary message alone', () => {
+    expect(findCashuToken('just a note')).toBeNull()
+    expect(textWithoutToken('just a note')).toBe('just a note')
   })
 })

--- a/src/lib/cashu.ts
+++ b/src/lib/cashu.ts
@@ -26,7 +26,19 @@ export type CashuState = 'unclaimed' | 'redeemed' | 'pending' | 'unknown'
 
 const TOKEN = /cashu[AB][A-Za-z0-9_\-+/=]{16,}/
 
-/** The first Cashu token in a text, or null. */
+/**
+ * What a message says once its token is taken out.
+ *
+ * A token can sit anywhere in the text, and usually has words around it: "for
+ * the drinks" and then two thousand characters of base64. Those words are the
+ * message and the base64 is the money, so they are drawn as different things.
+ */
+export function textWithoutToken(text: string | null | undefined): string {
+  if (!text) return ''
+  return text.replace(new RegExp(TOKEN.source, 'g'), '').replace(/\s+/g, ' ').trim()
+}
+
+/** The first Cashu token in a text, or null. Found anywhere in it. */
 export function findCashuToken(text: string | null | undefined): string | null {
   if (!text) return null
   const m = TOKEN.exec(text)

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -144,7 +144,7 @@ function fakeClient(over: Partial<HosakaClient>): HosakaClient {
   const reject = (): never => { throw new Error('unexpected call') }
   return {
     apiUrl: 'http://fake',
-    limits: reject, quote: reject, submitHop: reject, submitSidestep: reject, getJob: reject, balance: reject, deposit: reject,
+    limits: reject, quote: reject, submitHop: reject, submitSidestep: reject, submitRegionKey: reject, getJob: reject, balance: reject, deposit: reject,
     startJob: reject, claimDeposit: reject, waitForDeposit: reject, waitForJob: reject,
     ...over,
   }

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -185,6 +185,14 @@ export interface CloudSidestepResult {
 }
 
 /** A job as the API returns it: the row, plus the payment fields a submit or a start adds. */
+/** What a completed region_key job carries: §7.2's key and the id it is filed under. */
+export interface HosakaRegionKeyResult {
+  secret_key: string
+  lookup_id: string
+  height: number
+  base: { x: number | string; y: number | string; z: number | string }
+}
+
 export interface HosakaJob {
   id: string
   status: HosakaJobStatus
@@ -338,6 +346,14 @@ export interface HosakaClient {
   quote: (action: HosakaAction, v1: HosakaCoord, v2: HosakaCoord, signal?: AbortSignal) => Promise<HosakaQuote>
   submitHop: (v1: HosakaCoord, v2: HosakaCoord, previousEventId: string, signal?: AbortSignal) => Promise<HosakaJob>
   submitSidestep: (v1: HosakaCoord, v2: HosakaCoord, previousEventId: string, signal?: AbortSignal) => Promise<HosakaJob>
+  /**
+   * The key to the aligned cube of side 2^height around a coordinate.
+   *
+   * Not a movement: a hop's region is the three axes at their own crossing
+   * heights, which is a box, and everything is hidden in a cube. This computes
+   * the cube, which is what actually opens anything.
+   */
+  submitRegionKey: (at: { x: bigint; y: bigint; z: bigint }, height: number, signal?: AbortSignal) => Promise<HosakaJob>
   /** Reads with the poll token; no signature, so a bunker is never prompted per poll. */
   getJob: (jobId: string, pollToken: string, signal?: AbortSignal) => Promise<HosakaJob>
   startJob: (jobId: string, signal?: AbortSignal) => Promise<HosakaJob>
@@ -465,6 +481,13 @@ export function createHosaka(opts: HosakaClientOptions): HosakaClient {
       request<HosakaQuote>('/api/v1/quote', { method: 'POST', body: { action, v1, v2 }, signal }),
     submitHop: (v1, v2, previousEventId, signal) => submit('hop', v1, v2, previousEventId, signal),
     submitSidestep: (v1, v2, previousEventId, signal) => submit('sidestep', v1, v2, previousEventId, signal),
+    submitRegionKey: (at, height, signal) =>
+      request<HosakaJob>('/api/v1/region_key', {
+        method: 'POST',
+        auth: true,
+        body: { x: at.x.toString(), y: at.y.toString(), z: at.z.toString(), height },
+        signal,
+      }),
     getJob,
     startJob: (jobId, signal) => request<HosakaJob>(`/api/v1/jobs/${jobId}/start`, { method: 'POST', auth: true, signal }),
     claimDeposit,

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -54,6 +54,7 @@ import { PathTrail } from './PathTrail'
 import { Rooms } from './Rooms'
 import { SectorBox } from './SectorBox'
 import { ShaderPointField } from './ShaderPointField'
+import { SecretRegions } from './SecretRegions'
 import { SpawnMarker } from './SpawnMarker'
 import { TargetAvatars } from './TargetAvatars'
 import { WorldShards } from './WorldShards'
@@ -128,6 +129,7 @@ function World(): JSX.Element {
       <WorldMessages axes={axes} />
       <ShardGhost axes={axes} />
       <DeployRegionBox axes={axes} />
+      <SecretRegions axes={axes} />
       <Cursor axes={axes} />
       <Avatar />
     </group>

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -9,9 +9,10 @@
  * a key at its +X +Z corner, the same green the deploy box uses for "found
  * here", so the colour means one thing throughout.
  *
- * Only what is worth drawing is drawn. A cube smaller than a few pixels or
- * wider than the field says nothing, and the nearest few are enough: past that
- * the cages overlap into a haze and the frame pays for it.
+ * Only what is worth drawing is drawn. A region smaller than one cell at the
+ * current zoom says nothing and cannot be aimed at, and one wider than the
+ * field is a wall of lines; the nearest few are enough, since past that the
+ * cages overlap into a haze and the frame pays for it.
  */
 
 import { useMemo } from 'react'
@@ -99,7 +100,10 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
     for (const key of Object.values(keys)) {
       if (key.plane !== anchorPlane) continue
       const widest = sideOf(key.height)
-      if (widest > GRID_RADIUS * 6 || widest < 0.05) continue
+      // Smaller than the cell you are looking at: there is nothing to see and
+      // nothing to aim at, so it waits until you zoom back in. Measured on the
+      // longest side, so a bar stays while it still reaches across a cell.
+      if (widest > GRID_RADIUS * 6 || widest < 1) continue
       const centre: [number, number, number] = [0, 0, 0]
       const corner: [number, number, number] = [0, 0, 0]
       const sides: [number, number, number] = [1, 1, 1]

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -112,20 +112,24 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
       out.push({ key, centre, corner, sides })
     }
     /*
-     * Only the outermost regions.
+     * Only the innermost regions.
      *
      * Each hop's region contains both ends of that hop, so a walk away from
-     * where you started leaves a set of nested blocks, each swallowing the one
-     * before. Drawing them all put three or four shells around every step and
-     * said nothing the largest did not already say. A region contained in
-     * another held region is dropped, and the one that contains it is drawn.
+     * where you started leaves nested blocks, each swallowing the one before.
+     * Drawing them all put three or four shells around every step. Drawing the
+     * outermost instead threw the detail away: the widest block is the least
+     * specific thing you hold. So a region that contains another steps aside
+     * for the one inside it, and what is drawn is the finest grain you have.
+     *
+     * A region something was found in is always drawn, and so is the one you
+     * asked to look at: those are not detail, they are the point.
      */
-    // The one you asked to look at is always drawn, whatever contains it.
-    const outermost = out.filter((cage) => cage.key.lookupId === focused
-      || !out.some((other) => other !== cage && contains(other.key, cage.key)))
+    const innermost = out.filter((cage) => cage.key.lookupId === focused
+      || cage.key.source === 'scan'
+      || !out.some((other) => other !== cage && contains(cage.key, other.key)))
     // Nearest first, so the ones you are standing in are the ones you see.
-    outermost.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
-    return outermost.slice(0, DRAWN_MAX)
+    innermost.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
+    return innermost.slice(0, DRAWN_MAX)
   }, [show, keys, anchor, anchorPlane, scaleExp, axes, focused])
 
   if (cages.length === 0) return null

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -39,6 +39,22 @@ interface Props {
  * along X alone unlocks 2^7 × 2^0 × 2^0, a bar seven doublings long and one
  * gibson through, which is a different thing from a cube of side 2^7.
  */
+/** Whether `outer` covers every gibson of `inner`, on all three axes. */
+export function contains(outer: HeldKey, inner: HeldKey): boolean {
+  if (outer.lookupId === inner.lookupId || outer.plane !== inner.plane) return false
+  for (const axis of ['x', 'y', 'z'] as const) {
+    const ho = BigInt(outer.heights ? outer.heights[axis] : outer.height)
+    const hi = BigInt(inner.heights ? inner.heights[axis] : inner.height)
+    if (hi > ho) return false
+    const lo = BigInt(outer.base[axis])
+    const v = BigInt(inner.base[axis])
+    // Aligned blocks nest or miss: the inner one is inside when its base
+    // falls in the outer one and it does not run past the outer's end.
+    if (v < lo || v + (1n << hi) > lo + (1n << ho)) return false
+  }
+  return true
+}
+
 export function sizeLabel(key: HeldKey): string {
   const h = key.heights
   if (!h || (h.x === h.y && h.y === h.z)) return `2^${key.height}`
@@ -59,6 +75,7 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
   const anchorPlane = useCyberspace((s) => s.anchorPlane)
   const scaleExp = useCyberspace((s) => s.scaleExp)
   const show = useCyberspace((s) => s.showSecrets)
+  const focused = useSecrets((s) => s.focused)
 
   const geometry = useMemo(() => new EdgesGeometry(new BoxGeometry(1, 1, 1)), [])
 
@@ -94,10 +111,22 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
       if (far > GRID_RADIUS * 4) continue
       out.push({ key, centre, corner, sides })
     }
+    /*
+     * Only the outermost regions.
+     *
+     * Each hop's region contains both ends of that hop, so a walk away from
+     * where you started leaves a set of nested blocks, each swallowing the one
+     * before. Drawing them all put three or four shells around every step and
+     * said nothing the largest did not already say. A region contained in
+     * another held region is dropped, and the one that contains it is drawn.
+     */
+    // The one you asked to look at is always drawn, whatever contains it.
+    const outermost = out.filter((cage) => cage.key.lookupId === focused
+      || !out.some((other) => other !== cage && contains(other.key, cage.key)))
     // Nearest first, so the ones you are standing in are the ones you see.
-    out.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
-    return out.slice(0, DRAWN_MAX)
-  }, [show, keys, anchor, anchorPlane, scaleExp, axes])
+    outermost.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
+    return outermost.slice(0, DRAWN_MAX)
+  }, [show, keys, anchor, anchorPlane, scaleExp, axes, focused])
 
   if (cages.length === 0) return null
 
@@ -106,12 +135,13 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
       {cages.map((cage) => (
         <group key={cage.key.lookupId}>
           <lineSegments geometry={geometry} position={cage.centre} scale={cage.sides} frustumCulled={false} renderOrder={8}>
-            <lineBasicMaterial color={HELD} toneMapped={false} transparent opacity={0.4} depthTest={false} />
+            {/* The one you went to look at stands out; the rest step back. */}
+            <lineBasicMaterial color={HELD} toneMapped={false} transparent opacity={focused === null ? 0.4 : focused === cage.key.lookupId ? 0.95 : 0.12} depthTest={false} />
           </lineSegments>
           {/* The key and the region's size as one piece, hanging just under the
               corner: a cage says nothing about how big it is until it says so,
               and 2^7 × 2^0 × 2^0 is the difference between a room and a corridor. */}
-          <WorldLabel text={`⚿ ${sizeLabel(cage.key)}`} color={HELD} at={cage.corner} offset={[0, -0.5, 0]} px={14} opacity={0.9} align="left" />
+          <WorldLabel text={`⚿ ${sizeLabel(cage.key)}`} color={HELD} at={cage.corner} offset={[0, -0.5, 0]} px={18} opacity={focused === null || focused === cage.key.lookupId ? 0.9 : 0.3} align="left" />
         </group>
       ))}
     </>

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -67,6 +67,15 @@ interface Cage {
   corner: [number, number, number]
   /** Per view axis, because a movement's region is a box and not a cube. */
   sides: [number, number, number]
+  /** Whether this region holds another one you also hold. */
+  outer?: boolean
+}
+
+/** How strongly a cage is drawn: a door, the finest grain, or the context. */
+function weightOf(cage: Cage, focused: string | null): number {
+  if (focused !== null) return focused === cage.key.lookupId ? 0.95 : 0.1
+  if (cage.key.source !== 'hop') return 0.7
+  return cage.outer ? 0.18 : 0.45
 }
 
 export function SecretRegions({ axes }: Props): JSX.Element | null {
@@ -112,27 +121,23 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
       out.push({ key, centre, corner, sides })
     }
     /*
-     * Only the innermost regions.
+     * Every region is drawn; depth is carried by weight, not by hiding.
      *
-     * Each hop's region contains both ends of that hop, so a walk away from
-     * where you started leaves nested blocks, each swallowing the one before.
-     * Drawing them all put three or four shells around every step. Drawing the
-     * outermost instead threw the detail away: the widest block is the least
-     * specific thing you hold. So a region that contains another steps aside
-     * for the one inside it, and what is drawn is the finest grain you have.
-     *
-     * A region something was found in is always drawn, and so is the one you
-     * asked to look at: those are not detail, they are the point.
+     * Hiding the inner ones threw away the detail, and hiding the outer ones
+     * threw away the context: a small step inside a block you already held
+     * made that block vanish, and a wide hop that swallowed an earlier one
+     * never appeared. Both are true and both are yours, so both are drawn,
+     * and how strongly says which is which: a region with another inside it
+     * steps back, the finest grain stands forward, and a door you opened or
+     * bought is brighter than either, because it is the one that goes
+     * somewhere.
      */
-    const innermost = out.filter((cage) => cage.key.lookupId === focused
-      // A region you opened or bought stays on screen once it is there: it is
-      // a door, and a door does not stop existing because you stepped past it.
-      // Only the regions your movements granted give way to finer ones.
-      || cage.key.source !== 'hop'
-      || !out.some((other) => other !== cage && contains(cage.key, other.key)))
+    for (const cage of out) {
+      cage.outer = out.some((other) => other !== cage && contains(cage.key, other.key))
+    }
     // Nearest first, so the ones you are standing in are the ones you see.
-    innermost.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
-    return innermost.slice(0, DRAWN_MAX)
+    out.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
+    return out.slice(0, DRAWN_MAX)
   }, [show, keys, anchor, anchorPlane, scaleExp, axes, focused])
 
   if (cages.length === 0) return null
@@ -143,12 +148,12 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
         <group key={cage.key.lookupId}>
           <lineSegments geometry={geometry} position={cage.centre} scale={cage.sides} frustumCulled={false} renderOrder={8}>
             {/* The one you went to look at stands out; the rest step back. */}
-            <lineBasicMaterial color={HELD} toneMapped={false} transparent opacity={focused === null ? 0.4 : focused === cage.key.lookupId ? 0.95 : 0.12} depthTest={false} />
+            <lineBasicMaterial color={HELD} toneMapped={false} transparent opacity={weightOf(cage, focused)} depthTest={false} />
           </lineSegments>
           {/* The key and the region's size as one piece, hanging just under the
               corner: a cage says nothing about how big it is until it says so,
               and 2^7 × 2^0 × 2^0 is the difference between a room and a corridor. */}
-          <WorldLabel text={`⚿ ${sizeLabel(cage.key)}`} color={HELD} at={cage.corner} offset={[0, -0.5, 0]} px={18} opacity={focused === null || focused === cage.key.lookupId ? 0.9 : 0.3} align="left" />
+          <WorldLabel text={`⚿ ${sizeLabel(cage.key)}`} color={HELD} at={cage.corner} offset={[0, -0.5, 0]} px={18} opacity={Math.min(0.95, weightOf(cage, focused) + 0.3)} align="left" />
         </group>
       ))}
     </>

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -28,6 +28,11 @@ const HELD = '#52e39f'
 /** How many cages are drawn at once, nearest first. */
 const DRAWN_MAX = 16
 
+/** The key glyph's height in CSS pixels; the size beside it is smaller again
+ * (WorldLabel's `small`). Small on purpose: a dozen regions in view means a
+ * dozen of these, and they are a caption on the cage, not a headline. */
+const KEY_PX = 13
+
 interface Props {
   axes: ViewAxes
 }
@@ -157,7 +162,15 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
           {/* The key and the region's size as one piece, hanging just under the
               corner: a cage says nothing about how big it is until it says so,
               and 2^7 × 2^0 × 2^0 is the difference between a room and a corridor. */}
-          <WorldLabel text={`⚿ ${sizeLabel(cage.key)}`} color={HELD} at={cage.corner} offset={[0, -0.5, 0]} px={18} opacity={Math.min(0.95, weightOf(cage, focused) + 0.3)} align="left" />
+          <WorldLabel
+            text="⚿"
+            small={sizeLabel(cage.key)}
+            color={HELD}
+            at={cage.corner}
+            offset={[0, -0.5, 0]}
+            px={KEY_PX}
+            opacity={Math.min(0.95, weightOf(cage, focused) + 0.3)}
+          />
         </group>
       ))}
     </>

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -125,7 +125,10 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
      * asked to look at: those are not detail, they are the point.
      */
     const innermost = out.filter((cage) => cage.key.lookupId === focused
-      || cage.key.source === 'scan'
+      // A region you opened or bought stays on screen once it is there: it is
+      // a door, and a door does not stop existing because you stepped past it.
+      // Only the regions your movements granted give way to finer ones.
+      || cage.key.source !== 'hop'
       || !out.some((other) => other !== cage && contains(cage.key, other.key)))
     // Nearest first, so the ones you are standing in are the ones you see.
     innermost.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -35,7 +35,8 @@ interface Cage {
   key: HeldKey
   centre: [number, number, number]
   corner: [number, number, number]
-  side: number
+  /** Per view axis, because a movement's region is a box and not a cube. */
+  sides: [number, number, number]
 }
 
 export function SecretRegions({ axes }: Props): JSX.Element | null {
@@ -51,27 +52,33 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
     if (!show) return []
     const origin = alignedOrigin(anchor, scaleExp)
     const out: Cage[] = []
+    const sideOf = (height: number): number => {
+      const exp = height - scaleExp
+      return exp >= 0 ? Number(1n << BigInt(exp)) : 1 / Number(1n << BigInt(-exp))
+    }
     for (const key of Object.values(keys)) {
       if (key.plane !== anchorPlane) continue
-      const exp = key.height - scaleExp
-      const side = exp >= 0 ? Number(1n << BigInt(exp)) : 1 / Number(1n << BigInt(-exp))
-      if (side > GRID_RADIUS * 6 || side < 0.05) continue
+      const widest = sideOf(key.height)
+      if (widest > GRID_RADIUS * 6 || widest < 0.05) continue
       const centre: [number, number, number] = [0, 0, 0]
       const corner: [number, number, number] = [0, 0, 0]
+      const sides: [number, number, number] = [1, 1, 1]
       let far = 0
       ;[axes.right, axes.up, axes.out].forEach((a, i) => {
         const axis: AxisName = a.axis
+        // A hop's region is a box: each axis is as wide as its own crossing.
+        const side = sideOf(key.heights ? key.heights[axis] : key.height)
+        sides[i] = side
         const lo = cellDelta(BigInt(key.base[axis]), origin[axis], scaleExp)
         centre[i] = (lo + (side - 1) / 2) * a.dir
-        // Always the same corner of the cube: the one at +X and +Z, at the
-        // region's floor. A key hanging at a fixed corner says which cage it
-        // belongs to, where one at the nearest corner just floats.
-        const far_ = axis === 'y' ? -0.5 : side - 0.5
-        corner[i] = (lo + far_) * a.dir
+        // Always the same corner: +X and +Z, at the region's floor. A key
+        // hanging at a fixed corner says which cage it belongs to, where one
+        // at the nearest corner just floats.
+        corner[i] = (lo + (axis === 'y' ? -0.5 : side - 0.5)) * a.dir
         far = Math.max(far, Math.abs(centre[i]))
       })
       if (far > GRID_RADIUS * 4) continue
-      out.push({ key, centre, corner, side })
+      out.push({ key, centre, corner, sides })
     }
     // Nearest first, so the ones you are standing in are the ones you see.
     out.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
@@ -84,7 +91,7 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
     <>
       {cages.map((cage) => (
         <group key={cage.key.lookupId}>
-          <lineSegments geometry={geometry} position={cage.centre} scale={cage.side} frustumCulled={false} renderOrder={8}>
+          <lineSegments geometry={geometry} position={cage.centre} scale={cage.sides} frustumCulled={false} renderOrder={8}>
             <lineBasicMaterial color={HELD} toneMapped={false} transparent opacity={0.4} depthTest={false} />
           </lineSegments>
           {/* The key at the region's low corner: a held region is an open one. */}

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -3,9 +3,11 @@
  *
  * A held region key (store/useSecrets) is a cube of side 2^height, aligned on
  * every axis, and holding it means you can ask the relay what is hidden there
- * and read the answer. This draws each one you are near as a light green cage
- * with a key at its low corner, the same green the deploy box uses for "found
- * here", so the colour means one thing throughout: this region is open to you.
+ * and read the answer. A key is held when it opened something or when it was
+ * bought, so a cage here is not "somewhere you walked": it is somewhere with
+ * something in it. This draws each one you are near as a light green cage with
+ * a key at its +X +Z corner, the same green the deploy box uses for "found
+ * here", so the colour means one thing throughout.
  *
  * Only what is worth drawing is drawn. A cube smaller than a few pixels or
  * wider than the field says nothing, and the nearest few are enough: past that
@@ -61,7 +63,11 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
         const axis: AxisName = a.axis
         const lo = cellDelta(BigInt(key.base[axis]), origin[axis], scaleExp)
         centre[i] = (lo + (side - 1) / 2) * a.dir
-        corner[i] = lo * a.dir
+        // Always the same corner of the cube: the one at +X and +Z, at the
+        // region's floor. A key hanging at a fixed corner says which cage it
+        // belongs to, where one at the nearest corner just floats.
+        const far_ = axis === 'y' ? -0.5 : side - 0.5
+        corner[i] = (lo + far_) * a.dir
         far = Math.max(far, Math.abs(centre[i]))
       })
       if (far > GRID_RADIUS * 4) continue

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -1,0 +1,90 @@
+/**
+ * SecretRegions.tsx — the regions you can open, drawn where they are.
+ *
+ * A held region key (store/useSecrets) is a cube of side 2^height, aligned on
+ * every axis, and holding it means you can ask the relay what is hidden there
+ * and read the answer. This draws each one you are near as a light green cage
+ * with a key at its low corner, the same green the deploy box uses for "found
+ * here", so the colour means one thing throughout: this region is open to you.
+ *
+ * Only what is worth drawing is drawn. A cube smaller than a few pixels or
+ * wider than the field says nothing, and the nearest few are enough: past that
+ * the cages overlap into a haze and the frame pays for it.
+ */
+
+import { useMemo } from 'react'
+import { BoxGeometry, EdgesGeometry } from 'three'
+import { GRID_RADIUS, cellDelta, type AxisName, type ViewAxes } from '../lib/space'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { useSecrets, type HeldKey } from '../store/useSecrets'
+import { WorldLabel } from './WorldLabel'
+
+/** The green of "found here", dimmer than the deploy box so it sits behind the work. */
+const HELD = '#52e39f'
+
+/** How many cages are drawn at once, nearest first. */
+const DRAWN_MAX = 16
+
+interface Props {
+  axes: ViewAxes
+}
+
+interface Cage {
+  key: HeldKey
+  centre: [number, number, number]
+  corner: [number, number, number]
+  side: number
+}
+
+export function SecretRegions({ axes }: Props): JSX.Element | null {
+  const keys = useSecrets((s) => s.keys)
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+  const show = useCyberspace((s) => s.showSecrets)
+
+  const geometry = useMemo(() => new EdgesGeometry(new BoxGeometry(1, 1, 1)), [])
+
+  const cages = useMemo(() => {
+    if (!show) return []
+    const origin = alignedOrigin(anchor, scaleExp)
+    const out: Cage[] = []
+    for (const key of Object.values(keys)) {
+      if (key.plane !== anchorPlane) continue
+      const exp = key.height - scaleExp
+      const side = exp >= 0 ? Number(1n << BigInt(exp)) : 1 / Number(1n << BigInt(-exp))
+      if (side > GRID_RADIUS * 6 || side < 0.05) continue
+      const centre: [number, number, number] = [0, 0, 0]
+      const corner: [number, number, number] = [0, 0, 0]
+      let far = 0
+      ;[axes.right, axes.up, axes.out].forEach((a, i) => {
+        const axis: AxisName = a.axis
+        const lo = cellDelta(BigInt(key.base[axis]), origin[axis], scaleExp)
+        centre[i] = (lo + (side - 1) / 2) * a.dir
+        corner[i] = lo * a.dir
+        far = Math.max(far, Math.abs(centre[i]))
+      })
+      if (far > GRID_RADIUS * 4) continue
+      out.push({ key, centre, corner, side })
+    }
+    // Nearest first, so the ones you are standing in are the ones you see.
+    out.sort((a, b) => Math.hypot(...a.centre) - Math.hypot(...b.centre))
+    return out.slice(0, DRAWN_MAX)
+  }, [show, keys, anchor, anchorPlane, scaleExp, axes])
+
+  if (cages.length === 0) return null
+
+  return (
+    <>
+      {cages.map((cage) => (
+        <group key={cage.key.lookupId}>
+          <lineSegments geometry={geometry} position={cage.centre} scale={cage.side} frustumCulled={false} renderOrder={8}>
+            <lineBasicMaterial color={HELD} toneMapped={false} transparent opacity={0.4} depthTest={false} />
+          </lineSegments>
+          {/* The key at the region's low corner: a held region is an open one. */}
+          <WorldLabel text="⚿" color={HELD} at={cage.corner} px={16} opacity={0.85} align="center" />
+        </group>
+      ))}
+    </>
+  )
+}

--- a/src/scene/SecretRegions.tsx
+++ b/src/scene/SecretRegions.tsx
@@ -31,6 +31,20 @@ interface Props {
   axes: ViewAxes
 }
 
+/**
+ * How wide the region is, in the units the protocol uses.
+ *
+ * A hiding place is a cube and reads as one number. A movement's region is a
+ * box, each axis as wide as that axis's own crossing, and reads as three: a hop
+ * along X alone unlocks 2^7 × 2^0 × 2^0, a bar seven doublings long and one
+ * gibson through, which is a different thing from a cube of side 2^7.
+ */
+export function sizeLabel(key: HeldKey): string {
+  const h = key.heights
+  if (!h || (h.x === h.y && h.y === h.z)) return `2^${key.height}`
+  return `2^${h.x}×2^${h.y}×2^${h.z}`
+}
+
 interface Cage {
   key: HeldKey
   centre: [number, number, number]
@@ -94,8 +108,10 @@ export function SecretRegions({ axes }: Props): JSX.Element | null {
           <lineSegments geometry={geometry} position={cage.centre} scale={cage.sides} frustumCulled={false} renderOrder={8}>
             <lineBasicMaterial color={HELD} toneMapped={false} transparent opacity={0.4} depthTest={false} />
           </lineSegments>
-          {/* The key at the region's low corner: a held region is an open one. */}
-          <WorldLabel text="⚿" color={HELD} at={cage.corner} px={16} opacity={0.85} align="center" />
+          {/* The key and the region's size as one piece, hanging just under the
+              corner: a cage says nothing about how big it is until it says so,
+              and 2^7 × 2^0 × 2^0 is the difference between a room and a corridor. */}
+          <WorldLabel text={`⚿ ${sizeLabel(cage.key)}`} color={HELD} at={cage.corner} offset={[0, -0.5, 0]} px={14} opacity={0.9} align="left" />
         </group>
       ))}
     </>

--- a/src/scene/WorldLabel.tsx
+++ b/src/scene/WorldLabel.tsx
@@ -45,7 +45,7 @@ interface Props {
 
 export function WorldLabel({
   text, color, at, follow, offset = [0, 0, 0], px = 14, opacity = 1, align = 'left',
-  small, smallScale = 0.72,
+  small, smallScale = 0.68,
 }: Props): JSX.Element {
   const group = useRef<Group>(null)
   const scratch = useMemo(() => new Vector3(), [])

--- a/src/scene/WorldLabel.tsx
+++ b/src/scene/WorldLabel.tsx
@@ -32,10 +32,20 @@ interface Props {
   opacity?: number
   /** Left for labels that hang off a point, centre for labels that cap a face. */
   align?: 'left' | 'center'
+  /**
+   * A second string set beside the first at a smaller size, as one piece: a
+   * glyph and its reading, where the glyph carries and the reading explains.
+   * The pair straddles the anchor, so neither has to be measured to place the
+   * other, and both scale together because they share the group.
+   */
+  small?: string
+  /** How big the second string is, as a fraction of the first. */
+  smallScale?: number
 }
 
 export function WorldLabel({
   text, color, at, follow, offset = [0, 0, 0], px = 14, opacity = 1, align = 'left',
+  small, smallScale = 0.72,
 }: Props): JSX.Element {
   const group = useRef<Group>(null)
   const scratch = useMemo(() => new Vector3(), [])
@@ -62,16 +72,32 @@ export function WorldLabel({
         <Text
           font={WORLD_FONT}
           fontSize={1}
-          anchorX={align}
+          anchorX={small === undefined ? align : 'right'}
           anchorY="middle"
           color={color}
           textAlign={align}
           fillOpacity={opacity}
           outlineWidth={0.06}
           outlineColor="#05070d"
+          position={small === undefined ? undefined : [-0.14, 0, 0]}
         >
           {text}
         </Text>
+        {small !== undefined && (
+          <Text
+            font={WORLD_FONT}
+            fontSize={smallScale}
+            anchorX="left"
+            anchorY="middle"
+            color={color}
+            fillOpacity={opacity}
+            outlineWidth={0.06}
+            outlineColor="#05070d"
+            position={[0.14, 0, 0]}
+          >
+            {small}
+          </Text>
+        )}
       </Billboard>
     </group>
   )

--- a/src/scene/WorldMessages.tsx
+++ b/src/scene/WorldMessages.tsx
@@ -19,7 +19,7 @@ import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
 import { WorldLabel } from './WorldLabel'
-import { findCashuToken } from '../lib/cashu'
+import { findCashuToken, textWithoutToken } from '../lib/cashu'
 
 const TAP_SLOP = 8
 
@@ -122,7 +122,13 @@ export function WorldMessages({ axes }: Props): JSX.Element | null {
           <group key={w.key}>
             <WorldMark kind={coin ? 'coin' : 'note'} at={w.centre} />
             {coin
-              ? <WorldLabel text="₿" color={BITCOIN} at={w.centre} align="center" px={26} />
+              ? <>
+                  <WorldLabel text="₿" color={BITCOIN} at={w.centre} align="center" px={26} />
+                  {/* Words left around the token are the message; the base64 is not. */}
+                  {textWithoutToken(w.text) && (
+                    <WorldLabel text={messageBillboard(textWithoutToken(w.text))} color={NOTE} at={[w.centre[0], w.centre[1] - 0.55, w.centre[2]]} align="center" px={12} />
+                  )}
+                </>
               : births[w.key] !== undefined
                 ? <DecodingLabel text={messageBillboard(w.text)} seed={seedOf(w.key)} birth={births[w.key]} at={w.centre} />
                 : <WorldLabel text={messageBillboard(w.text)} color={NOTE} at={w.centre} align="center" px={13} />}

--- a/src/scene/WorldMessages.tsx
+++ b/src/scene/WorldMessages.tsx
@@ -7,23 +7,31 @@
  * shrinking to nothing. Culled past the same reach as everything else.
  */
 
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { markSceneTapHandled } from '../hooks/useCanvasTap'
 import { nip19 } from 'nostr-tools'
 import { ACCENT } from '../lib/palette'
 import { useFrame, type ThreeEvent } from '@react-three/fiber'
+import { BoxGeometry, EdgesGeometry, OctahedronGeometry, type Group, type PerspectiveCamera } from 'three'
 import { decodeText, seedOf, TEXT_DECODE_MS } from '../lib/decode'
 import { useCeremony } from '../store/useCeremony'
 import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
 import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
 import { useShards } from '../store/useShards'
 import { WorldLabel } from './WorldLabel'
+import { findCashuToken } from '../lib/cashu'
 
 const TAP_SLOP = 8
 
 const REACH = GRID_RADIUS * 8
 /** The message color: a warm note against the cool field. */
 const NOTE = '#ffd27d'
+/** Bitcoin's own orange, for a coin left in cyberspace. */
+const BITCOIN = '#f7931a'
+/** The note's own blue, for the cube a message hangs on. */
+const NOTE_BLUE = '#4aa3ff'
+/** How wide the mark behind an item stands, in CSS pixels. */
+const MARK_PX = 34
 
 interface Props {
   axes: ViewAxes
@@ -39,16 +47,42 @@ function shortAuthor(pubkey: string, mine: boolean): string {
   }
 }
 
-/** Wrap a long message onto a few lines so the billboard is not one long strip. */
+/** How much of a long message is shown in the world before the tap. */
+const PREVIEW_CHARS = 160
+
+/**
+ * Wrap a message onto a few lines so the billboard is not one long strip.
+ *
+ * Breaking on spaces alone was not enough: a Cashu token is a single word two
+ * thousand characters long, so it never broke, and the note became a band of
+ * text across the whole screen. A run longer than the line is cut to fit, and
+ * the whole thing is truncated: the whole message is one tap away.
+ */
 function wrap(text: string, width = 28): string {
-  const words = text.split(/\s+/)
   const lines: string[] = []
   let line = ''
-  for (const w of words) {
-    if ((line + ' ' + w).trim().length > width) { if (line) lines.push(line); line = w } else line = (line + ' ' + w).trim()
+  const push = (): void => { if (line) { lines.push(line); line = '' } }
+  for (const word of text.trim().split(/\s+/)) {
+    let rest = word
+    // A word longer than the line is broken at the line, not left to run on.
+    while (rest.length > width) {
+      push()
+      lines.push(rest.slice(0, width))
+      rest = rest.slice(width)
+    }
+    if (!rest) continue
+    if ((line + ' ' + rest).trim().length > width) push()
+    line = (line + ' ' + rest).trim()
   }
-  if (line) lines.push(line)
-  return lines.slice(0, 8).join('\n')
+  push()
+  return lines.slice(0, 6).join('\n')
+}
+
+/** A message as it reads in the world: cut to PREVIEW_CHARS, then wrapped. */
+export function messageBillboard(text: string): string {
+  const trimmed = text.trim()
+  const cut = trimmed.length > PREVIEW_CHARS ? `${trimmed.slice(0, PREVIEW_CHARS)}…` : trimmed
+  return wrap(cut)
 }
 
 export function WorldMessages({ axes }: Props): JSX.Element | null {
@@ -80,11 +114,18 @@ export function WorldMessages({ axes }: Props): JSX.Element | null {
           markSceneTapHandled()
           useShards.getState().selectSecret(w.key)
         }
+        // Money reads as money: a coin hidden here shows the mark and nothing
+        // else, because its token is two thousand characters of base64 and
+        // says nothing to anybody. Everything else shows what it says, cut.
+        const coin = findCashuToken(w.text) !== null
         return (
           <group key={w.key}>
-            {births[w.key] !== undefined
-              ? <DecodingLabel text={wrap(w.text)} seed={seedOf(w.key)} birth={births[w.key]} at={w.centre} />
-              : <WorldLabel text={wrap(w.text)} color={NOTE} at={w.centre} align="center" px={13} />}
+            <WorldMark kind={coin ? 'coin' : 'note'} at={w.centre} />
+            {coin
+              ? <WorldLabel text="₿" color={BITCOIN} at={w.centre} align="center" px={26} />
+              : births[w.key] !== undefined
+                ? <DecodingLabel text={messageBillboard(w.text)} seed={seedOf(w.key)} birth={births[w.key]} at={w.centre} />
+                : <WorldLabel text={messageBillboard(w.text)} color={NOTE} at={w.centre} align="center" px={13} />}
             <WorldLabel text={`— ${shortAuthor(w.author, w.mine)}`} color={ACCENT} at={[w.centre[0], w.centre[1] - 0.9, w.centre[2]]} align="center" px={9} opacity={0.7} />
             <mesh position={w.centre} onClick={open}>
               <sphereGeometry args={[1, 8, 8]} />
@@ -117,4 +158,38 @@ function DecodingLabel({ text, seed, birth, at }: { text: string; seed: number; 
     if (t >= 1) done.current = true
   })
   return <WorldLabel text={shown} color={NOTE} at={at} align="center" px={13} />
+}
+
+
+/**
+ * The shape behind a hidden thing: a turning diamond for a coin, a still cube
+ * for a message. Outlines rather than solids, so they read as drawn light like
+ * everything else in the scene, and held to a constant size on screen so a
+ * note is the same size to the eye wherever it is.
+ */
+function WorldMark({ kind, at }: { kind: 'coin' | 'note'; at: [number, number, number] }): JSX.Element {
+  const group = useRef<Group>(null)
+  const geometry = useMemo(
+    () => new EdgesGeometry(kind === 'coin' ? new OctahedronGeometry(0.5) : new BoxGeometry(0.72, 0.72, 0.72)),
+    [kind],
+  )
+  useEffect(() => () => geometry.dispose(), [geometry])
+
+  useFrame((state) => {
+    const g = group.current
+    if (!g) return
+    const cam = state.camera as PerspectiveCamera
+    const perPixel = 2 * Math.tan((cam.fov * Math.PI) / 360) / state.size.height
+    g.scale.setScalar(Math.max(1e-5, cam.position.distanceTo(g.position) * perPixel * MARK_PX))
+    // The coin turns; a note stays where it was left.
+    if (kind === 'coin') g.rotation.y = state.clock.elapsedTime * 0.6
+  })
+
+  return (
+    <group ref={group} position={at}>
+      <lineSegments geometry={geometry} frustumCulled={false}>
+        <lineBasicMaterial color={kind === 'coin' ? BITCOIN : NOTE_BLUE} toneMapped={false} transparent opacity={kind === 'coin' ? 0.9 : 0.55} depthWrite={false} />
+      </lineSegments>
+    </group>
+  )
 }

--- a/src/scene/WorldMessages.tsx
+++ b/src/scene/WorldMessages.tsx
@@ -30,8 +30,11 @@ const NOTE = '#ffd27d'
 const BITCOIN = '#f7931a'
 /** The note's own blue, for the cube a message hangs on. */
 const NOTE_BLUE = '#4aa3ff'
-/** How wide the mark behind an item stands, in CSS pixels. */
-const MARK_PX = 34
+/** How wide the mark behind an item stands, in CSS pixels. The coin is larger
+ * than the note: it is a whole object in itself, where the cube is a backing. */
+const MARK_PX = { coin: 51, note: 34 } as const
+/** The coin's own mark, in CSS pixels. */
+const COIN_PX = 39
 
 interface Props {
   axes: ViewAxes
@@ -123,10 +126,10 @@ export function WorldMessages({ axes }: Props): JSX.Element | null {
             <WorldMark kind={coin ? 'coin' : 'note'} at={w.centre} />
             {coin
               ? <>
-                  <WorldLabel text="₿" color={BITCOIN} at={w.centre} align="center" px={26} />
+                  <WorldLabel text="₿" color={BITCOIN} at={w.centre} align="center" px={COIN_PX} />
                   {/* Words left around the token are the message; the base64 is not. */}
                   {textWithoutToken(w.text) && (
-                    <WorldLabel text={messageBillboard(textWithoutToken(w.text))} color={NOTE} at={[w.centre[0], w.centre[1] - 0.55, w.centre[2]]} align="center" px={12} />
+                    <WorldLabel text={messageBillboard(textWithoutToken(w.text))} color={NOTE} at={[w.centre[0], w.centre[1] - 0.75, w.centre[2]]} align="center" px={12} />
                   )}
                 </>
               : births[w.key] !== undefined
@@ -186,7 +189,7 @@ function WorldMark({ kind, at }: { kind: 'coin' | 'note'; at: [number, number, n
     if (!g) return
     const cam = state.camera as PerspectiveCamera
     const perPixel = 2 * Math.tan((cam.fov * Math.PI) / 360) / state.size.height
-    g.scale.setScalar(Math.max(1e-5, cam.position.distanceTo(g.position) * perPixel * MARK_PX))
+    g.scale.setScalar(Math.max(1e-5, cam.position.distanceTo(g.position) * perPixel * MARK_PX[kind]))
     // The coin turns; a note stays where it was left.
     if (kind === 'coin') g.rotation.y = state.clock.elapsedTime * 0.6
   })

--- a/src/scene/secretRegions.test.ts
+++ b/src/scene/secretRegions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { contains, sizeLabel } from './SecretRegions'
+import type { HeldKey } from '../store/useSecrets'
+
+const key = (over: Partial<HeldKey>): HeldKey => ({
+  lookupId: Math.random().toString(36), keyHex: 'aa', height: 4,
+  base: { x: '0', y: '0', z: '0' }, plane: 0, source: 'hop', at: 1, ...over,
+})
+
+describe('nesting', () => {
+  it('a block inside a bigger one at the same corner is contained', () => {
+    expect(contains(key({ height: 8 }), key({ height: 4 }))).toBe(true)
+  })
+
+  it('a block is not inside itself', () => {
+    const k = key({ height: 8 })
+    expect(contains(k, k)).toBe(false)
+  })
+
+  it('a bigger block is not inside a smaller one', () => {
+    expect(contains(key({ height: 4 }), key({ height: 8 }))).toBe(false)
+  })
+
+  it('a block elsewhere is not contained, however small', () => {
+    expect(contains(key({ height: 8 }), key({ height: 2, base: { x: '4096', y: '0', z: '0' } }))).toBe(false)
+  })
+
+  it('a bar inside a cube is contained', () => {
+    const cube = key({ height: 8, heights: { x: 8, y: 8, z: 8 } })
+    const bar = key({ height: 5, heights: { x: 5, y: 0, z: 0 } })
+    expect(contains(cube, bar)).toBe(true)
+  })
+
+  it('a bar poking out of a cube on one axis is not', () => {
+    const cube = key({ height: 4, heights: { x: 4, y: 4, z: 4 } })
+    const bar = key({ height: 9, heights: { x: 9, y: 0, z: 0 } })
+    expect(contains(cube, bar)).toBe(false)
+  })
+
+  it('the other plane is another world', () => {
+    expect(contains(key({ height: 8 }), key({ height: 4, plane: 1 }))).toBe(false)
+  })
+})
+
+describe('the size label', () => {
+  it('says one number for a cube', () => {
+    expect(sizeLabel(key({ height: 12 }))).toBe('2^12')
+    expect(sizeLabel(key({ height: 12, heights: { x: 12, y: 12, z: 12 } }))).toBe('2^12')
+  })
+
+  it('says three for a box, because a box is three sizes', () => {
+    expect(sizeLabel(key({ height: 7, heights: { x: 7, y: 0, z: 0 } }))).toBe('2^7×2^0×2^0')
+  })
+})

--- a/src/scene/worldMessages.test.ts
+++ b/src/scene/worldMessages.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { messageBillboard } from './WorldMessages'
+
+/** A Cashu token as it really arrives: one word, thousands of characters. */
+const token = `cashuBo2FteCJodHRwczovL21pbnQubWluaWJpdHMuY2FzaCIsInVuaXQiOiJzYXQiLCJwcm9v${'A'.repeat(1800)}`
+
+describe('a message on the billboard', () => {
+  it('breaks a word longer than the line instead of running off the screen', () => {
+    const out = messageBillboard(token)
+    const lines = out.split('\n')
+    expect(lines.length).toBeGreaterThan(1)
+    for (const line of lines) expect(line.length).toBeLessThanOrEqual(28)
+  })
+
+  it('is cut short: the whole message is one tap away', () => {
+    const out = messageBillboard(token)
+    expect(out.replace(/\n/g, '').length).toBeLessThan(200)
+    expect(out.endsWith('…')).toBe(true)
+  })
+
+  it('leaves a short message alone', () => {
+    expect(messageBillboard('a note')).toBe('a note')
+  })
+
+  it('still wraps ordinary prose on its spaces', () => {
+    const prose = 'the sky above the port was the color of television tuned to a dead channel'
+    const lines = messageBillboard(prose).split('\n')
+    expect(lines.length).toBeGreaterThan(1)
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(28)
+      // Words are kept whole when they fit.
+      expect(line.startsWith(' ')).toBe(false)
+    }
+    expect(messageBillboard(prose).replace(/\n/g, ' ')).toContain('television')
+  })
+
+  it('never grows past six lines', () => {
+    expect(messageBillboard('word '.repeat(300)).split('\n').length).toBeLessThanOrEqual(6)
+  })
+
+  it('handles an empty message without throwing', () => {
+    expect(messageBillboard('   ')).toBe('')
+  })
+})

--- a/src/store/secrets.test.ts
+++ b/src/store/secrets.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+import { findLcaHeight } from 'cyberspace-core'
+import { SECRETS_MAX, bytesOf, heldList, keyStateForAction, useSecrets, type HeldKey } from './useSecrets'
+
+const key = (over: Partial<HeldKey> = {}): HeldKey => ({
+  lookupId: 'aa'.repeat(32),
+  keyHex: 'bb'.repeat(32),
+  height: 8,
+  base: { x: '256', y: '512', z: '768' },
+  plane: 0,
+  source: 'scan',
+  at: 1_800_000_000,
+  ...over,
+})
+
+describe('the keys you hold', () => {
+  beforeEach(() => { useSecrets.setState({ keys: {} }); localStorage.clear() })
+
+  it('holds a region once, however often you stand in it', () => {
+    useSecrets.getState().hold([key()])
+    useSecrets.getState().hold([key({ at: 1_800_000_999 })])
+    expect(Object.keys(useSecrets.getState().keys)).toHaveLength(1)
+    // The first holding is kept: when you found it is when you found it.
+    expect(useSecrets.getState().keys['aa'.repeat(32)].at).toBe(1_800_000_000)
+  })
+
+  it('survives a reload', () => {
+    useSecrets.getState().hold([key()])
+    useSecrets.setState({ keys: {} })
+    useSecrets.getState().load()
+    expect(Object.keys(useSecrets.getState().keys)).toHaveLength(1)
+  })
+
+  it('forgetting one leaves the rest', () => {
+    useSecrets.getState().hold([key(), key({ lookupId: 'cc'.repeat(32), height: 9 })])
+    useSecrets.getState().forget('aa'.repeat(32))
+    expect(Object.keys(useSecrets.getState().keys)).toEqual(['cc'.repeat(32)])
+  })
+
+  it('keeps the newest when there are too many', () => {
+    const many = Array.from({ length: SECRETS_MAX + 20 }, (_, i) =>
+      key({ lookupId: i.toString(16).padStart(64, '0'), at: 1_800_000_000 + i }))
+    useSecrets.getState().hold(many)
+    const held = heldList(useSecrets.getState().keys)
+    expect(held).toHaveLength(SECRETS_MAX)
+    expect(held[0].at).toBe(1_800_000_000 + SECRETS_MAX + 19)
+  })
+
+  it('is small on disk', () => {
+    expect(bytesOf(key())).toBeLessThan(400)
+  })
+})
+
+describe('what an action left behind', () => {
+  const at = (x: bigint): { x: bigint; y: bigint; z: bigint } => ({ x, y: 1n << 40n, z: 1n << 40n })
+  const prev = { position: at(1n << 40n) }
+  const hop = { type: 'hop', position: at((1n << 40n) ^ (1n << 9n)), plane: 0 as const }
+
+  it('a sidestep yields no key, which is the point of a sidestep', () => {
+    const side = { type: 'sidestep', position: hop.position, plane: 0 as const }
+    expect(keyStateForAction(side, prev, {}, findLcaHeight).state).toBe('none')
+  })
+
+  it('a spawn comes from nowhere and crosses nothing', () => {
+    expect(keyStateForAction({ type: 'spawn', position: at(1n << 40n), plane: 0 }, null, {}, findLcaHeight).state).toBe('none')
+  })
+
+  it('a hop yields one, and says when it is no longer held', () => {
+    const got = keyStateForAction(hop, prev, {}, findLcaHeight)
+    expect(got.state).toBe('gone')
+    expect(got.height).toBe(10)
+  })
+
+  it('a hop whose region is in the list reads as held', () => {
+    const h = 10n
+    const held = key({
+      lookupId: 'dd'.repeat(32),
+      height: 10,
+      base: {
+        x: String((hop.position.x >> h) << h),
+        y: String((hop.position.y >> h) << h),
+        z: String((hop.position.z >> h) << h),
+      },
+    })
+    const got = keyStateForAction(hop, prev, { [held.lookupId]: held }, findLcaHeight)
+    expect(got.state).toBe('held')
+  })
+
+  it('a key for the same region in the other plane is not this one', () => {
+    const h = 10n
+    const held = key({
+      lookupId: 'ee'.repeat(32),
+      height: 10,
+      plane: 1,
+      base: {
+        x: String((hop.position.x >> h) << h),
+        y: String((hop.position.y >> h) << h),
+        z: String((hop.position.z >> h) << h),
+      },
+    })
+    expect(keyStateForAction(hop, prev, { [held.lookupId]: held }, findLcaHeight).state).toBe('gone')
+  })
+})

--- a/src/store/secrets.test.ts
+++ b/src/store/secrets.test.ts
@@ -11,7 +11,7 @@ if (typeof localStorage === 'undefined') {
 }
 
 import { findLcaHeight } from 'cyberspace-core'
-import { SECRETS_MAX, bytesOf, heldList, keyStateForAction, useSecrets, type HeldKey } from './useSecrets'
+import { SECRETS_MAX, bytesOf, heldList, keyStateForAction, useSecrets, type HeldKey, volumeExponent } from './useSecrets'
 
 const key = (over: Partial<HeldKey> = {}): HeldKey => ({
   lookupId: 'aa'.repeat(32),
@@ -110,5 +110,38 @@ describe('what an action left behind', () => {
       },
     })
     expect(keyStateForAction(hop, prev, { [held.lookupId]: held }, findLcaHeight).state).toBe('gone')
+  })
+})
+
+describe('the order of the list', () => {
+  const at = (id: string, when: number, heights: { x: number; y: number; z: number }): HeldKey =>
+    key({ lookupId: id.repeat(32), at: when, height: Math.max(heights.x, heights.y, heights.z), heights })
+
+  const keys = {
+    ['aa'.repeat(32)]: at('aa', 300, { x: 4, y: 4, z: 4 }),   // volume 2^12, newest
+    ['bb'.repeat(32)]: at('bb', 200, { x: 20, y: 0, z: 0 }),  // volume 2^20, a long bar
+    ['cc'.repeat(32)]: at('cc', 100, { x: 8, y: 8, z: 8 }),   // volume 2^24, oldest and biggest
+  }
+
+  it('by most recent puts the newest first', () => {
+    expect(heldList(keys, 'recent').map((k) => k.at)).toEqual([300, 200, 100])
+  })
+
+  it('by volume puts the largest first, whatever its shape', () => {
+    expect(heldList(keys, 'volume').map((k) => volumeExponent(k))).toEqual([24, 20, 12])
+  })
+
+  it('measures a box by its whole volume, not its longest side', () => {
+    // A bar 2^20 long is a bigger region than a cube of side 2^6 (2^18).
+    expect(volumeExponent(at('dd', 1, { x: 20, y: 0, z: 0 }))).toBe(20)
+    expect(volumeExponent(at('ee', 1, { x: 6, y: 6, z: 6 }))).toBe(18)
+  })
+
+  it('a cube with no per-axis heights is still cubed', () => {
+    expect(volumeExponent(key({ height: 5 }))).toBe(15)
+  })
+
+  it('defaults to most recent', () => {
+    expect(heldList(keys).map((k) => k.at)).toEqual([300, 200, 100])
   })
 })

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -923,7 +923,7 @@ let hosaka: { url: string; client: HosakaClient } | null = null
 let limitsInFlight: { url: string; promise: Promise<HosakaLimits | null> } | null = null
 
 /** One client per API URL. It signs through `signEvent`, so it follows identity switches. */
-function cloudClient(apiUrl: string): HosakaClient {
+export function cloudClient(apiUrl: string): HosakaClient {
   if (!hosaka || hosaka.url !== apiUrl) hosaka = { url: apiUrl, client: createHosaka({ apiUrl, sign: signEvent }) }
   return hosaka.client
 }

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -1842,6 +1842,22 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
     saveChain(nextEvents, nextPublished, stats)
 
+    // What the hop unlocked: the region it crossed, held with the action that
+    // bought it, so the chain can say which hops left a key behind.
+    if (msg.type === 'done' && msg.mode === 'hop' && msg.region) {
+      useSecrets.getState().hold([{
+        lookupId: msg.region.lookupId,
+        keyHex: msg.region.keyHex,
+        height: Math.max(...msg.region.heights),
+        heights: { x: msg.region.heights[0], y: msg.region.heights[1], z: msg.region.heights[2] },
+        base: { x: msg.region.base[0], y: msg.region.base[1], z: msg.region.base[2] },
+        plane,
+        source: 'hop',
+        eventId: event.id,
+        at: Math.floor(Date.now() / 1000),
+      }])
+    }
+
     // A route continues from where this step landed, or ends here.
     const { plan } = get()
     if (plan && plan.status === 'running') {

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -123,6 +123,7 @@ import {
 import { nextStep, planSummary, type Ceilings, type PlanStep, type PlanSummary } from '../lib/movePlan'
 import { computeEnterProof } from '../lib/hyperspace/enter'
 import { targetColor, type CyberTarget } from '../lib/targets'
+import { useSecrets } from './useSecrets'
 import { useToast } from './useToast'
 
 /**
@@ -429,6 +430,9 @@ export interface CyberspaceState {
   /** Whether COMMIT runs one step of the route or all of them in order. */
   moveMode: MoveMode
   setMoveMode: (mode: MoveMode) => void
+  /** Whether the regions you hold keys to are drawn in the scene. */
+  showSecrets: boolean
+  setShowSecrets: (show: boolean) => void
   cancel: () => void
   /** Continue a paused route: ask for the pending signature again, or restart the step. */
   resumePlan: () => void
@@ -597,6 +601,11 @@ function chainKeyFor(pubkey: string): string {
 }
 const LIVE_KEY = 'onosendai:live'
 const MOVE_MODE_KEY = 'onosendai:moveMode'
+const SHOW_SECRETS_KEY = 'onosendai:showSecrets'
+
+function loadShowSecrets(): boolean {
+  try { return localStorage.getItem(SHOW_SECRETS_KEY) !== '0' } catch { return true }
+}
 
 /** One action per commit, or the whole route in order. */
 export type MoveMode = 'single' | 'auto'
@@ -1305,6 +1314,21 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         jobId: final.jobId,
         at: Math.floor(Date.now() / 1000),
       })
+      // And into the Secrets list, where every region you can open is listed
+      // together, whoever computed it.
+      useSecrets.getState().hold([{
+        lookupId: msg.lookupId,
+        keyHex: r.region_n.secret_key,
+        height: r.max_height,
+        base: {
+          x: String((move.to.x >> BigInt(r.max_height)) << BigInt(r.max_height)),
+          y: String((move.to.y >> BigInt(r.max_height)) << BigInt(r.max_height)),
+          z: String((move.to.z >> BigInt(r.max_height)) << BigInt(r.max_height)),
+        },
+        plane: move.plane,
+        source: 'cloud',
+        at: Math.floor(Date.now() / 1000),
+      }])
     }
     const before = get().events.length
     await get().finishProof(msg)
@@ -1577,6 +1601,12 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     })
     if (funded) startPlanStep()
     else await quoteRoute(++requestId)
+  },
+
+  setShowSecrets: (show) => {
+    if (show === get().showSecrets) return
+    try { localStorage.setItem(SHOW_SECRETS_KEY, show ? '1' : '0') } catch { /* private mode */ }
+    set({ showSecrets: show })
   },
 
   setMoveMode: (mode) => {
@@ -2193,6 +2223,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   cloud: IDLE_CLOUD,
   cloudPrefs: loadCloudPrefs(),
   moveMode: loadMoveMode(),
+  showSecrets: loadShowSecrets(),
 
   approveCloud: () => {
     const { cloud } = get()

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -1993,6 +1993,13 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   },
 
   clearFocus: () => {
+    // A view that came from the Secrets list goes back to it: RETURN is how
+    // you leave the region, and the list is where you were when you asked.
+    const secrets = useSecrets.getState()
+    if (secrets.focused !== null) {
+      secrets.focus(null)
+      secrets.setOpen(true)
+    }
     // Home is your position in the plane you have lined up, which is what
     // the scene showed before the focus began.
     const { position, plane, focusReturnScale, scaleExp, focus } = get()

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -1993,13 +1993,6 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   },
 
   clearFocus: () => {
-    // A view that came from the Secrets list goes back to it: RETURN is how
-    // you leave the region, and the list is where you were when you asked.
-    const secrets = useSecrets.getState()
-    if (secrets.focused !== null) {
-      secrets.focus(null)
-      secrets.setOpen(true)
-    }
     // Home is your position in the plane you have lined up, which is what
     // the scene showed before the focus began.
     const { position, plane, focusReturnScale, scaleExp, focus } = get()

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -73,6 +73,9 @@ interface SecretsState {
   /** Whether the list is on screen. In the store, so RETURN can bring it back. */
   open: boolean
   setOpen: (open: boolean) => void
+  /** How the list is ordered; kept while the modal is closed. */
+  sort: SecretsSort
+  setSort: (sort: SecretsSort) => void
   /** Why the last purchase did not happen. */
   buyError: string | null
   /** Note a key you now hold; keeps the one already held rather than replacing it. */
@@ -99,9 +102,25 @@ export function bytesOf(k: HeldKey): number {
   return JSON.stringify(k).length
 }
 
-/** The regions held, newest first. */
-export function heldList(keys: Record<string, HeldKey>): HeldKey[] {
-  return Object.values(keys).sort((a, b) => b.at - a.at || b.height - a.height)
+/** How the list is ordered. */
+export type SecretsSort = 'recent' | 'volume'
+
+/**
+ * How much space a region covers, as the exponent of its volume in gibsons
+ * cubed: a cube of side 2^8 is 2^24, and a bar of 2^8 x 2^0 x 2^0 is 2^8.
+ * Kept as the exponent because the volumes themselves run past what a number
+ * can hold, and the order is all that is being asked for.
+ */
+export function volumeExponent(k: HeldKey): number {
+  return k.heights ? k.heights.x + k.heights.y + k.heights.z : k.height * 3
+}
+
+/** The regions held, newest first or largest first. */
+export function heldList(keys: Record<string, HeldKey>, sort: SecretsSort = 'recent'): HeldKey[] {
+  const list = Object.values(keys)
+  return sort === 'volume'
+    ? list.sort((a, b) => volumeExponent(b) - volumeExponent(a) || b.at - a.at)
+    : list.sort((a, b) => b.at - a.at || volumeExponent(b) - volumeExponent(a))
 }
 
 export const useSecrets = create<SecretsState>((set, get) => ({
@@ -110,6 +129,7 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   buyError: null,
   focused: null,
   open: false,
+  sort: 'recent',
 
   hold: (incoming) => {
     if (incoming.length === 0) return
@@ -142,6 +162,8 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   focus: (lookupId) => set({ focused: lookupId }),
 
   setOpen: (open) => set({ open }),
+
+  setSort: (sort) => set({ sort }),
 
   buy: async (at, plane, height) => {
     if (get().buying) return false
@@ -208,7 +230,7 @@ export const useSecrets = create<SecretsState>((set, get) => ({
 }))
 
 function trim(keys: Record<string, HeldKey>): Record<string, HeldKey> {
-  const list = heldList(keys)
+  const list = heldList(keys, 'recent')
   if (list.length <= SECRETS_MAX) return keys
   const out: Record<string, HeldKey> = {}
   for (const k of list.slice(0, SECRETS_MAX)) out[k.lookupId] = k

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -67,6 +67,9 @@ interface SecretsState {
   keys: Record<string, HeldKey>
   /** The purchase in flight, or null. */
   buying: Buying | null
+  /** The region the list last sent you to look at: drawn bright, the rest dimmed. */
+  focused: string | null
+  focus: (lookupId: string | null) => void
   /** Why the last purchase did not happen. */
   buyError: string | null
   /** Note a key you now hold; keeps the one already held rather than replacing it. */
@@ -102,6 +105,7 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   keys: {},
   buying: null,
   buyError: null,
+  focused: null,
 
   hold: (incoming) => {
     if (incoming.length === 0) return
@@ -130,6 +134,8 @@ export const useSecrets = create<SecretsState>((set, get) => ({
     set({ keys: {} })
     save({})
   },
+
+  focus: (lookupId) => set({ focused: lookupId }),
 
   buy: async (at, plane, height) => {
     if (get().buying) return false

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -1,0 +1,167 @@
+/**
+ * useSecrets.ts — the regions you can open.
+ *
+ * A region key is not a password you are given, it is a number you computed:
+ * the Cantor root of an aligned region, hashed once for the key and twice for
+ * the lookup id it is published under (spec §7.2). Holding it means two
+ * things at once, and only for that exact region: you can ask the relay what
+ * is hidden there, and you can read what comes back.
+ *
+ * Keys are not hierarchical. A key for a region a mile wide tells you nothing
+ * about the block inside it: the child has its own root, and sha256 leaves no
+ * ladder between them. So this is a list, not a tree, and standing somewhere
+ * new adds the nested cubes you now stand in rather than refining an old key.
+ *
+ * What is kept is small: the key is 32 bytes and the rest is where and when.
+ * The regions themselves are never stored, only the numbers that open them.
+ */
+
+import { create } from 'zustand'
+import type { Plane } from 'cyberspace-core'
+
+/** How many keys are kept before the oldest are dropped. */
+export const SECRETS_MAX = 400
+
+const KEY = 'onosendai:secrets'
+
+export interface HeldKey {
+  /** What the relay knows the region as: sha256 of the key. */
+  lookupId: string
+  /** The key itself, 32 bytes as hex. */
+  keyHex: string
+  /** A cube of side 2^height, aligned on every axis. */
+  height: number
+  /** The region's aligned corner, as decimal strings. */
+  base: { x: string; y: string; z: string }
+  plane: Plane
+  /** How it was come by: your own scanning, or a hop HOSAKA computed for you. */
+  source: 'scan' | 'cloud'
+  /** The action that bought it, for the chain overlay's key marker. */
+  eventId?: string
+  /** First held, in seconds since the epoch. */
+  at: number
+}
+
+interface SecretsState {
+  keys: Record<string, HeldKey>
+  /** Note a key you now hold; keeps the one already held rather than replacing it. */
+  hold: (keys: HeldKey[]) => void
+  /** Forget one region. The key is gone; standing there again recomputes it. */
+  forget: (lookupId: string) => void
+  /** Forget every region. */
+  forgetAll: () => void
+  load: () => void
+}
+
+/** Roughly what one entry costs in local storage. */
+export function bytesOf(k: HeldKey): number {
+  return JSON.stringify(k).length
+}
+
+/** The regions held, newest first. */
+export function heldList(keys: Record<string, HeldKey>): HeldKey[] {
+  return Object.values(keys).sort((a, b) => b.at - a.at || b.height - a.height)
+}
+
+export const useSecrets = create<SecretsState>((set, get) => ({
+  keys: {},
+
+  hold: (incoming) => {
+    if (incoming.length === 0) return
+    const keys = { ...get().keys }
+    let changed = false
+    for (const k of incoming) {
+      if (keys[k.lookupId]) continue
+      keys[k.lookupId] = k
+      changed = true
+    }
+    if (!changed) return
+    const trimmed = trim(keys)
+    set({ keys: trimmed })
+    save(trimmed)
+  },
+
+  forget: (lookupId) => {
+    if (!get().keys[lookupId]) return
+    const keys = { ...get().keys }
+    delete keys[lookupId]
+    set({ keys })
+    save(keys)
+  },
+
+  forgetAll: () => {
+    set({ keys: {} })
+    save({})
+  },
+
+  load: () => {
+    try {
+      const raw = localStorage.getItem(KEY)
+      if (!raw) return
+      const parsed = JSON.parse(raw) as unknown
+      if (!parsed || typeof parsed !== 'object') return
+      const keys: Record<string, HeldKey> = {}
+      for (const [id, v] of Object.entries(parsed as Record<string, HeldKey>)) {
+        if (v && typeof v.keyHex === 'string' && typeof v.height === 'number' && v.base) keys[id] = v
+      }
+      set({ keys })
+    } catch { /* nothing kept */ }
+  },
+}))
+
+function trim(keys: Record<string, HeldKey>): Record<string, HeldKey> {
+  const list = heldList(keys)
+  if (list.length <= SECRETS_MAX) return keys
+  const out: Record<string, HeldKey> = {}
+  for (const k of list.slice(0, SECRETS_MAX)) out[k.lookupId] = k
+  return out
+}
+
+function save(keys: Record<string, HeldKey>): void {
+  try { localStorage.setItem(KEY, JSON.stringify(keys)) } catch { /* private mode */ }
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __secrets?: unknown }).__secrets = useSecrets
+}
+
+/** Whether a chain action left you a region key, and whether you still hold it. */
+export type KeyState = 'none' | 'held' | 'gone'
+
+/**
+ * What an action yielded.
+ *
+ * A hop computes the Cantor root of the region it crossed, which is the key to
+ * whatever is hidden there (spec §7). A sidestep computes a Merkle path across
+ * one boundary and no root at all, which is the whole difference between
+ * unlocking a wall and bypassing it. A spawn comes from nowhere and crosses
+ * nothing.
+ *
+ * `gone` means the key is not in the list any more: forgotten here, or never
+ * kept because the region is larger than this machine sweeps.
+ */
+export function keyStateForAction(
+  action: { type: string; position: { x: bigint; y: bigint; z: bigint }; plane: Plane },
+  previous: { position: { x: bigint; y: bigint; z: bigint } } | null,
+  keys: Record<string, HeldKey>,
+  lcaHeight: (a: bigint, b: bigint) => number,
+): { state: KeyState; height: number | null } {
+  if (action.type !== 'hop' || !previous) return { state: 'none', height: null }
+  const height = Math.max(
+    lcaHeight(previous.position.x, action.position.x),
+    lcaHeight(previous.position.y, action.position.y),
+    lcaHeight(previous.position.z, action.position.z),
+  )
+  if (height <= 0) return { state: 'none', height: null }
+  const h = BigInt(height)
+  const base = {
+    x: String((action.position.x >> h) << h),
+    y: String((action.position.y >> h) << h),
+    z: String((action.position.z >> h) << h),
+  }
+  for (const k of Object.values(keys)) {
+    if (k.height !== height || k.plane !== action.plane) continue
+    if (k.base.x === base.x && k.base.y === base.y && k.base.z === base.z) return { state: 'held', height }
+  }
+  return { state: 'gone', height }
+}

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -32,13 +32,21 @@ export interface HeldKey {
   lookupId: string
   /** The key itself, 32 bytes as hex. */
   keyHex: string
-  /** A cube of side 2^height, aligned on every axis. */
+  /**
+   * How wide the region is. A hiding place is a cube, so one height covers it;
+   * a movement's region is a box, its three axes at their own crossing
+   * heights, and `heights` carries those. `height` is the largest either way.
+   */
   height: number
+  heights?: { x: number; y: number; z: number }
   /** The region's aligned corner, as decimal strings. */
   base: { x: string; y: string; z: string }
   plane: Plane
-  /** How it was come by: your own scanning, or a hop HOSAKA computed for you. */
-  source: 'scan' | 'cloud'
+  /**
+   * How it was come by: a hop of your own, which grants the region it crossed;
+   * a scan that opened something where you stood; or a purchase from HOSAKA.
+   */
+  source: 'hop' | 'scan' | 'cloud'
   /** The action that bought it, for the chain overlay's key marker. */
   eventId?: string
   /** First held, in seconds since the epoch. */

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -70,6 +70,9 @@ interface SecretsState {
   /** The region the list last sent you to look at: drawn bright, the rest dimmed. */
   focused: string | null
   focus: (lookupId: string | null) => void
+  /** Whether the list is on screen. In the store, so RETURN can bring it back. */
+  open: boolean
+  setOpen: (open: boolean) => void
   /** Why the last purchase did not happen. */
   buyError: string | null
   /** Note a key you now hold; keeps the one already held rather than replacing it. */
@@ -106,6 +109,7 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   buying: null,
   buyError: null,
   focused: null,
+  open: false,
 
   hold: (incoming) => {
     if (incoming.length === 0) return
@@ -136,6 +140,8 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   },
 
   focus: (lookupId) => set({ focused: lookupId }),
+
+  setOpen: (open) => set({ open }),
 
   buy: async (at, plane, height) => {
     if (get().buying) return false

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -219,6 +219,28 @@ function save(keys: Record<string, HeldKey>): void {
   try { localStorage.setItem(KEY, JSON.stringify(keys)) } catch { /* private mode */ }
 }
 
+/**
+ * Leaving a region goes back to the list.
+ *
+ * A view can end several ways: RETURN on the bar, a hyperspace exit, walking
+ * the chain, a respawn. Rather than teach each of them about the Secrets list,
+ * this watches the focus itself: when a view that came from the list ends, the
+ * list comes back and nothing is left highlighted in the scene.
+ *
+ * Started from the app rather than at import: these two stores import each
+ * other, and subscribing at module scope reached for the other one before it
+ * existed.
+ */
+export function watchFocus(): () => void {
+  return useCyberspace.subscribe((state, previous) => {
+    if (previous.focus === null || state.focus !== null) return
+    const { focused, focus, setOpen } = useSecrets.getState()
+    if (focused === null) return
+    focus(null)
+    setOpen(true)
+  })
+}
+
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   ;(window as unknown as { __secrets?: unknown }).__secrets = useSecrets
 }

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -18,6 +18,9 @@
 
 import { create } from 'zustand'
 import type { Plane } from 'cyberspace-core'
+import type { HosakaRegionKeyResult } from '../lib/hosaka'
+import { cloudClient, useCyberspace } from './useCyberspace'
+import { useShards } from './useShards'
 
 /** How many keys are kept before the oldest are dropped. */
 export const SECRETS_MAX = 400
@@ -42,8 +45,22 @@ export interface HeldKey {
   at: number
 }
 
+/** A key being bought: what it is for, and how far along. */
+export interface Buying {
+  height: number
+  status: 'submitting' | 'computing'
+  costMsats: number
+  /** The provider's own estimate for the job, in seconds. */
+  estSeconds: number | null
+  startedAt: number
+}
+
 interface SecretsState {
   keys: Record<string, HeldKey>
+  /** The purchase in flight, or null. */
+  buying: Buying | null
+  /** Why the last purchase did not happen. */
+  buyError: string | null
   /** Note a key you now hold; keeps the one already held rather than replacing it. */
   hold: (keys: HeldKey[]) => void
   /** Forget one region. The key is gone; standing there again recomputes it. */
@@ -51,6 +68,16 @@ interface SecretsState {
   /** Forget every region. */
   forgetAll: () => void
   load: () => void
+  /**
+   * Buy the key to the aligned cube of side 2^height around a coordinate.
+   *
+   * The work is three axis subtrees at that height, which is a hop's work and
+   * is priced as one; this machine can do the small ones for itself as it
+   * moves, so this is for the heights it cannot. Paid from the HOSAKA balance:
+   * with nothing in it the purchase stops and says so, since topping up is the
+   * Cloud panel's business and not a thing to do behind a modal.
+   */
+  buy: (at: { x: bigint; y: bigint; z: bigint }, plane: Plane, height: number) => Promise<boolean>
 }
 
 /** Roughly what one entry costs in local storage. */
@@ -65,6 +92,8 @@ export function heldList(keys: Record<string, HeldKey>): HeldKey[] {
 
 export const useSecrets = create<SecretsState>((set, get) => ({
   keys: {},
+  buying: null,
+  buyError: null,
 
   hold: (incoming) => {
     if (incoming.length === 0) return
@@ -92,6 +121,55 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   forgetAll: () => {
     set({ keys: {} })
     save({})
+  },
+
+  buy: async (at, plane, height) => {
+    if (get().buying) return false
+    const cs = useCyberspace.getState()
+    const client = cloudClient(cs.cloudPrefs.apiUrl)
+    set({ buying: { height, status: 'submitting', costMsats: 0, estSeconds: null, startedAt: Date.now() }, buyError: null })
+    try {
+      const job = await client.submitRegionKey(at, height)
+      if (job.payment_required) {
+        set({ buying: null, buyError: `HOSAKA wants ${Math.ceil((job.amount_due_msats ?? job.cost_msats) / 1000)} sats for a 2^${height} key and your balance is short. Top up in the Cloud panel.` })
+        return false
+      }
+      if (!job.poll_token) {
+        set({ buying: null, buyError: 'HOSAKA took the job but gave no way to follow it.' })
+        return false
+      }
+      set({ buying: { height, status: 'computing', costMsats: job.cost_msats, estSeconds: null, startedAt: Date.now() } })
+      const done = await client.waitForJob(job.id, job.poll_token)
+      if (done.status !== 'completed' || !done.result) {
+        set({ buying: null, buyError: done.error ? `HOSAKA could not compute it: ${done.error}` : 'HOSAKA could not compute it.' })
+        return false
+      }
+      const r = done.result as HosakaRegionKeyResult
+      if (!r.secret_key || !r.lookup_id) {
+        set({ buying: null, buyError: 'HOSAKA returned no key.' })
+        return false
+      }
+      get().hold([{
+        lookupId: r.lookup_id,
+        keyHex: r.secret_key,
+        height: r.height ?? height,
+        base: {
+          x: String(r.base?.x ?? (at.x >> BigInt(height)) << BigInt(height)),
+          y: String(r.base?.y ?? (at.y >> BigInt(height)) << BigInt(height)),
+          z: String(r.base?.z ?? (at.z >> BigInt(height)) << BigInt(height)),
+        },
+        plane,
+        source: 'cloud',
+        at: Math.floor(Date.now() / 1000),
+      }])
+      set({ buying: null })
+      // What was bought is worth looking in at once.
+      void useShards.getState().rescan(r.lookup_id, r.secret_key)
+      return true
+    } catch (err) {
+      set({ buying: null, buyError: err instanceof Error ? err.message : String(err) })
+      return false
+    }
   },
 
   load: () => {

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -107,6 +107,8 @@ interface ShardsState {
   deleteInstance: (eventId: string) => Promise<void>
   /** Send a region's bag to the relays now: what LOCAL deferred. */
   broadcast: (lookupId: string) => Promise<boolean>
+  /** Ask the relay what is hidden in one region you hold the key to, and open it. */
+  rescan: (lookupId: string, keyHex: string) => Promise<number>
   inspect: (eventId: string | null) => void
   selectSecret: (eventId: string | null) => void
   addDiscovered: (items: Hidden[]) => void
@@ -316,6 +318,26 @@ export const useShards = create<ShardsState>((set, get) => {
       } catch (err) {
         set({ broadcasting: null, broadcastError: err instanceof Error ? err.message : String(err) })
         return false
+      }
+    },
+
+    /**
+     * One region, asked for by name. The discovery scan sweeps the cubes you
+     * stand in; this asks about a region you hold the key to but are nowhere
+     * near, which is what the Secrets list is for.
+     */
+    rescan: async (lookupId, keyHex) => {
+      set({ scanning: true })
+      try {
+        const events = await query({ kinds: [HIDDEN_KIND], '#d': [lookupId] })
+        const found: Hidden[] = []
+        for (const ev of events) found.push(...await unbag(ev, hexToBytes(keyHex)))
+        if (found.length > 0) get().addDiscovered(found)
+        return found.length
+      } catch {
+        return 0
+      } finally {
+        set({ scanning: false })
       }
     },
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -5407,3 +5407,13 @@ kbd {
 }
 
 .secrets__scan:disabled { opacity: 0.6; }
+
+/* How the Secrets list is ordered. */
+.secrets__sort {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-bottom: 2px;
+}
+
+.secrets__sort .login__label { margin-right: 2px; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5180,3 +5180,129 @@ kbd {
   line-height: 1.55;
   color: var(--dim);
 }
+
+/* Secrets: the regions you hold the key to. Green throughout, the same green
+   the deploy box uses for "found here". */
+.secrets__box {
+  width: min(560px, calc(100vw - 24px));
+  padding: 16px;
+  max-height: min(78vh, 720px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.secrets__box .panel__head h2 {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.secrets__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 10px;
+  color: var(--dim);
+}
+
+.secrets__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.secrets__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.secrets__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  border-top: 1px solid var(--border);
+}
+
+.secrets__row:first-child { border-top: none; }
+
+.secrets__go {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px 4px;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.secrets__where {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: #52e39f;
+}
+
+.secrets__meta,
+.secrets__id {
+  font-size: 9px;
+  color: var(--dim);
+}
+
+.secrets__id {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+}
+
+.secrets__found { color: #52e39f; }
+
+.secrets__scan {
+  flex: 0 0 auto;
+  padding: 3px 8px;
+  font: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: #52e39f;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, #52e39f 45%, transparent);
+  border-radius: 3px;
+}
+
+.proof__secrets { display: flex; }
+.proof__secrets .avatars__go {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* The region root a hop left on the chain, and whether it is still held.
+   Not .explorer__key, which is already the name of a field's label. */
+.explorer__root {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 8px;
+  letter-spacing: 0.1em;
+  color: #52e39f;
+}
+
+.explorer__root.is-gone {
+  color: var(--dim);
+  opacity: 0.7;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1238,7 +1238,10 @@ kbd {
 
 .targets__row {
   display: grid;
-  grid-template-columns: auto 1fr auto auto auto;
+  /* Dot, who, status, VIEW, SPECTATE, remove: six cells, and six columns. The
+     row was declared with five, so VIEW (added with the free view) pushed the
+     remove button onto a second line of its own. */
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto auto;
   align-items: center;
   gap: 8px;
   padding: 5px 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -5306,3 +5306,47 @@ kbd {
   color: var(--dim);
   opacity: 0.7;
 }
+
+/* Buying a key: the heights this machine cannot sweep for itself. */
+.secrets__buy {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.secrets__buy-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.secrets__buy-size {
+  flex: 1 1 auto;
+  font-size: 11px;
+  color: #52e39f;
+  font-variant-numeric: tabular-nums;
+}
+
+.secrets__step {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  font: inherit;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--ink);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.secrets__step:disabled { opacity: 0.35; }
+
+.secrets__error {
+  font-size: 9px;
+  line-height: 1.5;
+  color: var(--warn);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5353,3 +5353,50 @@ kbd {
   line-height: 1.5;
   color: var(--warn);
 }
+
+/* The Secrets button stands apart from the rows above and below it. */
+.proof__secrets {
+  display: flex;
+  padding: 10px 0;
+  margin: 4px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+/* A rule before the benchmark, which is a different subject from the controls. */
+.proof__rule {
+  height: 0;
+  margin: 10px 0 6px;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+
+/* The Secrets modal's head: title, count, and the way out on the right. */
+.secrets__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.secrets__close { margin-left: auto; }
+
+.secrets__gap { flex: 1 1 auto; }
+
+.secrets__forget-all {
+  padding: 2px 8px;
+  font: inherit;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  color: var(--danger);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
+  border-radius: 3px;
+}
+
+.secrets__dims {
+  font-size: 9px;
+  color: var(--dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.secrets__scan:disabled { opacity: 0.6; }

--- a/src/workers/proof.worker.ts
+++ b/src/workers/proof.worker.ts
@@ -8,6 +8,8 @@
  */
 
 import {
+  deriveRegionKeys,
+  alignedBase,
   computeHopProof,
   computeSidestepProof,
   encodeOpenings,
@@ -62,6 +64,18 @@ export type ProofResponse =
       jobId?: string
       costMsats?: number
       lookupId?: string
+      /**
+       * A hop's own region (spec §4.7 and §7.2): the box the movement crossed,
+       * its three axes at their own heights, with the key that opens whatever
+       * is hidden there. The computation makes it either way; dropping it threw
+       * away the one thing a hop grants beyond the movement itself.
+       */
+      region?: {
+        keyHex: string
+        lookupId: string
+        heights: [number, number, number]
+        base: [string, string, string]
+      }
     }
   | { type: 'error'; id: number; message: string; elapsedMs: number }
 
@@ -161,6 +175,18 @@ self.onmessage = (event: MessageEvent<ProofRequest>) => {
       terrainK: proof.terrainK,
       lca: { x: estimate.lcaX, y: estimate.lcaY, z: estimate.lcaZ },
       totalOps: estimate.totalOps,
+      // The region this hop crossed, and its key (§7.2). Free: the proof
+      // already built region_n on its way to the movement proof.
+      region: {
+        keyHex: bytesToHex(deriveRegionKeys(proof.regionN).locationDecryptionKey),
+        lookupId: deriveRegionKeys(proof.regionN).lookupIdHex,
+        heights: [estimate.lcaX, estimate.lcaY, estimate.lcaZ],
+        base: [
+          alignedBase(from.x, estimate.lcaX).toString(),
+          alignedBase(from.y, estimate.lcaY).toString(),
+          alignedBase(from.z, estimate.lcaZ).toString(),
+        ],
+      },
     }
     self.postMessage(response)
   } catch (err) {


### PR DESCRIPTION
The regions you can open, kept, listed, drawn, and marked on the chain.

**What a key is.** The Cantor root of one aligned cube, hashed once for the key and twice for the address the relay files it under. Holding it means two things for that cube alone: you can ask what is hidden there, and you can read what comes back. Until now the scan computed thirteen of them every time you crossed into a new region, used them for one query, and threw them away.

**`store/useSecrets`** keeps them: your own scanning and the hops HOSAKA computed, deduplicated by lookup id, capped at 400, in local storage. Four hundred is about 100 KB, because a key is 32 bytes and the rest is where and when.

**SECRETS**, a button in the Movement proof panel, opens the list. Each row says what the region covers in real units, which plane it is in, who computed it, how long ago, and what it has already yielded; the header says what the lot costs on disk. A row goes there (VIEW), scans it again for anything hidden since (SCAN, a new `useShards.rescan` that asks the relay about one region you may be nowhere near), or is forgotten, which is not permanent since standing there again computes it back.

**`scene/SecretRegions`** draws the nearest sixteen as light green cages with a key at the low corner, in the same green the deploy box uses for "found here", so the colour means one thing everywhere. Behind a switch in the list, remembered.

**The chain overlay** now says what each action left behind. A hop computes the root of the region it crossed and is marked with that region's height, dimmed when the key is no longer held. A sidestep is marked with nothing, because it computes a path across one boundary and no root at all. That is the whole difference between unlocking a wall and bypassing it, on the chain where it happened.

**A bug found while building it: discovery never ran in development.** React mounts effects twice there, so the first region worker was terminated mid-scan while the second sat idle: the scan skips a region it has already asked about, and the memory of having asked outlived the worker that was asked. Nothing was ever found locally, and SCANNING stayed lit forever. The cleanup clears that memory now, and a worker that fails says so instead of hanging the tag.

**On the shape.** Your movement's region is a box, 2^hx by 2^hy by 2^hz, and only a cube when the three crossings are the same height. Everything hidden is hidden in a cube, because the deploy picks one height. So this list holds cubes, which is what can actually open anything, and the cloud key it records is the one the hop returned. See the recap for what that implies for what HOSAKA should return.

10 new tests, 610 passing, tsc and build clean. Verified in a browser: 13 keys held after the first scan and persisted, 11 cages in view, the list at 4.0 KB with working SCAN, VIEW and forget.

---

**Second commit: buying a key, and what a hidden thing looks like.**

**BUY A KEY WHERE YOU STAND**, in the Secrets list. A height above what this machine sweeps for itself (2^13) up to what HOSAKA computes (2^27), priced from the provider's own published ladder before you press: at 2^17 it reads `BUY · 9 SATS`. It posts to `/api/v1/region_key`, live in production today (hosaka-api#11), waits for the job, holds the key beside every other one, and looks in the region at once. Paid from the HOSAKA balance; with nothing in it the purchase stops and says to top up in the Cloud panel, rather than opening a second payment flow inside a modal.

**A coin looks like a coin now.** A hidden message wrapped on spaces alone, and a Cashu token is a single word two thousand characters long, so it never wrapped: the note became a band of text across the whole screen, identical whether it held money or a sentence.

| | before | now |
|---|---|---|
| a Cashu token | 2000 characters across the screen | Bitcoin orange ₿ alone, with a turning diamond outline behind it |
| a long message | one unbroken line | its own words, cut at 160 characters over six lines, with a still blue cube behind it |

Long runs break at the line now, so nothing can stretch off screen again, and the whole message stays one tap away. Verified in the scene: one orange diamond, one blue cube, and the coin's rotation advancing between frames. 6 new tests for the billboard, 616 passing.

---

**Third commit: a cage means something is there.** You saw green regions you had never unlocked, and there were two reasons.

Every position sits inside thirteen cubes, and the scan computed all thirteen whenever you crossed into a new one; holding them all made the list a record of where the camera had been. And the scan runs at the **anchor**, which follows exploring, spectating and the free view, so *looking* at a coordinate marked its regions as yours.

A key is now kept when it **opens something where you actually stand**, or when you **buy** one. Everything else costs milliseconds to recompute the moment you are there, which is what the scan does anyway. Measured: a scan that opens nothing holds nothing and draws no cage; looking elsewhere holds nothing; a bought key is held and drawn.

The key also hangs at one fixed corner now, **+X and +Z at the region's floor** (verified: offset +32, −32, −32 from the centre of a 64-cell cage), so it says which cage it belongs to.

**Cashu tokens are read anywhere in a message**, which they always were, but the words around one were thrown away with the base64. A coin with something written on it now shows both: the orange mark, and "for the drinks" under it, with the two thousand characters nowhere. Four new tests.

620 passing.

---

**Fourth commit: a hop leaves its key, and it is a box.** Narrowing the rule to "a key that opened something" cut out the one key every hop genuinely grants: the region it crossed.

The hop already computes it. `computeHopProof` builds `region_n` on the way to the movement proof, and the worker was dropping it; it now returns the key and lookup id derived from it, which is two hashes on a number already in hand. Every hop holds it as it lands, with the event that bought it, so the chain overlay's marker reads held rather than gone.

**It is drawn as what it is.** A movement's region is a box, the three axes at their own crossing heights: a hop along X alone unlocks a slab 2^h wide and one gibson deep, not a cube. Cages take a side per axis now, and the list reads `2^7 × 2^0 × 2^0` where a region is not square. A hiding place stays a cube and still reads as one number.

Measured: a 64-gibson hop on X holds one key at heights x7 y0 z0, draws one cage, and the chain reads HOP with 2^7 beside it.

**Also:** the targets row had six children and five grid columns, so the close button had been dropping to its own line since VIEW was added. Six columns now, X flush right, verified at zero pixels from the row's right edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
