### PR TITLE
Hyperspace boots from its cache instead of re-verifying every header

### DIFF
--- a/src/lib/hyperspace/anchors.ts
+++ b/src/lib/hyperspace/anchors.ts
@@ -298,6 +298,11 @@ let db: IDBDatabase | null = null
 let covered: Array<[number, number]> = []
 /** Verified header-blob ranges, this session only (see the header comment). */
 let blobCovered: Array<[number, number]> = []
+/** What the adopted snapshot holds; its rows are in the index, not in IDB. */
+let snapshotCovered: Array<[number, number]> = []
+
+/** How the last boot's header phase went, for the HUD and for tests. */
+export const syncStats = { blobsVerified: 0, blobsSkipped: 0, skippedHeights: 0, cacheCovered: [] as Array<[number, number]> }
 /** Rows delivered by verified blobs, for the source label. */
 let blobRows = 0
 /** Index size and wall clock at the last snapshot write (or adoption), the
@@ -415,6 +420,10 @@ function persistTip(tip: number): void {
 function effectiveCovered(): Array<[number, number]> {
   let out = covered
   for (const range of blobCovered) out = mergeCovered(out, range)
+  // The snapshot's rows were pruned from IDB (they came from blobs), so
+  // `covered` alone under-reports what the index holds; without this a warm
+  // boot would ask the relay for every height the snapshot already has.
+  for (const range of snapshotCovered) out = mergeCovered(out, range)
   return out
 }
 
@@ -482,6 +491,7 @@ async function loadCache(cb: SyncCallbacks): Promise<void> {
     if (validSnapshotMeta(snapMeta) && adoptSnapshot(anchorIndex, snapMeta.snapshot)) {
       adopted = anchorIndex.size - before
       coveredAtSnapshot = snapMeta.coveredAtSnapshot
+      snapshotCovered = coveredAtSnapshot
       snapshotSize = anchorIndex.size
       snapshotAt = Date.now()
       cb.onLoaded(anchorIndex.size)
@@ -633,11 +643,17 @@ async function pruneBlobCovered(): Promise<void> {
 }
 
 /**
- * The whole pipeline: verified header blobs first (when the manifest is
- * reachable), then the IndexedDB replay of relay-cached rows, then the
- * batched relay backfill of whatever is left with a 30 s retry, then the
- * live tail. Runs once per page; the store's startSync is the idempotence
- * gate, this flag is just belt and braces.
+ * The whole pipeline: the cache first (the persisted snapshot, then the
+ * IndexedDB replay of relay-cached rows), then verified header blobs for
+ * only the heights the cache does not hold (when the manifest is reachable),
+ * then the batched relay backfill of whatever is left with a 30 s retry,
+ * then the live tail. Runs once per page; the store's startSync is the
+ * idempotence gate, this flag is just belt and braces.
+ *
+ * Blobs used to run before the cache, so every boot re-verified two million
+ * headers and the panel showed a full resync on each launch. The cache is a
+ * cheaper, already-verified copy of the same rows: it goes first, and the
+ * blob phase is told what it holds.
  */
 export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
   if (running) return
@@ -666,19 +682,30 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
     } catch { /* cache read is best effort */ }
   }
 
