### PR TITLE
The avatar faces the move that brought it to the link on show

### DIFF
--- a/src/lib/facing.ts
+++ b/src/lib/facing.ts
@@ -38,3 +38,21 @@ export function facingQuaternion(dir: Vector3): Quaternion {
   const y = new Vector3().crossVectors(z, x).normalize()
   return new Quaternion().setFromRotationMatrix(new Matrix4().makeBasis(x, y, z))
 }
+
+/**
+ * The two positions whose direction the avatar faces, at a point on the chain.
+ *
+ * Time decides the angle: the avatar faces the way the move that brought it
+ * to this link went. At the head that is the last two links, as before.
+ * While scrubbing the chain to link `index`, it is the link before and this
+ * one, so the avatar turns as the history is walked rather than keeping the
+ * heading it has now. At the spawn there is no move in yet, so it faces the
+ * first move out. A chain of one link faces nothing.
+ */
+export function facingPair<T>(chain: T[], index: number | null): [T, T] | null {
+  const n = chain.length
+  if (n < 2) return null
+  const i = index === null ? n - 1 : Math.max(0, Math.min(n - 1, index))
+  if (i === 0) return [chain[0], chain[1]]
+  return [chain[i - 1], chain[i]]
+}

--- a/src/lib/facingPair.test.ts
+++ b/src/lib/facingPair.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { facingPair } from './facing'
+
+const chain = ['spawn', 'a', 'b', 'c', 'd']
+
+describe('which move the avatar faces', () => {
+  it('at the head, the last move', () => {
+    expect(facingPair(chain, null)).toEqual(['c', 'd'])
+  })
+
+  it('while scrubbing, the move that arrived at the link on show', () => {
+    expect(facingPair(chain, 2)).toEqual(['a', 'b'])
+    expect(facingPair(chain, 1)).toEqual(['spawn', 'a'])
+  })
+
+  it('at the spawn, the first move out', () => {
+    expect(facingPair(chain, 0)).toEqual(['spawn', 'a'])
+  })
+
+  it('past the end it is the head; a chain of one faces nothing', () => {
+    expect(facingPair(chain, 99)).toEqual(['c', 'd'])
+    expect(facingPair(['spawn'], null)).toBeNull()
+    expect(facingPair(['spawn'], 0)).toBeNull()
+  })
+})

--- a/src/scene/Avatar.tsx
+++ b/src/scene/Avatar.tsx
@@ -18,7 +18,7 @@
 import { useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Group } from 'three'
-import { facingQuaternion, moveDirection } from '../lib/facing'
+import { facingPair, facingQuaternion, moveDirection } from '../lib/facing'
 import { travelOffset } from '../lib/travel'
 import { useCyberspace } from '../store/useCyberspace'
 import { AvatarShape } from './AvatarShape'
@@ -34,18 +34,21 @@ export function Avatar(): JSX.Element | null {
   // The last move on the chain drawn, as a key so a re-render costs nothing
   // until the chain grows; the avatar turns to face the way it went.
   const view = useCyberspace((s) => s.view)
+  // Time decides the angle: the move that brought the avatar to the link on
+  // show, which while scrubbing the chain is the link before the explored one
+  // and this one, not the head's last move (lib/facing.ts facingPair).
   const moveKey = useCyberspace((s) => {
-    const chain = s.focusChain()
-    const n = chain.length
-    if (n < 2) return null
-    const a = chain[n - 2].position, b = chain[n - 1].position
+    const pair = facingPair(s.focusChain(), s.exploreIndex)
+    if (!pair) return null
+    const a = pair[0].position, b = pair[1].position
     return `${a.x},${a.y},${a.z}>${b.x},${b.y},${b.z}`
   })
   const facing = useMemo(() => {
     if (!moveKey) return null
     const s = useCyberspace.getState()
-    const chain = s.focusChain()
-    const dir = moveDirection(chain[chain.length - 2].position, chain[chain.length - 1].position, s.axes())
+    const pair = facingPair(s.focusChain(), s.exploreIndex)
+    if (!pair) return null
+    const dir = moveDirection(pair[0].position, pair[1].position, s.axes())
     return dir ? facingQuaternion(dir) : null
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [moveKey, view])


### PR DESCRIPTION
Scrubbing the chain moved the avatar back along its history with the heading it has now: pointing up at the head, it pointed up at every link. It faced the last two links of the whole chain whatever the anchor stood on.

Time decides the angle now. At the head, the last move, as before; while scrubbing to link i, the move from link i-1 to i, so the avatar turns as the history is walked; at the spawn, the first move out. `facingPair` in lib/facing.ts picks the pair; Avatar.tsx asks it with the explored index.

Four unit tests. tsc, build and the suite gated before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
