### PR TITLE
Live subscriptions outlive their socket

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { TouchControls } from './hud/TouchControls'
 import { RouteOverlay } from './hud/RouteOverlay'
 import { ViewMenu } from './hud/ViewMenu'
 import { Compass3D } from './scene/Compass3D'
+import { watchConnectivity } from './lib/relay'
 import { Scene } from './scene/Scene'
 import { useCanvasTap } from './hooks/useCanvasTap'
 import { useKeyboard } from './hooks/useKeyboard'
@@ -54,6 +55,10 @@ export default function App(): JSX.Element {
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
   useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load(); watchFocus() }, [])
+  // The feeds that watch other people, the loot and the anchors are reissued
+  // when the tab returns from a real absence or the network comes back; a
+  // socket that died while the tab was away looks open and delivers nothing.
+  useEffect(() => watchConnectivity(), [])
   // A cloud job paid or computing when the tab last closed is picked up here,
   // if the chain head is still the one it was bound to. Also fetches the caps.
   useEffect(() => { void useCyberspace.getState().resumeCloudJob() }, [])

--- a/src/lib/liveSub.test.ts
+++ b/src/lib/liveSub.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LiveRegistry, backoffFor, resumedFilter, RESUME_OVERLAP_S, type Transport } from './liveSub'
+import type { Filter } from 'nostr-tools/filter'
+import type { NostrEvent } from './events'
+
+/** A pool that remembers every open, and lets the test end a subscription. */
+function fakeTransport() {
+  const opens: Array<{ filter: Filter; emit: (ev: NostrEvent) => void; end: (reason: string) => void; closed: boolean; failed?: boolean }> = []
+  let failNext = false
+  const transport: Transport = {
+    open: async (filter, handlers, onClose) => {
+      if (failNext) { failNext = false; throw new Error('relay down') }
+      const rec = { filter, emit: handlers.onEvent, end: onClose, closed: false }
+      opens.push(rec)
+      return () => { rec.closed = true }
+    },
+  }
+  return { transport, opens, failNext: () => { failNext = true } }
+}
+
+const ev = (created_at: number): NostrEvent => ({ id: String(created_at), kind: 1, created_at, pubkey: 'p', content: '', tags: [], sig: 's' })
+
+describe('the resumed filter', () => {
+  it('leaves a subscription that has seen nothing alone', () => {
+    expect(resumedFilter({ kinds: [1], since: 5 }, null)).toEqual({ kinds: [1], since: 5 })
+  })
+
+  it('moves since up to a minute before the last event seen', () => {
+    expect(resumedFilter({ kinds: [1] }, 1000).since).toBe(1000 - RESUME_OVERLAP_S)
+  })
+
+  it('never moves since backwards', () => {
+    expect(resumedFilter({ kinds: [1], since: 2000 }, 1000).since).toBe(2000)
+  })
+})
+
+describe('the backoff', () => {
+  it('starts at a second and tops out at thirty', () => {
+    expect(backoffFor(1)).toBe(1_000)
+    expect(backoffFor(3)).toBe(5_000)
+    expect(backoffFor(50)).toBe(30_000)
+  })
+})
+
+describe('a live subscription', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('delivers events and remembers the newest', async () => {
+    const { transport, opens } = fakeTransport()
+    const reg = new LiveRegistry(transport)
+    const got: number[] = []
+    reg.subscribe({ kinds: [1] }, { onEvent: (e) => got.push(e.created_at) })
+    await vi.runAllTicks()
+    opens[0].emit(ev(10)); opens[0].emit(ev(30)); opens[0].emit(ev(20))
+    expect(got).toEqual([10, 30, 20])
+    expect(reg.list()[0].lastSeen).toBe(30)
+  })
+
+  it('reopens after the relay ends it, with since moved up', async () => {
+    const { transport, opens } = fakeTransport()
+    const reg = new LiveRegistry(transport)
+    reg.subscribe({ kinds: [1] }, { onEvent: () => {} })
+    await vi.runAllTicks()
+    opens[0].emit(ev(500))
+    opens[0].end('connection closed')
+    expect(opens).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(opens).toHaveLength(2)
+    expect(opens[1].filter.since).toBe(500 - RESUME_OVERLAP_S)
+    expect(reg.list()[0].reopens).toBe(1)
+  })
+
+  it('backs off across repeated closes and resets once something arrives', async () => {
+    const { transport, opens } = fakeTransport()
+    const reg = new LiveRegistry(transport)
+    reg.subscribe({ kinds: [1] }, { onEvent: () => {} })
+    await vi.runAllTicks()
+    opens[0].end('x')
+    await vi.advanceTimersByTimeAsync(1_000)   // 1 s
+    opens[1].end('x')
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(opens).toHaveLength(2)              // not yet: second wait is 2 s
+    await vi.advanceTimersByTimeAsync(1)
+    expect(opens).toHaveLength(3)
+    opens[2].emit(ev(1))                       // life: the count resets
+    opens[2].end('x')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(opens).toHaveLength(4)
+  })
+
+  it('a failed open is retried too', async () => {
+    const { transport, opens, failNext } = fakeTransport()
+    failNext()
+    const reg = new LiveRegistry(transport)
+    reg.subscribe({ kinds: [1] }, { onEvent: () => {} })
+    await vi.runAllTicks()
+    expect(opens).toHaveLength(0)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(opens).toHaveLength(1)
+    expect(reg.list()).toHaveLength(1)
+  })
+
+  it('a closer ends it for good: no reopen, and a late close is ignored', async () => {
+    const { transport, opens } = fakeTransport()
+    const reg = new LiveRegistry(transport)
+    const stop = reg.subscribe({ kinds: [1] }, { onEvent: () => {} })
+    await vi.runAllTicks()
+    stop()
+    expect(opens[0].closed).toBe(true)
+    opens[0].end('closed by us')
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(opens).toHaveLength(1)
+    expect(reg.list()).toHaveLength(0)
+  })
+
+  it('resumeAll drops the sockets once and reissues every record at once', async () => {
+    const { transport, opens } = fakeTransport()
+    const reg = new LiveRegistry(transport)
+    reg.subscribe({ kinds: [1] }, { onEvent: () => {} })
+    reg.subscribe({ kinds: [2] }, { onEvent: () => {} })
+    await vi.runAllTicks()
+    opens[0].emit(ev(900))
+    let drops = 0
+    reg.resumeAll(() => { drops++ })
+    await vi.runAllTicks()
+    expect(drops).toBe(1)
+    expect(opens).toHaveLength(4)
+    expect(reg.list().map((l) => l.reopens)).toEqual([1, 1])
+    expect(opens[2].filter).toMatchObject({ kinds: [1], since: 900 - RESUME_OVERLAP_S })
+    expect(opens[3].filter).toEqual({ kinds: [2] })
+  })
+
+  it('a close from the socket that was replaced does not reopen again', async () => {
+    const { transport, opens } = fakeTransport()
+    const reg = new LiveRegistry(transport)
+    reg.subscribe({ kinds: [1] }, { onEvent: () => {} })
+    await vi.runAllTicks()
+    reg.resumeAll(() => {})
+    await vi.runAllTicks()
+    expect(opens).toHaveLength(2)
+    opens[0].end('late close of the old socket')
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(opens).toHaveLength(2)
+  })
+})

