### PR TITLE
OPTIMIZE FOR: LOOT, TIME or COST

### DIFF
--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -137,6 +137,27 @@ export function CloudPanel(): JSX.Element {
         ))}
       </div>
 
+      {prefs.mode === 'auto' && (
+        <label className="cloud__budget">
+          <span className="login__label">Auto-approve up to (sats, 0 asks every time)</span>
+          <input
+            className="avatars__input login__input"
+            type="number"
+            min={0}
+            step={1}
+            inputMode="numeric"
+            value={prefs.autoMaxSats}
+            onChange={(e) => {
+              const n = Math.floor(Number(e.target.value))
+              if (Number.isFinite(n) && n >= 0) store().setCloudPrefs({ autoMaxSats: n })
+            }}
+            aria-label="Auto-approve budget in sats"
+          />
+        </label>
+      )}
+
+      <hr className="cloud__rule" />
+
       {/* What a route optimizes for at a wall this machine cannot hop. Not a
           spending limit: AUTO and ASK still decide what actually gets paid. */}
       {prefs.mode !== 'off' && (
@@ -162,26 +183,8 @@ export function CloudPanel(): JSX.Element {
                 : ' On this machine, walking is faster everywhere it can reach, so TIME buys only where it cannot cross at all.'
             )}
           </span>
+          <hr className="cloud__rule" />
         </div>
-      )}
-
-      {prefs.mode === 'auto' && (
-        <label className="cloud__budget">
-          <span className="login__label">Auto-approve up to (sats, 0 asks every time)</span>
-          <input
-            className="avatars__input login__input"
-            type="number"
-            min={0}
-            step={1}
-            inputMode="numeric"
-            value={prefs.autoMaxSats}
-            onChange={(e) => {
-              const n = Math.floor(Number(e.target.value))
-              if (Number.isFinite(n) && n >= 0) store().setCloudPrefs({ autoMaxSats: n })
-            }}
-            aria-label="Auto-approve budget in sats"
-          />
-        </label>
       )}
 
       <dl className="stats">
