### PR TITLE
Buy compute credit before anything needs it

### DIFF
--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -22,6 +22,9 @@ import { useCalibration } from '../lib/calibration'
 import { Explanation } from './Explanation'
 
 const MODES: Array<[CloudMode, string]> = [['auto', 'AUTO'], ['ask', 'ASK'], ['off', 'OFF']]
+/** The amounts most people want, so the common case is one tap. */
+const TOP_UPS = [1_000, 5_000, 25_000]
+
 const PROFILES: Array<[RouteProfile, string]> = [['unlock', 'UNLOCK'], ['bypass', 'BYPASS']]
 
 const STAGE_LABEL: Record<string, string> = {
@@ -54,6 +57,8 @@ export function CloudPanel(): JSX.Element {
   const cloud = useCyberspace((s) => s.cloud)
   const provider = cloud.provider
   const [editingUrl, setEditingUrl] = useState(false)
+  const [topUpOpen, setTopUpOpen] = useState(false)
+  const [topUpSats, setTopUpSats] = useState('1000')
   const [urlDraft, setUrlDraft] = useState(prefs.apiUrl)
   const store = useCyberspace.getState
 
@@ -186,19 +191,69 @@ export function CloudPanel(): JSX.Element {
         </div>
         <div>
           <dt>Prepaid balance</dt>
-          <dd>
-            {balance ? balanceLabel(balance.msats) : '—'}{' '}
-            <button
-              className="cloud__link"
-              onClick={() => { void useCyberspace.getState().refreshBalance() }}
-              disabled={cloud.balanceChecking}
-              title={signerKind === 'local' ? 'Ask HOSAKA for the balance' : 'Ask HOSAKA for the balance (your signer will be asked to sign the request)'}
-            >
-              {cloud.balanceChecking ? 'CHECKING…' : balance ? `REFRESH · ${sinceLabel(balance.at, now || Date.now())}` : 'CHECK'}
-            </button>
+          <dd className="cloud__balance">
+            <span>
+              {balance ? balanceLabel(balance.msats) : '—'}{' '}
+              <button
+                className="cloud__link"
+                onClick={() => { void useCyberspace.getState().refreshBalance() }}
+                disabled={cloud.balanceChecking}
+                title={signerKind === 'local' ? 'Ask HOSAKA for the balance' : 'Ask HOSAKA for the balance (your signer will be asked to sign the request)'}
+              >
+                {cloud.balanceChecking ? 'CHECKING…' : balance ? `REFRESH · ${sinceLabel(balance.at, now || Date.now())}` : 'CHECK'}
+              </button>
+            </span>
+            {/* Credit bought before anything needs it: the route's own funding
+                only ever tops up what one move is short by. */}
+            {prefs.mode !== 'off' && (
+              <button
+                className="avatars__go cloud__topup"
+                onClick={() => setTopUpOpen((v) => !v)}
+                aria-expanded={topUpOpen}
+              >{topUpOpen ? 'CANCEL' : 'INCREASE COMPUTE BALANCE'}</button>
+            )}
           </dd>
         </div>
       </dl>
+      {topUpOpen && (
+        <form
+          className="cloud__topup-form"
+          onSubmit={(e) => {
+            e.preventDefault()
+            const sats = Math.floor(Number(topUpSats))
+            if (!Number.isFinite(sats) || sats <= 0) return
+            setTopUpOpen(false)
+            void useCyberspace.getState().topUp(sats)
+          }}
+        >
+          <span className="login__label">How many sats</span>
+          <div className="cloud__topup-row">
+            {TOP_UPS.map((n) => (
+              <button
+                key={n}
+                type="button"
+                className={`secret__act cloud__mode ${Number(topUpSats) === n ? 'is-on' : ''}`}
+                onClick={() => setTopUpSats(String(n))}
+              >{n.toLocaleString()}</button>
+            ))}
+            <input
+              className="avatars__input login__input cloud__topup-input"
+              type="number"
+              min={1}
+              step={1}
+              inputMode="numeric"
+              value={topUpSats}
+              onChange={(e) => setTopUpSats(e.target.value)}
+              aria-label="Top-up amount in sats"
+            />
+            <button className="avatars__go" type="submit">GET INVOICE ▸</button>
+          </div>
+          <span className="cloud__profile-note">
+            HOSAKA sends a lightning invoice. The balance updates the moment the node reports it paid, and nothing is spent until a move needs it.
+          </span>
+        </form>
+      )}
+
       {cloud.balanceError && <p className="legend__note">{cloud.balanceError}</p>}
 
       {editingUrl && (

--- a/src/store/topup.test.ts
+++ b/src/store/topup.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+const calls: { deposits: number[]; waits: string[] } = { deposits: [], waits: [] }
+let settleAs: 'settled' | 'expired' = 'settled'
+
+vi.mock('../lib/hosaka', async () => {
+  const actual = await vi.importActual<typeof import('../lib/hosaka')>('../lib/hosaka')
+  return {
+    ...actual,
+    createHosakaClient: () => ({}),
+  }
+})
+
+import { useCyberspace } from './useCyberspace'
+
+const LIMITS = {
+  max_hop_height: 27, max_sidestep_height: 29, hop_min_msats: 1000,
+  deposit_min_msats: 1000, deposit_max_msats: 5_000_000_000, invoice_ttl_seconds: 3600,
+}
+
+/** The client the store talks to, replaced for the test. */
+function stubClient(): void {
+  const invoice = {
+    deposit_id: 'dep-1', status: 'pending', amount_msats: 0, bolt11: 'lnbc1fake',
+    payment_hash: 'ff'.repeat(32), created_at: 1, expires_at: Math.floor(Date.now() / 1000) + 3600,
+    settled_at: null, settled_msats: null, balance_msats: 0,
+  }
+  const client = {
+    deposit: async (msats: number) => { calls.deposits.push(msats); return { ...invoice, amount_msats: msats } },
+    waitForDeposit: async (id: string) => { calls.waits.push(id); return { ...invoice, status: settleAs, balance_msats: settleAs === 'settled' ? 21_000 : 0 } },
+    balance: async () => ({ pubkey: 'x', balance_msats: 21_000, ledger: [] }),
+  }
+  ;(globalThis as { __hosakaStub?: unknown }).__hosakaStub = client
+}
+
+describe('topping up the compute balance', () => {
+  beforeEach(() => {
+    calls.deposits = []; calls.waits = []
+    settleAs = 'settled'
+    stubClient()
+    useCyberspace.setState({
+      cloud: { ...useCyberspace.getState().cloud, limits: LIMITS, status: 'idle', invoice: null, invoiceOpen: false, balanceError: null, message: null },
+      plan: null,
+    })
+  })
+
+  it('refuses an amount below the provider’s minimum, without asking for an invoice', async () => {
+    await useCyberspace.getState().topUp(0)
+    expect(calls.deposits).toHaveLength(0)
+    expect(useCyberspace.getState().cloud.balanceError).toMatch(/between/)
+  })
+
+  it('refuses while a move is in flight, because they share one invoice', async () => {
+    useCyberspace.setState({ cloud: { ...useCyberspace.getState().cloud, status: 'computing' } })
+    await useCyberspace.getState().topUp(1000)
+    expect(calls.deposits).toHaveLength(0)
+    expect(useCyberspace.getState().cloud.balanceError).toMatch(/in progress/)
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -535,6 +535,8 @@ export interface CyberspaceState {
   ensureBalance: () => void
   /** Ask HOSAKA for the balance (a signed request) and remember the answer. */
   refreshBalance: () => Promise<void>
+  /** Buy compute credit with no movement waiting on it; sats, not millisats. */
+  topUp: (sats: number) => Promise<void>
   /**
    * Pick up the persisted job (on load, after an identity switch, or from the
    * panel) when its chain head is still ours; drop it when the head moved or
@@ -2259,6 +2261,76 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     if (cloud.balance !== null) return
     const known = loadBalance(identity.pubkey)
     if (known) set({ cloud: { ...cloud, balance: known } })
+  },
+
+  /**
+   * Put sats on the HOSAKA balance, with no movement waiting on them.
+   *
+   * The route's own funding tops up as much as one route needs and no more,
+   * which is the right shape when a hop is waiting but leaves no way to fill
+   * the balance in advance. This is that way: a deposit for the amount asked,
+   * the invoice on screen through the same modal a route uses, and the balance
+   * refreshed the moment the node reports it settled. Nothing else waits on
+   * it, so cancelling costs nothing but the invoice.
+   */
+  topUp: async (sats) => {
+    const { cloud, cloudPrefs, plan } = get()
+    // A route in flight owns the cloud flow and its invoice; two invoices at
+    // once would fight over the same modal and the same saved deposit.
+    if (plan !== null || (cloud.status !== 'idle' && cloud.status !== 'error')) {
+      set({ cloud: { ...cloud, balanceError: 'Finish or cancel the move in progress first.' } })
+      return
+    }
+    const msats = Math.max(0, Math.round(sats)) * 1000
+    const min = cloud.limits?.deposit_min_msats ?? 1000
+    const max = cloud.limits?.deposit_max_msats ?? Number.MAX_SAFE_INTEGER
+    if (msats < min || msats > max) {
+      set({ cloud: { ...cloud, balanceError: `HOSAKA takes between ${satsOf(min)} and ${satsOf(max)} sats at a time.` } })
+      return
+    }
+
+    const client = cloudClient(cloudPrefs.apiUrl)
+    stopCloud()
+    const id = ++requestId
+    const abort = new AbortController()
+    const waker = createWaker()
+    cloudAbort = abort
+    cloudWaker = waker
+    try {
+      set({ cloud: { ...get().cloud, status: 'funding', balanceError: null, message: currentSigner.kind === 'local' ? 'Asking HOSAKA for an invoice.' : 'Waiting for your signer to approve the request.' } })
+      const dep = await client.deposit(msats, abort.signal)
+      if (id !== requestId) return
+      const invoice = invoiceOf(dep)
+      // On disk before the invoice is on screen: a reload after paying claims it.
+      saveCloudDeposit({ depositId: dep.deposit_id, pubkey: get().identity.pubkey, amountMsats: msats, expiresAt: invoice.expiresAt, bolt11: invoice.bolt11 })
+      set({ cloud: { ...get().cloud, status: 'awaiting_payment', invoice, invoiceOpen: true, message: null, checking: false, lastCheck: null } })
+
+      const settled = await client.waitForDeposit(dep.deposit_id, {
+        signal: abort.signal,
+        expiresAt: invoice.expiresAt,
+        intervalMs: claimIntervalFor(currentSigner.kind),
+        waker,
+        onPoll: (d) => { if (id === requestId) set({ cloud: { ...get().cloud, checking: false, lastCheck: { at: Date.now(), status: d.status } } }) },
+        onPollError: () => { if (id === requestId) set({ cloud: { ...get().cloud, checking: false } }) },
+      })
+      if (typeof settled.balance_msats === 'number') get().noteBalance(settled.balance_msats)
+      if (id !== requestId) return
+      clearCloudDeposit()
+      if (settled.status !== 'settled') {
+        set({ cloud: { ...get().cloud, status: 'idle', invoice: null, invoiceOpen: false, message: null, balanceError: 'The invoice expired unpaid. Nothing was charged.' } })
+        return
+      }
+      set({ cloud: { ...get().cloud, status: 'idle', invoice: null, invoiceOpen: false, message: null, credited: { msats, at: Date.now() } } })
+      // The node's own figure is authoritative, but ask anyway: it settles
+      // what the panel shows without waiting for the next reason to look.
+      void get().refreshBalance()
+    } catch (err) {
+      if (id !== requestId || abort.signal.aborted) return
+      clearCloudDeposit()
+      set({ cloud: { ...get().cloud, status: 'idle', invoice: null, invoiceOpen: false, message: null, balanceError: describeCloudError(err) } })
+    } finally {
+      if (cloudAbort === abort) { cloudAbort = null; cloudWaker = null }
+    }
   },
 
   refreshBalance: async () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5417,3 +5417,37 @@ kbd {
 }
 
 .secrets__sort .login__label { margin-right: 2px; }
+
+/* Buying compute credit before anything needs it. */
+.cloud__balance {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.cloud__topup {
+  padding: 3px 8px;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+}
+
+.cloud__topup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.cloud__topup-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.cloud__topup-input {
+  width: 90px;
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
The Cloud compute panel could show the prepaid balance and never add to it. The only way sats reached HOSAKA was a route's own funding, which tops up exactly what one move is short by, and only while that move waits.

**INCREASE COMPUTE BALANCE**, beside the balance it increases. A thousand, five thousand or twenty-five thousand sats in one tap, or type an amount; HOSAKA answers with a lightning invoice through the same modal a route uses; the balance updates the moment the node reports it settled, and the panel asks the provider again so what it shows is its figure rather than an inference.

- **Refuses while a move is in flight.** A route owns the cloud flow and its invoice, and two invoices would fight over one modal and one saved deposit.
- **Refuses an amount outside the provider's range**, naming it from `deposit_min_msats` / `deposit_max_msats`.
- **An expired invoice charges nothing** and says so.
- **The deposit is written to disk before the invoice is on screen**, so a reload after paying still claims it, exactly as a route's deposit does.

**Verified against a stubbed provider in a browser:** press the button, pick 5,000, get the invoice (`awaiting_payment`, modal open, one deposit created), pay it, and the balance reads 5,000 sats about six seconds later with no further press.

Two unit tests cover the guards. The happy path is covered by the browser run above rather than by a unit test, because the store builds its own signed client and stubbing that in vitest would test the stub.

639 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
