### PR TITLE
The chain panel counts hyperjumps, and the identity counts its respawns

### DIFF
--- a/src/hud/ChainPanel.tsx
+++ b/src/hud/ChainPanel.tsx
@@ -11,6 +11,7 @@
  */
 
 import { formatMs, formatOps } from '../lib/space'
+import { expectedRidePairs } from '../lib/hyperspace/ride'
 import { useCyberspace } from '../store/useCyberspace'
 import { CYBERSPACE_RELAY } from '../lib/relay'
 import { Explanation } from './Explanation'
@@ -25,6 +26,7 @@ export function ChainPanel(): JSX.Element {
   const publishError = useCyberspace((s) => s.publishError)
   const live = useCyberspace((s) => s.live)
   const exploreIndex = useCyberspace((s) => s.exploreIndex)
+  const respawns = useCyberspace((s) => s.respawns)
 
   const statuses = events.map((e) => published[e.id])
   const sent = statuses.filter((st) => st === 'ok').length
@@ -61,6 +63,10 @@ export function ChainPanel(): JSX.Element {
           <dt>Sidesteps</dt>
           <dd>{chain.sidesteps}</dd>
         </div>
+        <div title="DECK-0001 rides on the block line, and the blocks they passed between them">
+          <dt>Hyperjumps</dt>
+          <dd>{chain.hyperjumps}{chain.blocksRidden > 0 ? ` · ${chain.blocksRidden.toLocaleString()} BLOCKS` : ''}</dd>
+        </div>
         <div>
           <dt>Cantor ops</dt>
           <dd>{formatOps(chain.totalOps)}</dd>
@@ -69,6 +75,12 @@ export function ChainPanel(): JSX.Element {
           <dt>SHA-256 hashes</dt>
           <dd>{formatOps(chain.totalHashes)}</dd>
         </div>
+        {chain.blocksRidden > 0 && (
+          <div title="The rides' work: about 42,000 Cantor pairs per block passed (DECK-0001 v3 §5.7), which is expected, not measured">
+            <dt>Ride pairs</dt>
+            <dd>≈ {formatOps(expectedRidePairs(chain.blocksRidden))}</dd>
+          </div>
+        )}
         <div>
           <dt>Compute time</dt>
           <dd>{formatMs(chain.totalMs)}</dd>
@@ -83,6 +95,12 @@ export function ChainPanel(): JSX.Element {
             {sent} / {events.length}{' '}
             <span className={`relay relay--${relayState.toLowerCase()}`}>{relayState}</span>
           </dd>
+        </div>
+        {/* Last and apart: each respawn began a new chain, so this is a fact
+            about the identity, not about the chain above it. */}
+        <div title="Times this identity has respawned. Each one started a new chain; counted on this device.">
+          <dt>Respawns</dt>
+          <dd>{respawns}</dd>
         </div>
       </dl>
 

--- a/src/lib/hyperspace/ride.test.ts
+++ b/src/lib/hyperspace/ride.test.ts
@@ -5,28 +5,9 @@
  * tests prove the verifier is actually looking.
  */
 import { describe, expect, it } from 'vitest'
+import type { ActionEvent } from '../events'
 import { bytesToHex, sha256 } from 'cyberspace-core'
-import {
-  CALIBRATION_KS,
-  K_LINE,
-  SAMPLES,
-  buildRideProof,
-  calibrationHashes,
-  computeRideLeaf,
-  decodeOpenings,
-  encodeOpenings,
-  exactRidePairs,
-  inclusionPath,
-  lineTerrainK,
-  merkleDepth,
-  merkleLayers,
-  rideBlocks,
-  rideSeed,
-  sampleIndices,
-  timeCalibrationSample,
-  verifyInclusion,
-  verifyRideLevel1,
-} from './ride'
+import { CALIBRATION_KS, K_LINE, SAMPLES, buildRideProof, calibrationHashes, computeRideLeaf, decodeOpenings, encodeOpenings, exactRidePairs, inclusionPath, lineTerrainK, merkleDepth, merkleLayers, rideBlocks, rideSeed, sampleIndices, timeCalibrationSample, verifyInclusion, verifyRideLevel1, rideStatsOf } from './ride'
 
 const PREV = 'ab'.repeat(32)
 
@@ -234,5 +215,32 @@ describe('calibration sample', () => {
     const { elapsedMs, pairs } = timeCalibrationSample()
     expect(elapsedMs).toBeGreaterThan(0)
     expect(pairs).toBe(exactRidePairs(calibrationHashes()))
+  })
+})
+
+describe('rideStatsOf: what the chain has ridden', () => {
+  const act = (over: Partial<ActionEvent>): ActionEvent => ({
+    id: 'e'.repeat(64), pubkey: 'p'.repeat(64), createdAt: 1, type: 'hop', coordHex: 'c'.repeat(64),
+    position: { x: 0n, y: 0n, z: 0n }, plane: 0, prevCoordHex: null, genesisId: null, previousId: null, proofHash: null, sector: '0-0-0',
+    ...over,
+  })
+
+  it('is zero with no rides', () => {
+    expect(rideStatsOf([act({ type: 'spawn' }), act({ type: 'hop' })])).toEqual({ hyperjumps: 0, blocksRidden: 0 })
+  })
+
+  it('counts each hyperjump and the blocks it passed, whichever way it went', () => {
+    const chain = [
+      act({ type: 'spawn' }),
+      act({ type: 'enter-hyperspace' }),
+      act({ type: 'hyperjump', fromHeight: 100, toHeight: 398 }),
+      act({ type: 'hyperjump', fromHeight: 398, toHeight: 250 }),
+      act({ type: 'hop' }),
+    ]
+    expect(rideStatsOf(chain)).toEqual({ hyperjumps: 2, blocksRidden: 298 + 148 })
+  })
+
+  it('a zero-length ride counts as a ride that passed nothing', () => {
+    expect(rideStatsOf([act({ type: 'hyperjump', fromHeight: 50, toHeight: 50 })])).toEqual({ hyperjumps: 1, blocksRidden: 0 })
   })
 })

--- a/src/lib/hyperspace/ride.ts
+++ b/src/lib/hyperspace/ride.ts
@@ -7,6 +7,7 @@
  * Everything here is consensus-critical and pure; the worker pool wraps it.
  */
 import { alignedBase, bytesToHex, computeSubtreeCantor, hexToBytes, intToBytesBE, sha256 } from 'cyberspace-core'
+import type { ActionEvent } from '../events'
 
 export const K_LINE = 6
 export const RIDE_MAX_HEIGHT = 16 + K_LINE
@@ -87,6 +88,25 @@ export function computeRideLeaf(previousEventIdHex: string, height: number, bloc
 }
 
 /** The heights a ride from `from` to `to` passes: (lo, hi], ascending. */
+/**
+ * What the chain's rides add up to: how many hyperjumps, and how many blocks
+ * they passed between them (§5.3: the ride passes every block from the
+ * lower height exclusive to the higher inclusive, so a ride's length is the
+ * difference). Exact from the events themselves, which is why it is derived
+ * from the chain rather than tallied as proofs finish: an adopted chain has
+ * the same numbers as one ridden here.
+ */
+export function rideStatsOf(actions: ActionEvent[]): { hyperjumps: number; blocksRidden: number } {
+  let hyperjumps = 0
+  let blocksRidden = 0
+  for (const a of actions) {
+    if (a.type !== 'hyperjump' || a.fromHeight === undefined || a.toHeight === undefined) continue
+    hyperjumps += 1
+    blocksRidden += Math.abs(a.toHeight - a.fromHeight)
+  }
+  return { hyperjumps, blocksRidden }
+}
+
 export function rideBlocks(fromHeight: number, toHeight: number): number[] {
   const lo = Math.min(fromHeight, toHeight)
   const hi = Math.max(fromHeight, toHeight)

--- a/src/store/chainStats.test.ts
+++ b/src/store/chainStats.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { coordToXyz, hexToCoord } from 'cyberspace-core'
+import { enterHyperspaceTemplate, hyperjumpTemplate, spawnTemplate, type NostrEvent } from '../lib/events'
+import { addRespawn, loadRespawns, useCyberspace } from './useCyberspace'
+
+describe('chain stats count rides', () => {
+  beforeEach(() => {
+    const sk = generateSecretKey()
+    const pubkey = getPublicKey(sk)
+    const spawn = finalizeEvent(spawnTemplate(pubkey, 1_700_000_000), sk)
+    const { x, y, z, plane } = coordToXyz(hexToCoord(pubkey))
+    const enter = finalizeEvent(enterHyperspaceTemplate({ createdAt: 1_700_000_001, genesisId: spawn.id, previousId: spawn.id, at: { x, y, z }, plane, proofHash: 'a'.repeat(64) }), sk)
+    const stop = '56db6db6db6db6db6db6db3e27c436f9d3b79fb5fc6457798936b3e749e38f56'
+    const jump = finalizeEvent(hyperjumpTemplate({ createdAt: 1_700_000_002, genesisId: spawn.id, previousId: enter.id, prevCoordHex: pubkey, toCoordHex: stop, fromHeight: 100, toHeight: 398, asOf: 400, rootHex: '0'.repeat(64), mp: '' }), sk)
+    const events = [spawn, enter, jump] as NostrEvent[]
+    const dest = coordToXyz(hexToCoord(stop))
+    useCyberspace.setState({
+      identity: { pubkey, npub: 'npub1test' },
+      events, genesisId: spawn.id, prevEventId: jump.id,
+      position: { x: dest.x, y: dest.y, z: dest.z }, plane: dest.plane,
+      chain: { hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0, hyperjumps: 1, blocksRidden: 298 },
+      // Boarded state, as this branch's completeRide still requires (the ride from a stop is #120).
+      transit: { stage: 'boarded', enterEventId: jump.id, enterCoordHex: stop },
+    })
+  })
+
+  it('a completed ride adds a hyperjump and the blocks it passed', async () => {
+    await useCyberspace.getState().completeRide({
+      toCoordHex: '56db6db6db6db6db6db6db3e27c436f9d3b79fb5fc6457798936b3e749e38f57',
+      fromHeight: 398, toHeight: 500, asOf: 600, rootHex: '1'.repeat(64), mp: '',
+    })
+    const chain = useCyberspace.getState().chain
+    expect(chain.hyperjumps).toBe(2)
+    expect(chain.blocksRidden).toBe(298 + 102)
+    // The hop and sidestep tallies are untouched by a ride.
+    expect(chain.hops).toBe(0)
+    expect(chain.sidesteps).toBe(0)
+  })
+})
+
+describe('respawns are counted per identity', () => {
+  it('starts at zero and counts up, surviving a reload of the table', () => {
+    const pk = 'f'.repeat(64)
+    expect(loadRespawns(pk)).toBe(0)
+    expect(addRespawn(pk)).toBe(1)
+    expect(addRespawn(pk)).toBe(2)
+    expect(loadRespawns(pk)).toBe(2)
+    expect(loadRespawns('e'.repeat(64))).toBe(0)
+  })
+})

--- a/src/store/respawn.test.ts
+++ b/src/store/respawn.test.ts
@@ -19,11 +19,18 @@ describe('respawn', () => {
     useCyberspace.setState({
       position: { ...SPAWN, x: SPAWN.x + 5n },
       cursor: { ...SPAWN, x: SPAWN.x + 9n },
-      chain: { hops: 3, sidesteps: 1, totalOps: 99, totalHashes: 7, totalMs: 12 },
+      chain: { hops: 3, sidesteps: 1, totalOps: 99, totalHashes: 7, totalMs: 12, hyperjumps: 2, blocksRidden: 400 },
     })
+    const respawnsBefore = before.respawns
 
     await useCyberspace.getState().respawn()
     const s = useCyberspace.getState()
+
+    // Each respawn is one more on the identity's count, and the new chain
+    // starts with no rides.
+    expect(s.respawns).toBe(respawnsBefore + 1)
+    expect(s.chain.hyperjumps).toBe(0)
+    expect(s.chain.blocksRidden).toBe(0)
 
     expect(s.events).toHaveLength(1)
     const spawn = parseAction(s.events[0])
@@ -37,7 +44,7 @@ describe('respawn', () => {
     expect(s.positionHistory).toEqual([SPAWN])
     expect(s.plane).toBe(spawn?.plane)
     expect(s.headPlane).toBe(spawn?.plane)
-    expect(s.chain).toEqual({ hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0 })
+    expect(s.chain).toEqual({ hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0, hyperjumps: 0, blocksRidden: 0 })
     expect(Object.keys(s.published)).toEqual([s.events[0].id])
     expect(s.published[s.events[0].id]).toBe('queued')
     expect(s.pendingTarget).toBeNull()

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -16,6 +16,7 @@
  */
 
 import { create } from 'zustand'
+import { rideStatsOf } from '../lib/hyperspace/ride'
 import { Quaternion } from 'three'
 import { finalizeEvent, generateSecretKey } from 'nostr-tools/pure'
 import { nip19 } from 'nostr-tools'
@@ -234,9 +235,43 @@ export interface ChainStats {
   totalHashes: number
   /** Cumulative proof compute time. */
   totalMs: number
+  /** Completed hyperjumps (DECK-0001 rides), from the chain's own events. */
+  hyperjumps: number
+  /** Blocks those rides passed, summed; the ride proof's unit of work. */
+  blocksRidden: number
 }
 
-const EMPTY_STATS: ChainStats = { hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0 }
+const EMPTY_STATS: ChainStats = { hops: 0, sidesteps: 0, totalOps: 0, totalHashes: 0, totalMs: 0, hyperjumps: 0, blocksRidden: 0 }
+
+/**
+ * Respawns are a fact about the identity, not the chain: each one starts a
+ * new chain and the old events leave the store, so the count lives beside
+ * the identity in storage rather than in the chain's stats.
+ */
+const RESPAWNS_KEY = 'onosendai:respawns'
+
+function respawnTable(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(RESPAWNS_KEY)
+    const parsed = raw ? (JSON.parse(raw) as unknown) : null
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, number>) : {}
+  } catch {
+    return {}
+  }
+}
+
+export function loadRespawns(pubkey: string): number {
+  const v = respawnTable()[pubkey]
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
+}
+
+export function addRespawn(pubkey: string): number {
+  const table = respawnTable()
+  const next = loadRespawns(pubkey) + 1
+  table[pubkey] = next
+  try { localStorage.setItem(RESPAWNS_KEY, JSON.stringify(table)) } catch { /* storage unavailable: the number is still in memory */ }
+  return next
+}
 
 /**
  * The cloud flow's stations. `quoting` covers every exchange before there is
@@ -366,6 +401,8 @@ export interface CyberspaceState {
   plan: MovePlan | null
   /** Sats spent on HOSAKA for the current chain, in msats. Kept on this device only, never published. */
   spentMsats: number
+  /** How many times this identity has respawned; each one began a new chain. */
+  respawns: number
   /**
    * The plane the next commit lands in. Part of the lined-up action, like the
    * cursor: toggling it costs nothing until committed, and a commit with the
@@ -902,7 +939,9 @@ function derive(saved: PersistedChain): {
     genesisId: actions[0].id,
     prevEventId: head.id,
     published,
-    chain: saved.stats,
+    // Rides are counted from the events, so an adopted chain reads the same
+    // as one ridden here; the local measurements stay what was saved.
+    chain: { ...saved.stats, ...rideStatsOf(actions) },
     position: head.position,
     positionHistory: actions.map((a) => a.position),
     plane: head.plane,
@@ -1390,6 +1429,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       pendingTarget: null,
       plan: null,
       spentMsats: loadSpent(base.genesisId),
+      respawns: loadRespawns(signer.pubkey),
       proof: IDLE_PROOF,
       publishError: null,
       spectate: null,
@@ -1429,6 +1469,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   pendingTarget: null,
   plan: null,
   spentMsats: loadSpent(initial.genesisId),
+  respawns: loadRespawns(pubkeyHex),
   scaleExp: 0,
   // Facing the black sun, the section 11.3 canonical orientation, the same
   // one the SUN button restores. The spec's left/right/above/below language
@@ -1805,6 +1846,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
     const now = get()
     const stats: ChainStats = {
+      // Rides are counted from the events (rideStatsOf), untouched here.
+      ...now.chain,
       hops: now.chain.hops + (msg.mode === 'hop' ? 1 : 0),
       sidesteps: now.chain.sidesteps + (msg.mode === 'sidestep' ? 1 : 0),
       totalOps: now.chain.totalOps + (msg.mode === 'hop' ? msg.totalOps : 0),
@@ -1904,6 +1947,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       proof: IDLE_PROOF,
       publishError: null,
       spentMsats: loadSpent(fresh.genesisId),
+      respawns: addRespawn(get().identity.pubkey),
       cloud: { ...IDLE_CLOUD, limits: get().cloud.limits, balance: get().cloud.balance },
     })
     saveChain(fresh.events, fresh.published, fresh.chain)
@@ -2078,10 +2122,12 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
     const newPosition: Position = { x: dest.x, y: dest.y, z: dest.z }
     const published: Record<string, PublishStatus> = { ...get().published, [event.id]: 'queued' }
     const nextEvents = [...get().events, event]
+    const chain: ChainStats = { ...get().chain, ...rideStatsOf(buildChain(nextEvents)) }
     set({
       events: nextEvents,
       prevEventId: event.id,
       published,
+      chain,
       position: newPosition,
       cursor: { ...newPosition },
       plane: dest.plane,


### PR DESCRIPTION
Fixes #53. The proof chain panel counted hops and sidesteps and nothing about rides.

| Row | Where it comes from |
|---|---|
| Hyperjumps, with blocks passed | Counted from the chain's events (`rideStatsOf`): each hyperjump, and the difference of its `from_height` and `B` (§5.3). Exact, so an adopted chain reads the same as one ridden here. Recomputed on load and after every completed ride. |
| Ride pairs | Shown when any blocks were ridden: about 42,000 Cantor pairs per block passed (§5.7), marked as expected rather than measured, beside the Cantor ops and SHA-256 totals. |
| Respawns | Last and apart. Each respawn starts a new chain and the old events leave the store, so the count lives beside the identity in storage, keyed by pubkey, and counts up on every respawn. |

**Measured in the browser:** a fresh chain reads HYPERJUMPS 0 and RESPAWNS 0; with two rides over 400 blocks and three respawns the rows read "2 · 400 BLOCKS", "≈ 16.8M" ride pairs, and "3" at the bottom.

**Tests:** `rideStatsOf` over no rides, two rides in opposite directions and a zero-length ride; a completed ride raising the tally without touching hops or sidesteps; the respawn counter from zero, counting up and surviving a reload of its table; respawn resetting the new chain's rides while the identity's count rises. 681 passing, tsc and build clean.

Note: the `ChainStats` shape gains two fields; saved chains without them read as zero and are recomputed from their events on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
