### PR TITLE
A rider at a stop rides again without a second BOARD

### DIFF
--- a/src/hud/HyperspacePanel.tsx
+++ b/src/hud/HyperspacePanel.tsx
@@ -19,7 +19,7 @@ import { Earth } from 'lucide-react'
 import { create } from 'zustand'
 import { coordToHex, coordToXyz, xyzToCoord, type Plane } from 'cyberspace-core'
 import { coordToLatLon } from '../lib/hyperspace/landfall'
-import { expectedRidePairs, rideBlocks } from '../lib/hyperspace/ride'
+import { expectedRidePairs, lineStateOf, rideBlocks } from '../lib/hyperspace/ride'
 import { calibrate, computeRideProof, leafBenchmarkMs, type RideProgress } from '../lib/hyperspace/ridePool'
 import { findStation } from '../lib/hyperspace/station'
 import { stopCoordExact, type Stop } from '../lib/hyperspace/stops'
@@ -91,36 +91,53 @@ export async function startRide(): Promise<void> {
   if (riding) return
   const destination = useHyperspace.getState().destination
   const transit = useCyberspace.getState().transit
-  if (destination === null || transit === null) return
+  // A boarding this session, or the chain head already on the line: after a
+  // ride you stand at a stop and the next ride chains from it (§4.3), with
+  // no second boarding; after a reload an enter-hyperspace head is still a
+  // boarding. Either gives the ride its `previous` and its seed.
+  const line = lineStateOf(useCyberspace.getState().actions())
+  if (destination === null || (transit === null && line === null)) return
+  const previousId = transit?.enterEventId ?? line!.previousId
   const destStop = getStopByHeight(destination)
   if (destStop === undefined) {
     useRideRun.setState({ error: `Block ${destination} is not in the stop index yet` })
     return
   }
-  // §4.2: the station is evaluated over stops with height <= the destination
-  // height, so it only becomes a fact of the trip once the destination is
-  // fixed. Recompute it here, with the same function the panel's estimate
-  // uses, rather than trusting anything cached from before the choice.
   const { position, plane } = useCyberspace.getState()
-  const here = xyzToCoord(position.x, position.y, position.z, plane)
-  // DECK-0001 v3 §4.2 (as amended): the station set is bounded by a declared
-  // as_of height, not the destination. Declare the tip we synced, so the
-  // station is the genuine nearest stop; the bound rides in the event.
-  const asOf = useHyperspace.getState().tipHeight
-  if (asOf === null || asOf < destination) {
-    useRideRun.setState({ error: 'The line is not synced past the destination yet.', progress: null })
-    return
-  }
-  const station = findStation(getStopIndex(), here, asOf)
-  if (station === null) {
-    useRideRun.setState({ error: 'No station: no stop at or below the destination height' })
-    return
+  // Chained from a stop: the ride starts where the last one ended, and the
+  // station set bound is not declared, because no station is computed (§5.2).
+  let fromHeight: number
+  let asOf: number | undefined
+  if (line !== null && line.fromHeight !== null) {
+    fromHeight = line.fromHeight
+    asOf = undefined
+  } else {
+    // §4.2: the station is evaluated over stops with height <= the destination
+    // height, so it only becomes a fact of the trip once the destination is
+    // fixed. Recompute it here, with the same function the panel's estimate
+    // uses, rather than trusting anything cached from before the choice.
+    const here = xyzToCoord(position.x, position.y, position.z, plane)
+    // DECK-0001 v3 §4.2 (as amended): the station set is bounded by a declared
+    // as_of height, not the destination. Declare the tip we synced, so the
+    // station is the genuine nearest stop; the bound rides in the event.
+    const tip = useHyperspace.getState().tipHeight
+    if (tip === null || tip < destination) {
+      useRideRun.setState({ error: 'The line is not synced past the destination yet.', progress: null })
+      return
+    }
+    const station = findStation(getStopIndex(), here, tip)
+    if (station === null) {
+      useRideRun.setState({ error: 'No station: no stop at or below the destination height' })
+      return
+    }
+    fromHeight = station.stop.height
+    asOf = tip
   }
   // Every passed block's hash seeds its leaf work (§5.3); a gap means the
   // sync has not covered that stretch of the line yet. A zero-length ride
   // (station is the destination) passes nothing and is valid (§5.6).
   const blocks: Array<{ height: number; blockHash: string }> = []
-  for (const height of rideBlocks(station.stop.height, destination)) {
+  for (const height of rideBlocks(fromHeight, destination)) {
     const blockHash = getStopByHeight(height)?.blockHash
     if (!blockHash) {
       useRideRun.setState({ error: `Block ${height} has no hash in the index yet; let the sync finish` })
@@ -134,7 +151,7 @@ export async function startRide(): Promise<void> {
   useRideRun.setState({
     error: null,
     progress: { done: 0, total: blocks.length, etaMs: null },
-    path: { fromHeight: station.stop.height, toHeight: destination },
+    path: { fromHeight, toHeight: destination },
   })
   // The ride is a spectacle: pull back to the whole cube so the path can be
   // watched threading through it (RidePath). RETURN undoes the seat; the
@@ -149,14 +166,14 @@ export async function startRide(): Promise<void> {
   )
   try {
     const { rootHex, mp } = await computeRideProof(
-      { previousEventIdHex: transit.enterEventId, blocks },
+      { previousEventIdHex: previousId, blocks },
       (p) => useRideRun.setState({ progress: p }),
       controller.signal,
     )
     await useCyberspace.getState().completeRide({
       asOf,
       toCoordHex: coordToHex(stopCoordExact(destStop)),
-      fromHeight: station.stop.height,
+      fromHeight,
       toHeight: destination,
       rootHex,
       mp,
@@ -181,9 +198,16 @@ export function HyperspacePanel(): JSX.Element {
   const indexVersion = useHyperspace((s) => s.indexVersion)
   const destination = useHyperspace((s) => s.destination)
   const transit = useCyberspace((s) => s.transit)
+  const events = useCyberspace((s) => s.events)
   const position = useCyberspace((s) => s.position)
   const plane = useCyberspace((s) => s.plane)
   const atHead = useCyberspace((s) => s.atHead())
+  // Where the chain head already puts you: boarded (an enter-hyperspace head)
+  // or at a stop (a hyperjump head). Neither needs a BOARD.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const line = useMemo(() => lineStateOf(useCyberspace.getState().actions()), [events])
+  const atStop = line !== null && line.fromHeight !== null
+  const onLine = transit !== null || line !== null
   const progress = useRideRun((s) => s.progress)
   const rideError = useRideRun((s) => s.error)
   const ready = sync.status === 'ready'
@@ -216,12 +240,16 @@ export function HyperspacePanel(): JSX.Element {
   // you get (§4.2 binds the station to the destination height).
   const estimate = useMemo(() => {
     if (destination === null) return null
+    // From a stop, the ride starts at the stop; no station is involved.
+    if (line !== null && line.fromHeight !== null) {
+      return { from: line.fromHeight, fromLabel: 'At block', length: rideBlocks(line.fromHeight, destination).length }
+    }
     const here = xyzToCoord(position.x, position.y, position.z, plane)
     const asOf = useHyperspace.getState().tipHeight
     const station = findStation(getStopIndex(), here, Math.max(asOf ?? destination, destination))
     if (station === null) return null
-    return { station, length: rideBlocks(station.stop.height, destination).length }
-  }, [destination, position, plane, indexVersion])
+    return { from: station.stop.height, fromLabel: 'Station', length: rideBlocks(station.stop.height, destination).length }
+  }, [destination, position, plane, indexVersion, line])
 
   const destStop = destination !== null ? getStopByHeight(destination) : undefined
   const tag = ready ? `READY ${stopCount()} BLOCKS`
@@ -301,8 +329,8 @@ export function HyperspacePanel(): JSX.Element {
               {estimate && (
                 <>
                   <div>
-                    <dt>Station</dt>
-                    <dd>{estimate.station.stop.height}</dd>
+                    <dt>{estimate.fromLabel}</dt>
+                    <dd>{estimate.from}</dd>
                   </div>
                   <div>
                     <dt>Ride length</dt>
@@ -345,15 +373,21 @@ export function HyperspacePanel(): JSX.Element {
       )}
 
       <div className="hyper__actions">
-        <button
-          className="hyper__btn"
-          disabled={!atHead || !ready || destination === null}
-          onClick={() => void useCyberspace.getState().boardHyperspace()}
-        >BOARD</button>
+        {/* BOARD only when the chain head is off the line. After a ride you
+            stand at a stop and the next ride chains from it (§4.3); a second
+            enter-hyperspace there is a needless event, and the panel used to
+            demand one. */}
+        {!onLine && (
+          <button
+            className="hyper__btn"
+            disabled={!atHead || !ready || destination === null}
+            onClick={() => void useCyberspace.getState().boardHyperspace()}
+          >BOARD</button>
+        )}
         {progress === null ? (
           <button
             className="hyper__btn hyper__btn--ride"
-            disabled={transit === null || destination === null || !ready}
+            disabled={!onLine || destination === null || !ready || (transit === null && !atHead)}
             onClick={() => void startRide()}
           >RIDE</button>
         ) : (
@@ -363,12 +397,15 @@ export function HyperspacePanel(): JSX.Element {
       {/* A dead button that never says why reads as broken. One line names
           the gate that is actually holding BOARD shut; the answer is never
           proof of work, because boarding itself costs none. */}
-      {transit === null && progress === null && (
+      {!onLine && progress === null && (
         !ready ? (
           <p className="hyper__why">BOARD UNLOCKS WHEN THE LINE FINISHES SYNCING</p>
         ) : destination === null ? null : !atHead ? (
           <p className="hyper__why">BOARD STARTS FROM YOUR AVATAR: RETURN TO IT FIRST</p>
         ) : null
+      )}
+      {atStop && progress === null && (
+        <p className="hyper__why">ON THE LINE AT BLOCK {line!.fromHeight}: PICK A BLOCK AND RIDE, OR HOP TO LEAVE</p>
       )}
       <button
         className="hyper__btn hyper__btn--earth"

--- a/src/lib/hyperspace/ride.test.ts
+++ b/src/lib/hyperspace/ride.test.ts
@@ -5,28 +5,9 @@
  * tests prove the verifier is actually looking.
  */
 import { describe, expect, it } from 'vitest'
+import type { ActionEvent } from '../events'
 import { bytesToHex, sha256 } from 'cyberspace-core'
-import {
-  CALIBRATION_KS,
-  K_LINE,
-  SAMPLES,
-  buildRideProof,
-  calibrationHashes,
-  computeRideLeaf,
-  decodeOpenings,
-  encodeOpenings,
-  exactRidePairs,
-  inclusionPath,
-  lineTerrainK,
-  merkleDepth,
-  merkleLayers,
-  rideBlocks,
-  rideSeed,
-  sampleIndices,
-  timeCalibrationSample,
-  verifyInclusion,
-  verifyRideLevel1,
-} from './ride'
+import { CALIBRATION_KS, K_LINE, SAMPLES, buildRideProof, calibrationHashes, computeRideLeaf, decodeOpenings, encodeOpenings, exactRidePairs, inclusionPath, lineTerrainK, merkleDepth, merkleLayers, rideBlocks, rideSeed, sampleIndices, timeCalibrationSample, verifyInclusion, verifyRideLevel1, lineStateOf } from './ride'
 
 const PREV = 'ab'.repeat(32)
 
@@ -234,5 +215,32 @@ describe('calibration sample', () => {
     const { elapsedMs, pairs } = timeCalibrationSample()
     expect(elapsedMs).toBeGreaterThan(0)
     expect(pairs).toBe(exactRidePairs(calibrationHashes()))
+  })
+})
+
+describe('lineStateOf: what the chain head says about the line', () => {
+  const action = (over: Partial<ActionEvent>): ActionEvent => ({
+    id: 'e'.repeat(64), pubkey: 'p'.repeat(64), createdAt: 1, type: 'hop', coordHex: 'c'.repeat(64),
+    position: { x: 0n, y: 0n, z: 0n }, plane: 0, prevCoordHex: null, genesisId: null, previousId: null, proofHash: null, sector: '0-0-0',
+    ...over,
+  })
+
+  it('is nothing with no chain, and nothing after a hop', () => {
+    expect(lineStateOf([])).toBeNull()
+    expect(lineStateOf([action({ type: 'spawn' }), action({ type: 'hop', id: 'h'.repeat(64) })])).toBeNull()
+  })
+
+  it('an enter-hyperspace head is boarded, with the station still to decide the start', () => {
+    const s = lineStateOf([action({ type: 'spawn' }), action({ type: 'enter-hyperspace', id: 'a'.repeat(64), coordHex: 'b'.repeat(64) })])
+    expect(s).toEqual({ previousId: 'a'.repeat(64), coordHex: 'b'.repeat(64), fromHeight: null })
+  })
+
+  it('a hyperjump head stands at its stop: the next ride starts from B and chains from it', () => {
+    const s = lineStateOf([action({ type: 'enter-hyperspace' }), action({ type: 'hyperjump', id: 'j'.repeat(64), coordHex: 'd'.repeat(64), fromHeight: 100, toHeight: 398 })])
+    expect(s).toEqual({ previousId: 'j'.repeat(64), coordHex: 'd'.repeat(64), fromHeight: 398 })
+  })
+
+  it('a hop after a hyperjump leaves the line', () => {
+    expect(lineStateOf([action({ type: 'hyperjump', toHeight: 398 }), action({ type: 'hop' })])).toBeNull()
   })
 })

--- a/src/lib/hyperspace/ride.ts
+++ b/src/lib/hyperspace/ride.ts
@@ -7,6 +7,7 @@
  * Everything here is consensus-critical and pure; the worker pool wraps it.
  */
 import { alignedBase, bytesToHex, computeSubtreeCantor, hexToBytes, intToBytesBE, sha256 } from 'cyberspace-core'
+import type { ActionEvent } from '../events'
 
 export const K_LINE = 6
 export const RIDE_MAX_HEIGHT = 16 + K_LINE
@@ -87,6 +88,35 @@ export function computeRideLeaf(previousEventIdHex: string, height: number, bloc
 }
 
 /** The heights a ride from `from` to `to` passes: (lo, hi], ascending. */
+/**
+ * Where the chain head puts you on the line, or null when it does not.
+ *
+ * DECK-0001 v3 §4.3: a rider who has entered stays entered until a hop or a
+ * sidestep leaves; every further hyperjump chains from the previous one,
+ * with `from_height` equal to its `B`, and a hyperjump whose previous event
+ * is neither an enter-hyperspace nor a hyperjump is invalid. So the head
+ * alone says whether the next ride needs a boarding: an enter-hyperspace
+ * head is boarded and the station decides where the ride starts
+ * (`fromHeight` null); a hyperjump head is standing at its stop and the next
+ * ride starts there. Anything else is off the line.
+ */
+export interface LineState {
+  /** The head's id: the next ride's `previous`, and what seeds its leaves (§5.3). */
+  previousId: string
+  /** The head's coordinate: the next ride's `c` (§5.2). */
+  coordHex: string
+  /** The stop you stand at after a ride, or null when boarding decides it. */
+  fromHeight: number | null
+}
+
+export function lineStateOf(actions: ActionEvent[]): LineState | null {
+  const head = actions[actions.length - 1]
+  if (!head) return null
+  if (head.type === 'enter-hyperspace') return { previousId: head.id, coordHex: head.coordHex, fromHeight: null }
+  if (head.type === 'hyperjump' && head.toHeight !== undefined) return { previousId: head.id, coordHex: head.coordHex, fromHeight: head.toHeight }
+  return null
+}
+
 export function rideBlocks(fromHeight: number, toHeight: number): number[] {
   const lo = Math.min(fromHeight, toHeight)
   const hi = Math.max(fromHeight, toHeight)

--- a/src/store/secondBoard.test.ts
+++ b/src/store/secondBoard.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { coordToXyz, hexToCoord } from 'cyberspace-core'
+import { enterHyperspaceTemplate, hyperjumpTemplate, parseAction, spawnTemplate, type NostrEvent } from '../lib/events'
+import { useCyberspace } from './useCyberspace'
+
+/** spawn, enter-hyperspace, hyperjump: a rider standing at a stop. */
+function chainAtStop() {
+  const sk = generateSecretKey()
+  const pubkey = getPublicKey(sk)
+  const spawn = finalizeEvent(spawnTemplate(pubkey, 1_700_000_000), sk)
+  const { x, y, z, plane } = coordToXyz(hexToCoord(pubkey))
+  const at = { x, y, z }
+  const enter = finalizeEvent(enterHyperspaceTemplate({ createdAt: 1_700_000_001, genesisId: spawn.id, previousId: spawn.id, at, plane, proofHash: 'a'.repeat(64) }), sk)
+  const stopCoord = '56db6db6db6db6db6db6db3e27c436f9d3b79fb5fc6457798936b3e749e38f56'
+  const jump = finalizeEvent(hyperjumpTemplate({ createdAt: 1_700_000_002, genesisId: spawn.id, previousId: enter.id, prevCoordHex: pubkey, toCoordHex: stopCoord, fromHeight: 100, toHeight: 398, asOf: 400, rootHex: '0'.repeat(64), mp: '' }), sk)
+  return { sk, pubkey, events: [spawn, enter, jump] as NostrEvent[], stopCoord }
+}
+
+describe('riding again from a stop', () => {
+  beforeEach(() => {
+    const { pubkey, events } = chainAtStop()
+    const dest = coordToXyz(hexToCoord(events[2].tags.find((t) => t[0] === 'C')![1]))
+    useCyberspace.setState({
+      identity: { pubkey, npub: 'npub1test' },
+      events, genesisId: events[0].id, prevEventId: events[2].id,
+      position: { x: dest.x, y: dest.y, z: dest.z }, plane: dest.plane,
+      transit: null, exploreIndex: null, spectate: null, focus: null,
+    })
+  })
+
+  it('completes a second ride with no boarding: previous is the last hyperjump, from_height is its B, no as_of', async () => {
+    const before = useCyberspace.getState().events
+    const prevId = before[before.length - 1].id
+    await useCyberspace.getState().completeRide({
+      toCoordHex: '56db6db6db6db6db6db6db3e27c436f9d3b79fb5fc6457798936b3e749e38f57',
+      fromHeight: 398, toHeight: 500, rootHex: '1'.repeat(64), mp: '',
+    })
+    const events = useCyberspace.getState().events
+    expect(events).toHaveLength(before.length + 1)
+    const ride = parseAction(events[events.length - 1])!
+    expect(ride.type).toBe('hyperjump')
+    expect(ride.previousId).toBe(prevId)
+    expect(ride.fromHeight).toBe(398)
+    expect(ride.toHeight).toBe(500)
+    expect(ride.asOf).toBeUndefined()
+    // c is the stop you stood at: the previous hyperjump's C.
+    expect(ride.prevCoordHex).toBe(before[before.length - 1].tags.find((t) => t[0] === 'C')![1])
+    // Still at a stop afterwards: transit stays clear so an ordinary hop can leave.
+    expect(useCyberspace.getState().transit).toBeNull()
+  })
+
+  it('refuses to complete a ride off the line', async () => {
+    const { events } = useCyberspace.getState()
+    // A chain whose head is the spawn: not on the line, and no boarding.
+    useCyberspace.setState({ events: events.slice(0, 1), prevEventId: events[0].id })
+    await useCyberspace.getState().completeRide({ toCoordHex: 'a'.repeat(64), fromHeight: 1, toHeight: 2, rootHex: '0'.repeat(64), mp: '' })
+    expect(useCyberspace.getState().events).toHaveLength(1)
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -16,6 +16,7 @@
  */
 
 import { create } from 'zustand'
+import { lineStateOf } from '../lib/hyperspace/ride'
 import { Quaternion } from 'three'
 import { finalizeEvent, generateSecretKey } from 'nostr-tools/pure'
 import { nip19 } from 'nostr-tools'
@@ -2049,12 +2050,15 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
   completeRide: async (ride) => {
     const { events, genesisId, prevEventId, transit } = get()
-    if (!transit || !genesisId || !prevEventId) return
+    if (!genesisId || !prevEventId) return
     const head = events[events.length - 1]
     if (!head) return
-    // One ride per boarding for now; the spec allows chaining rides (§4.3) and
-    // the builder supports it, but the client boards fresh each time.
-    const prevCoordHex = head.tags.find((t) => t[0] === 'C')?.[1] ?? transit.enterCoordHex
+    // From a boarding, or chained from the stop the last ride reached (§4.3):
+    // either way the head is on the line, and `c` is its coordinate.
+    const line = lineStateOf(buildChain(events))
+    if (!transit && !line) return
+    const prevCoordHex = head.tags.find((t) => t[0] === 'C')?.[1] ?? transit?.enterCoordHex ?? line?.coordHex
+    if (!prevCoordHex) return
     const template = hyperjumpTemplate({
       createdAt: nextCreatedAt(head),
       genesisId,


### PR DESCRIPTION
Fixes #52. After a ride the panel demanded BOARD, and a second enter-hyperspace, before it would ride anywhere else, although the avatar had never left the line. DECK-0001 v3 §4.3: a rider who has entered stays entered until a hop or sidestep leaves; every further hyperjump chains from the previous one with `from_height` equal to its `B`. The client kept "boarded" as a flag it cleared on arrival, and that flag was all RIDE looked at.

**What changed.** The chain head decides.

| Head | State | BOARD | RIDE starts from | `previous` / seed | `as_of` |
|---|---|---|---|---|---|
| enter-hyperspace | boarded | hidden | the station (§4.2) | the enter event | declared, the synced tip |
| hyperjump | at its stop | hidden | that stop's `B` | the hyperjump | none: no station is computed |
| spawn, hop, sidestep | off the line | shown | n/a | n/a | n/a |

The boarded flag still clears on arrival so `atHead` holds and an ordinary hop leaves the line (§6). A reload with an enter-hyperspace head is a boarding again, not a demand to board twice. A line under the buttons names the block you stand at; the estimate row reads "At block" from a stop and "Station" from a boarding.

**Measured in the browser:** with a hyperjump head, RIDE enabled and no BOARD, the reason line, "At block"; with a hop head, BOARD enabled, RIDE disabled, "Station".

**Tests:** `lineStateOf` over every head type; a store test that `completeRide` from a stop with no boarding appends a hyperjump whose `previous` is the last hyperjump, `from_height` its `B`, `c` its `C`, no `as_of`, transit still clear; and that it refuses off the line. 682 passing, tsc and build clean.

Not verified: an actual chained ride proof against the live relay (a full ride is minutes to hours of work); the proof path is unchanged except for which id seeds it, and the spec's verifier accepts a hyperjump previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
