### PR TITLE
Presence at any distance, and a chip that lights when someone arrives

### DIFF
--- a/src/hooks/useTargets.ts
+++ b/src/hooks/useTargets.ts
@@ -9,7 +9,8 @@
 
 import { useMemo } from 'react'
 import { EARTH } from '../lib/palette'
-import type { CyberTarget } from '../lib/targets'
+import { targetColor, type CyberTarget } from '../lib/targets'
+import { usePresence } from '../store/usePresence'
 import { useCyberspace } from '../store/useCyberspace'
 
 /** The avatar's own red, so the marker for you is the color you are drawn in. */
@@ -27,6 +28,8 @@ export function useTargets(): CyberTarget[] {
   const headPlane = useCyberspace((s) => s.headPlane)
   const tracked = useCyberspace((s) => s.targets)
   const focus = useCyberspace((s) => s.focusPubkey())
+  const people = usePresence((s) => s.people)
+  const me = useCyberspace((s) => s.identity.pubkey)
 
   return useMemo(() => {
     const out: CyberTarget[] = []
@@ -39,6 +42,14 @@ export function useTargets(): CyberTarget[] {
       const tr = tracked[t.id]
       if (tr && tr.plane !== plane) continue
       out.push(t)
+    }
+    // Everyone else in the sector, at any distance: the same marker a target
+    // gets, dimmer, so a person shows at the screen's edge before they are in
+    // the field, and passing one without knowing stops being the normal case.
+    // Same plane rule as a target; your targets and you are already covered.
+    for (const p of Object.values(people)) {
+      if (p.pubkey === me || p.pubkey === focus || tracked[p.pubkey] || p.plane !== plane) continue
+      out.push({ id: p.pubkey, label: `${p.pubkey.slice(0, 8)}…`.toUpperCase(), color: targetColor(p.pubkey), at: p.position, presence: true })
     }
     // While the camera is anywhere you are not (someone else's eyes, a
     // hyperspace stop, EARTH, a shard), the way home is a thing worth
@@ -58,5 +69,5 @@ export function useTargets(): CyberTarget[] {
     return out
     // tracked is what targetList reads; listed so the memo follows it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [plane, headPlane, spectating, focused, position, tracked, focus])
+  }, [plane, headPlane, spectating, focused, position, tracked, focus, people, me])
 }

--- a/src/hud/PresenceChip.tsx
+++ b/src/hud/PresenceChip.tsx
@@ -8,10 +8,11 @@
  * scene following them.
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Users } from 'lucide-react'
 import { useCyberspace } from '../store/useCyberspace'
 import { usePresence, type Person } from '../store/usePresence'
+import { useChat } from '../store/useChat'
 import { useProfile } from '../hooks/useProfile'
 import { ProfilePic } from './ProfileBadge'
 import { formatDistance } from '../lib/scale'
@@ -42,18 +43,33 @@ function Row({ person, now }: { person: Person; now: number }): JSX.Element {
   )
 }
 