+  try {
+    await loadCache(cb)
+  } catch {
+    // A corrupt cache is not fatal: whatever validated is in the index, and
+    // the network stage re-fetches anything the cache failed to deliver.
+  }
+  // Everything the cache delivered, snapshot and rows: the blob phase skips
+  // any blob touching it, and the relay phase treats it as done.
+  syncStats.cacheCovered = effectiveCovered()
+
   // Header-blob phase. fetchManifest never throws; null means the relay owns
   // everything this session.
   const mf = await fetchManifest()
   if (mf) {
     cb.onSource('blobs')
     setStatus(cb, 'syncing')
-    knownTip = mf.manifest.generatedAtHeight
+    knownTip = Math.max(mf.manifest.generatedAtHeight, knownTip ?? 0)
     cb.onTip(knownTip)
     persistTip(knownTip)
     const result = await runHeaderSync(mf.manifest, mf.url, {
       onProgress: (_startHeight, verified) => cb.onLoaded(anchorIndex.size + verified),
       onColumns: (cols) => {
         blobRows += appendColumns(anchorIndex, cols)
+        syncStats.blobsVerified += 1
         cb.onLoaded(anchorIndex.size)
         scheduleBump(cb)
         pumpMerge(cb)
@@ -688,18 +715,19 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
           `[hyperspace] header blob ${startHeight}..${startHeight + count - 1} discarded: ${reason}; falling back to relay sync for that range`,
         )
       },
-    })
+    }, syncStats.cacheCovered)
     blobCovered = result.covered
