### PR TITLE
The chat steps aside while spectating

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,7 +186,10 @@ export default function App(): JSX.Element {
       {showPanels && !offerUp && <Hud menuOpen={crowded} />}
       <SpectateBar />
       {!crowded && !offerUp && !deploying && <Compass3D onTap={() => setViewMenuOpen((open) => !open)} />}
-      {!crowded && !offerUp && !deploying && !secretOpen && <ChatDock />}
+      {/* Not while spectating: the spectate bar owns the bottom of the screen,
+          and on a foldable's wide screen the folded CHAT chip sat on top of
+          it. You cannot speak from someone else's head anyway. */}
+      {!crowded && !offerUp && !deploying && !secretOpen && !spectating && <ChatDock />}
       {!crowded && !offerUp && !deploying && viewMenuOpen && <ViewMenu onClose={() => setViewMenuOpen(false)} />}
       {showPad && !offerUp && <TouchControls />}
       {showPad && !offerUp && <RouteOverlay />}


### PR DESCRIPTION
On a foldable phone in wide mode the folded CHAT chip sat on top of the spectate bar (over the last-active line, against END SPECTATION). The chat now hides while spectating, as it already does under a secret modal, the deploy bar and the HOSAKA offer; the composer refuses off your own head anyway. tsc, build and tests gated before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