@@ -211,18 +214,18 @@ export function CloudPanel(): JSX.Element {
                 {cloud.balanceChecking ? 'CHECKING…' : balance ? `REFRESH · ${sinceLabel(balance.at, now || Date.now())}` : 'CHECK'}
               </button>
             </span>
-            {/* Credit bought before anything needs it: the route's own funding
-                only ever tops up what one move is short by. */}
-            {prefs.mode !== 'off' && (
-              <button
-                className="avatars__go cloud__topup"
-                onClick={() => setTopUpOpen((v) => !v)}
-                aria-expanded={topUpOpen}
-              >{topUpOpen ? 'CANCEL' : 'INCREASE COMPUTE BALANCE'}</button>
-            )}
           </dd>
         </div>
       </dl>
+      {/* Credit bought before anything needs it: the route's own funding
+          only ever tops up what one move is short by. */}
+      {prefs.mode !== 'off' && (
+        <button
+          className="avatars__go cloud__topup"
+          onClick={() => setTopUpOpen((v) => !v)}
+          aria-expanded={topUpOpen}
+        >{topUpOpen ? 'CANCEL' : 'INCREASE COMPUTE BALANCE'}</button>
+      )}
       {topUpOpen && (
         <form
           className="cloud__topup-form"

--- a/src/hud/CloudPanel.tsx
+++ b/src/hud/CloudPanel.tsx
@@ -25,7 +25,14 @@ const MODES: Array<[CloudMode, string]> = [['auto', 'AUTO'], ['ask', 'ASK'], ['o
 /** The amounts most people want, so the common case is one tap. */
 const TOP_UPS = [1_000, 5_000, 25_000]
 
-const PROFILES: Array<[RouteProfile, string]> = [['unlock', 'UNLOCK'], ['bypass', 'BYPASS']]
+const PROFILES: Array<[RouteProfile, string]> = [['loot', 'LOOT'], ['time', 'TIME'], ['cost', 'COST']]
+
+/** What each strategy does, in plain words, under the buttons. */
+const PROFILE_NOTES: Record<RouteProfile, string> = {
+  loot: 'Buy the hop at every wall this machine cannot cross on its own, and land holding that region\u2019s key, so what is hidden there opens for you. Where HOSAKA cannot hop either, a sidestep gets you across without the key.',
+  time: 'Buy the hop wherever paying is faster than walking, measured on this machine against HOSAKA\u2019s own times. Below that, walk and sidestep for free. You keep the keys only from the hops you paid for.',
+  cost: 'Never buy a hop. Walk to each wall and sidestep through it, and pay for a sidestep only where this machine cannot manage one. You arrive without keys, so what is hidden along the way stays shut.',
+}
 
 const STAGE_LABEL: Record<string, string> = {
   awaiting_payment: 'AWAITING PAYMENT',
@@ -86,7 +93,7 @@ export function CloudPanel(): JSX.Element {
 
   // Where the paid hop starts winning, measured (lib/crossover): the setting
   // explains itself with the number rather than a promise.
-  const crossover = offloadFrom('unlock', {
+  const crossover = offloadFrom('time', {
     hopCeiling: hopCeil,
     sidestepCeiling: sidestepCeil,
     cloudHop: cloud.limits?.max_hop_height ?? 0,
@@ -130,12 +137,12 @@ export function CloudPanel(): JSX.Element {
         ))}
       </div>
 
-      {/* How to get past a wall this machine cannot hop. Not a spending limit:
-          AUTO and ASK still decide what actually gets paid. */}
+      {/* What a route optimizes for at a wall this machine cannot hop. Not a
+          spending limit: AUTO and ASK still decide what actually gets paid. */}
       {prefs.mode !== 'off' && (
         <div className="cloud__profile">
-          <span className="login__label">Crossing a wall</span>
-          <div className="cloud__modes" role="radiogroup" aria-label="Crossing a wall">
+          <span className="login__label">OPTIMIZE FOR:</span>
+          <div className="cloud__modes" role="radiogroup" aria-label="Optimize for">
             {PROFILES.map(([profile, label]) => (
               <button
                 key={profile}
@@ -148,11 +155,12 @@ export function CloudPanel(): JSX.Element {
             ))}
           </div>
           <span className="cloud__profile-note">
-            {prefs.profile === 'bypass'
-              ? 'Sidestep around every wall this machine can, however many steps that walk takes, and pay nothing. You arrive without the region’s Cantor root, so anything hidden along the way stays shut. HOSAKA is used only where this machine cannot cross at all.'
-              : Number.isFinite(crossover)
-                ? `Buy the hop from 2^${crossover} up, where the walk also costs more time than the hop does, and arrive holding the region’s Cantor root. Below that this machine is quicker as well as free, so nothing is bought.`
-                : 'Measured against HOSAKA’s own published times, this machine crosses faster than HOSAKA everywhere it can reach, so nothing is bought here. HOSAKA still takes the walls this machine cannot cross at all, and those arrive with the region’s root.'}
+            {PROFILE_NOTES[prefs.profile]}
+            {prefs.profile === 'time' && (
+              Number.isFinite(crossover)
+                ? ` On this machine, paying is faster from 2^${crossover} up.`
+                : ' On this machine, walking is faster everywhere it can reach, so TIME buys only where it cannot cross at all.'
+            )}
           </span>
         </div>
       )}

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -107,9 +107,9 @@ describe('persistence', () => {
 
   it('defaults prefs, round-trips them, and refuses junk', () => {
     expect(loadCloudPrefs()).toEqual(defaultCloudPrefs())
-    saveCloudPrefs({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765/', profile: 'bypass' })
+    saveCloudPrefs({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765/', profile: 'cost' })
     // A trailing slash is dropped on the way back in, so paths never double it.
-    expect(loadCloudPrefs()).toEqual({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765', profile: 'bypass' })
+    expect(loadCloudPrefs()).toEqual({ mode: 'ask', autoMaxSats: 21, apiUrl: 'http://127.0.0.1:8765', profile: 'cost' })
     localStorage.setItem('onosendai:cloud', JSON.stringify({ mode: 'yes', autoMaxSats: -4, apiUrl: 'ftp://x' }))
     expect(loadCloudPrefs()).toEqual(defaultCloudPrefs())
     localStorage.setItem('onosendai:cloud', '{not json')
@@ -297,5 +297,21 @@ describe('remembered balance', () => {
     expect(loadBalance('pk-a')).toEqual({ msats: 1235, at: 42 })
     expect(loadBalance('pk-b')).toBeNull()
     expect(saveBalance('pk-b', -5, 1).msats).toBe(0)
+  })
+})
+
+describe('the strategy names people saved before', () => {
+  it('reads UNLOCK as TIME, since that was the measured crossover, and BYPASS as COST', () => {
+    localStorage.setItem('onosendai:cloud', JSON.stringify({ mode: 'ask', autoMaxSats: 0, apiUrl: 'http://127.0.0.1:8765', profile: 'unlock' }))
+    expect(loadCloudPrefs().profile).toBe('time')
+    localStorage.setItem('onosendai:cloud', JSON.stringify({ mode: 'ask', autoMaxSats: 0, apiUrl: 'http://127.0.0.1:8765', profile: 'bypass' }))
+    expect(loadCloudPrefs().profile).toBe('cost')
+    localStorage.setItem('onosendai:cloud', JSON.stringify({ mode: 'ask', autoMaxSats: 0, apiUrl: 'http://127.0.0.1:8765', profile: 'loot' }))
+    expect(loadCloudPrefs().profile).toBe('loot')
+  })
+
+  it('defaults to LOOT', () => {
+    localStorage.removeItem('onosendai:cloud')
+    expect(loadCloudPrefs().profile).toBe('loot')
   })
 })

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -57,7 +57,7 @@ export function defaultCloudPrefs(): CloudPrefs {
   // Unlock by default: the walk across a high boundary is dozens of signed
   // events and arrives blind, and one paid hop replaces all of them with the
   // region's key in hand.
-  return { mode: 'auto', autoMaxSats: 0, apiUrl: defaultHosakaUrl(), profile: 'unlock' }
+  return { mode: 'auto', autoMaxSats: 0, apiUrl: defaultHosakaUrl(), profile: 'loot' }
 }
 
 const PREFS_KEY = 'onosendai:cloud'
@@ -76,10 +76,12 @@ export function loadCloudPrefs(): CloudPrefs {
         ? Math.floor(p.autoMaxSats)
         : d.autoMaxSats,
       apiUrl: typeof p.apiUrl === 'string' && /^https?:\/\/\S+$/.test(p.apiUrl) ? p.apiUrl.replace(/\/+$/, '') : d.apiUrl,
-      // The pair was briefly called fastest and cheapest; anything kept under
-      // those names still reads.
-      profile: p.profile === 'bypass' || p.profile === 'cheapest' ? 'bypass'
-        : p.profile === 'unlock' || p.profile === 'fastest' ? 'unlock'
+      // The three were UNLOCK and BYPASS, and before that fastest and cheapest;
+      // a setting kept under any of those names still reads. UNLOCK was the
+      // measured crossover, which is TIME now, not LOOT.
+      profile: p.profile === 'loot' ? 'loot'
+        : p.profile === 'time' || p.profile === 'unlock' || p.profile === 'fastest' ? 'time'
+        : p.profile === 'cost' || p.profile === 'bypass' || p.profile === 'cheapest' ? 'cost'
         : d.profile,
     }
   } catch {

--- a/src/lib/crossover.ts
+++ b/src/lib/crossover.ts
@@ -1,8 +1,9 @@
 /**
  * crossover.ts - the wall height where buying the hop beats walking it.
  *
- * The choice used to be structural: under UNLOCK any boundary above this
- * machine's hop ceiling went to HOSAKA. Measured, that is wrong at the
+ * LOOT is structural on purpose: any boundary above this machine's hop
+ * ceiling goes to HOSAKA, because the key is the point. TIME asks a different
+ * question, and measured, the structural answer is wrong for it at the
  * bottom of the range. A single sidestep is one hash chain and this machine
  * beats HOSAKA at every height it can reach at all: a 2^20 crossing is four
  * seconds here against about two and a half minutes there.
@@ -135,7 +136,10 @@ let cached: { key: string; value: number } | null = null
 
 /** The same, memoised: the inputs change rarely and the answer is asked per cursor move. */
 export function crossoverFor(profile: RouteProfile, inputs: CrossoverInputs): number {
-  if (profile !== 'unlock') return Infinity
+  // COST never buys a hop; LOOT buys every wall above this machine's hop
+  // ceiling; TIME is the measured question below.
+  if (profile === 'cost') return Infinity
+  if (profile === 'loot') return inputs.hopCeiling + 1
   const key = [
     inputs.hopCeiling, inputs.sidestepCeiling, inputs.cloudHop, inputs.signerKind,
     Math.round(inputs.sha256PerSec ?? 0),

--- a/src/lib/crossoverProfiles.test.ts
+++ b/src/lib/crossoverProfiles.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { crossoverFor } from './crossover'
+
+const inputs = { hopCeiling: 17, sidestepCeiling: 24, cloudHop: 30, cantorMsByHeight: null, sha256PerSec: null, ladder: null, signerKind: 'local' as const }
+
+describe('where each strategy hands a wall to HOSAKA', () => {
+  it('LOOT: one above this machine\'s hop ceiling, so every wall is bought', () => {
+    expect(crossoverFor('loot', inputs)).toBe(18)
+  })
+
+  it('COST: never', () => {
+    expect(crossoverFor('cost', inputs)).toBe(Infinity)
+  })
+
+  it('TIME: measured, and with nothing measured it does not pretend to know', () => {
+    const h = crossoverFor('time', inputs)
+    expect(h === Infinity || (Number.isFinite(h) && h > 17)).toBe(true)
+  })
+})

--- a/src/lib/movePlan.ts
+++ b/src/lib/movePlan.ts
@@ -54,26 +54,31 @@ export interface Ceilings {
   /**
    * The lowest wall height HOSAKA takes over at, when it can hop it. Infinity
    * (or absent) means it never does unless this machine cannot cross at all,
-   * which is BYPASS; lib/crossover.ts measures where UNLOCK takes over.
+   * which is COST; LOOT sets it one above this machine's hop ceiling, so every
+   * wall is bought; lib/crossover.ts measures where TIME takes over.
    */
   offloadFrom?: number
 }
 
 /**
- * How to get past a wall this machine cannot hop.
+ * What a route optimizes for, at a wall this machine cannot hop.
  *
- * `bypass` goes around it. A sidestep crosses one gibson of the boundary and
- * costs nothing, and the walk to the wall and on from it is however many hops
- * that takes. You arrive without the Cantor root of the regions you crossed,
- * so nothing hidden in them will open for you.
+ * `loot` buys the hop at every such wall, so you land holding that region's
+ * key and what is hidden there opens for you. Where HOSAKA cannot hop either,
+ * a sidestep gets you across without the key.
  *
- * `unlock` buys the hop. One event instead of the walk, and you arrive holding
- * the region's root, which is the key to whatever is hidden there. It is taken
- * only from the height where it is also the quicker way across, measured
- * rather than assumed (lib/crossover.ts): below that this machine is faster as
- * well as free. A hop this machine can make is never paid for under either.
+ * `time` buys the hop only from the height where paying is also the quicker
+ * way across, measured rather than assumed (lib/crossover.ts); below that this
+ * machine walks and sidesteps, which is faster as well as free.
+ *
+ * `cost` never buys a hop. It walks to each wall and sidesteps through it,
+ * and pays for a sidestep only where this machine cannot manage one. You
+ * arrive without keys, so what is hidden along the way stays shut.
+ *
+ * Under every one of them a hop this machine can make is never paid for, and
+ * a wall above HOSAKA's hop cap is crossed by a sidestep.
  */
-export type RouteProfile = 'unlock' | 'bypass'
+export type RouteProfile = 'loot' | 'time' | 'cost'
 
 export function localOnly(hop: number, sidestep: number = hop): Ceilings {
   return { hop, sidestep, cloudHop: 0, cloudSidestep: 0 }

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -123,7 +123,7 @@ describe('cloud routes', () => {
     // This machine stops at h12 for hops AND sidesteps, so an h13 move has no local way and is
     // the cloud's (HOSAKA is used only when needed); the caps are already known.
     useCalibration.setState({ status: 'measured', hopHeight: 12, sidestepHeight: 12 })
-    useCyberspace.setState({ cloud: { ...S().cloud, limits: LIMITS, status: 'idle', job: null, message: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://fake', profile: 'bypass' }, plan: null })
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: LIMITS, status: 'idle', job: null, message: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://fake', profile: 'cost' }, plan: null })
     for (const fn of Object.values(fake)) if (typeof fn === 'function' && 'mockReset' in fn) fn.mockReset()
     fake.limits.mockResolvedValue(LIMITS)
     fake.balance.mockResolvedValue({ pubkey: S().identity.pubkey, balance_msats: 5000, ledger: [] })
@@ -517,7 +517,7 @@ describe('cloud routes', () => {
   it('a caps request out for another API URL is not reused: the current URL gets its own (#69)', async () => {
     const old = deferred<HosakaLimits>()
     fake.limits.mockReturnValueOnce(old.promise).mockResolvedValueOnce(LIMITS)
-    useCyberspace.setState({ cloud: { ...S().cloud, limits: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://old', profile: 'bypass' } })
+    useCyberspace.setState({ cloud: { ...S().cloud, limits: null }, cloudPrefs: { mode: 'auto', autoMaxSats: 100, apiUrl: 'http://old', profile: 'cost' } })
     const first = S().resumeCloudJob()
     await vi.waitFor(() => expect(fake.limits).toHaveBeenCalledTimes(1))
     useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, apiUrl: 'http://fake' } })

--- a/src/styles.css
+++ b/src/styles.css
@@ -5649,9 +5649,22 @@ kbd {
 }
 
 .cloud__topup {
+  margin-top: 12px;
   padding: 3px 8px;
   font-size: 8px;
   letter-spacing: 0.12em;
+}
+/* The panel reads in three bands, a rule between each: how HOSAKA may be
+   used (mode and budget), what a route optimizes for, then the account. */
+.cloud__rule {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 12px 0;
+}
+/* Inside the profile's column the flex gap already gives 5px, so the rule
+   keeps the same 12px above it as the one under the budget. */
+.cloud__profile > .cloud__rule {
+  margin-top: 7px;
 }
 
 .cloud__topup-form {


### PR DESCRIPTION
UNLOCK and BYPASS were both misread in a day, and UNLOCK bought the hop only from the measured crossover, so a wall below it was walked with a sidestep and you arrived with no key. Three strategies now, named by what they optimize, under the headline OPTIMIZE FOR.

| Strategy | At a wall this machine cannot hop | Arrives with keys |
|---|---|---|
| LOOT (default) | buy the hop; sidestep only where HOSAKA cannot hop either | at every wall |
| TIME (the old UNLOCK) | buy from the measured crossover up; walk and sidestep below | where it paid |
| COST (the old BYPASS) | sidestep; buy a sidestep only where this machine cannot | no |

Each has a plain description under the buttons; TIME's carries the measured number. Saved UNLOCK reads as TIME, saved BYPASS as COST.

**Measured** on the same 2^19 wall (hop limit 17, cloud on): LOOT routes one CLOUD HOP 2^19 via HOSAKA; TIME and COST route three hops and two sidesteps on this machine.

731 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
