### PR TITLE
Spectating: a bar as wide as its words, the black sun view, and the chain open

### DIFF
--- a/src/hud/ChainExplorer.tsx
+++ b/src/hud/ChainExplorer.tsx
@@ -47,6 +47,19 @@ export function ChainExplorer(): JSX.Element {
   // Minimized by default: the chip alone reads "CHAIN n/N", and the panel
   // opens on a tap when you actually want to walk the chain.
   const [open, setOpen] = useState(false)
+  // Spectating opens it: the chain is the thing you came to look at. What you
+  // had it set to is put back when spectation ends.
+  const openBefore = useRef<boolean | null>(null)
+  useEffect(() => {
+    if (spectate) {
+      if (openBefore.current === null) { openBefore.current = open; setOpen(true) }
+    } else if (openBefore.current !== null) {
+      setOpen(openBefore.current)
+      openBefore.current = null
+    }
+    // `open` is read once, at the moment spectation starts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spectate !== null])
   // Relative times drift; refresh them on a slow clock rather than per frame.
   const [now, setNow] = useState(() => Date.now() / 1000)
   useEffect(() => {

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -279,6 +279,9 @@ function Rig(): JSX.Element {
   // zero offset to its minimum distance straight overhead: the avatar seen
   // from two units above, looking down.
   const lastOffset = useRef(new Vector3(0, 0, START_DISTANCE))
+  // The orbit to land a cut with: the one the camera had, unless it has
+  // collapsed, in which case the standard framing distance straight on.
+  const keptOffset = (): Vector3 => (lastOffset.current.lengthSq() >= 1 ? lastOffset.current.clone() : new Vector3(0, 0, START_DISTANCE))
 
   // Re-framed on an axis snap and on a respawn. A respawn moves the render
   // origin home in one step, and the per-frame shift below would faithfully
@@ -307,7 +310,6 @@ function Rig(): JSX.Element {
     // not rendered the new anchor yet, else the frame before the change.
     const last = lastSeen.current
     const seen = last === null ? null : !same(last) ? last : (lastChange.current !== null && same(lastChange.current.to) ? lastChange.current.from : null)
-    const keptOffset = (): Vector3 => (lastOffset.current.lengthSq() >= 1 ? lastOffset.current.clone() : new Vector3(0, 0, START_DISTANCE))
     if (stepOnly && seen !== null) {
       // The plane is not part of the frame: the axes come from the camera and
       // the origin from the anchor, so a hop that lands in the other plane
@@ -423,9 +425,28 @@ function Rig(): JSX.Element {
     //
     // It also must not be eased. Easing a frame change would slide the world
     // under a camera that is looking at something stationary.
+    const [tx, ty, tz] = s.cursorOffset()
     if (prevOrigin.current && prevScale.current === s.scaleExp) {
       const shift = originShift(prevOrigin.current, origin, s.scaleExp, s.axes())
-      if (shift[0] !== 0 || shift[1] !== 0 || shift[2] !== 0) {
+      if (Math.max(Math.abs(shift[0]), Math.abs(shift[1]), Math.abs(shift[2])) >= GLIDE_MAX_CELLS) {
+        // Too far to fly: a cut, the same one the effect above makes for a
+        // chain step that far. This path is for the anchor changes that do
+        // not pass through the effect, whose dependencies are the framing
+        // and the explored link, not the anchor: a spectated chain arriving
+        // with its head a universe from the spawn the rig framed first (a
+        // traveller's hops and hyperjumps add up to 1e22 cells), or a friend
+        // watched live making a hop. Shifting the camera that far and easing
+        // it back was not a fly. At 1e22 a double cannot hold the 26-unit
+        // orbit: the offset rounded to zero, OrbitControls clamped it to its
+        // 2-unit minimum straight overhead, and the target then sailed home
+        // over five seconds with the camera stuck there. That was the
+        // close-up from above that greeted every spectation of a
+        // well-travelled avatar.
+        glideLeft.current = 0
+        smooth.current.set(tx, ty, tz)
+        c.object.position.copy(smooth.current).add(keptOffset())
+        locked.current = true
+      } else if (shift[0] !== 0 || shift[1] !== 0 || shift[2] !== 0) {
         c.object.position.x += shift[0]
         c.object.position.y += shift[1]
         c.object.position.z += shift[2]
@@ -434,8 +455,6 @@ function Rig(): JSX.Element {
         smooth.current.z += shift[2]
       }
     }
-
-    const [tx, ty, tz] = s.cursorOffset()
 
     // A zoom rescales every render coordinate, so there is no continuous path
     // between the old framing and the new one to ease along.

--- a/src/store/spectate.test.ts
+++ b/src/store/spectate.test.ts
@@ -103,3 +103,28 @@ describe('spectate', () => {
     useCyberspace.getState().endSpectate()
   })
 })
+
+describe('the view while spectating', () => {
+  it('arrives in the black sun orientation and leaves the way it came', async () => {
+    const { canonicalQuaternion, topDownQuaternion } = await import('../lib/space')
+    const before = topDownQuaternion()
+    useCyberspace.setState({ view: before.clone(), viewHistory: [], spectate: null })
+    useCyberspace.getState().beginSpectate('ab'.repeat(32))
+    const during = useCyberspace.getState().view
+    const canon = canonicalQuaternion()
+    expect(Math.abs(during.dot(canon))).toBeCloseTo(1, 5)
+    expect(useCyberspace.getState().spectate?.returnView.dot(before)).toBeCloseTo(1, 5)
+    useCyberspace.getState().endSpectate()
+    expect(Math.abs(useCyberspace.getState().view.dot(before))).toBeCloseTo(1, 5)
+    expect(useCyberspace.getState().spectate).toBeNull()
+  })
+
+  it('switching avatars keeps the first return view', async () => {
+    const { topDownQuaternion } = await import('../lib/space')
+    const before = topDownQuaternion()
+    useCyberspace.setState({ view: before.clone(), viewHistory: [], spectate: null })
+    useCyberspace.getState().beginSpectate('ab'.repeat(32))
+    useCyberspace.getState().beginSpectate('cd'.repeat(32))
+    expect(useCyberspace.getState().spectate?.returnView.dot(before)).toBeCloseTo(1, 5)
+  })
+})

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -155,6 +155,8 @@ export interface SpectateState {
   /** created_at of their newest action; null when the relay has none. */
   lastActive: number | null
   status: 'loading' | 'live' | 'empty' | 'error'
+  /** The view you had before spectating, put back when it ends. */
+  returnView: Quaternion
 }
 
 export type ProofStatus = 'idle' | 'computing' | 'done' | 'infeasible'
@@ -1996,14 +1998,23 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
   beginSpectate: (pubkey) => {
     const spawn = spawnOf(pubkey)
+    const { view, viewHistory, spectate } = get()
+    // The view you arrive with is the black sun orientation (section 11.3),
+    // the same the C key gives, at the standard distance the rig frames from:
+    // a stranger's neighborhood seen from whatever angle you had orbited to
+    // was a view of nothing in particular. What you had is kept and put back
+    // when spectation ends; switching from one avatar to another keeps the
+    // first one's return view.
     set({
-      spectate: { pubkey, npub: nip19.npubEncode(pubkey), events: [], actions: [], lastActive: null, status: 'loading' },
+      spectate: { pubkey, npub: nip19.npubEncode(pubkey), events: [], actions: [], lastActive: null, status: 'loading', returnView: spectate?.returnView ?? view.clone() },
       exploreIndex: null,
       // A standing focus (a shard, EARTH, a viewed stop) would hide the
       // avatar and keep the rig on the old point: spectating replaces it.
       focus: null,
       anchor: spawn.position,
       anchorPlane: spawn.plane,
+      view: canonicalQuaternion(),
+      viewHistory: [...viewHistory, view.clone()],
     })
   },
 
@@ -2034,9 +2045,10 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
   },
 
   endSpectate: () => {
-    // Back to your own head, in the plane you have lined up there.
-    const { position, plane } = get()
-    set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: plane })
+    // Back to your own head, in the plane you have lined up there, looking
+    // the way you were looking before.
+    const { position, plane, spectate } = get()
+    set({ spectate: null, exploreIndex: null, anchor: position, anchorPlane: plane, ...(spectate ? { view: spectate.returnView } : {}) })
   },
 
   focusOn: (position, plane, label, scaleExp, drive = false) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2100,12 +2100,16 @@ kbd {
   background: #ff5c5c;
 }
 
+/* Under 1100px the bar moves to the bottom. It hangs from the right edge and
+ * is as wide as what it says, no wider: pinned to both edges it stretched
+ * across the whole bottom with a field of nothing to the right of the button.
+ * The cap keeps it clear of the menu button's corner on the left. */
 @media (max-width: 1100px) {
   .spectate {
     top: auto;
     right: 14px;
     bottom: 14px;
-    left: 92px;
+    max-width: calc(100vw - 106px);
   }
 
   .spectate__meta {


### PR DESCRIPTION
Three things arkinox noticed while spectating.

| Fix | Before | After | Measured |
|---|---|---|---|
| The bar | Under 1100px pinned to both edges, a field of nothing right of END SPECTATION | Hangs from the right edge, as wide as its words, capped clear of the menu button; desktop stays top right | 314 / 268 px wide at 1400 / 900 / 430, 14 px from the right, 9 px right of the button, clear of the menu button |
| The view on entry | Whatever you had orbited to; from the top-down view that Escape gives, a camera looking along Y minus | The black sun orientation (section 11.3, the C key), straight on at the standard distance; your view is put back when spectation ends | From top-down: view reads as the identity during, camera 26 cells straight on, top-down restored after END |
| The chain overlay | Stayed as it was | Opens when spectation begins; what you had is put back when it ends | Open during a live spectate, closed again after END |

Two store tests for the view on entry and exit. 728 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