+/** How long the chip stays lit after someone arrives. */
+const ARRIVAL_MS = 4000
+
 export function PresenceChip(): JSX.Element | null {
   const people = usePresence((s) => s.people)
   const loading = usePresence((s) => s.loading)
+  const lastArrivalAt = usePresence((s) => s.lastArrivalAt)
   const targets = useCyberspace((s) => s.targets)
   const me = useCyberspace((s) => s.identity.pubkey)
+  const muted = useChat((s) => s.muted)
   const [open, setOpen] = useState(false)
+  // Lit for a few seconds after an arrival, then back to plain.
+  const [lit, setLit] = useState(false)
+  useEffect(() => {
+    if (lastArrivalAt === null) return
+    setLit(true)
+    const t = window.setTimeout(() => setLit(false), ARRIVAL_MS)
+    return () => window.clearTimeout(t)
+  }, [lastArrivalAt])
   const others = Object.values(people).filter((p) => p.pubkey !== me && !targets[p.pubkey]).sort((a, b) => b.lastActive - a.lastActive)
   if (others.length === 0 && !loading) return null
   const now = Math.floor(Date.now() / 1000)
+  const title = "People whose newest move landed in this sector or one beside it. A sector is 2^30 gibsons on a side. An arrival lights this chip"
+    + (muted ? "; the sound is off, which is the chat's mute." : " and chimes; the chat's mute silences it.")
   return (
-    <div className={`hyperbar presence ${open ? 'is-open' : ''}`} role="status">
-      <button className="presence__head" onClick={() => setOpen((o) => !o)} aria-expanded={open} title="People whose newest move landed in this sector or one beside it. A sector is 2^30 gibsons on a side.">
+    <div className={`hyperbar presence ${open ? 'is-open' : ''} ${lit ? 'is-arrival' : ''}`} role="status">
+      <button className="presence__head" onClick={() => setOpen((o) => !o)} aria-expanded={open} title={title}>
         <Users size={12} strokeWidth={2.25} aria-hidden />
         <span className="hyperbar__label">{loading && others.length === 0 ? 'LOOKING' : `${others.length} IN THIS SECTOR`}</span>
       </button>

--- a/src/hud/Targets.tsx
+++ b/src/hud/Targets.tsx
@@ -118,7 +118,7 @@ function TargetMarker({ target }: { target: CyberTarget }): JSX.Element {
   const profile = useProfile(person ? target.id : null)
   const name = (person && profile?.name) || target.label
   return (
-    <div className="target" data-target={target.id} style={{ color: target.color }}>
+    <div className={`target${target.presence ? ' target--presence' : ''}`} data-target={target.id} style={{ color: target.color }}>
       <span className="target__ring" />
       {/* Points along +x unrotated, so a rotation by the screen bearing aims it
           at the target. The previous glyph pointed up and left, which put every

--- a/src/lib/targets.ts
+++ b/src/lib/targets.ts
@@ -29,6 +29,8 @@ export interface CyberTarget {
   at: Position
   /** Drawn as a ring of this many gibsons, when it has a real extent. */
   radius?: bigint
+  /** Someone in the sector you have not targeted: the same marker, dimmer. */
+  presence?: boolean
 }
 
 export interface TargetScreen {

--- a/src/store/presence.test.ts
+++ b/src/store/presence.test.ts
@@ -81,3 +81,34 @@ describe('taking people in', () => {
     expect(Object.keys(usePresence.getState().people)).toHaveLength(0)
   })
 })
+
+describe('arrivals', () => {
+  beforeEach(() => { usePresence.setState({ people: {}, sector: null, loading: false, arrivals: 0, lastArrivalAt: null }) })
+
+  it('someone first seen after the backfill is an arrival', () => {
+    usePresence.getState().ingest(spawnAt(here, 100))
+    expect(usePresence.getState().arrivals).toBe(1)
+    expect(usePresence.getState().lastArrivalAt).not.toBeNull()
+  })
+
+  it('someone seen during the backfill is not', () => {
+    usePresence.setState({ loading: true })
+    usePresence.getState().ingest(spawnAt(here, 100))
+    expect(usePresence.getState().arrivals).toBe(0)
+  })
+
+  it('a later move by someone already here is not an arrival', () => {
+    const sk = generateSecretKey()
+    usePresence.getState().ingest(spawnAt(here, 100, sk))
+    usePresence.getState().ingest(spawnAt({ ...here, x: here.x + 1n }, 200, sk))
+    expect(usePresence.getState().arrivals).toBe(1)
+  })
+
+  it('a target arriving is not announced: you already know where they are', () => {
+    const sk = generateSecretKey()
+    useCyberspace.setState({ targets: { [getPublicKey(sk)]: { pubkey: getPublicKey(sk), npub: 'npub1x', name: null, position: here, plane: 0, lastActive: null, status: 'live' } } })
+    usePresence.getState().ingest(spawnAt(here, 100, sk))
+    expect(usePresence.getState().arrivals).toBe(0)
+    useCyberspace.setState({ targets: {} })
+  })
+})

--- a/src/store/usePresence.ts
+++ b/src/store/usePresence.ts
@@ -29,6 +29,8 @@ import { V2_ACTIONS } from '../lib/chains'
 import { query, subscribe } from '../lib/relay'
 import type { Position } from '../lib/space'
 import { useCyberspace } from './useCyberspace'
+import { useChat } from './useChat'
+import { chime } from '../lib/chime'
 
 export interface Person {
   pubkey: string
@@ -75,6 +77,10 @@ interface PresenceState {
   sector: string | null
   /** True while the neighborhood's backfill is in flight. */
   loading: boolean
+  /** People first seen after the backfill finished: arrivals, not history. */
+  arrivals: number
+  /** When the last arrival was noticed, ms since the epoch, or null. */
+  lastArrivalAt: number | null
   /** Take an action event in: the newest per author wins. */
   ingest: (ev: NostrEvent, now?: number) => void
   /** Drop someone; the sweep does this when their newest action is elsewhere. */
@@ -87,6 +93,8 @@ export const usePresence = create<PresenceState>((set, get) => ({
   people: {},
   sector: null,
   loading: false,
+  arrivals: 0,
+  lastArrivalAt: null,
 
   ingest: (ev, now = Math.floor(Date.now() / 1000)) => {
     const action = parseAction(ev)
@@ -95,10 +103,19 @@ export const usePresence = create<PresenceState>((set, get) => ({
     if (action.pubkey === me) return
     const have = get().people[action.pubkey]
     if (have && have.lastActive >= action.createdAt) return
-    set({ people: { ...get().people, [action.pubkey]: {
-      pubkey: action.pubkey, position: action.position, plane: action.plane,
-      lastActive: action.createdAt, type: action.type, checkedAt: now,
-    } } })
+    // Someone new, after the backfill: an arrival. During the backfill every
+    // person is new and none of them just arrived. Your targets are not
+    // arrivals either; you already know where they are.
+    const arrived = !have && !get().loading && !useCyberspace.getState().targets[action.pubkey]
+    set({
+      people: { ...get().people, [action.pubkey]: {
+        pubkey: action.pubkey, position: action.position, plane: action.plane,
+        lastActive: action.createdAt, type: action.type, checkedAt: now,
+      } },
+      ...(arrived ? { arrivals: get().arrivals + 1, lastArrivalAt: Date.now() } : {}),
+    })
+    // The chat's mute is the one switch for sounds about other people.
+    if (arrived && !useChat.getState().muted) chime()
   },
 
   forget: (pubkey) => {
@@ -184,7 +201,7 @@ export function stopPresence(): void {
   stopLive = null
   if (sweepHandle) { clearInterval(sweepHandle); sweepHandle = null }
   started = false
-  usePresence.setState({ people: {}, sector: null, loading: false })
+  usePresence.setState({ people: {}, sector: null, loading: false, arrivals: 0, lastArrivalAt: null })
 }
 
 if (import.meta.env.DEV && typeof window !== 'undefined') {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5703,3 +5703,17 @@ kbd {
 .presence__name { font-size: 11px; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .presence__meta { font-size: 9px; color: var(--dim); letter-spacing: 0.08em; }
 .presence__target { padding: 2px 8px; font-size: 8px; }
+
+/* Someone in the sector you have not targeted: the target marker, dimmer. */
+.target--presence { opacity: 0.55; }
+.target--presence .target__ring { border-style: dashed; }
+
+/* An arrival lights the sector chip for a few seconds. */
+@keyframes presence-arrival {
+  0% { box-shadow: 0 0 0 0 rgba(0, 229, 255, 0.55); }
+  100% { box-shadow: 0 0 0 10px rgba(0, 229, 255, 0); }
+}
+.presence.is-arrival { animation: presence-arrival 1s ease-out 3; }
+@media (prefers-reduced-motion: reduce) {
+  .presence.is-arrival { animation: none; border-color: var(--accent, #00e5ff); }
+}


### PR DESCRIPTION
Follow-ups to presence (#117). People in the sector were drawn only inside the field and otherwise only counted; an arrival while you looked elsewhere was nothing at all.

| Piece | Behavior |
|---|---|
| Markers at any distance | Everyone in the sector you have not targeted gets a target's marker through `useTargets` and the projector, unchanged: edge-clamped chevron with face, name and distance; a ring on screen. Dimmed to 0.55 with a dashed ring (`.target--presence`), the one thing that says "not yet yours". Same plane rule as a target. |
| Arrival notice | Someone first seen after the backfill finished. Not during the backfill (everyone is new then), never a target. Lights the sector chip for 4 s and plays the chat's chime. |
| One mute | The chat's mute silences the arrival chime too; the chip's title says which state it is in. Reduced motion gets a lit border instead of the pulse. |

**Measured in the browser:** two people set 2^20 and 2^22 gibsons out appear as dimmed off-screen markers reading 122 μm and 488 μm; one set three gibsons away is a dimmed on-screen ring at 349 pm. A stranger's hop ingested during the backfill counts no arrival; the same hop after it counts one and lights the chip; their next move counts none more; the chip is plain after four seconds.

Four unit tests on arrivals. 680 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
