### PR TITLE
A find says how many, stays until tapped, and opens the list of what is here

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { DeploymentDetail } from './hud/DeploymentDetail'
 import { SecretModal } from './hud/SecretModal'
 import { FocusBar } from './hud/FocusBar'
 import { KeyFoundChip } from './hud/KeyFoundChip'
+import { NearbyChip } from './hud/NearbyChip'
 import { ToastChip } from './hud/ToastChip'
 import { LootDetail } from './hud/LootDetail'
 import { NearbyLootModal } from './hud/NearbyLootModal'
@@ -178,6 +179,7 @@ export default function App(): JSX.Element {
           <HyperspaceBar />
           <FocusBar />
           <KeyFoundChip />
+          <NearbyChip />
           <ToastChip />
           <ChainExplorer />
           <BitReadout />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { SecretModal } from './hud/SecretModal'
 import { FocusBar } from './hud/FocusBar'
 import { KeyFoundChip } from './hud/KeyFoundChip'
 import { NearbyChip } from './hud/NearbyChip'
+import { watchNearbyReturn } from './lib/nearbyReturn'
 import { ToastChip } from './hud/ToastChip'
 import { LootDetail } from './hud/LootDetail'
 import { NearbyLootModal } from './hud/NearbyLootModal'
@@ -60,7 +61,7 @@ export default function App(): JSX.Element {
   useDiscovery()
   // The chain drains to the relay from here on, whenever Live is on, and the
   // targets' positions are kept current.
-  useEffect(() => { startPublisher(); startTracker(); startPresence(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load(); watchFocus() }, [])
+  useEffect(() => { startPublisher(); startTracker(); startPresence(); startSelfSync(); startCalibration(); void useCyberspace.getState().initSigner(); useHyperspace.getState().startSync(); useAvatars.getState().loadMine(); useSecrets.getState().load(); watchFocus(); watchNearbyReturn() }, [])
   // The feeds that watch other people, the loot and the anchors are reissued
   // when the tab returns from a real absence or the network comes back; a
   // socket that died while the tab was away looks open and delivers nothing.
@@ -182,11 +183,12 @@ export default function App(): JSX.Element {
           <LineScrubber />
           <HyperspaceBar />
           <FocusBar />
-          <KeyFoundChip />
           <ToastChip />
           <ChainExplorer />
           <BitReadout />
-          {/* Under XOR BITS, spaced as the rest are: what is open to you here, then the scan. */}
+          {/* Under XOR BITS, spaced as the rest are: what was just found, what
+              is open to you here, then the scan. */}
+          <KeyFoundChip />
           <NearbyChip />
           <PresenceChip />
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { FocusBar } from './hud/FocusBar'
 import { KeyFoundChip } from './hud/KeyFoundChip'
 import { ToastChip } from './hud/ToastChip'
 import { LootDetail } from './hud/LootDetail'
+import { NearbyLootModal } from './hud/NearbyLootModal'
 import { CloudApproval, CreditedModal, InvoiceModal, PaidModal } from './hud/InvoiceModal'
 import { HosakaOffer } from './hud/HosakaOffer'
 import { HosakaPulse } from './hud/HosakaPulse'
@@ -210,6 +211,7 @@ export default function App(): JSX.Element {
       <DeploymentDetail />
       <SecretModal />
       <LootDetail />
+      <NearbyLootModal />
       <HosakaOffer hidden={crowded || secretOpen} />
       {/* While the panels are open the job is on screen in Cloud compute; the pulse is for when it is not. */}
       {!showPanels && <HosakaPulse />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,7 +125,11 @@ export default function App(): JSX.Element {
   // A region tapped in the Secrets list is the same kind of asking: the panels
   // are what you were reading, and the region is what you asked to see.
   const viewingSecret = useSecrets((s) => s.focused !== null)
-  useEffect(() => { if ((driving || stationView || viewingSecret) && isMobile) setPanelsOpen(false) }, [driving, stationView, viewingSecret, isMobile])
+  // Any view that begins, driven or not: VIEW on a Nearby Loot row while
+  // spectating ends the spectation, and the panels hidden behind it would
+  // come straight back over the thing just asked for.
+  const viewing = useCyberspace((s) => s.focus !== null)
+  useEffect(() => { if ((driving || stationView || viewingSecret || viewing) && isMobile) setPanelsOpen(false) }, [driving, stationView, viewingSecret, viewing, isMobile])
 
   // Only a phone has to choose between reading the panels and driving. On a
   // desktop there is room for both at once.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,11 +179,11 @@ export default function App(): JSX.Element {
           <HyperspaceBar />
           <FocusBar />
           <KeyFoundChip />
-          <NearbyChip />
           <ToastChip />
           <ChainExplorer />
           <BitReadout />
-          {/* Last in the stack, under XOR BITS, spaced as the rest are. */}
+          {/* Under XOR BITS, spaced as the rest are: what is open to you here, then the scan. */}
+          <NearbyChip />
           <PresenceChip />
         </div>
       )}

--- a/src/hooks/useNearbyLoot.ts
+++ b/src/hooks/useNearbyLoot.ts
@@ -1,0 +1,30 @@
+/**
+ * useNearbyLoot.ts — the items decrypted in the region the anchor stands in.
+ *
+ * Every placed thing this client has opened or placed, filtered by lib/nearby:
+ * its own cube holds the anchor, or it is filed under a key you hold whose
+ * region does. Recomputed when the anchor, the plane, the finds or the keys
+ * change, so the chip's count, the panel's button and the list agree.
+ */
+
+import { useMemo } from 'react'
+import { nearbyItems } from '../lib/nearby'
+import { useCyberspace } from '../store/useCyberspace'
+import { useSecrets } from '../store/useSecrets'
+import { useShards, type WorldItem } from '../store/useShards'
+
+export type NearbyItem = WorldItem & { distance: bigint }
+
+export function useNearbyLoot(): NearbyItem[] {
+  const anchor = useCyberspace((s) => s.anchor)
+  const plane = useCyberspace((s) => s.anchorPlane)
+  const discovered = useShards((s) => s.discovered)
+  const mine = useShards((s) => s.mine)
+  const keys = useSecrets((s) => s.keys)
+  return useMemo(() => {
+    const held = Object.values(keys)
+    return nearbyItems(useShards.getState().worldItems(), held, anchor, plane)
+    // discovered and mine are what worldItems reads.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchor, plane, discovered, mine, keys])
+}

--- a/src/hud/KeyFoundChip.tsx
+++ b/src/hud/KeyFoundChip.tsx
@@ -1,14 +1,17 @@
 /**
  * KeyFoundChip.tsx — the HUD half of the find ceremony.
  *
- * When a scan opens a bag, a chip rises in the instruments stack: KEY FOUND,
- * the region's size and the item count, and the found item's label resolving
- * out of glyphs in step with the scene. It stays a few seconds or until tapped.
+ * When a scan opens a bag, a chip rises in the instruments stack saying how
+ * many were found here, with the last find's label resolving out of glyphs in
+ * step with the scene. It has no clock: it stays until tapped, more finds
+ * add to its count, and the tap opens the Nearby Loot list.
  */
 
 import { useEffect, useState } from 'react'
-import { CHIP_MS, decodeText, seedOf, TEXT_DECODE_MS } from '../lib/decode'
+import { decodeText, seedOf, TEXT_DECODE_MS } from '../lib/decode'
+import { foundLabel } from '../lib/nearby'
 import { useCeremony } from '../store/useCeremony'
+import { useShards } from '../store/useShards'
 
 export function KeyFoundChip(): JSX.Element | null {
   const chip = useCeremony((s) => s.chip)
@@ -26,17 +29,17 @@ export function KeyFoundChip(): JSX.Element | null {
       if (t < 1) raf = window.requestAnimationFrame(tick)
     }
     raf = window.requestAnimationFrame(tick)
-    const timer = window.setTimeout(() => useCeremony.getState().dismiss(), CHIP_MS)
-    return () => { window.cancelAnimationFrame(raf); window.clearTimeout(timer) }
+    return () => window.cancelAnimationFrame(raf)
   }, [chip])
 
   if (!chip) return null
+  const open = (): void => { useCeremony.getState().dismiss(); useShards.getState().setNearbyOpen(true) }
   return (
-    <div className="hyperbar hyperbar--found" role="status" onClick={() => useCeremony.getState().dismiss()}>
+    <div className="hyperbar hyperbar--found" role="status" onClick={open} title="Tap to see what was found here">
       <span className="hyperbar__glyph" aria-hidden="true">◈</span>
       <span className="hyperbar__text">
-        <span className="hyperbar__label">KEY FOUND</span>
-        <span className="hyperbar__meta">{chip.meta}</span>
+        <span className="hyperbar__label">{foundLabel(chip.count)}</span>
+        <span className="hyperbar__meta">{chip.meta} · tap to see</span>
       </span>
       <span className="foundchip__decode">{shown}</span>
     </div>

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -77,8 +77,6 @@ export function LootPanel(): JSX.Element {
       <header className="panel__head">
         <h2>Loot</h2>
         <span className="loot__tags">
-          {/* What is decrypted where you stand, however it was found. */}
-          <button className="tag tag--live loot__nearby" onClick={() => useShards.getState().setNearbyOpen(true)} title="What has been decrypted in the region you stand in">NEARBY {nearbyCount}</button>
           {foundCount > 0 && <span className="tag tag--live">{foundCount} FOUND</span>}
           <span className="tag">{status === 'loading' ? 'LOADING' : `${items.length} HIDDEN`}</span>
         </span>
@@ -92,9 +90,15 @@ export function LootPanel(): JSX.Element {
           <li className="avatars__empty">Nothing hidden on the relay yet.</li>
         )}
       </ul>
-      {items.length > SHOWN && (
-        <button className="avatars__more" onClick={() => setMore(true)}>VIEW MORE ({items.length - SHOWN})</button>
-      )}
+      {/* Two doors under the list, side by side: what is decrypted where you
+          stand, and the rest of what the relay holds. A button is not a tag,
+          so neither lives in the header. */}
+      <div className={`loot__actions ${items.length > SHOWN ? '' : 'loot__actions--one'}`}>
+        <button className="avatars__more" onClick={() => useShards.getState().setNearbyOpen(true)} title="What has been decrypted in the region you stand in">NEARBY {nearbyCount}</button>
+        {items.length > SHOWN && (
+          <button className="avatars__more" onClick={() => setMore(true)}>VIEW MORE ({items.length - SHOWN})</button>
+        )}
+      </div>
 
       <Explanation>
         Identities can encrypt messages, 3D objects (shards), or other data by

--- a/src/hud/LootPanel.tsx
+++ b/src/hud/LootPanel.tsx
@@ -24,6 +24,7 @@ import { useLootView } from '../store/useLootView'
 import { useShards } from '../store/useShards'
 import { ProfileBadge } from './ProfileBadge'
 import { Explanation } from './Explanation'
+import { useNearbyLoot } from '../hooks/useNearbyLoot'
 
 /** Rows the panel shows before VIEW MORE takes over. */
 const SHOWN = 4
@@ -46,6 +47,7 @@ export function LootPanel(): JSX.Element {
     return out
   }, [discovered])
   const found = useMemo(() => new Set(kinds.keys()), [kinds])
+  const nearbyCount = useNearbyLoot().length
   const foundCount = useMemo(() => items.filter((it) => found.has(it.bagId)).length, [items, found])
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {
@@ -75,6 +77,8 @@ export function LootPanel(): JSX.Element {
       <header className="panel__head">
         <h2>Loot</h2>
         <span className="loot__tags">
+          {/* What is decrypted where you stand, however it was found. */}
+          <button className="tag tag--live loot__nearby" onClick={() => useShards.getState().setNearbyOpen(true)} title="What has been decrypted in the region you stand in">NEARBY {nearbyCount}</button>
           {foundCount > 0 && <span className="tag tag--live">{foundCount} FOUND</span>}
           <span className="tag">{status === 'loading' ? 'LOADING' : `${items.length} HIDDEN`}</span>
         </span>

--- a/src/hud/NearbyChip.tsx
+++ b/src/hud/NearbyChip.tsx
@@ -5,7 +5,9 @@
  * stays as long as anything nearby is open to you, glowing like the find
  * chip, and opens the Nearby Loot list. It is the way back to that list
  * while spectating, when the menu is locked, and after the find chip has
- * been tapped away. Shown only when there is something to show.
+ * been tapped away. Built on the same markup as the scan chip beside it,
+ * so the two read as one row of the same instrument: the same 9px label,
+ * the same 29px height, a 12px mark.
  */
 
 import { Gem } from 'lucide-react'
@@ -17,9 +19,11 @@ export function NearbyChip(): JSX.Element | null {
   const open = useShards((s) => s.nearbyOpen)
   if (count === 0 || open) return null
   return (
-    <button className="hyperbar hyperbar--found nearby__chip" onClick={() => useShards.getState().setNearbyOpen(true)} title="What your keys open where you stand">
-      <Gem size={13} strokeWidth={2.25} aria-hidden />
-      <span className="hyperbar__label">NEARBY {count}</span>
-    </button>
+    <div className="hyperbar presence hyperbar--found nearby__chip" role="status">
+      <button className="presence__head" onClick={() => useShards.getState().setNearbyOpen(true)} title="What your keys open where you stand">
+        <Gem size={12} strokeWidth={2.25} aria-hidden />
+        <span className="hyperbar__label">NEARBY {count}</span>
+      </button>
+    </div>
   )
 }

--- a/src/hud/NearbyChip.tsx
+++ b/src/hud/NearbyChip.tsx
@@ -1,0 +1,25 @@
+/**
+ * NearbyChip.tsx — there is something decrypted where you stand.
+ *
+ * The find chip says how many just arrived and goes when tapped. This one
+ * stays as long as anything nearby is open to you, glowing like the find
+ * chip, and opens the Nearby Loot list. It is the way back to that list
+ * while spectating, when the menu is locked, and after the find chip has
+ * been tapped away. Shown only when there is something to show.
+ */
+
+import { Gem } from 'lucide-react'
+import { useNearbyLoot } from '../hooks/useNearbyLoot'
+import { useShards } from '../store/useShards'
+
+export function NearbyChip(): JSX.Element | null {
+  const count = useNearbyLoot().length
+  const open = useShards((s) => s.nearbyOpen)
+  if (count === 0 || open) return null
+  return (
+    <button className="hyperbar hyperbar--found nearby__chip" onClick={() => useShards.getState().setNearbyOpen(true)} title="What your keys open where you stand">
+      <Gem size={13} strokeWidth={2.25} aria-hidden />
+      <span className="hyperbar__label">NEARBY {count}</span>
+    </button>
+  )
+}

--- a/src/hud/NearbyLootModal.tsx
+++ b/src/hud/NearbyLootModal.tsx
@@ -13,7 +13,6 @@ import { useNearbyLoot, type NearbyItem } from '../hooks/useNearbyLoot'
 import { useProfile } from '../hooks/useProfile'
 import { findCashuToken } from '../lib/cashu'
 import { messagePreview } from '../lib/hidden'
-import { regionLabel } from '../lib/loot'
 import { formatDistance } from '../lib/scale'
 import { useCyberspace } from '../store/useCyberspace'
 import { profileLabel } from '../store/useProfiles'
@@ -25,9 +24,16 @@ function safeNpub(pubkey: string): string {
   try { return nip19.npubEncode(pubkey) } catch { return pubkey }
 }
 
+/** The first line: the message itself, or the shard named in quotes with its size. */
 function labelOf(item: NearbyItem): string {
-  if (item.type === 'message') return findCashuToken(item.text) ? '₿ cashu token' : messagePreview(item.text ?? '', 60)
-  return item.shard?.name ?? 'shard'
+  if (item.type === 'message') return findCashuToken(item.text) ? '₿ cashu token' : messagePreview(item.text ?? '', 160)
+  const shard = item.shard
+  return shard ? `\u201c${shard.name}\u201d shard \u00b7 ${shard.vertices.length} vertices \u00b7 ${shard.faces.length} faces` : 'shard'
+}
+
+/** The second line: where it is, in the words the panels use. */
+function whereOf(item: NearbyItem): string {
+  return `${item.plane === 1 ? 'Ideaspace' : 'Dataspace'}, height ${item.height}`
 }
 
 function Row({ item, me, onView }: { item: NearbyItem; me: string; onView: (item: NearbyItem) => void }): JSX.Element {
@@ -39,10 +45,10 @@ function Row({ item, me, onView }: { item: NearbyItem; me: string; onView: (item
       <span className="nearby__glyph" aria-hidden="true">{item.type === 'message' ? (findCashuToken(item.text) ? '₿' : '✎') : '◇'}</span>
       <div className="nearby__body">
         <span className="nearby__label">{labelOf(item)}</span>
+        <span className="nearby__where">{whereOf(item)}</span>
         <span className="nearby__meta">
           {author && <ProfilePic pubkey={author} size={14} />}
           <span>{name}</span>
-          <span>· {regionLabel(item.height)}</span>
           <span>· {item.distance === 0n ? 'right here' : `${formatDistance(item.distance)} away`}</span>
         </span>
       </div>

--- a/src/hud/NearbyLootModal.tsx
+++ b/src/hud/NearbyLootModal.tsx
@@ -17,6 +17,7 @@ import { formatDistance } from '../lib/scale'
 import { useCyberspace } from '../store/useCyberspace'
 import { profileLabel } from '../store/useProfiles'
 import { useShards } from '../store/useShards'
+import { rememberNearbyReturn } from '../lib/nearbyReturn'
 import { ProfilePic } from './ProfileBadge'
 import { nip19 } from 'nostr-tools'
 
@@ -65,6 +66,8 @@ export function NearbyLootModal(): JSX.Element | null {
   if (!open) return null
   const close = (): void => useShards.getState().setNearbyOpen(false)
   const view = (item: NearbyItem): void => {
+    // Where to come back to, spectation and link included, before looking away.
+    rememberNearbyReturn()
     close()
     const unit = item.type === 'shard' ? item.shard?.unit ?? 0 : 0
     useCyberspace.getState().focusOn(item.at, item.plane, labelOf(item).toUpperCase(), unit)

--- a/src/hud/NearbyLootModal.tsx
+++ b/src/hud/NearbyLootModal.tsx
@@ -46,7 +46,7 @@ function Row({ item, me, onView }: { item: NearbyItem; me: string; onView: (item
           <span>· {item.distance === 0n ? 'right here' : `${formatDistance(item.distance)} away`}</span>
         </span>
       </div>
-      <button className="secrets__scan" onClick={() => onView(item)} title="Fly to it">VIEW</button>
+      <button className="avatars__go nearby__view" onClick={() => onView(item)} title="Fly to it">VIEW ▸</button>
     </li>
   )
 }

--- a/src/hud/NearbyLootModal.tsx
+++ b/src/hud/NearbyLootModal.tsx
@@ -1,0 +1,84 @@
+/**
+ * NearbyLootModal.tsx — what has been decrypted where you stand.
+ *
+ * The green box is the region your keys open; this is the list of what is in
+ * it: every shard and message this client has opened or placed whose region
+ * holds the anchor, nearest first. Reached from the found chip, which says
+ * how many, and from NEARBY on the Loot panel. VIEW flies to the thing the
+ * way the loot record's VIEW does.
+ */
+
+import { useMemo } from 'react'
+import { useNearbyLoot, type NearbyItem } from '../hooks/useNearbyLoot'
+import { useProfile } from '../hooks/useProfile'
+import { findCashuToken } from '../lib/cashu'
+import { messagePreview } from '../lib/hidden'
+import { regionLabel } from '../lib/loot'
+import { formatDistance } from '../lib/scale'
+import { useCyberspace } from '../store/useCyberspace'
+import { profileLabel } from '../store/useProfiles'
+import { useShards } from '../store/useShards'
+import { ProfilePic } from './ProfileBadge'
+import { nip19 } from 'nostr-tools'
+
+function safeNpub(pubkey: string): string {
+  try { return nip19.npubEncode(pubkey) } catch { return pubkey }
+}
+
+function labelOf(item: NearbyItem): string {
+  if (item.type === 'message') return findCashuToken(item.text) ? '₿ cashu token' : messagePreview(item.text ?? '', 60)
+  return item.shard?.name ?? 'shard'
+}
+
+function Row({ item, me, onView }: { item: NearbyItem; me: string; onView: (item: NearbyItem) => void }): JSX.Element {
+  const profile = useProfile(item.author ?? null)
+  const author = item.author ?? ''
+  const name = author === me ? 'you' : profileLabel(profile, safeNpub(author))
+  return (
+    <li className="secrets__row nearby__row">
+      <span className="nearby__glyph" aria-hidden="true">{item.type === 'message' ? (findCashuToken(item.text) ? '₿' : '✎') : '◇'}</span>
+      <div className="nearby__body">
+        <span className="nearby__label">{labelOf(item)}</span>
+        <span className="nearby__meta">
+          {author && <ProfilePic pubkey={author} size={14} />}
+          <span>{name}</span>
+          <span>· {regionLabel(item.height)}</span>
+          <span>· {item.distance === 0n ? 'right here' : `${formatDistance(item.distance)} away`}</span>
+        </span>
+      </div>
+      <button className="secrets__scan" onClick={() => onView(item)} title="Fly to it">VIEW</button>
+    </li>
+  )
+}
+
+export function NearbyLootModal(): JSX.Element | null {
+  const open = useShards((s) => s.nearbyOpen)
+  const me = useCyberspace((s) => s.identity.pubkey)
+  const items = useNearbyLoot()
+  const list = useMemo(() => items, [items])
+  if (!open) return null
+  const close = (): void => useShards.getState().setNearbyOpen(false)
+  const view = (item: NearbyItem): void => {
+    close()
+    const unit = item.type === 'shard' ? item.shard?.unit ?? 0 : 0
+    useCyberspace.getState().focusOn(item.at, item.plane, labelOf(item).toUpperCase(), unit)
+  }
+  return (
+    <div className="modal" role="dialog" aria-label="Nearby loot" aria-modal="true" onPointerDown={close}>
+      <div className="modal__card secrets__box" onPointerDown={(e) => e.stopPropagation()}>
+        <header className="panel__head secrets__head">
+          <h2>Nearby loot</h2>
+          <span className="tag">{list.length === 0 ? 'NOTHING HERE' : `${list.length} DECRYPTED HERE`}</span>
+          <button className="targets__remove secrets__close" onClick={close} aria-label="Close" title="Close">✕</button>
+        </header>
+        <div className="secrets__summary">
+          <span>What your keys open in the region you stand in, the green box, nearest first.</span>
+        </div>
+        <ul className="secrets__list">
+          {list.length === 0 && <li className="secrets__empty">Nothing decrypted where you stand. Move, and the scan looks again.</li>}
+          {list.map((item) => <Row key={item.key} item={item} me={me} onView={view} />)}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/hud/NearbyLootModal.tsx
+++ b/src/hud/NearbyLootModal.tsx
@@ -72,10 +72,10 @@ export function NearbyLootModal(): JSX.Element | null {
           <button className="targets__remove secrets__close" onClick={close} aria-label="Close" title="Close">✕</button>
         </header>
         <div className="secrets__summary">
-          <span>What your keys open in the region you stand in, the green box, nearest first.</span>
+          <span>Hop actions produce region keys that decrypt hidden things nearby.</span>
         </div>
         <ul className="secrets__list">
-          {list.length === 0 && <li className="secrets__empty">Nothing decrypted where you stand. Move, and the scan looks again.</li>}
+          {list.length === 0 && <li className="secrets__empty">Nothing decrypted in this region. A rescan is triggered after every movement action.</li>}
           {list.map((item) => <Row key={item.key} item={item} me={me} onView={view} />)}
         </ul>
       </div>

--- a/src/lib/nearby.test.ts
+++ b/src/lib/nearby.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { foundLabel, itemNearby, nearbyItems, regionContains } from './nearby'
+
+const anchor = { x: 1000n, y: 2000n, z: 3000n }
+
+describe('a region holds a point', () => {
+  it('when the point aligns to the region\'s base on every axis', () => {
+    const base = { x: 1000n >> 4n << 4n, y: 2000n >> 4n << 4n, z: 3000n >> 4n << 4n }
+    expect(regionContains({ base, heights: { x: 4, y: 4, z: 4 } }, anchor)).toBe(true)
+    expect(regionContains({ base: { ...base, x: base.x + 16n }, heights: { x: 4, y: 4, z: 4 } }, anchor)).toBe(false)
+  })
+
+  it('takes a box with a height per axis, as a hop\'s key has', () => {
+    const base = { x: '0', y: String(2000n >> 1n << 1n), z: '3000' }
+    expect(regionContains({ base, heights: { x: 12, y: 1, z: 0 } }, anchor)).toBe(true)
+    expect(regionContains({ base, heights: { x: 9, y: 1, z: 0 } }, anchor)).toBe(false)
+  })
+})
+
+describe('an item is nearby', () => {
+  it('when its own cube holds the anchor, in the same plane', () => {
+    expect(itemNearby({ at: { x: 1007n, y: 2015n, z: 3001n }, height: 4, plane: 0 }, anchor, 0)).toBe(true)
+    expect(itemNearby({ at: { x: 1007n, y: 2015n, z: 3001n }, height: 4, plane: 1 }, anchor, 0)).toBe(false)
+    expect(itemNearby({ at: { x: 1040n, y: 2000n, z: 3000n }, height: 4, plane: 0 }, anchor, 0)).toBe(false)
+  })
+
+  it('at height 0 only on the exact point', () => {
+    expect(itemNearby({ at: anchor, height: 0, plane: 0 }, anchor, 0)).toBe(true)
+    expect(itemNearby({ at: { ...anchor, x: 1001n }, height: 0, plane: 0 }, anchor, 0)).toBe(false)
+  })
+})
+
+describe('the nearby list', () => {
+  const near = { key: 'near', at: { x: 1002n, y: 2001n, z: 3000n }, plane: 0 as const, height: 3 }
+  const nearer = { key: 'nearer', at: { x: 1000n, y: 2000n, z: 3001n }, plane: 0 as const, height: 3 }
+  const far = { key: 'far', at: { x: 5000n, y: 2000n, z: 3000n }, plane: 0 as const, height: 3 }
+  const filed = { key: 'filed', at: { x: 9000n, y: 9000n, z: 9000n }, plane: 0 as const, height: 2, lookupId: 'ff'.repeat(32) }
+
+  it('holds what the anchor\'s cubes hold, nearest first, and leaves the rest out', () => {
+    const out = nearbyItems([near, far, nearer], [], anchor, 0)
+    expect(out.map((x) => x.key)).toEqual(['nearer', 'near'])
+    expect(out[0].distance).toBe(1n)
+    expect(out[1].distance).toBe(2n)
+  })
+
+  it('includes an item filed under a held key whose region holds the anchor', () => {
+    const keys = [{ lookupId: 'ff'.repeat(32), plane: 0 as const, height: 20, base: { x: '0', y: '0', z: '0' } }]
+    expect(nearbyItems([filed], keys, anchor, 0).map((x) => x.key)).toEqual(['filed'])
+    const elsewhere = [{ lookupId: 'ff'.repeat(32), plane: 0 as const, height: 4, base: { x: '9000', y: '9000', z: '9000' } }]
+    expect(nearbyItems([filed], elsewhere, anchor, 0)).toHaveLength(0)
+  })
+})
+
+describe('the toast', () => {
+  it('says how many', () => {
+    expect(foundLabel(1)).toBe('1 FOUND HERE')
+    expect(foundLabel(3)).toBe('3 FOUND HERE')
+  })
+})

--- a/src/lib/nearby.ts
+++ b/src/lib/nearby.ts
@@ -1,0 +1,89 @@
+/**
+ * nearby.ts — what has been decrypted where you stand.
+ *
+ * A hidden thing lives in one aligned cube, the region its key opens: side
+ * 2^height around the point it was placed at, base per axis the point with
+ * its low `height` bits cleared. It is nearby when the cube holds the anchor
+ * on every axis and the planes match. A key you hold is a region too, a box
+ * with a height per axis, and anything filed under that key's lookup id is
+ * nearby whenever that box holds the anchor. Nearest first, by the largest
+ * axis distance from the anchor.
+ */
+
+import type { Plane } from 'cyberspace-core'
+import type { Position } from './space'
+
+export interface NearbyRegion {
+  base: { x: bigint | string; y: bigint | string; z: bigint | string }
+  heights: { x: number; y: number; z: number }
+}
+
+export interface NearbyCandidate {
+  key: string
+  at: Position
+  plane: Plane
+  height: number
+  lookupId?: string
+}
+
+export interface NearbyKey {
+  lookupId: string
+  plane: Plane
+  height: number
+  heights?: { x: number; y: number; z: number }
+  base: { x: string; y: string; z: string }
+}
+
+function aligned(v: bigint, h: number): bigint {
+  const s = BigInt(h)
+  return (v >> s) << s
+}
+
+/** Whether a box (a base and a height per axis) holds a point. */
+export function regionContains(region: NearbyRegion, p: Position): boolean {
+  for (const a of ['x', 'y', 'z'] as const) {
+    if (aligned(p[a], region.heights[a]) !== BigInt(region.base[a])) return false
+  }
+  return true
+}
+
+/** The cube of side 2^height around an item's point holds the anchor. */
+export function itemNearby(item: { at: Position; height: number; plane: Plane }, anchor: Position, plane: Plane): boolean {
+  if (item.plane !== plane) return false
+  const h = { x: item.height, y: item.height, z: item.height }
+  const base = { x: aligned(item.at.x, item.height), y: aligned(item.at.y, item.height), z: aligned(item.at.z, item.height) }
+  return regionContains({ base, heights: h }, anchor)
+}
+
+/** The largest axis distance from the anchor, in gibsons. */
+export function axisDistance(at: Position, anchor: Position): bigint {
+  let far = 0n
+  for (const a of ['x', 'y', 'z'] as const) {
+    const d = at[a] > anchor[a] ? at[a] - anchor[a] : anchor[a] - at[a]
+    if (d > far) far = d
+  }
+  return far
+}
+
+/**
+ * The items decrypted in the region the anchor stands in: those whose own
+ * cube holds the anchor, plus those filed under a held key whose region
+ * holds the anchor. Nearest first.
+ */
+export function nearbyItems<T extends NearbyCandidate>(items: T[], keys: NearbyKey[], anchor: Position, plane: Plane): Array<T & { distance: bigint }> {
+  const openHere = new Set<string>()
+  for (const k of keys) {
+    if (k.plane !== plane) continue
+    const heights = k.heights ?? { x: k.height, y: k.height, z: k.height }
+    if (regionContains({ base: k.base, heights }, anchor)) openHere.add(k.lookupId)
+  }
+  return items
+    .filter((it) => itemNearby(it, anchor, plane) || (it.lookupId !== undefined && it.plane === plane && openHere.has(it.lookupId)))
+    .map((it) => ({ ...it, distance: axisDistance(it.at, anchor) }))
+    .sort((a, b) => (a.distance < b.distance ? -1 : a.distance > b.distance ? 1 : 0))
+}
+
+/** The toast's line: how many were found here. */
+export function foundLabel(count: number): string {
+  return `${count} FOUND HERE`
+}

--- a/src/lib/nearbyReturn.test.ts
+++ b/src/lib/nearbyReturn.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+// The spectator would fetch from the relay; here it only does what its first
+// synchronous step does, which is what the restore has to survive.
+vi.mock('./spectator', () => ({
+  spectate: async (pubkey: string) => { useCyberspace.getState().beginSpectate(pubkey) },
+  stopSpectating: () => {},
+}))
+
+import { useCyberspace } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+import { rememberNearbyReturn, watchNearbyReturn } from './nearbyReturn'
+import type { ActionEvent } from './events'
+
+const friend = 'f1'.repeat(32)
+const link = (i: number): ActionEvent => ({ id: String(i).repeat(32).slice(0, 64), pubkey: friend, createdAt: 100 + i, type: 'hop', coordHex: 'c'.repeat(64), position: { x: 1000n + BigInt(i), y: 5n, z: 5n }, plane: 0, prevCoordHex: null, genesisId: null, previousId: null, proofHash: null, sector: '0-0-0' })
+
+describe('RETURN after VIEW from Nearby Loot', () => {
+  let stop: () => void
+  beforeEach(() => {
+    stop?.()
+    stop = watchNearbyReturn()
+    useShards.setState({ nearbyOpen: false, nearbyReturn: null })
+    useCyberspace.setState({ focus: null, spectate: null, exploreIndex: null })
+  })
+
+  it('puts you back on the friend at the same link, and reopens the list', () => {
+    const s = useCyberspace.getState()
+    s.beginSpectate(friend)
+    useCyberspace.setState({ spectate: { ...useCyberspace.getState().spectate!, actions: [link(0), link(1), link(2)], status: 'live' }, exploreIndex: 1, anchor: link(1).position, anchorPlane: 0 })
+    rememberNearbyReturn()
+    useShards.getState().setNearbyOpen(false)
+    s.focusOn({ x: 7n, y: 7n, z: 7n }, 0, 'A SHARD', 0)
+    expect(useCyberspace.getState().spectate).toBeNull()
+
+    useCyberspace.getState().clearFocus()
+
+    const after = useCyberspace.getState()
+    expect(after.spectate?.pubkey).toBe(friend)
+    expect(after.exploreIndex).toBe(1)
+    expect(after.anchor.x).toBe(1001n)
+    expect(useShards.getState().nearbyOpen).toBe(true)
+    expect(useShards.getState().nearbyReturn).toBeNull()
+  })
+
+  it('with no spectation, only the list comes back', () => {
+    rememberNearbyReturn()
+    useCyberspace.getState().focusOn({ x: 7n, y: 7n, z: 7n }, 0, 'A NOTE', 0)
+    useCyberspace.getState().clearFocus()
+    expect(useCyberspace.getState().spectate).toBeNull()
+    expect(useShards.getState().nearbyOpen).toBe(true)
+  })
+
+  it('a snapshot already waiting is not overwritten by a second VIEW', () => {
+    useCyberspace.getState().beginSpectate(friend)
+    rememberNearbyReturn()
+    useCyberspace.getState().focusOn({ x: 7n, y: 7n, z: 7n }, 0, 'ONE', 0)
+    rememberNearbyReturn()
+    expect(useShards.getState().nearbyReturn?.spectate?.pubkey).toBe(friend)
+  })
+})

--- a/src/lib/nearbyReturn.ts
+++ b/src/lib/nearbyReturn.ts
@@ -1,0 +1,59 @@
+/**
+ * nearbyReturn.ts — RETURN from a Nearby Loot view goes back to where you were.
+ *
+ * VIEW on a Nearby Loot row begins a focus, and a focus replaces whatever the
+ * scene was doing: spectating a friend at some link of their chain, say. When
+ * that focus ends, RETURN used to go home to your own avatar, and the list
+ * was gone. So VIEW takes a snapshot first (who you were spectating, which
+ * link, where the anchor stood), and when the focus ends the snapshot is put
+ * back: the spectation resumes on the same chain at the same link, its live
+ * watch re-armed, and the list reopens. Not spectating? Then only the list
+ * comes back, over your own avatar, which is where RETURN goes anyway.
+ *
+ * Restoring the spectation calls the spectator, which resets to "loading"
+ * and refetches; the saved chain and index are written straight back over
+ * that, and when the fetch lands the store keeps the explored index because
+ * the chain's ids match (setSpectateChain). Started from the app, since the
+ * stores import each other.
+ */
+
+import type { Plane } from 'cyberspace-core'
+import { useCyberspace, type SpectateState } from '../store/useCyberspace'
+import { useShards } from '../store/useShards'
+import { spectate } from './spectator'
+import type { Position } from './space'
+
+export interface NearbyReturn {
+  spectate: SpectateState | null
+  exploreIndex: number | null
+  anchor: Position
+  anchorPlane: Plane
+}
+
+/** What VIEW remembers before it looks away. A snapshot already waiting is kept. */
+export function rememberNearbyReturn(): void {
+  if (useShards.getState().nearbyReturn) return
+  const s = useCyberspace.getState()
+  useShards.getState().setNearbyReturn({ spectate: s.spectate, exploreIndex: s.exploreIndex, anchor: s.anchor, anchorPlane: s.anchorPlane })
+}
+
+/** Put the snapshot back. Exported for the test; the watch below calls it. */
+export function restoreNearbyReturn(r: NearbyReturn): void {
+  if (r.spectate) {
+    // Re-arms the live watch and refetches; then the saved chain and link go
+    // back over the "loading" it just set, so nothing flickers to the spawn.
+    void spectate(r.spectate.pubkey, r.spectate.events)
+    useCyberspace.setState({ spectate: { ...useCyberspace.getState().spectate!, events: r.spectate.events, actions: r.spectate.actions, status: r.spectate.status }, exploreIndex: r.exploreIndex, anchor: r.anchor, anchorPlane: r.anchorPlane })
+  }
+  useShards.getState().setNearbyOpen(true)
+}
+
+export function watchNearbyReturn(): () => void {
+  return useCyberspace.subscribe((state, previous) => {
+    if (previous.focus === null || state.focus !== null) return
+    const r = useShards.getState().nearbyReturn
+    if (!r) return
+    useShards.getState().setNearbyReturn(null)
+    restoreNearbyReturn(r)
+  })
+}

--- a/src/lib/spectator.ts
+++ b/src/lib/spectator.ts
@@ -10,10 +10,11 @@
 
 import { fetchChainEvents, mergeEvents, watchAuthor } from './chains'
 import { useCyberspace } from '../store/useCyberspace'
+import type { NostrEvent } from './events'
 
 let current: { pubkey: string; close: () => void } | null = null
 
-export async function spectate(pubkey: string): Promise<void> {
+export async function spectate(pubkey: string, seed: NostrEvent[] = []): Promise<void> {
   stopSpectating()
   const store = useCyberspace.getState()
   store.beginSpectate(pubkey)
@@ -21,7 +22,10 @@ export async function spectate(pubkey: string): Promise<void> {
   // Anything published while the fetch is in flight is caught by the watch,
   // which starts from a minute ago so nothing falls between the two.
   const since = Math.floor(Date.now() / 1000) - 60
-  let events: ReturnType<typeof mergeEvents> = []
+  // A chain already in hand (a spectation being resumed) stands at once, so
+  // the explored link survives the refetch: the ids match and the store keeps it.
+  let events: ReturnType<typeof mergeEvents> = mergeEvents([], seed)
+  if (events.length > 0) store.setSpectateChain(pubkey, events)
   const close = watchAuthor(pubkey, since, (ev) => {
     if (current?.pubkey !== pubkey) return
     events = mergeEvents(events, [ev])

--- a/src/store/ceremony.test.ts
+++ b/src/store/ceremony.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+if (typeof performance === 'undefined') (globalThis as { performance?: unknown }).performance = { now: () => Date.now() }
+
+import { useCeremony } from './useCeremony'
+import type { Hidden } from '../lib/hidden'
+
+const item = (id: string, text: string): Hidden => ({
+  eventId: id, bagId: 'bag', lookupId: 'aa'.repeat(32), author: 'b'.repeat(64), at: { x: 1n, y: 2n, z: 3n }, plane: 0,
+  height: 4, createdAt: 1, type: 'message', text,
+})
+
+describe('the found chip', () => {
+  beforeEach(() => { useCeremony.setState({ chip: null, births: {} }) })
+
+  it('counts what was found, and keeps counting until tapped', () => {
+    useCeremony.getState().mark([item('a', 'one'), item('b', 'two')])
+    expect(useCeremony.getState().chip?.count).toBe(2)
+    useCeremony.getState().mark([item('c', 'three')])
+    expect(useCeremony.getState().chip?.count).toBe(3)
+    expect(useCeremony.getState().chip?.label).toBe('three')
+    useCeremony.getState().dismiss()
+    expect(useCeremony.getState().chip).toBeNull()
+    useCeremony.getState().mark([item('d', 'four')])
+    expect(useCeremony.getState().chip?.count).toBe(1)
+  })
+
+  it('does nothing for an empty find', () => {
+    useCeremony.getState().mark([])
+    expect(useCeremony.getState().chip).toBeNull()
+  })
+})

--- a/src/store/useCeremony.ts
+++ b/src/store/useCeremony.ts
@@ -3,7 +3,8 @@
  *
  * Finding is a decryption, so the scene shows one: items born from a scan
  * carry a birth time here, and the shard and message renderers read it to run
- * their decode. The HUD shows a KEY FOUND chip for the newest find. A DEV
+ * their decode. The HUD shows a chip with how many were found, which stays
+ * until tapped and opens the Nearby Loot list. A DEV
  * trigger fabricates a found bag beside the avatar so the ceremony can be
  * watched without hiding anything first.
  */
@@ -18,10 +19,12 @@ import { useShards } from './useShards'
 
 export interface FoundChip {
   id: string
-  /** What was found, for the decoding line: a message preview or a shard name. */
+  /** What was found last, for the decoding line: a message preview or a shard name. */
   label: string
-  /** Region size and item count. */
+  /** Region size of the last find. */
   meta: string
+  /** Everything found since the chip was last tapped away. */
+  count: number
   at: number
 }
 
@@ -71,7 +74,10 @@ export const useCeremony = create<CeremonyState>((set, get) => ({
     for (const h of items) births[h.eventId] = now
     const first = items[0]
     const label = first.type === 'message' ? messagePreview(first.text ?? '', 40) : first.shard?.name ?? 'shard'
-    set({ births, chip: { id: `${now}`, label, meta: `${regionLabel(first.height)} · ${items.length} ${items.length === 1 ? 'item' : 'items'}`, at: now } })
+    // Finds pile onto a chip nobody has tapped yet: the count is everything
+    // since the last tap, and the chip stays until it is.
+    const count = (get().chip?.count ?? 0) + items.length
+    set({ births, chip: { id: `${now}`, label, meta: regionLabel(first.height), count, at: now } })
   },
 
   dismiss: () => set({ chip: null }),
@@ -115,4 +121,5 @@ export const useCeremony = create<CeremonyState>((set, get) => ({
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   ;(window as unknown as { __ceremony?: () => void }).__ceremony = () => useCeremony.getState().preview()
   ;(window as unknown as { __ceremonyClear?: () => void }).__ceremonyClear = () => useCeremony.getState().clearPreview()
+  ;(window as unknown as { __ceremonyStore?: typeof useCeremony }).__ceremonyStore = useCeremony
 }

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -997,6 +997,17 @@ function moveAction(action: HosakaAction): ProofMode {
   return action === 'sidestep' ? 'sidestep' : 'hop'
 }
 
+/**
+ * What a hop unlocked, listed. A hop leaves the key to the region it crossed,
+ * whether this machine or HOSAKA computed it, and the key is only worth
+ * something if it opens what is there: ask the relay at once, so the finds
+ * get their ceremony and the Nearby Loot list. Imported lazily: the shards
+ * store imports this one.
+ */
+function scanHeldKey(lookupId: string, keyHex: string): void {
+  void import('./useShards').then((m) => m.useShards.getState().rescan(lookupId, keyHex)).catch(() => { /* the relay was asked; a miss is a miss */ })
+}
+
 export const useCyberspace = create<CyberspaceState>((set, get) => {
   /**
    * Replace the active identity. A known pubkey keeps its stored chain; a new
@@ -1388,6 +1399,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         source: 'cloud',
         at: Math.floor(Date.now() / 1000),
       }])
+      scanHeldKey(msg.lookupId, r.region_n.secret_key)
     }
     const before = get().events.length
     await get().finishProof(msg)
@@ -1919,6 +1931,7 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         eventId: event.id,
         at: Math.floor(Date.now() / 1000),
       }])
+      scanHeldKey(msg.region.lookupId, msg.region.keyHex)
     }
 
     // A route continues from where this step landed, or ends here.

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -38,6 +38,7 @@ import { useCeremony } from './useCeremony'
 import type { ShardModel } from '../lib/shards'
 import type { Plane } from 'cyberspace-core'
 import type { Position } from '../lib/space'
+import type { NearbyReturn } from '../lib/nearbyReturn'
 
 /** One item this device hid. Its identity is its inner event id. */
 export interface MyDeployment {
@@ -109,6 +110,9 @@ interface ShardsState {
   /** Whether the Nearby Loot list is on screen: what is decrypted where you stand. */
   nearbyOpen: boolean
   setNearbyOpen: (open: boolean) => void
+  /** What VIEW on a Nearby Loot row will return to (lib/nearbyReturn.ts); null when nothing is pending. */
+  nearbyReturn: NearbyReturn | null
+  setNearbyReturn: (r: NearbyReturn | null) => void
 
   startDeployShard: (shardId: string) => void
   startDeployMessage: (text: string) => void
@@ -234,7 +238,9 @@ export const useShards = create<ShardsState>((set, get) => {
     broadcastError: null,
     selectedSecret: null,
     nearbyOpen: false,
+    nearbyReturn: null,
     setNearbyOpen: (open) => set({ nearbyOpen: open }),
+    setNearbyReturn: (r) => set({ nearbyReturn: r }),
 
     startDeployShard: (shardId) => set({ pending: { type: 'shard', shardId }, deployStatus: 'idle', deployError: null }),
     startDeployMessage: (text) => set({ pending: { type: 'message', text }, deployStatus: 'idle', deployError: null }),

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -34,6 +34,7 @@ import {
   type HiddenType,
 } from '../lib/hidden'
 import { useWorkshop } from './useWorkshop'
+import { useCeremony } from './useCeremony'
 import type { ShardModel } from '../lib/shards'
 import type { Plane } from 'cyberspace-core'
 import type { Position } from '../lib/space'
@@ -105,6 +106,9 @@ interface ShardsState {
   broadcastError: string | null
   /** A world item clicked open, by its inner event id. */
   selectedSecret: string | null
+  /** Whether the Nearby Loot list is on screen: what is decrypted where you stand. */
+  nearbyOpen: boolean
+  setNearbyOpen: (open: boolean) => void
 
   startDeployShard: (shardId: string) => void
   startDeployMessage: (text: string) => void
@@ -229,6 +233,8 @@ export const useShards = create<ShardsState>((set, get) => {
     broadcasting: null,
     broadcastError: null,
     selectedSecret: null,
+    nearbyOpen: false,
+    setNearbyOpen: (open) => set({ nearbyOpen: open }),
 
     startDeployShard: (shardId) => set({ pending: { type: 'shard', shardId }, deployStatus: 'idle', deployError: null }),
     startDeployMessage: (text) => set({ pending: { type: 'message', text }, deployStatus: 'idle', deployError: null }),
@@ -380,7 +386,12 @@ export const useShards = create<ShardsState>((set, get) => {
         const events = await query({ kinds: [HIDDEN_KIND], '#d': [lookupId] })
         const found: Hidden[] = []
         for (const ev of events) found.push(...await unbag(ev, hexToBytes(keyHex)))
+        // What this scan opened for the first time gets the ceremony: the
+        // decode in the scene and the chip that says how many.
+        const { discovered, deleted } = get()
+        const fresh = found.filter((h) => !discovered[h.eventId] && !deleted[h.eventId])
         if (found.length > 0) get().addDiscovered(found)
+        if (fresh.length > 0) useCeremony.getState().mark(fresh)
         return found.length
       } catch {
         return 0

--- a/src/styles.css
+++ b/src/styles.css
@@ -5773,3 +5773,10 @@ kbd {
 .nearby__body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .nearby__label { font-size: 11px; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .nearby__meta { display: inline-flex; align-items: center; gap: 5px; font-size: 9px; color: var(--dim); letter-spacing: 0.06em; }
+
+/* NEARBY: a chip that stays while anything decrypted is around you, glowing
+ * like the find chip; the way to the list while the menu is locked. */
+.nearby__chip { font: inherit; color: var(--fg); gap: 8px; }
+.nearby__chip svg { color: var(--accent); flex: none; }
+/* VIEW on a Nearby Loot row: a button, not a label. */
+.nearby__view { flex: none; padding: 3px 9px; font-size: 8px; letter-spacing: 0.14em; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5776,7 +5776,6 @@ kbd {
 
 /* NEARBY: a chip that stays while anything decrypted is around you, glowing
  * like the find chip; the way to the list while the menu is locked. */
-.nearby__chip { font: inherit; color: var(--fg); gap: 8px; }
-.nearby__chip svg { color: var(--accent); flex: none; }
+.nearby__chip .presence__head svg { color: var(--accent); }
 /* VIEW on a Nearby Loot row: a button, not a label. */
 .nearby__view { flex: none; padding: 3px 9px; font-size: 8px; letter-spacing: 0.14em; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5779,3 +5779,7 @@ kbd {
 .nearby__chip .presence__head svg { color: var(--accent); }
 /* VIEW on a Nearby Loot row: a button, not a label. */
 .nearby__view { flex: none; padding: 3px 9px; font-size: 8px; letter-spacing: 0.14em; }
+
+/* The Nearby Loot row's second line: the plane and the height. */
+.nearby__where { font-size: 9px; color: var(--dim); letter-spacing: 0.06em; }
+.nearby__label { white-space: normal; overflow-wrap: anywhere; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5762,3 +5762,11 @@ kbd {
   border-radius: 10px;
   cursor: pointer;
 }
+
+/* Nearby loot: what is decrypted where you stand. */
+.loot__nearby { cursor: pointer; font: inherit; font-size: 8px; letter-spacing: 0.14em; }
+.nearby__row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 10px; }
+.nearby__glyph { font-size: 14px; color: var(--accent, #00e5ff); }
+.nearby__body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.nearby__label { font-size: 11px; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nearby__meta { display: inline-flex; align-items: center; gap: 5px; font-size: 9px; color: var(--dim); letter-spacing: 0.06em; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5764,7 +5764,10 @@ kbd {
 }
 
 /* Nearby loot: what is decrypted where you stand. */
-.loot__nearby { cursor: pointer; font: inherit; font-size: 8px; letter-spacing: 0.14em; }
+/* NEARBY and VIEW MORE, side by side under the list; NEARBY alone takes the row. */
+.loot__actions { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-top: 6px; }
+.loot__actions--one { grid-template-columns: 1fr; }
+.loot__actions .avatars__more { margin-top: 0; }
 .nearby__row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 10px; }
 .nearby__glyph { font-size: 14px; color: var(--accent, #00e5ff); }
 .nearby__body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }


### PR DESCRIPTION
The find chip said KEY FOUND with one item's name and left on a clock, and nothing listed what a region had opened for you.

| Piece | Before | Now |
|---|---|---|
| The find chip | KEY FOUND, one name, gone after a few seconds | "3 FOUND HERE", accumulating until tapped, no clock; the tap opens Nearby Loot |
| Nearby Loot | none | A modal listing everything decrypted in the region you stand in (the green box), nearest first, with author, region size, distance, and VIEW |
| Loot panel | | A NEARBY button with the count |
| After a hop | The key was held and nothing asked with it | The relay is scanned with the key at once, whether this machine or HOSAKA computed it; first-time finds get the ceremony, the chip and the list |
| Region keys SCAN | Opened items silently | Raises the same chip |

**The nearby rule** (`lib/nearby.ts`): an item is nearby when the aligned cube of side 2^height around its point holds the anchor on every axis in the same plane, or when it is filed under a held key whose region (a box with a height per axis) holds the anchor.

**Measured in the browser:** two finds whose cubes hold the avatar and one far away give NEARBY 2; three fresh finds in two batches give a chip reading 3 FOUND HERE, still present after 15 s; tapping it removes the chip and opens the list with the two nearby rows nearest first (233 pm, then 582 pm) under 2 DECRYPTED HERE; VIEW closes the list and focuses the item; the NEARBY button opens the list.

Nine unit tests. 735 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