--- a/src/lib/liveSub.ts
+++ b/src/lib/liveSub.ts
@@ -1,0 +1,165 @@
+/**
+ * liveSub.ts — a subscription that outlives its socket.
+ *
+ * A relay socket dies for reasons the page never sees: a phone suspends the
+ * tab for a thirty-minute hyperjump, a NAT forgets an idle connection, the
+ * browser reclaims everything while a wallet is up. The pool underneath us
+ * then closes every open subscription for good, and nothing reissued them:
+ * publishing recovered on its own (it drops dead sockets and retries), but
+ * the feeds that watch other people, the loot, the anchors and the chat went
+ * quiet until a reload. That is why a friend who had just ridden hyperspace
+ * could not see anyone: their feeds had been dead for half an hour.
+ *
+ * This keeps each live subscription as a record and reopens it whenever the
+ * pool reports it closed, with backoff, and on demand when the tab comes back
+ * from the background. Authentication happens before the request is sent,
+ * because the relay auth-gates reads and answers an unauthed REQ with CLOSED.
+ * `since` is moved forward to just before the last event seen, with a minute
+ * of overlap: a repeat is cheaper than a gap, and every consumer merges by id.
+ *
+ * The transport is injected so the loop can be tested with a fake pool.
+ */
+
+import type { Filter } from 'nostr-tools/filter'
+import type { NostrEvent } from './events'
+
+export interface Handlers {
+  onEvent: (ev: NostrEvent) => void
+  onEose?: () => void
+}
+
+/** What the transport must do: open one subscription and tell us when it closes. */
+export interface Transport {
+  /** Authenticate and open; resolves to a closer. `onClose` fires when the relay ended it. */
+  open: (filter: Filter, handlers: Handlers, onClose: (reason: string) => void) => Promise<() => void>
+}
+
+/** Seconds of overlap when a subscription is reissued. */
+export const RESUME_OVERLAP_S = 60
+/** How long a reopen waits after each successive close, in milliseconds. */
+export const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000]
+
+export interface Live {
+  id: number
+  filter: Filter
+  handlers: Handlers
+  /** created_at of the newest event delivered, or null before any. */
+  lastSeen: number | null
+  /** Events delivered over the record's whole life, reopens included. */
+  events: number
+  /** Times the subscription has been reissued. */
+  reopens: number
+  /** Consecutive closes without an event between them; drives the backoff. */
+  attempts: number
+  closed: boolean
+  closer: (() => void) | null
+  timer: ReturnType<typeof setTimeout> | null
+  opening: boolean
+}
+
+/** The filter to reissue with: `since` moved up to just before the last event seen. */
+export function resumedFilter(filter: Filter, lastSeen: number | null): Filter {
+  if (lastSeen === null) return filter
+  const since = Math.max(filter.since ?? 0, lastSeen - RESUME_OVERLAP_S)
+  return { ...filter, since }
+}
+
+export function backoffFor(attempts: number): number {
+  return BACKOFF_MS[Math.min(Math.max(0, attempts - 1), BACKOFF_MS.length - 1)]
+}
+
+export class LiveRegistry {
+  private records = new Map<number, Live>()
+  private nextId = 1
+
+  constructor(private transport: Transport) {}
+
+  /** Open a subscription that will be kept open. Returns its closer. */
+  subscribe(filter: Filter, handlers: Handlers): () => void {
+    const live: Live = {
+      id: this.nextId++, filter, handlers, lastSeen: null, events: 0, reopens: 0,
+      attempts: 0, closed: false, closer: null, timer: null, opening: false,
+    }
+    this.records.set(live.id, live)
+    void this.open(live)
+    return () => this.close(live)
+  }
+
+  /** Every record still wanted. */
+  list(): Live[] {
+    return [...this.records.values()]
+  }
+
+  /**
+   * Reissue everything now, without waiting out a backoff. For when the tab
+   * comes back from the background: the sockets it holds may be half-open,
+   * which looks connected and delivers nothing, so waiting for a close would
+   * wait forever. `dropSockets` runs once first, so every record then opens
+   * over a fresh connection.
+   */
+  resumeAll(dropSockets: () => void): void {
+    dropSockets()
+    for (const live of this.records.values()) {
+      if (live.closed) continue
+      if (live.timer) { clearTimeout(live.timer); live.timer = null }
+      // The pool has already closed these; a closer that still exists is stale,
+      // and the open that follows is a new generation, so a late close from
+      // the socket being replaced is not mistaken for the new one dying.
+      live.closer = null
+      live.attempts = 0
+      live.reopens++
+      void this.open(live)
+    }
+  }
+
+  private async open(live: Live): Promise<void> {
+    if (live.closed || live.opening) return
+    live.opening = true
+    const generation = live.reopens
+    try {
+      const closer = await this.transport.open(
+        resumedFilter(live.filter, live.lastSeen),
+        {
+          onEvent: (ev) => {
+            if (live.closed) return
+            live.events++
+            live.attempts = 0
+            if (live.lastSeen === null || ev.created_at > live.lastSeen) live.lastSeen = ev.created_at
+            live.handlers.onEvent(ev)
+          },
+          onEose: live.handlers.onEose,
+        },
+        () => {
+          // A close from an earlier generation is the one we replaced: ignore it.
+          if (live.closed || live.reopens !== generation) return
+          live.closer = null
+          this.scheduleReopen(live)
+        },
+      )
+      if (live.closed) { closer(); return }
+      live.closer = closer
+    } catch {
+      this.scheduleReopen(live)
+    } finally {
+      live.opening = false
+    }
+  }
+
+  private scheduleReopen(live: Live): void {
+    if (live.closed || live.timer) return
+    live.attempts++
+    live.timer = setTimeout(() => {
+      live.timer = null
+      live.reopens++
+      void this.open(live)
+    }, backoffFor(live.attempts))
+  }
+
+  private close(live: Live): void {
+    live.closed = true
+    if (live.timer) { clearTimeout(live.timer); live.timer = null }
+    live.closer?.()
+    live.closer = null
+    this.records.delete(live.id)
+  }
+}

