### PR TITLE
Ephemeral chat: talk to whoever is standing where you are

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import { TouchControls } from './hud/TouchControls'
 import { RouteOverlay } from './hud/RouteOverlay'
 import { ViewMenu } from './hud/ViewMenu'
 import { Compass3D } from './scene/Compass3D'
+import { ChatDock } from './hud/ChatDock'
+import { useChatFeed } from './hooks/useChatFeed'
 import { Scene } from './scene/Scene'
 import { useCanvasTap } from './hooks/useCanvasTap'
 import { useKeyboard } from './hooks/useKeyboard'
@@ -74,6 +76,7 @@ export default function App(): JSX.Element {
   }, [])
 
   const isMobile = useIsMobile()
+  useChatFeed()
   const targets = useTargets()
   // Spectating locks the panels: they describe you, and the scene is not about
   // you right now. The bar carries what matters and the way out.
@@ -175,6 +178,7 @@ export default function App(): JSX.Element {
       {showPanels && !offerUp && <Hud menuOpen={crowded} />}
       <SpectateBar />
       {!crowded && !offerUp && !deploying && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
+      {!crowded && !offerUp && !deploying && !secretOpen && <ChatDock />}
       {!crowded && !offerUp && !deploying && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && !offerUp && <TouchControls />}
       {showPad && !offerUp && <RouteOverlay />}

--- a/src/hooks/useChatFeed.ts
+++ b/src/hooks/useChatFeed.ts
@@ -1,0 +1,26 @@
+/**
+ * useChatFeed.ts — listen for what is said where you stand.
+ *
+ * One live subscription for ephemeral envelopes (kind 23330) filed under any
+ * of the regions the passive scan says you are in, reopened whenever that set
+ * changes. There is nothing to backfill: the relay keeps none of these, so a
+ * line said before you were listening is gone, which is what ephemeral means.
+ */
+
+import { useEffect } from 'react'
+import { subscribe } from '../lib/relay'
+import { CHAT_BAG_KIND } from '../lib/hidden'
+import { useChat } from '../store/useChat'
+import { useSecrets } from '../store/useSecrets'
+
+export function useChatFeed(): void {
+  const current = useSecrets((s) => s.current)
+  const regions = Object.keys(current).sort().join(',')
+
+  useEffect(() => {
+    if (regions === '') return
+    const ids = regions.split(',')
+    const stop = subscribe({ kinds: [CHAT_BAG_KIND], '#d': ids }, (ev) => { void useChat.getState().receive(ev) })
+    return stop
+  }, [regions])
+}

--- a/src/hooks/useDiscovery.ts
+++ b/src/hooks/useDiscovery.ts
@@ -19,7 +19,7 @@ import { hexToBytes } from '../lib/events'
 import { MAX_COMPUTE_HEIGHT, useCyberspace } from '../store/useCyberspace'
 import { useCeremony } from '../store/useCeremony'
 import { SCAN_MAX_HEIGHT, useShards } from '../store/useShards'
-import { useSecrets } from '../store/useSecrets'
+import { useSecrets, type CurrentKey } from '../store/useSecrets'
 import type { RegionRequest, RegionResponse } from '../workers/region.worker'
 
 /** The aligned base of a value at a height: what decides "same region". */
@@ -90,6 +90,12 @@ export function useDiscovery(): void {
       if (msg.type !== 'done') return
       w.removeEventListener('message', onMessage)
       if (keys.size === 0) { useShards.getState().setScanning(false); return }
+
+      // The chat needs these before the relay answers, and whether it answers:
+      // an envelope said in one of these cubes opens with one of these keys.
+      const current: Record<string, CurrentKey> = {}
+      for (const [lookupId, keyHex] of keys) current[lookupId] = { keyHex, height: heights.get(lookupId) ?? 0 }
+      useSecrets.getState().setCurrent(current)
 
       // A superseded scan must not write stale finds.
       const events = await query({ kinds: [HIDDEN_KIND], '#d': [...keys.keys()] })

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -12,6 +12,7 @@ import { useCyberspace } from '../store/useCyberspace'
 import { exitHyperspaceView, useHyperspace } from '../store/useHyperspace'
 import { useWorkshop } from '../store/useWorkshop'
 import { useShards } from '../store/useShards'
+import { useChat } from '../store/useChat'
 import { nextAction, useOffer } from '../store/useOffer'
 import { moveDirection, type MoveName } from '../lib/moves'
 import type { RotateDirection } from '../lib/space'
@@ -72,8 +73,18 @@ export function useKeyboard(): void {
         return
       }
 
+      // The chat: / unfolds it with the caret in the line. Escape inside the
+      // line is handled by the line itself, which is an INPUT and never gets
+      // here; Escape with the dock unfolded but the caret elsewhere folds it.
+      if (event.code === 'Slash') {
+        event.preventDefault()
+        useChat.setState({ open: true, unread: 0, focusOnOpen: true })
+        return
+      }
+
       if (event.code === 'Escape') {
         event.preventDefault()
+        if (useChat.getState().open) { useChat.getState().setOpen(false); return }
         // Deploying: back out of it rather than resetting the view.
         if (useShards.getState().pending) { useShards.getState().cancelDeploy(); return }
         // Viewing a stop or EARTH: come home before anything else.

--- a/src/hud/ChatDock.tsx
+++ b/src/hud/ChatDock.tsx
@@ -1,0 +1,157 @@
+/**
+ * ChatDock.tsx — the room you are standing in.
+ *
+ * Folded, it is a chip at the bottom centre with a count of what came in
+ * while it was folded. Unfolded, it is the last lines of talk in this region,
+ * newest at the bottom, older ones climbing and fading out above a third of
+ * the screen, and a line to type into. It sits between the menu button on
+ * the left and the controls on the right, so it never covers either.
+ *
+ * `/` unfolds it and puts the caret in the line; Escape folds it. A line that
+ * arrives from someone else unfolds it on its own, so a room that starts
+ * talking is heard.
+ */
+
+import { useEffect, useMemo, useRef } from 'react'
+import { MessageSquare, SendHorizontal, Trash2, Volume2, VolumeX, ChevronDown } from 'lucide-react'
+import { useChat, sendKey, type ChatLine } from '../store/useChat'
+import { useCyberspace } from '../store/useCyberspace'
+import { useSecrets } from '../store/useSecrets'
+import { ProfilePic } from './ProfileBadge'
+import { useProfile } from '../hooks/useProfile'
+import { formatCellSize } from '../lib/scale'
+import { MAX_CHAT_LENGTH } from '../lib/hidden'
+
+/** How many lines the unfolded dock shows; the rest are a scroll away. */
+const SHOWN = 200
+
+function whenLabel(at: number, now: number): string {
+  const s = Math.max(0, now - at)
+  if (s < 60) return 'now'
+  if (s < 3600) return `${Math.floor(s / 60)}m`
+  if (s < 86400) return `${Math.floor(s / 3600)}h`
+  return `${Math.floor(s / 86400)}d`
+}
+
+function Line({ line, now }: { line: ChatLine; now: number }): JSX.Element {
+  const profile = useProfile(line.from)
+  const name = line.mine ? 'you' : (profile?.name ?? line.from.slice(0, 8))
+  return (
+    <li className={`chat__line ${line.mine ? 'is-mine' : ''}`}>
+      <ProfilePic pubkey={line.from} size={22} />
+      <div className="chat__body">
+        <span className="chat__meta">
+          <span className="chat__who">{name}</span>
+          <span className="chat__when">{whenLabel(line.at, now)}</span>
+        </span>
+        <span className="chat__text">{line.text}</span>
+      </div>
+    </li>
+  )
+}
+
+export function ChatDock(): JSX.Element {
+  const open = useChat((s) => s.open)
+  const lines = useChat((s) => s.lines)
+  const unread = useChat((s) => s.unread)
+  const muted = useChat((s) => s.muted)
+  const draft = useChat((s) => s.draft)
+  const sendStatus = useChat((s) => s.sendStatus)
+  const sendError = useChat((s) => s.sendError)
+  const current = useSecrets((s) => s.current)
+  const atHead = useCyberspace((s) => s.atHead())
+  const input = useRef<HTMLInputElement>(null)
+  const list = useRef<HTMLUListElement>(null)
+  const now = Math.floor(Date.now() / 1000)
+
+  // The region a line would go to right now: its size is the room's name.
+  const key = useMemo(() => sendKey(), [current])
+  const room = key ? `2^${key.height} · ${formatCellSize(key.height)}` : 'no region yet'
+  const shown = lines.slice(-SHOWN)
+
+  // Unfolding puts the caret in the line, and the newest line in view.
+  useEffect(() => {
+    if (!open) return
+    const el = list.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [open, lines.length])
+
+  useEffect(() => {
+    if (open && useChat.getState().focusOnOpen) {
+      input.current?.focus()
+      useChat.setState({ focusOnOpen: false })
+    }
+  }, [open])
+
+  if (!open) {
+    return (
+      <button
+        className="chip chatdock__chip"
+        onClick={() => useChat.setState({ open: true, unread: 0, focusOnOpen: false })}
+        aria-label={unread > 0 ? `Open chat, ${unread} new` : 'Open chat'}
+        title="Chat with whoever is standing here (/)"
+      >
+        <MessageSquare size={12} strokeWidth={2.25} aria-hidden /> CHAT
+        {unread > 0 && <span className="chatdock__badge">{unread > 99 ? '99+' : unread}</span>}
+      </button>
+    )
+  }
+
+  const busy = sendStatus === 'signing' || sendStatus === 'sending'
+
+  return (
+    <section className="chatdock" aria-label="Chat">
+      <header className="chatdock__head">
+        <span className="chatdock__title">
+          <MessageSquare size={12} strokeWidth={2.25} aria-hidden /> CHAT
+          <span className="chatdock__room" title="The region a line reaches: everyone whose passive scan covers this cube">{room}</span>
+        </span>
+        <span className="chatdock__acts">
+          <button className="chatdock__act" onClick={() => useChat.getState().toggleMuted()} aria-pressed={muted} title={muted ? 'Sound off. Tap for sound on arrival' : 'Sound on arrival. Tap to mute'}>
+            {muted ? <VolumeX size={12} strokeWidth={2.25} aria-hidden /> : <Volume2 size={12} strokeWidth={2.25} aria-hidden />}
+          </button>
+          <button className="chatdock__act" onClick={() => { if (lines.length === 0 || window.confirm('Forget every line on this device?')) useChat.getState().clear() }} title="Clear the chat on this device" aria-label="Clear chat">
+            <Trash2 size={12} strokeWidth={2.25} aria-hidden />
+          </button>
+          <button className="chatdock__act" onClick={() => useChat.getState().setOpen(false)} title="Fold the chat away (Esc)" aria-label="Collapse chat">
+            <ChevronDown size={13} strokeWidth={2.25} aria-hidden />
+          </button>
+        </span>
+      </header>
+
+      <ul className="chat__list" ref={list}>
+        {shown.length === 0 && (
+          <li className="chat__empty">
+            Nothing said here yet. A line reaches everyone standing in the same {key ? `2^${key.height}` : ''} cube, and the relay keeps none of it.
+          </li>
+        )}
+        {shown.map((l) => <Line key={l.id} line={l} now={now} />)}
+      </ul>
+
+      <form
+        className="chat__compose"
+        onSubmit={(e) => { e.preventDefault(); void useChat.getState().send() }}
+      >
+        <input
+          ref={input}
+          className="chat__input"
+          value={draft}
+          onChange={(e) => useChat.getState().setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Escape') { e.preventDefault(); useChat.getState().setOpen(false) } }}
+          placeholder={!atHead ? 'Come back to your head to talk' : key ? 'Say something to this region' : 'Waiting for the scan of where you stand'}
+          maxLength={MAX_CHAT_LENGTH}
+          disabled={busy || !atHead}
+          autoComplete="off"
+          autoCapitalize="sentences"
+          enterKeyHint="send"
+          aria-label="Chat message"
+        />
+        <button className="chat__send" type="submit" disabled={busy || !atHead || draft.trim() === '' || !key} aria-label="Send" title={busy ? 'Sending' : 'Send (Enter)'}>
+          <SendHorizontal size={15} strokeWidth={2.25} aria-hidden />
+        </button>
+      </form>
+      {sendStatus === 'error' && sendError && <p className="chat__error">{sendError}</p>}
+      {busy && <p className="chat__status">{sendStatus === 'signing' ? 'SIGNING' : 'SENDING'}</p>}
+    </section>
+  )
+}

--- a/src/hud/ChatDock.tsx
+++ b/src/hud/ChatDock.tsx
@@ -91,7 +91,7 @@ export function ChatDock(): JSX.Element {
         aria-label={unread > 0 ? `Open chat, ${unread} new` : 'Open chat'}
         title="Chat with whoever is standing here (/)"
       >
-        <MessageSquare size={12} strokeWidth={2.25} aria-hidden /> CHAT
+        <MessageSquare size={11} strokeWidth={2.25} aria-hidden /> CHAT
         {unread > 0 && <span className="chatdock__badge">{unread > 99 ? '99+' : unread}</span>}
       </button>
     )

--- a/src/lib/chatBag.test.ts
+++ b/src/lib/chatBag.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { bagTemplate, chatInnerTemplate, chatInners, ciphertextOf, unbag, CHAT_BAG_KIND, CHAT_KIND, HIDDEN_KIND } from './hidden'
+
+const key = new Uint8Array(32).map((_, i) => (i * 7 + 3) & 0xff)
+const at = { x: 1n << 40n, y: 5n, z: 9n }
+
+async function said(text: string, sk = generateSecretKey()) {
+  const inner = finalizeEvent(chatInnerTemplate(text, at, 0, 1_700_000_000), sk)
+  const outer = finalizeEvent(await bagTemplate([inner], key, 'aa'.repeat(32), 12, 1_700_000_000, CHAT_BAG_KIND), sk)
+  return { inner, outer, sk }
+}
+
+describe('the ephemeral envelope', () => {
+  it('is a 33330 in everything but the kind', async () => {
+    const { outer } = await said('hello')
+    expect(outer.kind).toBe(CHAT_BAG_KIND)
+    expect(outer.tags.find((t) => t[0] === 'd')?.[1]).toBe('aa'.repeat(32))
+    expect(outer.tags.find((t) => t[0] === 'h')?.[1]).toBe('12')
+    expect(outer.tags.find((t) => t[0] === 'encrypted')?.[1]).toBeTruthy()
+    expect(ciphertextOf(outer)).not.toBeNull()
+  })
+
+  it('opens with the region key and gives back the signed line', async () => {
+    const { inner, outer } = await said('is anyone here')
+    const lines = await chatInners(outer, key)
+    expect(lines).toHaveLength(1)
+    expect(lines[0].id).toBe(inner.id)
+    expect(lines[0].kind).toBe(CHAT_KIND)
+    expect(lines[0].content).toBe('is anyone here')
+  })
+
+  it('stays shut to the wrong key', async () => {
+    const { outer } = await said('secret')
+    const wrong = new Uint8Array(32).map((_, i) => (i * 11 + 1) & 0xff)
+    expect(await chatInners(outer, wrong)).toHaveLength(0)
+  })
+
+  it('refuses a line wrapped by someone who did not sign it', async () => {
+    const speaker = generateSecretKey()
+    const wrapper = generateSecretKey()
+    const inner = finalizeEvent(chatInnerTemplate('not mine to carry', at, 0, 1), speaker)
+    const outer = finalizeEvent(await bagTemplate([inner], key, 'bb'.repeat(32), 12, 1, CHAT_BAG_KIND), wrapper)
+    expect(getPublicKey(speaker)).not.toBe(outer.pubkey)
+    expect(await chatInners(outer, key)).toHaveLength(0)
+  })
+
+  it('is not mistaken for a hiding place, and a hiding place is not chat', async () => {
+    const { outer } = await said('talk')
+    // The hidden-thing reader sees no items: a chat line has no coordinate item shape it accepts.
+    expect(await unbag(outer, key)).toHaveLength(0)
+    const sk = generateSecretKey()
+    const stored = finalizeEvent(await bagTemplate([], key, 'cc'.repeat(32), 12, 1, HIDDEN_KIND), sk)
+    expect(await chatInners(stored, key)).toHaveLength(0)
+  })
+
+  it('caps a line at the chat length', () => {
+    const t = chatInnerTemplate('x'.repeat(2000), at, 0, 1)
+    expect(t.content).toHaveLength(500)
+  })
+})

--- a/src/lib/chime.ts
+++ b/src/lib/chime.ts
@@ -1,0 +1,44 @@
+/**
+ * chime.ts — the sound of a message arriving.
+ *
+ * Two short sine notes a fifth apart, synthesised on the spot: no asset to
+ * load, nothing to cache, and quiet enough to sit under whatever else the
+ * machine is doing. Browsers keep audio silent until the page has been
+ * touched, so the context is made lazily and resumed on each play; a play
+ * that the browser refuses is simply a message that arrived without a sound.
+ */
+
+let ctx: AudioContext | null = null
+
+function context(): AudioContext | null {
+  if (typeof window === 'undefined') return null
+  const Ctor = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+  if (!Ctor) return null
+  if (!ctx) ctx = new Ctor()
+  return ctx
+}
+
+/** Play the arrival chime. Safe to call anywhere; fails silent. */
+export function chime(): void {
+  try {
+    const ac = context()
+    if (!ac) return
+    if (ac.state === 'suspended') void ac.resume()
+    const t0 = ac.currentTime
+    const gain = ac.createGain()
+    gain.gain.setValueAtTime(0.0001, t0)
+    gain.gain.exponentialRampToValueAtTime(0.08, t0 + 0.01)
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + 0.28)
+    gain.connect(ac.destination)
+    for (const [freq, at] of [[880, 0], [1318.5, 0.09]] as const) {
+      const osc = ac.createOscillator()
+      osc.type = 'sine'
+      osc.frequency.setValueAtTime(freq, t0 + at)
+      osc.connect(gain)
+      osc.start(t0 + at)
+      osc.stop(t0 + at + 0.2)
+    }
+  } catch {
+    /* no audio here */
+  }
+}

--- a/src/lib/hidden.ts
+++ b/src/lib/hidden.ts
@@ -29,6 +29,16 @@ import type { Position } from './space'
 
 /** The location-encrypted envelope (spec §8.6). */
 export const HIDDEN_KIND = 33330
+/**
+ * The same envelope in the ephemeral range: a relay hands it to whoever is
+ * subscribed at that moment and keeps nothing. Chat lives here. A 23330 is a
+ * 33330 in every respect but the kind: same `d`, same `encrypted`, same `h`.
+ */
+export const CHAT_BAG_KIND = 23330
+/** A chat line, inside the ephemeral envelope; the kind other clients use for ephemeral chat. */
+export const CHAT_KIND = 23333
+/** Longest chat line. Short on purpose: it is a room, not a wall. */
+export const MAX_CHAT_LENGTH = 500
 /** A shard, inside the envelope (v1's shard kind). */
 export const SHARD_KIND = 3330
 /** A plain note, inside the envelope. */
@@ -87,6 +97,22 @@ export function messageInnerTemplate(text: string, at: Position, plane: Plane, c
 }
 
 /**
+ * The inner chat event template (kind 23333), signed by the author.
+ *
+ * Never published bare: it only ever travels inside a CHAT_BAG_KIND envelope
+ * keyed to the region it was said in, so a relay sees ciphertext and the
+ * people standing in that region see the words.
+ */
+export function chatInnerTemplate(text: string, at: Position, plane: Plane, createdAt: number): EventTemplate {
+  return {
+    kind: CHAT_KIND,
+    created_at: createdAt,
+    content: text.slice(0, MAX_CHAT_LENGTH),
+    tags: [['C', positionHex(at, plane)]],
+  }
+}
+
+/**
  * Wrap a BAG of signed inner events into one region envelope template.
  *
  * Spec §8.6: the envelope is keyed by `d = lookup_id`, so there is one per
@@ -100,10 +126,10 @@ export function messageInnerTemplate(text: string, at: Position, plane: Plane, c
  * and buys little anyway — the location encryption is the real gate, and anyone
  * who can decrypt can re-sign identical content as themselves regardless.
  */
-export async function bagTemplate(inners: NostrEvent[], regionKey: Uint8Array, lookupId: string, height: number, createdAt: number): Promise<EventTemplate> {
+export async function bagTemplate(inners: NostrEvent[], regionKey: Uint8Array, lookupId: string, height: number, createdAt: number, kind: number = HIDDEN_KIND): Promise<EventTemplate> {
   const ciphertext = await encryptForRegion(regionKey, JSON.stringify(inners))
   return {
-    kind: HIDDEN_KIND,
+    kind,
     created_at: createdAt,
     content: '',
     tags: [['d', lookupId], ['encrypted', ALGO, ciphertext], ['version', '2'], ['h', String(height)]],
@@ -116,7 +142,7 @@ function tag(ev: NostrEvent, name: string): string | undefined {
 
 /** The ciphertext out of an envelope, or null if it is not one. */
 export function ciphertextOf(ev: NostrEvent): string | null {
-  if (ev.kind !== HIDDEN_KIND) return null
+  if (ev.kind !== HIDDEN_KIND && ev.kind !== CHAT_BAG_KIND) return null
   const enc = ev.tags.find((t) => t[0] === 'encrypted')
   if (!enc || enc[1] !== ALGO || !enc[2]) return null
   return enc[2]
@@ -184,6 +210,17 @@ export async function unbag(outer: NostrEvent, regionKey: Uint8Array): Promise<H
     if (h) out.push(h)
   }
   return out
+}
+
+/**
+ * The chat lines in an ephemeral envelope: every inner that is a CHAT_KIND,
+ * verifies, and was signed by the same key that wrapped it. Anything else in
+ * the bag is not chat and is left where it is.
+ */
+export async function chatInners(outer: NostrEvent, regionKey: Uint8Array): Promise<NostrEvent[]> {
+  if (outer.kind !== CHAT_BAG_KIND) return []
+  const inners = await bagInners(outer, regionKey)
+  return inners.filter((e) => e.kind === CHAT_KIND && typeof e.content === 'string' && e.content.length > 0)
 }
 
 /** The signed inner events currently in an envelope's bag (unverified passthrough). */

--- a/src/store/chat.test.ts
+++ b/src/store/chat.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { bagTemplate, chatInnerTemplate, CHAT_BAG_KIND } from '../lib/hidden'
+import { mergeLines, sendKey, useChat, type ChatLine } from './useChat'
+import { useSecrets } from './useSecrets'
+import { useCyberspace } from './useCyberspace'
+
+const bytesToHex = (b: Uint8Array): string => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('')
+
+const line = (id: string, at: number, over: Partial<ChatLine> = {}): ChatLine => ({ id, from: 'f'.repeat(64), text: id, at, region: 'r', height: 12, mine: false, ...over })
+
+describe('lines', () => {
+  it('merge newest last and never repeat', () => {
+    const have = [line('a', 10), line('b', 20)]
+    const out = mergeLines(have, [line('b', 20), line('c', 15)])
+    expect(out.map((l) => l.id)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('return the same list when nothing is new', () => {
+    const have = [line('a', 10)]
+    expect(mergeLines(have, [line('a', 10)])).toBe(have)
+  })
+})
+
+describe('the key a line goes out with', () => {
+  it('is the widest cube the scan reaches', () => {
+    useSecrets.setState({ current: { r4: { keyHex: '04', height: 4 }, r12: { keyHex: '0c', height: 12 }, r9: { keyHex: '09', height: 9 } } })
+    expect(sendKey()).toEqual({ lookupId: 'r12', keyHex: '0c', height: 12 })
+  })
+
+  it('is nothing before the first scan', () => {
+    useSecrets.setState({ current: {} })
+    expect(sendKey()).toBeNull()
+  })
+})
+
+describe('receiving', () => {
+  const regionKey = new Uint8Array(32).map((_, i) => (i * 5 + 1) & 0xff)
+  const region = 'dd'.repeat(32)
+
+  beforeEach(() => {
+    useChat.setState({ lines: [], open: false, unread: 0, muted: true })
+    useSecrets.setState({ current: { [region]: { keyHex: bytesToHex(regionKey), height: 12 } } })
+  })
+
+  it('opens an envelope from someone else, unfolds the dock and keeps the line', async () => {
+    const sk = generateSecretKey()
+    const inner = finalizeEvent(chatInnerTemplate('anyone around?', { x: 1n, y: 2n, z: 3n }, 0, 1_700_000_100), sk)
+    const outer = finalizeEvent(await bagTemplate([inner], regionKey, region, 12, 1_700_000_100, CHAT_BAG_KIND), sk)
+    await useChat.getState().receive(outer)
+    const s = useChat.getState()
+    expect(s.lines).toHaveLength(1)
+    expect(s.lines[0]).toMatchObject({ id: inner.id, from: getPublicKey(sk), text: 'anyone around?', region, height: 12, mine: false })
+    expect(s.open).toBe(true)
+    expect(JSON.parse(localStorage.getItem('onosendai:chat') ?? '[]')).toHaveLength(1)
+  })
+
+  it('ignores an envelope for a region it has no key for', async () => {
+    const sk = generateSecretKey()
+    const inner = finalizeEvent(chatInnerTemplate('elsewhere', { x: 1n, y: 2n, z: 3n }, 0, 1), sk)
+    const outer = finalizeEvent(await bagTemplate([inner], regionKey, 'ee'.repeat(32), 12, 1, CHAT_BAG_KIND), sk)
+    await useChat.getState().receive(outer)
+    expect(useChat.getState().lines).toHaveLength(0)
+    expect(useChat.getState().open).toBe(false)
+  })
+
+  it('does not unfold for your own echo', async () => {
+    const sk = generateSecretKey()
+    useCyberspace.setState({ identity: { ...useCyberspace.getState().identity, pubkey: getPublicKey(sk) } })
+    const inner = finalizeEvent(chatInnerTemplate('me', { x: 1n, y: 2n, z: 3n }, 0, 2), sk)
+    const outer = finalizeEvent(await bagTemplate([inner], regionKey, region, 12, 2, CHAT_BAG_KIND), sk)
+    await useChat.getState().receive(outer)
+    expect(useChat.getState().lines[0]?.mine).toBe(true)
+    expect(useChat.getState().open).toBe(false)
+  })
+
+  it('the same envelope twice is one line', async () => {
+    const sk = generateSecretKey()
+    const inner = finalizeEvent(chatInnerTemplate('once', { x: 1n, y: 2n, z: 3n }, 0, 3), sk)
+    const outer = finalizeEvent(await bagTemplate([inner], regionKey, region, 12, 3, CHAT_BAG_KIND), sk)
+    await useChat.getState().receive(outer)
+    await useChat.getState().receive(outer)
+    expect(useChat.getState().lines).toHaveLength(1)
+  })
+
+  it('clear forgets everything on this device', () => {
+    useChat.setState({ lines: [line('a', 1)], unread: 3 })
+    useChat.getState().clear()
+    expect(useChat.getState().lines).toHaveLength(0)
+    expect(useChat.getState().unread).toBe(0)
+    expect(localStorage.getItem('onosendai:chat')).toBe('[]')
+  })
+})

--- a/src/store/useChat.ts
+++ b/src/store/useChat.ts
@@ -1,0 +1,191 @@
+/**
+ * useChat.ts — talk to whoever is standing where you are.
+ *
+ * A chat line is a kind 23333 event, signed by you, that never travels bare:
+ * it is sealed inside a kind 23330 ephemeral envelope keyed to the region you
+ * said it in, the cube of side 2^SCAN_MAX_HEIGHT around you. The relay keeps
+ * nothing and hands the envelope to whoever is subscribed at that moment;
+ * whoever is standing in that cube has its key from their own passive scan
+ * and reads the words. Everyone else sees ciphertext, and only while it is
+ * in flight.
+ *
+ * What is kept on this device is the words, who said them, when, and which
+ * region they were said in: enough to read the room again after a reload.
+ * The signed events are not kept; they are said and gone, as the kind says.
+ */
+
+import { create } from 'zustand'
+import { chatInnerTemplate, chatInners, bagTemplate, CHAT_BAG_KIND, MAX_CHAT_LENGTH } from '../lib/hidden'
+import { hexToBytes, type NostrEvent } from '../lib/events'
+import { publishMany, relaySet } from '../lib/relay'
+import { chime } from '../lib/chime'
+import { useCyberspace } from './useCyberspace'
+import { useSecrets } from './useSecrets'
+import { SCAN_MAX_HEIGHT } from './useShards'
+
+export interface ChatLine {
+  /** The inner event's id: the line's identity, what stops a repeat. */
+  id: string
+  from: string
+  text: string
+  /** Seconds since the epoch, as the sender signed it. */
+  at: number
+  /** The region it was said in: the envelope's `d`. */
+  region: string
+  /** The cube's height; how far the words carried. */
+  height: number
+  mine: boolean
+}
+
+const STORAGE_KEY = 'onosendai:chat'
+const MUTE_KEY = 'onosendai:chat:muted'
+/** Lines kept on this device, oldest dropped first. */
+export const CHAT_MAX = 500
+
+function loadLines(): ChatLine[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const list = JSON.parse(raw) as unknown
+    return Array.isArray(list) ? (list as ChatLine[]).filter((l) => l && typeof l.id === 'string' && typeof l.text === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function saveLines(lines: ChatLine[]): void {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(lines.slice(-CHAT_MAX))) } catch { /* private mode */ }
+}
+
+function loadMuted(): boolean {
+  try { return localStorage.getItem(MUTE_KEY) === '1' } catch { return false }
+}
+
+export type SendStatus = 'idle' | 'signing' | 'sending' | 'error'
+
+interface ChatState {
+  lines: ChatLine[]
+  /** Whether the dock is unfolded. Folded by default; a message unfolds it. */
+  open: boolean
+  /** Lines that arrived while the dock was folded. */
+  unread: number
+  muted: boolean
+  draft: string
+  /** Set by the `/` key: unfold and put the caret in the line. */
+  focusOnOpen: boolean
+  sendStatus: SendStatus
+  sendError: string | null
+  setOpen: (open: boolean) => void
+  toggleMuted: () => void
+  setDraft: (draft: string) => void
+  /** Say the draft into the region you are standing in. */
+  send: () => Promise<void>
+  /** An ephemeral envelope from the relay: open it with what you have. */
+  receive: (outer: NostrEvent) => Promise<void>
+  /** Forget every line on this device. The relay never had them. */
+  clear: () => void
+}
+
+/**
+ * The key a line is sealed with: the widest cube the passive scan reaches,
+ * so that anyone whose scan reaches it (which is everyone standing in it)
+ * can open it. A smaller cube would carry less far for no gain.
+ */
+export function sendKey(): { lookupId: string; keyHex: string; height: number } | null {
+  const current = useSecrets.getState().current
+  let best: { lookupId: string; keyHex: string; height: number } | null = null
+  for (const [lookupId, k] of Object.entries(current)) {
+    if (k.height > SCAN_MAX_HEIGHT) continue
+    if (!best || k.height > best.height) best = { lookupId, keyHex: k.keyHex, height: k.height }
+  }
+  return best
+}
+
+/** Newest last, no repeats: one line per inner event id. */
+export function mergeLines(have: ChatLine[], add: ChatLine[]): ChatLine[] {
+  const seen = new Set(have.map((l) => l.id))
+  const fresh = add.filter((l) => !seen.has(l.id))
+  if (fresh.length === 0) return have
+  return [...have, ...fresh].sort((a, b) => a.at - b.at).slice(-CHAT_MAX)
+}
+
+export const useChat = create<ChatState>((set, get) => ({
+  lines: loadLines(),
+  open: false,
+  unread: 0,
+  muted: loadMuted(),
+  draft: '',
+  focusOnOpen: false,
+  sendStatus: 'idle',
+  sendError: null,
+
+  setOpen: (open) => set({ open, unread: open ? 0 : get().unread }),
+
+  toggleMuted: () => {
+    const muted = !get().muted
+    try { localStorage.setItem(MUTE_KEY, muted ? '1' : '0') } catch { /* private mode */ }
+    set({ muted })
+  },
+
+  setDraft: (draft) => set({ draft: draft.slice(0, MAX_CHAT_LENGTH) }),
+
+  send: async () => {
+    const text = get().draft.trim()
+    if (!text || get().sendStatus === 'signing' || get().sendStatus === 'sending') return
+    const key = sendKey()
+    if (!key) {
+      set({ sendStatus: 'error', sendError: 'No region key yet: the scan of where you stand has not finished.' })
+      return
+    }
+    const cyber = useCyberspace.getState()
+    const now = Math.floor(Date.now() / 1000)
+    try {
+      set({ sendStatus: 'signing', sendError: null })
+      const inner = await cyber.signEvent(chatInnerTemplate(text, cyber.position, cyber.plane, now))
+      set({ sendStatus: 'sending' })
+      const outer = await cyber.signEvent(await bagTemplate([inner], hexToBytes(key.keyHex), key.lookupId, key.height, now, CHAT_BAG_KIND))
+      const result = await publishMany(relaySet(), outer)
+      if (!result.ok) {
+        set({ sendStatus: 'error', sendError: `Not sent: ${result.reason}` })
+        return
+      }
+      // Your own line goes straight in: an ephemeral event is not echoed back
+      // by every relay, and a line you said should not depend on that.
+      const line: ChatLine = { id: inner.id, from: inner.pubkey, text: inner.content, at: inner.created_at, region: key.lookupId, height: key.height, mine: true }
+      const lines = mergeLines(get().lines, [line])
+      saveLines(lines)
+      set({ lines, draft: '', sendStatus: 'idle', sendError: null })
+    } catch (err) {
+      set({ sendStatus: 'error', sendError: err instanceof Error ? err.message : String(err) })
+    }
+  },
+
+  receive: async (outer) => {
+    const region = outer.tags.find((t) => t[0] === 'd')?.[1]
+    if (!region) return
+    const key = useSecrets.getState().current[region]
+    if (!key) return
+    const inners = await chatInners(outer, hexToBytes(key.keyHex))
+    if (inners.length === 0) return
+    const me = useCyberspace.getState().identity.pubkey
+    const add = inners.map((e) => ({ id: e.id, from: e.pubkey, text: e.content.slice(0, MAX_CHAT_LENGTH), at: e.created_at, region, height: key.height, mine: e.pubkey === me }))
+    const before = get().lines
+    const lines = mergeLines(before, add)
+    if (lines === before) return
+    saveLines(lines)
+    const theirs = lines.length - before.length
+    const fromOthers = add.some((l) => !l.mine)
+    // Someone spoke: the dock unfolds and, unless it is muted, chimes.
+    set({ lines, open: fromOthers ? true : get().open, unread: get().open || fromOthers ? 0 : get().unread + theirs })
+    if (fromOthers && !get().muted) chime()
+  },
+
+  clear: () => {
+    saveLines([])
+    set({ lines: [], unread: 0 })
+  },
+}))
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __chat: typeof useChat }).__chat = useChat
+}

--- a/src/store/useSecrets.ts
+++ b/src/store/useSecrets.ts
@@ -63,8 +63,19 @@ export interface Buying {
   startedAt: number
 }
 
+/** A region key the machine has for where you are, this moment. */
+export interface CurrentKey { keyHex: string; height: number }
+
 interface SecretsState {
   keys: Record<string, HeldKey>
+  /**
+   * The keys of every region the anchor is standing in, all scan heights,
+   * replaced whole on each passive scan. Not held and not persisted: they are
+   * the thirteen cubes around you, recomputed the moment you cross into new
+   * ones, and they are what opens an ephemeral envelope said in one of them.
+   */
+  current: Record<string, CurrentKey>
+  setCurrent: (current: Record<string, CurrentKey>) => void
   /** The purchase in flight, or null. */
   buying: Buying | null
   /** The region the list last sent you to look at: drawn bright, the rest dimmed. */
@@ -128,6 +139,7 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   buying: null,
   buyError: null,
   focused: null,
+  current: {},
   open: false,
   sort: 'recent',
 
@@ -160,6 +172,8 @@ export const useSecrets = create<SecretsState>((set, get) => ({
   },
 
   focus: (lookupId) => set({ focused: lookupId }),
+
+  setCurrent: (current) => set({ current }),
 
   setOpen: (open) => set({ open }),
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3236,24 +3236,30 @@ kbd {
 .touchpad {
   bottom: 92px;
   display: grid;
-  grid-template-columns: repeat(4, 38px);
-  grid-template-rows: repeat(3, 38px);
+  grid-template-columns: repeat(3, 38px);
+  grid-template-rows: repeat(4, 38px);
   gap: 4px;
   grid-template-areas:
-    ".    away    up   toward"
-    ".    left    hub  right"
-    "cube zoomout down zoomin";
+    ".       .    cube"
+    "away    up   toward"
+    "left    hub  right"
+    "zoomout down zoomin";
 }
-/* Off your own head only scale is left to drive, so the pad folds to one
- * row: coarser, the readout, finer, and the cube. The direction cells leave
- * the grid rather than standing empty in it. */
+/* Off your own head only scale is left to drive, so the pad folds to the
+ * scale row with the cube above it. The direction cells leave the grid
+ * rather than standing empty in it. */
 .touchpad--scale {
-  grid-template-rows: 38px;
-  grid-template-areas: "cube zoomout hub zoomin";
+  grid-template-rows: repeat(2, 38px);
+  grid-template-areas:
+    ".       .   cube"
+    "zoomout hub zoomin";
 }
 .touchpad--scale .is-standdown { display: none; }
-/* The purple cube: the scale keys' own end of the ladder, so it sits with them,
-   directly left of the coarser key rather than up in the direction cells. */
+/* The purple cube: the whole ladder in one press, and a thing you want to
+   press on purpose. It sat at the bottom left of the pad, beside the coarser
+   key, where a thumb reaching for the pad's edge kept landing on it. It sits
+   above NEAR now, in its own row at the top right corner: out of the path to
+   every other key, and clear of the chat that lives to the pad's left. */
 .touchpad__key--cube {
   grid-area: cube;
   color: #dcc2ff;
@@ -3521,19 +3527,22 @@ kbd {
   }
 }
 
-/* The compass sat bottom-centre, directly under the action row, so the controls
- * buried it. On a phone it moves out of the thumb zone entirely. */
+/* The compass sat bottom-centre, which is where the chat lives now. It stands
+ * at the top right on every width: out of the thumb zone on a phone, and out
+ * of the way of talk on a desktop. The view menu it summons already opens
+ * under that corner. */
+.compass-3d {
+  bottom: auto;
+  top: 12px;
+  left: auto;
+  right: 12px;
+  transform: none;
+}
 @media (max-width: 1100px) {
   .compass-3d {
-    bottom: auto;
-    top: 12px;
-    left: auto;
-    right: 12px;
-    transform: none;
     width: 84px;
     height: 84px;
   }
-
 }
 
 /* ---------- Summoned controls: view menu, hint chip ---------- */
@@ -5417,3 +5426,195 @@ kbd {
 }
 
 .secrets__sort .login__label { margin-right: 2px; }
+
+/* ---------- Chat: the room you are standing in ----------
+ * Bottom centre, between the menu button (left, 56px + margins) and the
+ * controls (right, 122px wide pad column + margins), so it never covers
+ * either. The list runs newest at the bottom; what climbs above a third of
+ * the screen fades to nothing rather than stopping at an edge. */
+.chatdock__chip {
+  position: fixed;
+  bottom: 22px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 101;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chatdock__badge {
+  min-width: 16px;
+  padding: 0 5px;
+  border-radius: 8px;
+  font-size: 9px;
+  line-height: 16px;
+  text-align: center;
+  color: #06121a;
+  background: var(--accent, #00e5ff);
+}
+
+.chatdock {
+  position: fixed;
+  bottom: 14px;
+  left: 84px;
+  right: 152px;
+  margin: 0 auto;
+  width: min(480px, 100%);
+  max-height: 33vh;
+  z-index: 101;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(6, 14, 22, 0.82);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.chatdock__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--dim);
+}
+
+.chatdock__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg);
+}
+
+.chatdock__room {
+  margin-left: 4px;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+  text-transform: none;
+}
+
+.chatdock__acts { display: inline-flex; gap: 4px; }
+
+.chatdock__act {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 22px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.chatdock__act:hover, .chatdock__act[aria-pressed="true"] { color: var(--fg); border-color: var(--border); }
+
+/* Newest at the bottom, oldest fading out at the top. The mask is what makes
+ * the fade: lines that scroll up into the last quarter thin to nothing. The
+ * scrollbar is there and is not drawn. */
+.chat__list {
+  list-style: none;
+  margin: 0;
+  padding: 10px 2px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  overflow-y: auto;
+  min-height: 48px;
+  scrollbar-width: none;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 1) 28%);
+  mask-image: linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 1) 28%);
+  overscroll-behavior: contain;
+}
+.chat__list::-webkit-scrollbar { display: none; }
+
+.chat__line {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.chat__line.is-mine .chat__who { color: var(--accent, #00e5ff); }
+
+.chat__body { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+
+.chat__meta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
+.chat__who { color: var(--fg); text-transform: none; letter-spacing: 0; font-size: 10px; }
+.chat__when { font-variant-numeric: tabular-nums; }
+
+.chat__text {
+  color: var(--fg);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.chat__empty {
+  font-size: 10px;
+  color: var(--dim);
+  line-height: 1.4;
+}
+
+.chat__compose {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chat__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 7px 10px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--fg);
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.chat__input:focus { outline: none; border-color: var(--accent, #00e5ff); }
+.chat__input:disabled { opacity: 0.55; }
+
+.chat__send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 32px;
+  color: #06121a;
+  background: var(--accent, #00e5ff);
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.chat__send:disabled { opacity: 0.35; cursor: default; }
+
+.chat__error { margin: 0; font-size: 9px; color: var(--danger); }
+.chat__status { margin: 0; font-size: 8px; letter-spacing: 0.14em; color: var(--dim); }
+
+/* Under 1100px the pad column is the same width, but the menu button and the
+ * dock fight for the bottom on a narrow phone: the dock takes the width and
+ * sits above the button row. */
+@media (max-width: 640px) {
+  .chatdock {
+    left: 10px;
+    right: 10px;
+    bottom: 80px;
+    width: auto;
+    max-height: 38vh;
+  }
+  .chatdock__chip { bottom: 84px; }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3151,7 +3151,9 @@ kbd {
   display: block;
   width: 100%;
   height: 2px;
-  background: var(--fg);
+  /* The same blue as the CONTROLS and CHAT chips' text: the three bottom
+     controls read as one set. */
+  background: var(--accent, #00e5ff);
   border-radius: 1px;
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
@@ -3715,14 +3717,30 @@ kbd {
     height: 46px;
   }
 
-  /* The view menu hangs off the compass, which is bottom-centre on a desktop
-   * rather than top-right, so the menu follows it down. It has to clear the
-   * movement pad, whose top edge is 184px up: the pad is 122px tall and sits
-   * 62px from the bottom. At 150 the menu covered the pad's top row. */
-  .viewmenu {
-    top: auto;
-    bottom: 226px;
+  /* The compass is top-right on every width now (the chat took the bottom
+   * centre). Flush right on a desktop is underneath the 300px panel column,
+   * so it moves to the scene's right edge, 332px in, like the pad; and the
+   * view menu hangs off it, directly beneath. */
+  .compass-3d {
     right: 332px;
+  }
+
+  .viewmenu {
+    top: 140px;
+    right: 332px;
+  }
+
+  /* The chat sits between the hamburger (352px in, 46px wide) and the pad
+   * column (332px in from the right, 122px wide), never under either. The
+   * chip centres on the scene, which is 10px right of the viewport's centre
+   * with 320px of panels on the left and 300px on the right. */
+  .chatdock {
+    left: 424px;
+    right: 470px;
+  }
+
+  .chatdock__chip {
+    left: calc(50% + 10px);
   }
 }
 
@@ -5434,13 +5452,17 @@ kbd {
  * the screen fades to nothing rather than stopping at an edge. */
 .chatdock__chip {
   position: fixed;
-  bottom: 22px;
+  /* Level with the CONTROLS chip, which sits at the same 14px. */
+  bottom: 14px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 101;
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  /* The same height as CONTROLS beside it: 9px text at line-height 1 in 9px
+     of padding is 29px; an 11px glyph in 8px of padding is the same. */
+  padding: 8px 12px;
 }
 
 .chatdock__badge {
@@ -5616,5 +5638,4 @@ kbd {
     width: auto;
     max-height: 38vh;
   }
-  .chatdock__chip { bottom: 84px; }
 }


### PR DESCRIPTION
Press `/` and a line opens at the bottom of the screen. Type, press Enter or the arrow, and what you said reaches everyone standing in the same 2^12 cube as you. Nobody else can read it, and the relay keeps none of it.

## The wire

A line is a **kind 23333** event, the kind other clients use for ephemeral chat, signed by you. It never travels bare. It is sealed inside a **kind 23330** envelope keyed to the region it was said in. A 23330 is a 33330 in every respect but the kind: the same `d` tag naming the region's lookup id, the same `encrypted` tag carrying the ciphertext, the same `h` tag naming the cube's height. The difference is what a relay does with it: a 33330 is stored and replaced, a 23330 is handed to whoever is subscribed at that moment and then forgotten.

The passive scan already computes the thirteen region keys of the cubes you stand in (heights 0 through 12). It now hands them to the store as `current` before it asks the relay anything: not held, not persisted, replaced whole on every scan. One live subscription asks for kind 23330 with those thirteen `d` tags, and whatever arrives is opened with the key whose region matches. A line said in a cube you are not standing in never opens, because you do not have its key.

## What was asked, what shipped

| Asked | Shipped |
|---|---|
| `/` opens the chat, Esc closes it | `/` unfolds the dock with the caret in the line; Escape folds it (from the line or anywhere else) |
| Enter or a send arrow sends | Both; the arrow is disabled until there is something to send and a key to seal it with |
| A signed kind 23333, never broadcast alone | Signed, then sealed in a 23330; only the 23330 is published |
| A 23330 exactly like a 33330 but ephemeral | Same `d`, `encrypted`, `h`; `bagTemplate` takes the kind, `ciphertextOf` accepts either |
| Cubic region defaults to the highest passive scan range | 2^12 (SCAN_MAX_HEIGHT), the widest cube every scanner can open |
| Bottom centre, between the controls and the menu button | Fixed between 84px from the left and 152px from the right; measured clear of both |
| Newest at the bottom, older upward, fading past a third of the screen | Column list, max height 33vh, mask fading the top |
| Scrollable with an invisible scrollbar | Scrolls; `scrollbar-width: none` and the WebKit equivalent |
| Poll for 23330 and decrypt with the current scan keys | One live subscription on the thirteen current `d` tags; the matching key opens each envelope |
| Persist chats, not the signed events | `onosendai:chat`, 500 lines of words, sender, time, region; no events |
| Small clear button top right | Trash icon; asks once before forgetting |
| Collapsible, collapsed by default, opens when a message arrives | Chip by default; a line from someone else unfolds it |
| Notification sound | Two synthesized sine notes a fifth apart, no asset |
| Avatar bubble next to each message | `ProfilePic` per line, with name and age |
| Move the 3-axis overlay to the top right on desktop | Top right on every width, where the view menu already opens |
| Move the cube button above NEAR | Its own row above NEAR, out of the path to every other key |
| Tapping the compose box activates the keyboard | Plain input with `enterKeyHint="send"` |

## Niceties added beyond the ask

| Nicety | Why |
|---|---|
| Unread badge on the folded chip | A room that talked while you were folded should say how much |
| Mute toggle, remembered across reloads | A chime is a courtesy until it is not |
| Relative timestamps per line | "3m" tells you whether the room is live |
| Dedupe by inner event id | Two relays, or a relay echo plus the local echo, is still one line |
| Local echo of your own line | Ephemeral events are not echoed back by every relay |
| Confirm before clearing | The relay never had the lines; this device is their only copy |
| Composer disabled off your head, with the reason in the placeholder | A line carries your coordinate; it should be where you are |
| Room label naming the cube size | 2^12 and its size in real units, so reach is never a guess |
| 500 character cap per line, 500 line cap on the device | A room, not a wall |

## Decisions to check

- **The send cube is 2^12, not 2^9.** SCAN_MAX_HEIGHT is 12, so every passive scanner already has the key. A smaller cube would carry less far for no gain. Easy to change if you want a tighter room.
- **The inner 23333 carries only a `C` tag** with the sender's coordinate, like the app's other inner kinds. No `d` room tag: nothing outside the envelope can see it anyway.
- **Lines are shown for every region**, not filtered to the one you are standing in. Moving does not empty the dock. Each line remembers its region if a filter is wanted later.
- **The chat is hidden** while a secret modal, the deploy bar, or a HOSAKA offer is on screen, the same rule the compass and instruments follow.

## Measured in a browser (1400 by 900)

- Folded chip centred at x=700; compass at the top right; cube key directly above NEAR in the same column.
- `/` unfolds the dock with the caret in the input; the dock is clear of the menu button and the pad.
- Fourteen lines with fourteen avatar bubbles, newest at the bottom, list scrolled to its end, scrollbar hidden.
- Enter signs a line, seals it, and the local echo appears. Escape folds. One unread shows a badge of 1.

Tests: 654 passing. tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
