### PR TITLE
The question under the wordmark, with a link to the answers

### DIFF
--- a/src/hud/AskBubble.tsx
+++ b/src/hud/AskBubble.tsx
@@ -1,0 +1,54 @@
+/**
+ * AskBubble.tsx — the question everyone asks, under the wordmark.
+ *
+ * "ONOSENDAI looks amazing but I have no idea what I'm looking at." So the
+ * menu says it first: a small face and a speech bubble that cycles through
+ * the things people say, each phrase decoding out of glyph noise the way a
+ * found key's chip does, then holding, then giving way to the next. The
+ * whole row is a link to the channel where the one-minute videos answer it.
+ * Under reduced motion the words simply change.
+ */
+
+import { useEffect, useState } from 'react'
+import { decodeText, seedOf, TEXT_DECODE_MS } from '../lib/decode'
+
+/** The one asking. */
+export const ASK_EMOJI = '🤔'
+export const CHANNEL_URL = 'https://youtube.com/channel/UC1f8lCTlq6WvQ9ucCe3Dpyw'
+/** In the words people use. */
+export const ASKS = ['what is all this?', 'what am i looking at?', "i'm confused", 'can someone explain this?', 'where am i?']
+/** How long each phrase holds once it has decoded. */
+const HOLD_MS = 2600
+
+export function AskBubble(): JSX.Element {
+  const [index, setIndex] = useState(0)
+  const [shown, setShown] = useState(ASKS[0])
+
+  useEffect(() => {
+    const target = ASKS[index % ASKS.length]
+    const reduced = typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    const seed = seedOf(`ask-${index}`)
+    const started = performance.now()
+    let raf = 0
+    let frame = 0
+    const tick = (): void => {
+      frame++
+      const t = (performance.now() - started) / TEXT_DECODE_MS
+      setShown(reduced ? target : decodeText(target, t, seed, frame))
+      if (t < 1 && !reduced) raf = window.requestAnimationFrame(tick)
+    }
+    raf = window.requestAnimationFrame(tick)
+    // The frame loop is throttled in a background tab; the whole phrase lands
+    // on schedule either way.
+    const settle = window.setTimeout(() => { window.cancelAnimationFrame(raf); setShown(target) }, reduced ? 0 : TEXT_DECODE_MS + 40)
+    const next = window.setTimeout(() => setIndex((i) => i + 1), (reduced ? 0 : TEXT_DECODE_MS) + HOLD_MS)
+    return () => { window.cancelAnimationFrame(raf); window.clearTimeout(settle); window.clearTimeout(next) }
+  }, [index])
+
+  return (
+    <a className="ask" href={CHANNEL_URL} target="_blank" rel="noopener noreferrer" title="One-minute videos on what cyberspace is and what you are looking at">
+      <span className="ask__emoji" aria-hidden="true">{ASK_EMOJI}</span>
+      <span className="ask__bubble">{shown}</span>
+    </a>
+  )
+}

--- a/src/hud/AskBubble.tsx
+++ b/src/hud/AskBubble.tsx
@@ -16,7 +16,7 @@ import { decodeText, seedOf, TEXT_DECODE_MS } from '../lib/decode'
 export const ASK_EMOJI = '🤔'
 export const CHANNEL_URL = 'https://youtube.com/channel/UC1f8lCTlq6WvQ9ucCe3Dpyw'
 /** In the words people use. */