--- a/src/lib/relay.ts
+++ b/src/lib/relay.ts
@@ -17,6 +17,8 @@ import type { Filter } from 'nostr-tools/filter'
 import type { EventTemplate, VerifiedEvent } from 'nostr-tools/core'
 import type { NostrEvent } from './events'
 import { currentRelays, DEFAULT_RELAY } from '../store/useRelays'
+import { LiveRegistry, type Transport } from './liveSub'
+import { normalizeURL } from 'nostr-tools/utils'
 import { useCyberspace } from '../store/useCyberspace'
 
 /** The default relay, always present; kept here so panels can name it. */
@@ -53,6 +55,17 @@ export function getPool(): AbstractSimplePool {
       // SimplePool's own default (3e3), restated because the abstract
       // constructor requires the field.
       maxWaitForConnection: 3000,
+      // A ping every 29 seconds, and a socket that misses its pong for 20 is
+      // declared dead. Without it a socket a NAT or a suspended phone has
+      // forgotten stays "open" forever, delivering nothing: the "already in
+      // CLOSING or CLOSED state" lines in the console were writes to exactly
+      // that. A declared death closes the subscriptions on it, and the live
+      // registry below reopens them.
+      enablePing: true,
+      // Not the pool's own reconnect: it refires REQs the instant the socket
+      // opens, before the relay's fresh NIP-42 challenge is answered, and the
+      // relay auth-gates reads. The registry authenticates first, then asks.
+      enableReconnect: false,
     })
     // Not in SimplePool's constructor options, but the abstract pool honours it:
     // when a relay proactively sends an AUTH challenge, authenticate with it.
