### PR TITLE
Presence: the people in this sector, targeted or not

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import { TouchControls } from './hud/TouchControls'
 import { RouteOverlay } from './hud/RouteOverlay'
 import { ViewMenu } from './hud/ViewMenu'
 import { Compass3D } from './scene/Compass3D'
+import { PresenceChip } from './hud/PresenceChip'
+import { startPresence } from './store/usePresence'
 import { Scene } from './scene/Scene'
 import { useCanvasTap } from './hooks/useCanvasTap'
 import { useKeyboard } from './hooks/useKeyboard'
@@ -53,7 +55,7 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load(); watchFocus() }, [])
+  useEffect(() => { startPublisher(); startTracker(); startPresence(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load(); watchFocus() }, [])
   // A cloud job paid or computing when the tab last closed is picked up here,
   // if the chain head is still the one it was bound to. Also fetches the caps.
   useEffect(() => { void useCyberspace.getState().resumeCloudJob() }, [])
@@ -167,6 +169,7 @@ export default function App(): JSX.Element {
           <HyperspaceBar />
           <FocusBar />
           <KeyFoundChip />
+          <PresenceChip />
           <ToastChip />
           <ChainExplorer />
           <BitReadout />

--- a/src/hud/PresenceChip.tsx
+++ b/src/hud/PresenceChip.tsx
@@ -1,0 +1,67 @@
+/**
+ * PresenceChip.tsx — how many people are in this sector, and who.
+ *
+ * A sector is 2^30 gibsons on a side, so "in this sector" is not "beside
+ * you": it is the part of cyberspace you are in, and the chip says so with
+ * that word. Tap it for the names; TARGET makes one of them a target, which
+ * is the existing path to their chain, their marker at any distance, and the
+ * scene following them.
+ */
+
+import { useState } from 'react'
+import { Users } from 'lucide-react'
+import { useCyberspace } from '../store/useCyberspace'
+import { usePresence, type Person } from '../store/usePresence'
+import { useProfile } from '../hooks/useProfile'
+import { ProfilePic } from './ProfileBadge'
+import { formatDistance } from '../lib/scale'
+
+function ageLabel(at: number, now: number): string {
+  const s = Math.max(0, now - at)
+  if (s < 60) return 'now'
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+function Row({ person, now }: { person: Person; now: number }): JSX.Element {
+  const profile = useProfile(person.pubkey)
+  const me = useCyberspace((s) => s.position)
+  const name = profile?.name ?? `${person.pubkey.slice(0, 12)}…`
+  const d = [person.position.x - me.x, person.position.y - me.y, person.position.z - me.z].map((v) => (v < 0n ? -v : v))
+  const far = d.reduce((a, b) => (a > b ? a : b), 0n)
+  return (
+    <li className="presence__row">
+      <ProfilePic pubkey={person.pubkey} size={20} />
+      <span className="presence__who">
+        <span className="presence__name">{name}</span>
+        <span className="presence__meta">{formatDistance(far)} away · {ageLabel(person.lastActive, now)}</span>
+      </span>
+      <button className="avatars__go presence__target" onClick={() => useCyberspace.getState().addTarget(person.pubkey, profile?.name ?? null)}>TARGET</button>
+    </li>
+  )
+}
+
+export function PresenceChip(): JSX.Element | null {
+  const people = usePresence((s) => s.people)
+  const loading = usePresence((s) => s.loading)
+  const targets = useCyberspace((s) => s.targets)
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const [open, setOpen] = useState(false)
+  const others = Object.values(people).filter((p) => p.pubkey !== me && !targets[p.pubkey]).sort((a, b) => b.lastActive - a.lastActive)
+  if (others.length === 0 && !loading) return null
+  const now = Math.floor(Date.now() / 1000)
+  return (
+    <div className={`hyperbar presence ${open ? 'is-open' : ''}`} role="status">
+      <button className="presence__head" onClick={() => setOpen((o) => !o)} aria-expanded={open} title="People whose newest move landed in this sector or one beside it. A sector is 2^30 gibsons on a side.">
+        <Users size={12} strokeWidth={2.25} aria-hidden />
+        <span className="hyperbar__label">{loading && others.length === 0 ? 'LOOKING' : `${others.length} IN THIS SECTOR`}</span>
+      </button>
+      {open && others.length > 0 && (
+        <ul className="presence__list">
+          {others.slice(0, 12).map((p) => <Row key={p.pubkey} person={p} now={now} />)}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/lib/scale.test.ts
+++ b/src/lib/scale.test.ts
@@ -1,3 +1,4 @@
+import { formatDistance } from './scale'
 /**
  * scale.test.ts - a cell's size reads in the unit it is best read in, short
  * for the ladder and spelled out for the readout; the step reads in gibsons.
@@ -23,5 +24,16 @@ describe('step', () => {
     expect(formatStep(0)).toBe('1 gibson')
     expect(formatStep(10)).toBe('1,024 gibsons')
     expect(formatStep(40)).toBe('2^40 gibsons')
+  })
+})
+
+describe('formatDistance under a micrometer', () => {
+  it('does not floor a few gibsons to zero', () => {
+    expect(formatDistance(3n)).not.toBe('0 pm')
+    expect(formatDistance(3n)).toMatch(/^349 pm$/)
+  })
+
+  it('still reads a large distance the same way', () => {
+    expect(formatDistance(1n << 40n)).toBe('128 m')
   })
 })

--- a/src/lib/scale.ts
+++ b/src/lib/scale.ts
@@ -38,8 +38,14 @@ function inUnit(meters: number): { figure: number; unit: (typeof UNITS)[number] 
  */
 export function formatDistance(gibsons: bigint): string {
   if (gibsons === 0n) return '0'
-  // 2^33 gibsons per meter, so this is exact rather than a rounding.
-  const meters = Number((gibsons * 1_000_000n) >> 33n) / 1_000_000
+  // 2^33 gibsons per meter. Below 2^53 gibsons a double holds the count
+  // exactly and the division keeps every picometer; the old integer-microns
+  // shortcut floored anything under a micrometer to zero, so a person three
+  // gibsons away read as "0 pm". Past 2^53 the shift is exact and the
+  // microns are all anyone reads.
+  const meters = gibsons < (1n << 53n)
+    ? Number(gibsons) / 2 ** 33
+    : Number((gibsons * 1_000_000n) >> 33n) / 1_000_000
   for (let i = 0; i < UNITS.length; i++) {
     const u = UNITS[i]
     if (meters < u.threshold || i === UNITS.length - 1) {

--- a/src/scene/PresenceAvatars.tsx
+++ b/src/scene/PresenceAvatars.tsx
@@ -1,0 +1,58 @@
+/**
+ * PresenceAvatars.tsx — the people here whom you have not targeted.
+ *
+ * Drawn exactly as a target is, in their own color with their name over
+ * them, from the presence feed's idea of where they are: the same wireframe
+ * or the shard they chose, culled to the field the way targets are. The
+ * label is dimmer than a target's, which is the one thing that says "not
+ * yet yours". Targeting one is in the sector chip, where the name is.
+ */
+
+import { useMemo } from 'react'
+import { GRID_RADIUS, cellCentre, type ViewAxes } from '../lib/space'
+import { targetColor } from '../lib/targets'
+import { alignedOrigin, useCyberspace } from '../store/useCyberspace'
+import { usePresence } from '../store/usePresence'
+import { useProfile } from '../hooks/useProfile'
+import { AvatarShape } from './AvatarShape'
+import { WorldLabel } from './WorldLabel'
+
+const REACH = GRID_RADIUS * 8
+const AVATAR_SCALE_LIMIT = 10
+
+function PersonLabel({ pubkey, color }: { pubkey: string; color: string }): JSX.Element {
+  const profile = useProfile(pubkey)
+  const text = (profile?.name ?? `${pubkey.slice(0, 8)}…`).toUpperCase()
+  return <WorldLabel text={text} color={color} at={[0, 0.9, 0]} align="center" px={11} opacity={0.6} />
+}
+
+export function PresenceAvatars({ axes }: { axes: ViewAxes }): JSX.Element | null {
+  const people = usePresence((s) => s.people)
+  const targets = useCyberspace((s) => s.targets)
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const anchor = useCyberspace((s) => s.anchor)
+  const anchorPlane = useCyberspace((s) => s.anchorPlane)
+  const scaleExp = useCyberspace((s) => s.scaleExp)
+
+  const near = useMemo(() => {
+    if (scaleExp >= AVATAR_SCALE_LIMIT) return []
+    const origin = alignedOrigin(anchor, scaleExp)
+    return Object.values(people)
+      .filter((p) => p.pubkey !== me && !targets[p.pubkey] && p.plane === anchorPlane)
+      .map((p) => ({ ...p, centre: cellCentre(p.position, origin, scaleExp, axes) }))
+      .filter((p) => Math.hypot(...p.centre) <= REACH)
+  }, [people, targets, me, anchor, anchorPlane, scaleExp, axes])
+
+  if (near.length === 0) return null
+
+  return (
+    <>
+      {near.map((p) => (
+        <group key={p.pubkey} position={p.centre}>
+          <AvatarShape pubkey={p.pubkey} color={targetColor(p.pubkey)} />
+          <PersonLabel pubkey={p.pubkey} color={targetColor(p.pubkey)} />
+        </group>
+      ))}
+    </>
+  )
+}

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -57,6 +57,7 @@ import { ShaderPointField } from './ShaderPointField'
 import { SecretRegions } from './SecretRegions'
 import { SpawnMarker } from './SpawnMarker'
 import { TargetAvatars } from './TargetAvatars'
+import { PresenceAvatars } from './PresenceAvatars'
 import { WorldShards } from './WorldShards'
 import { WorldMessages } from './WorldMessages'
 import { ShardGhost } from './ShardGhost'
@@ -125,6 +126,7 @@ function World(): JSX.Element {
       <PathTrail axes={axes} scaleExp={scaleExp} />
       <SpawnMarker pubkey={pubkey} axes={axes} />
       <TargetAvatars axes={axes} />
+      <PresenceAvatars axes={axes} />
       <WorldShards axes={axes} />
       <WorldMessages axes={axes} />
       <ShardGhost axes={axes} />

--- a/src/store/presence.test.ts
+++ b/src/store/presence.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { ACTION_KIND, hopTemplate, positionHex } from '../lib/events'
+import { inNeighborhood, neighborhoodFilter, sectorKey, usePresence } from './usePresence'
+import { useCyberspace } from './useCyberspace'
+
+const SECTOR = 1n << 30n
+const here = { x: 5n * SECTOR + 7n, y: 9n * SECTOR + 1n, z: 3n * SECTOR + 2n }
+
+/**
+ * A hop by a key to a position: the smallest positional action the parser
+ * accepts. A spawn's coordinate is its pubkey, so it cannot be placed; a hop
+ * can, and the parser checks the shape of its links and proof, not their truth.
+ */
+function spawnAt(at: { x: bigint; y: bigint; z: bigint }, createdAt: number, sk = generateSecretKey()) {
+  return finalizeEvent(hopTemplate({ createdAt, genesisId: 'a'.repeat(64), previousId: 'b'.repeat(64), prevCoordHex: positionHex(at, 0), to: at, plane: 0, proofHash: 'c'.repeat(64) }), sk)
+}
+
+describe('the neighborhood', () => {
+  it('is one filter over the three axis tags, each with the sector and its two neighbors', () => {
+    const f = neighborhoodFilter(here)
+    expect(f.kinds).toEqual([ACTION_KIND])
+    expect(f['#X']).toEqual(['4', '5', '6'])
+    expect(f['#Y']).toEqual(['8', '9', '10'])
+    expect(f['#Z']).toEqual(['2', '3', '4'])
+  })
+
+  it('names the sector the way the S tag does', () => {
+    expect(sectorKey(here)).toBe('5-9-3')
+  })
+
+  it('knows a position one sector over is in it, and two sectors over is not', () => {
+    expect(inNeighborhood({ ...here, x: here.x + SECTOR }, here)).toBe(true)
+    expect(inNeighborhood({ ...here, x: here.x + 2n * SECTOR }, here)).toBe(false)
+  })
+})
+
+describe('taking people in', () => {
+  beforeEach(() => { usePresence.setState({ people: {}, sector: null, loading: false }) })
+
+  it('keeps the newest action per author', () => {
+    const sk = generateSecretKey()
+    usePresence.getState().ingest(spawnAt(here, 100, sk))
+    usePresence.getState().ingest(spawnAt({ ...here, x: here.x + 1n }, 200, sk))
+    usePresence.getState().ingest(spawnAt({ ...here, x: here.x + 2n }, 150, sk))
+    const p = usePresence.getState().people[getPublicKey(sk)]
+    expect(p.lastActive).toBe(200)
+    expect(p.position.x).toBe(here.x + 1n)
+  })
+
+  it('leaves you out', () => {
+    const sk = generateSecretKey()
+    useCyberspace.setState({ identity: { ...useCyberspace.getState().identity, pubkey: getPublicKey(sk) } })
+    usePresence.getState().ingest(spawnAt(here, 100, sk))
+    expect(Object.keys(usePresence.getState().people)).toHaveLength(0)
+  })
+
+  it('others() leaves out your targets as well', () => {
+    const sk = generateSecretKey()
+    usePresence.getState().ingest(spawnAt(here, 100, sk))
+    expect(usePresence.getState().others()).toHaveLength(1)
+    useCyberspace.setState({ targets: { [getPublicKey(sk)]: { pubkey: getPublicKey(sk), npub: 'npub1x', name: null, position: here, plane: 0, lastActive: null, status: 'live' } } })
+    expect(usePresence.getState().others()).toHaveLength(0)
+    useCyberspace.setState({ targets: {} })
+  })
+
+  it('ignores an event that is not an action', () => {
+    const sk = generateSecretKey()
+    usePresence.getState().ingest(finalizeEvent({ kind: 1, created_at: 1, content: 'hi', tags: [] }, sk))
+    expect(Object.keys(usePresence.getState().people)).toHaveLength(0)
+  })
+})

--- a/src/store/usePresence.ts
+++ b/src/store/usePresence.ts
@@ -1,0 +1,192 @@
+/**
+ * usePresence.ts — who is in this part of cyberspace, targeted or not.
+ *
+ * Until now the only people ever drawn were your targets. Cyberspace is
+ * 2^85 gibsons on a side; passing an avatar without knowing is the normal
+ * case, and the first meeting in it happened only because both people
+ * targeted each other by hand. This is the feed that makes the meeting
+ * happen on its own.
+ *
+ * Every action carries its destination's sector on four tags: X, Y and Z per
+ * axis and S combined, a sector being 2^30 gibsons on a side (spec §10). A
+ * relay indexes single-letter tags, and tag filters combine with AND across
+ * tags and OR within one, so one subscription on the three axis tags, each
+ * listing your sector and its two neighbors, returns every action landing in
+ * the 27 sectors around you. One filter, reissued when you cross a sector.
+ *
+ * Each author's newest action in the neighborhood is where they are. Someone
+ * who leaves does not announce it here (their next action lands outside the
+ * filter), so people not heard from in a while are confirmed by asking the
+ * relay for their newest action and dropped if it is elsewhere.
+ */
+
+import { create } from 'zustand'
+import { xyzToSectorId } from 'cyberspace-core'
+import type { Filter } from 'nostr-tools/filter'
+import { ACTION_KIND, parseAction, type NostrEvent, type ActionType } from '../lib/events'
+import type { Plane } from 'cyberspace-core'
+import { V2_ACTIONS } from '../lib/chains'
+import { query, subscribe } from '../lib/relay'
+import type { Position } from '../lib/space'
+import { useCyberspace } from './useCyberspace'
+
+export interface Person {
+  pubkey: string
+  position: Position
+  plane: Plane
+  /** created_at of the action that put them here. */
+  lastActive: number
+  type: ActionType
+  /** When the relay last confirmed this is still their newest action. */
+  checkedAt: number
+}
+
+/** Newest actions fetched when a neighborhood is entered. */
+export const BACKFILL_LIMIT = 500
+/** A person not heard from for this long is asked about before being kept. */
+export const CONFIRM_AFTER_S = 10 * 60
+/** How often the sweep that confirms quiet people runs. */
+export const SWEEP_EVERY_MS = 5 * 60 * 1000
+
+/** The sector a position is in, as the string the S tag carries. */
+export function sectorKey(p: Position): string {
+  const s = xyzToSectorId(p.x, p.y, p.z)
+  return `${s.sx}-${s.sy}-${s.sz}`
+}
+
+/** The 27 sectors around a position, as one relay filter. */
+export function neighborhoodFilter(p: Position): Filter {
+  const s = xyzToSectorId(p.x, p.y, p.z)
+  const around = (v: bigint): string[] => [v - 1n, v, v + 1n].map(String)
+  return { kinds: [ACTION_KIND], '#A': V2_ACTIONS, '#X': around(s.sx), '#Y': around(s.sy), '#Z': around(s.sz) }
+}
+
+/** Whether a position's sector is within one of the given sector on every axis. */
+export function inNeighborhood(p: Position, of: Position): boolean {
+  const a = xyzToSectorId(p.x, p.y, p.z)
+  const b = xyzToSectorId(of.x, of.y, of.z)
+  const near = (u: bigint, v: bigint): boolean => u >= v - 1n && u <= v + 1n
+  return near(a.sx, b.sx) && near(a.sy, b.sy) && near(a.sz, b.sz)
+}
+
+interface PresenceState {
+  people: Record<string, Person>
+  /** The sector the feed is anchored to, or null before the first. */
+  sector: string | null
+  /** True while the neighborhood's backfill is in flight. */
+  loading: boolean
+  /** Take an action event in: the newest per author wins. */
+  ingest: (ev: NostrEvent, now?: number) => void
+  /** Drop someone; the sweep does this when their newest action is elsewhere. */
+  forget: (pubkey: string) => void
+  /** Everyone here who is not you and not already a target. */
+  others: () => Person[]
+}
+
+export const usePresence = create<PresenceState>((set, get) => ({
+  people: {},
+  sector: null,
+  loading: false,
+
+  ingest: (ev, now = Math.floor(Date.now() / 1000)) => {
+    const action = parseAction(ev)
+    if (!action) return
+    const me = useCyberspace.getState().identity.pubkey
+    if (action.pubkey === me) return
+    const have = get().people[action.pubkey]
+    if (have && have.lastActive >= action.createdAt) return
+    set({ people: { ...get().people, [action.pubkey]: {
+      pubkey: action.pubkey, position: action.position, plane: action.plane,
+      lastActive: action.createdAt, type: action.type, checkedAt: now,
+    } } })
+  },
+
+  forget: (pubkey) => {
+    const people = { ...get().people }
+    delete people[pubkey]
+    set({ people })
+  },
+
+  others: () => {
+    const { identity, targets } = useCyberspace.getState()
+    return Object.values(get().people).filter((p) => p.pubkey !== identity.pubkey && !targets[p.pubkey])
+  },
+}))
+
+let stopLive: (() => void) | null = null
+let started = false
+let sweepHandle: ReturnType<typeof setInterval> | null = null
+
+/** Enter the neighborhood around `at`: forget the old one, fetch, then listen. */
+async function enter(at: Position): Promise<void> {
+  const key = sectorKey(at)
+  if (usePresence.getState().sector === key) return
+  stopLive?.()
+  stopLive = null
+  usePresence.setState({ sector: key, people: {}, loading: true })
+  const filter = neighborhoodFilter(at)
+  // Listen from a minute back before the fetch, so nothing lands in the gap.
+  const since = Math.floor(Date.now() / 1000) - 60
+  stopLive = subscribe({ ...filter, since }, (ev) => {
+    if (usePresence.getState().sector !== key) return
+    usePresence.getState().ingest(ev)
+  })
+  try {
+    const events = await query({ ...filter, limit: BACKFILL_LIMIT })
+    if (usePresence.getState().sector !== key) return
+    for (const ev of events) usePresence.getState().ingest(ev)
+  } catch {
+    /* the live feed still stands */
+  } finally {
+    if (usePresence.getState().sector === key) usePresence.setState({ loading: false })
+  }
+}
+
+/**
+ * Confirm the quiet ones. A person's newest action in the neighborhood is
+ * where they are only until they act somewhere else, and that action never
+ * arrives here. Ask the relay for their newest action of any kind; keep them
+ * if it is still in the neighborhood, at its position, or drop them.
+ */
+async function sweep(): Promise<void> {
+  const now = Math.floor(Date.now() / 1000)
+  const here = useCyberspace.getState().position
+  const quiet = Object.values(usePresence.getState().people).filter((p) => now - p.checkedAt >= CONFIRM_AFTER_S)
+  for (const person of quiet) {
+    try {
+      const newest = (await query({ kinds: [ACTION_KIND], authors: [person.pubkey], '#A': V2_ACTIONS, limit: 1 }))
+        .sort((a, b) => b.created_at - a.created_at)[0]
+      const action = newest ? parseAction(newest) : null
+      if (!action || !inNeighborhood(action.position, here)) { usePresence.getState().forget(person.pubkey); continue }
+      usePresence.setState((s) => ({ people: { ...s.people, [person.pubkey]: {
+        ...s.people[person.pubkey], position: action.position, plane: action.plane, lastActive: action.createdAt, type: action.type, checkedAt: now,
+      } } }))
+    } catch {
+      /* ask again next sweep */
+    }
+  }
+}
+
+/** Idempotent. Follows your avatar from sector to sector for the life of the page. */
+export function startPresence(): void {
+  if (started) return
+  started = true
+  void enter(useCyberspace.getState().position)
+  useCyberspace.subscribe((s, prev) => {
+    if (s.position !== prev.position) void enter(s.position)
+  })
+  sweepHandle = setInterval(() => { void sweep() }, SWEEP_EVERY_MS)
+}
+
+/** For tests: forget everything and stop listening. */
+export function stopPresence(): void {
+  stopLive?.()
+  stopLive = null
+  if (sweepHandle) { clearInterval(sweepHandle); sweepHandle = null }
+  started = false
+  usePresence.setState({ people: {}, sector: null, loading: false })
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __presence: typeof usePresence }).__presence = usePresence
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -5417,3 +5417,33 @@ kbd {
 }
 
 .secrets__sort .login__label { margin-right: 2px; }
+
+/* ---------- Presence: who is in this sector ---------- */
+.presence { pointer-events: auto; flex-direction: column; align-items: stretch; gap: 0; }
+.presence__head {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+.presence__list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 6px 0 0;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 40vh;
+  overflow-y: auto;
+}
+.presence__row { display: flex; align-items: center; gap: 8px; }
+.presence__who { display: flex; flex-direction: column; min-width: 0; flex: 1 1 auto; }
+.presence__name { font-size: 11px; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.presence__meta { font-size: 9px; color: var(--dim); letter-spacing: 0.08em; }
+.presence__target { padding: 2px 8px; font-size: 8px; }


### PR DESCRIPTION
Until now the only people ever drawn were your targets. Passing an avatar without knowing was the normal case, and the first meeting in cyberspace happened only because both people targeted each other by hand.

**How it finds people.** Every action carries its destination's sector on four tags (X, Y, Z per axis, S combined; a sector is 2^30 gibsons on a side, spec §10). Relays index single-letter tags, and tag filters AND across tags and OR within one, so one subscription on the three axis tags, each listing your sector and its two neighbors, returns every action landing in the 27 sectors around you. Reissued when your avatar crosses a sector. Verified against cyberspace.nostr1.com: the neighborhood query answers in 38 ms and every hit is within one sector per axis.

| Piece | Behavior |
|---|---|
| `store/usePresence.ts` | Enter a neighborhood: forget the old one, fetch its newest 500 actions, listen from a minute back. Each author's newest action is where they are. You and your targets are excluded. |
| Leavers | Someone who leaves does not announce it here (their next action lands outside the filter). Every 5 minutes, people not heard from in 10 are confirmed by asking the relay for their newest action of any kind, and dropped if it is elsewhere. |
| `scene/PresenceAvatars.tsx` | Drawn exactly as a target is: own color, name over them, same cull to the field, below the same scale limit. The label is dimmer, the one thing that says "not yet yours". |
| `hud/PresenceChip.tsx` | "N IN THIS SECTOR" in the instrument stack, with that word, since a sector is not "beside you". Open it for names, distance, and how long ago they moved. TARGET makes them a target, the existing path to their chain and marker. |
| `formatDistance` | Floored anything under a micrometer to zero, so a person three gibsons away read "0 pm". Divides exactly below 2^53 gibsons now: 349 pm. |

**Measured in the browser:** three people set near the avatar, one in the other plane. The scene draws self plus the two in this plane. The chip reads 3 IN THIS SECTOR; rows carry distance and age; TARGET on a row makes them a target, the chip drops to 2, and the wireframe count holds because the person moved from presence to targets.

**Depends on nothing else, but works best with #116:** the neighborhood feed is a live subscription, and #116 is what keeps live subscriptions alive across a dead socket.

Seven unit tests. 648 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