-export const ASKS = ['what is all this?', 'what am i looking at?', "i'm confused", 'can someone explain this?', 'where am i?']
+export const ASKS = ['what is all this?', 'what am i looking at?', "i'm confused", 'can someone explain this?', 'where am i?', 'i need an adult', 'cyberspace???', 'help, what is this?', 'is this for real?', "i'm lost"]
 /** How long each phrase holds once it has decoded. */
 const HOLD_MS = 2600
 

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -10,6 +10,7 @@ import { canonicalViewAt, parseViewAt, rememberView, type RecentView, type ViewT
 import { useCyberspace } from '../store/useCyberspace'
 import { shortHex } from '../lib/time'
 import { ProfilePic } from './ProfileBadge'
+import { AskBubble } from './AskBubble'
 import { useProfile } from '../hooks/useProfile'
 import { profileLabel } from '../store/useProfiles'
 import { LoginModal } from './LoginModal'
@@ -42,6 +43,7 @@ function Brand(): JSX.Element {
           even a cold cache cannot shift the layout under the pointer. */}
       <img src="/logo.png" alt="ONOSENDAI" width={1871} height={354} decoding="async" />
       <p>Cyberspace Protocol v2 spatial explorer</p>
+      <AskBubble />
     </header>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5764,10 +5764,9 @@ kbd {
 }
 
 /* The question under the wordmark: a face, a bubble, a link to the answers.
- * The row is boxed like the wordmark (the same width, centred the same way),
- * so the face sits on the wordmark's left edge and stays there whatever the
- * bubble says. The row's height is fixed at two lines, so a phrase that
- * wraps changes the bubble and not the panel. */
+ * Left-aligned in the panel, the face on the panel's left edge, where it
+ * stays whatever the bubble says. The row's height is fixed at two lines, so
+ * a phrase that wraps changes the bubble and not the panel. */
 .ask {
   --ask-bg: #061a22;
   pointer-events: auto;
@@ -5775,8 +5774,7 @@ kbd {
   align-items: center;
   gap: 8px;
   height: 46px;
-  max-width: 290px;
-  margin: 12px auto 0;
+  margin: 12px 0 0;
   text-decoration: none;
   text-align: left;
   cursor: pointer;

--- a/src/styles.css
+++ b/src/styles.css
@@ -5762,3 +5762,44 @@ kbd {
   border-radius: 10px;
   cursor: pointer;
 }
+
+/* The question under the wordmark: a face, a bubble, a link to the answers.
+ * Left-aligned on purpose inside the centred brand block, and the one thing
+ * in it that takes the pointer. */
+.ask {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0 0;
+  text-decoration: none;
+  text-align: left;
+  cursor: pointer;
+}
+.ask__emoji { font-size: 20px; line-height: 1; flex: none; }
+.ask__bubble {
+  position: relative;
+  padding: 5px 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  background: rgba(0, 229, 255, 0.06);
+  border: 1px solid rgba(0, 229, 255, 0.3);
+  border-radius: 10px;
+  white-space: nowrap;
+}
+/* The bubble's tail, pointing at the face. */
+.ask__bubble::before {
+  content: '';
+  position: absolute;
+  left: -6px;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  transform: translateY(-50%) rotate(45deg);
+  background: #0a121a;
+  border-left: 1px solid rgba(0, 229, 255, 0.3);
+  border-bottom: 1px solid rgba(0, 229, 255, 0.3);
+}
+.ask:hover .ask__bubble { background: rgba(0, 229, 255, 0.12); }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5764,14 +5764,19 @@ kbd {
 }
 
 /* The question under the wordmark: a face, a bubble, a link to the answers.
- * Left-aligned on purpose inside the centred brand block, and the one thing
- * in it that takes the pointer. */
+ * The row is boxed like the wordmark (the same width, centred the same way),
+ * so the face sits on the wordmark's left edge and stays there whatever the
+ * bubble says. The row's height is fixed at two lines, so a phrase that
+ * wraps changes the bubble and not the panel. */
 .ask {
+  --ask-bg: #061a22;
   pointer-events: auto;
   display: flex;
   align-items: center;
   gap: 8px;
-  margin: 12px 0 0;
+  height: 46px;
+  max-width: 290px;
+  margin: 12px auto 0;
   text-decoration: none;
   text-align: left;
   cursor: pointer;
@@ -5779,27 +5784,32 @@ kbd {
 .ask__emoji { font-size: 20px; line-height: 1; flex: none; }
 .ask__bubble {
   position: relative;
+  min-width: 0;
   padding: 5px 10px;
   font-family: var(--mono);
   font-size: 10px;
+  line-height: 1.3;
   letter-spacing: 0.08em;
   color: var(--accent);
-  background: rgba(0, 229, 255, 0.06);
+  /* Opaque, so the tail can be the same color and hide the outline where it joins. */
+  background: var(--ask-bg);
   border: 1px solid rgba(0, 229, 255, 0.3);
   border-radius: 10px;
-  white-space: nowrap;
 }
-/* The bubble's tail, pointing at the face. */
+/* The bubble's tail, pointing at the face: a square turned on its corner,
+   overlapping the bubble by a pixel so there is no gap, in the bubble's own
+   color so the outline it covers disappears and its two outer edges read as
+   the outline continuing. */
 .ask__bubble::before {
   content: '';
   position: absolute;
-  left: -6px;
+  left: -5px;
   top: 50%;
   width: 8px;
   height: 8px;
   transform: translateY(-50%) rotate(45deg);
-  background: #0a121a;
+  background: var(--ask-bg);
   border-left: 1px solid rgba(0, 229, 255, 0.3);
   border-bottom: 1px solid rgba(0, 229, 255, 0.3);
 }
-.ask:hover .ask__bubble { background: rgba(0, 229, 255, 0.12); }
+.ask:hover .ask__bubble { border-color: rgba(0, 229, 255, 0.55); }


### PR DESCRIPTION
Held until the videos exist, per arkinox.

Under the wordmark, left-aligned: a face at emoji size and a speech bubble cycling through "what is all this?", "what am i looking at?", "i'm confused", "can someone explain this?", "where am i?", each decoding out of glyph noise like a found key's chip, holding, then giving way. Text in the buttons' blue. The row is a link to the channel (new tab). Reduced motion: the words simply change. The phrase lands whole on schedule even when a background tab throttles the frame loop.

**Placeholder:** the face is 🤔 until the intended emoji is named (one constant, `ASK_EMOJI`).

Measured: scrambled at 0 s, whole by 1.5 s, next phrase at 5.5 s, whole by 6.9 s; 20 px emoji, accent text, href to the channel with target _blank. 726 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