@@ -212,26 +225,141 @@ export async function queryAny(relays: string[], filter: Filter, maxWait?: numbe
 }
 
 /** A live subscription across the configured relays; the returned function closes it. */
+/**
+ * The transport under the live registry: authenticate, then ask, and report
+ * the relay ending the subscription so the registry can ask again.
+ */
+const liveTransport: Transport = {
+  open: async (filter, handlers, onClose) => {
+    const relays = relaySet()
+    // Authenticate first; a live subscription opened on an unauthed socket is
+    // closed by the relay before it delivers anything.
+    await authAll(relays)
+    const sub = getPool().subscribe(relays, filter, {
+      onevent: handlers.onEvent,
+      oneose: handlers.onEose,
+      onauth: authSign,
+      // Fires once every relay in the set has ended it: for the one relay we
+      // run on, once, and that is the socket dying under us.
+      onclose: (reasons) => onClose(reasons.map((r) => r.reason).join('; ')),
+    })
+    return () => sub.close()
+  },
+}
+
+const live = new LiveRegistry(liveTransport)
+
+/**
+ * A live subscription that stays open for the life of its closer: reissued
+ * after any close the relay makes, and on demand when the tab comes back.
+ */
 export function subscribe(
   filter: Filter,
   onEvent: (ev: NostrEvent) => void,
   onEose?: () => void,
 ): () => void {
-  const relays = relaySet()
-  let closed = false
-  let sub: { close: () => void } | null = null
-  // Authenticate first; a live subscription opened on an unauthed socket is
-  // closed by the relay before it delivers anything.
-  void authAll(relays).then(() => {
-    if (closed) return
-    sub = getPool().subscribe(relays, filter, { onevent: onEvent, oneose: onEose, onauth: authSign })
-  })
-  return () => { closed = true; sub?.close() }
+  return live.subscribe(filter, { onEvent, onEose })
 }
 