+    syncStats.blobsSkipped = result.skipped
+    syncStats.skippedHeights = result.skippedHeights
+    // Skipped blobs are blob-sourced rows the cache carried over; the source
+    // label should not call a warm boot "relay" for holding them.
+    blobRows += result.skippedHeights
+    if (result.skipped > 0) {
+      console.info(`[hyperspace] header phase: ${result.skipped} blobs (${result.skippedHeights} heights) already in the cache, ${result.covered.length} verified`)
+    }
     announceSource(cb)
   } else {
     cb.onSource('relay')
-  }
-
-  try {
-    await loadCache(cb)
-  } catch {
-    // A corrupt cache is not fatal: whatever validated is in the index, and
-    // the network stage re-fetches anything the cache failed to deliver.
   }
 
   for (;;) {
@@ -739,4 +767,12 @@ export async function runAnchorSync(cb: SyncCallbacks): Promise<void> {
 
   startTail(cb)
   void pruneBlobCovered()
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  ;(window as unknown as { __anchors: { stats: typeof syncStats; size: () => number; status: () => string } }).__anchors = {
+    stats: syncStats,
+    size: () => anchorIndex.size,
+    status: () => currentStatus,
+  }
 }

--- a/src/lib/hyperspace/headerSync.test.ts
+++ b/src/lib/hyperspace/headerSync.test.ts
@@ -6,7 +6,7 @@
  * gate that makes those invariants safe to assume everywhere downstream.
  */
 import { describe, expect, it } from 'vitest'
-import { HEADERS_MANIFEST_URL, blobUrl, manifestUrl, parseManifest } from './headerSync'
+import { HEADERS_MANIFEST_URL, blobUrl, manifestUrl, overlapsCovered, parseManifest, shouldSkipBlob } from './headerSync'
 
 const good = () => ({
   formatVersion: 1,
@@ -81,5 +81,34 @@ describe('URL plumbing', () => {
       .toBe('https://example.com/x/headers-000.bin')
     expect(blobUrl('https://example.com/x/manifest.json', 'https://cdn.example.com/h.bin'))
       .toBe('https://cdn.example.com/h.bin')
+  })
+})
+
+describe('skipping blobs the cache already holds', () => {
+  const blob = (startHeight: number, count: number) => ({ ordinal: 0, startHeight, count, sha256: 'a'.repeat(64), file: 'x.bin' })
+
+  it('overlapsCovered sees touching ranges and misses disjoint ones', () => {
+    const covered: Array<[number, number]> = [[0, 999], [5000, 5999]]
+    expect(overlapsCovered(covered, [1000, 1999])).toBe(false)
+    expect(overlapsCovered(covered, [999, 1999])).toBe(true)
+    expect(overlapsCovered(covered, [4000, 5000])).toBe(true)
+    expect(overlapsCovered(covered, [6000, 7000])).toBe(false)
+    expect(overlapsCovered([], [0, 10])).toBe(false)
+  })
+
+  it('a blob fully inside the cache is skipped', () => {
+    expect(shouldSkipBlob(blob(0, 1000), [[0, 9999]])).toBe(true)
+  })
+
+  it('a blob the cache has no height of is verified', () => {
+    expect(shouldSkipBlob(blob(10000, 1000), [[0, 9999]])).toBe(false)
+  })
+
+  it('a blob the cache holds only part of is skipped whole, for the relay to finish', () => {
+    expect(shouldSkipBlob(blob(9500, 1000), [[0, 9999]])).toBe(true)
+  })
+
+  it('a cold cache skips nothing', () => {
+    expect(shouldSkipBlob(blob(0, 1000), [])).toBe(false)
   })
 })

--- a/src/lib/hyperspace/headerSync.ts
+++ b/src/lib/hyperspace/headerSync.ts
@@ -151,6 +151,31 @@ export interface HeaderSyncHandlers {
 export interface HeaderSyncResult {
   /** Verified inclusive height ranges, ascending, one per delivered blob. */
   covered: Array<[number, number]>
+  /** Blobs the caller asked to skip because it already held their heights. */
+  skipped: number
+  /** Heights those skipped blobs would have delivered. */
+  skippedHeights: number
+}
+
+/** Whether an inclusive range touches any of a sorted, merged covered list. */
+export function overlapsCovered(covered: Array<[number, number]>, range: [number, number]): boolean {
+  for (const [start, end] of covered) {
+    if (end < range[0]) continue
+    if (start > range[1]) return false
+    return true
+  }
+  return false
+}
+
+/**
+ * Whether a blob is not worth verifying: any of its heights is already held.
+ * A blob that only partly overlaps is skipped whole rather than verified and
+ * then dropped, because the index refuses a column set with a duplicate
+ * height; the few heights beyond the overlap are the relay backfill's, which
+ * is exactly where a partial blob's remainder went before blobs existed.
+ */
+export function shouldSkipBlob(blob: ManifestBlob, skip: Array<[number, number]>): boolean {
+  return overlapsCovered(skip, [blob.startHeight, blob.startHeight + blob.count - 1])
 }
 
 /**
@@ -162,15 +187,19 @@ export function runHeaderSync(
   manifest: HeadersManifest,
   url: string,
   handlers: HeaderSyncHandlers,
+  /** Heights already held: blobs touching these are not verified again. */
+  skip: Array<[number, number]> = [],
 ): Promise<HeaderSyncResult> {
   return new Promise((resolve) => {
     const worker = new Worker(new URL('../../workers/headers.worker.ts', import.meta.url), {
       type: 'module',
     })
     const covered: Array<[number, number]> = []
+    let skipped = 0
+    let skippedHeights = 0
     const finish = (): void => {
       worker.terminate()
-      resolve({ covered })
+      resolve({ covered, skipped, skippedHeights })
     }
     worker.onmessage = (event: MessageEvent<HeadersResponse>) => {
       const msg = event.data
@@ -179,6 +208,9 @@ export function runHeaderSync(
       } else if (msg.type === 'blob') {
         covered.push([msg.columns.startHeight, msg.columns.startHeight + msg.columns.count - 1])
         handlers.onColumns(msg.columns)
+      } else if (msg.type === 'blob-skipped') {
+        skipped += 1
+        skippedHeights += msg.count
       } else if (msg.type === 'blob-failed') {
         handlers.onBlobFailed(msg.startHeight, msg.count, msg.reason)
       } else {
@@ -191,7 +223,7 @@ export function runHeaderSync(
       console.warn('[hyperspace] headers worker failed:', event.message)
       finish()
     }
-    const request: HeadersRequest = { type: 'sync', manifest, manifestUrl: url }
+    const request: HeadersRequest = { type: 'sync', manifest, manifestUrl: url, skip }
     worker.postMessage(request)
   })
 }

--- a/src/workers/headers.worker.ts
+++ b/src/workers/headers.worker.ts
@@ -23,17 +23,26 @@ import {
   type BlobColumns,
   type ChainState,
 } from '../lib/hyperspace/headers'
-import type { HeadersManifest } from '../lib/hyperspace/headerSync'
+import { shouldSkipBlob, type HeadersManifest } from '../lib/hyperspace/headerSync'
 
 export interface HeadersRequest {
   type: 'sync'
   manifest: HeadersManifest
   manifestUrl: string
+  /**
+   * Inclusive height ranges the page already holds (its cache). A blob that
+   * touches one is not downloaded or verified; the chain state is dropped
+   * across it and the next blob re-seeds from its checkpoint, exactly as
+   * after a discarded blob. This is what turns a warm boot from two million
+   * hashes into none.
+   */
+  skip?: Array<[number, number]>
 }
 
 export type HeadersResponse =
   | { type: 'progress'; startHeight: number; verified: number; count: number }
   | { type: 'blob'; columns: BlobColumns }
+  | { type: 'blob-skipped'; startHeight: number; count: number }
   | { type: 'blob-failed'; startHeight: number; count: number; reason: string }
   | { type: 'done' }
 
@@ -101,7 +110,7 @@ function post(msg: HeadersResponse, transfer?: Transferable[]): void {
 }
 
 self.onmessage = async (event: MessageEvent<HeadersRequest>) => {
-  const { manifest, manifestUrl } = event.data
+  const { manifest, manifestUrl, skip = [] } = event.data
   const embedded = new Map(EMBEDDED_CHECKPOINTS.map((c) => [c.height, c.blockHash]))
   const manifestCp = new Map(manifest.checkpoints.map((c) => [c.height, c.blockHash]))
 
@@ -113,6 +122,13 @@ self.onmessage = async (event: MessageEvent<HeadersRequest>) => {
     const fail = (reason: string): void => {
       post({ type: 'blob-failed', startHeight: blob.startHeight, count: blob.count, reason })
       state = null
+    }
+    if (shouldSkipBlob(blob, skip)) {
+      // Already held: nothing to download or verify. Its final hash cannot
+      // seed the next blob's linkage, so that one re-seeds from a checkpoint.
+      post({ type: 'blob-skipped', startHeight: blob.startHeight, count: blob.count })
+      state = null
+      continue
     }
     const finalHeight = blob.startHeight + blob.count - 1
     const finalHashHex = manifestCp.get(finalHeight)


### PR DESCRIPTION
Every launch showed a full hyperspace resync. The pipeline ran the header-blob phase before it loaded the cache, so each boot re-verified two million headers (about fifty seconds of hashing) and only then adopted the snapshot that already held every one of those rows.

**What changed**

| Piece | Before | After |
|---|---|---|
| Order | blobs, then cache, then relay delta | cache (snapshot, then IndexedDB rows), then blobs, then relay delta |
| Header worker | verifies every blob in the manifest | takes a `skip` list of held heights; a blob touching it is not downloaded or verified, the chain state drops across it and the next blob re-seeds from its checkpoint, as after a discarded blob |
| Partial overlap | not possible before (index was empty) | skipped whole; the remainder is the relay backfill's, which is where it always went |
| Relay phase coverage | `covered` (IndexedDB rows) plus verified blobs | plus the snapshot's coverage, whose rows were pruned from IndexedDB when they came from blobs; without this a warm boot would ask the relay for every height it already had |
| HUD source label | a warm boot read "relay" | skipped blob heights count as blob-sourced |

**Measured** in a headless browser against the live manifest and relay:

| Boot | Blobs verified | Blobs skipped | Snapshot | Ready after |
|---|---|---|---|---|
| Cold | 19 | 0 | none | 56 s |
| Warm (reload) | 0 | 19 (950,000 heights) | 966,247 stops in 293 ms | 2 s |

Same index size on both boots. Five unit tests on the overlap and skip decisions. 681 passing, tsc and build clean. A DEV hook `__anchors` exposes the stats and status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
