### PR TITLE
Restore the stylesheet the merge of #114 broke

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5592,32 +5592,6 @@ kbd {
 
 .chat__compose {
   display: flex;
-
-/* Buying compute credit before anything needs it. */
-.cloud__balance {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-}
-
-.cloud__topup {
-  padding: 3px 8px;
-  font-size: 8px;
-  letter-spacing: 0.12em;
-}
-
-.cloud__topup-form {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 0;
-  border-top: 1px solid var(--border);
-}
-
-.cloud__topup-row {
-  display: flex;
-  flex-wrap: wrap;
   align-items: center;
   gap: 6px;
 }
@@ -5664,6 +5638,36 @@ kbd {
     width: auto;
     max-height: 38vh;
   }
+}
+
+/* Buying compute credit before anything needs it. */
+.cloud__balance {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.cloud__topup {
+  padding: 3px 8px;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+}
+
+.cloud__topup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.cloud__topup-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
 
 .cloud__topup-input {
   width: 90px;


### PR DESCRIPTION
v2 did not build after #114 merged: the stylesheet conflict resolution split the chat compose rule and dropped the closing brace of the chat phone media block ("Unclosed block"). The file is rebuilt from the stylesheet exactly as #115 left it plus the 34 lines #114 appended, taken from its own commit. Braces balance; build and tsc pass; the merge was gated on the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