-/** Whether any configured relay is currently connected. */
+/**
+ * Back from the background: every socket may be half-open, which looks
+ * connected and delivers nothing. Drop them and reissue every live
+ * subscription over fresh ones. Cheap, and only worth it after a real absence:
+ * an alt-tab on a desktop is not an absence, so the caller says how long.
+ */
+export function resumeLive(): void {
+  live.resumeAll(() => dropRelays(relaySet()))
+}
+
+/** How long the tab must have been hidden before its return reissues the feeds. */
+export const RESUME_AFTER_HIDDEN_MS = 15_000
+/** How often the connection is asked whether it is really there. */
+export const PROBE_EVERY_MS = 20_000
+/** How long a probe waits for the relay's answer before calling the socket dead. */
+export const PROBE_TIMEOUT_MS = 8_000
+/** An id no event has: the probe wants only the relay's EOSE, never an event. */
+const NO_SUCH_ID = '0'.repeat(64)
+
+let hiddenAt: number | null = null
+let probing = false
+
+/**
+ * Ask the relay for nothing and see whether it says so.
+ *
+ * A half-open socket is the case nothing else catches: the pool believes it
+ * is connected, the browser's WebSocket reports open, and every write goes
+ * into the void. The pool's own ping notices that and calls close(), but a
+ * close on a half-open socket waits for a close handshake that never comes,
+ * so the pool never learns the socket is dead and never ends the
+ * subscriptions on it. This does not wait for the socket to admit anything:
+ * a probe the relay does not answer in time is a dead connection, and the
+ * feeds are reissued over fresh sockets. Only run while the pool thinks it
+ * is connected; a connection the pool already knows is down is the registry's
+ * own backoff path, and probing it would only reset that backoff.
+ */
+export async function probeLiveness(): Promise<'alive' | 'dead' | 'skipped'> {
+  if (probing || live.list().length === 0 || !connected()) return 'skipped'
+  probing = true
+  try {
+    const relays = relaySet()
+    const answered = await new Promise<boolean>((resolve) => {
+      let settled = false
+      const done = (ok: boolean): void => { if (!settled) { settled = true; resolve(ok) } }
+      const timer = setTimeout(() => done(false), PROBE_TIMEOUT_MS)
+      const sub = getPool().subscribe(relays, { ids: [NO_SUCH_ID] }, {
+        onevent: () => {},
+        oneose: () => { clearTimeout(timer); done(true); sub.close() },
+        onclose: () => { clearTimeout(timer); done(false) },
+        onauth: authSign,
+        maxWait: PROBE_TIMEOUT_MS,
+      })
+    })
+    if (answered) return 'alive'
+    resumeLive()
+    return 'dead'
+  } finally {
+    probing = false
+  }
+}
+
+/**
+ * Watch the tab's visibility and the network, and keep asking the connection
+ * whether it is there; resume the feeds when any of them says it is not.
+ */
+export function watchConnectivity(): () => void {
+  const onVisibility = (): void => {
+    if (document.visibilityState === 'hidden') { hiddenAt = Date.now(); return }
+    if (hiddenAt !== null && Date.now() - hiddenAt >= RESUME_AFTER_HIDDEN_MS) resumeLive()
+    hiddenAt = null
+  }
+  const onOnline = (): void => resumeLive()
+  // Not while hidden: a background tab's timers are throttled anyway, and the
+  // return is handled above.
+  const tick = (): void => { if (document.visibilityState === 'visible') void probeLiveness() }
+  document.addEventListener('visibilitychange', onVisibility)
+  window.addEventListener('online', onOnline)
+  const interval = setInterval(tick, PROBE_EVERY_MS)
+  return () => {
+    document.removeEventListener('visibilitychange', onVisibility)
+    window.removeEventListener('online', onOnline)
+    clearInterval(interval)
+  }
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __live: LiveRegistry; __pool: () => AbstractSimplePool; __resumeLive: () => void }).__live = live
+  ;(window as unknown as { __pool: () => AbstractSimplePool }).__pool = getPool
+  ;(window as unknown as { __resumeLive: () => void }).__resumeLive = resumeLive
+  ;(window as unknown as { __probeLiveness: () => Promise<string> }).__probeLiveness = probeLiveness
+}
+
+/**
+ * Whether any configured relay is currently connected, as far as the pool
+ * knows. The pool files relays under normalized URLs (a trailing slash on a
+ * bare host), so the lookup normalizes too; compared raw, this was never true.
+ */
 export function connected(): boolean {
   const status = pool?.listConnectionStatus()
   if (!status) return false
-  return relaySet().some((r) => status.get(r))
+  return relaySet().some((r) => status.get(normalizeURL(r)))
 }

--- a/src/store/useRelays.ts
+++ b/src/store/useRelays.ts
@@ -83,3 +83,7 @@ export const useRelays = create<RelaysState>((set, get) => ({
 export function currentRelays(): string[] {
   return useRelays.getState().relays
 }
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __relays: typeof useRelays }).__relays = useRelays
+}


### PR DESCRIPTION
The feeds that watch other people, the loot, the anchors and the chat went quiet after any socket death and stayed quiet until a reload. Publishing recovered on its own, which is why a friend who had just ridden hyperspace could still be seen moving but could not see anyone: their feeds had been dead for half an hour while their own moves still went out.

**Root cause.** The pool was built without reconnect or keepalive. On any hard close it closes every open subscription for good, and nothing in the app reissued them.

**What changed.**

| Piece | Behavior |
|---|---|
| `lib/liveSub.ts`, a registry | Every live subscription is a record. When the pool reports it closed, it is reissued with backoff of 1, 2, 5, 10 and 30 seconds, and `since` moved up to a minute before the last event seen. A repeat is cheaper than a gap; every consumer merges by id. |
| Auth before REQ | The transport authenticates, then asks. The pool's own reconnect was not used because it refires REQs the instant the socket opens, before the relay's fresh NIP-42 challenge is answered, and the relay auth-gates reads. |
| Liveness probe | Every 20 seconds while the pool thinks it is connected: a request for an id no event has, answered by EOSE within 8 seconds or the sockets are dropped and every feed reissued. This catches the half-open socket, which the pool's ping cannot: its `close()` waits for a close handshake a half-open socket never completes. |
| Tab return | Hidden 15 seconds or more, then visible, or the network coming back: drop the sockets and reissue everything at once. A short alt-tab does nothing. |
| Keepalive | `enablePing` on in the pool (29 s, 20 s to answer). |
| `connected()` | Compared raw URLs with the pool's normalized keys and had never been true. Normalizes now. |

**Measured** against a local relay behind a proxy that can kill or half-open the socket under the running app, publishing a probe event after each death:

| Death | Reissued after | Next event arrived |
|---|---|---|
| Hard close (OS reclaims the socket) | ~1.5 s | 0.25 s |
| Half-open (looks connected, delivers nothing) | 9.5 s, by the probe | 0.25 s |
| Tab hidden 16 s, then visible | 0.25 s | 0.25 s |
| Alt-tab for 1.5 s | not reissued, by design | |

Eleven unit tests on the registry with a fake pool. 650 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
