### PR TITLE
The build signs the foot of the menu with its version

### DIFF
--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -368,6 +368,9 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
         <Controls />
         <DerezzPanel />
         <RelaysPanel />
+        {/* The build, last thing in the menu: 2, the day it was merged, how
+            many PRs had merged that day, and which PR this is. */}
+        <div className="hud__version" title="2 . day merged . PRs merged that day . this PR">{__ONOSENDAI_VERSION__}</div>
       </div>
     </div>
   )

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { dayOf, headPrOf, resolveVersion, versionOf, UNVERSIONED } from './version'
+
+// The real merges of 2026-09-10 and 2026-09-11 as GitHub reports them, in
+// UTC: four late on the 10th Chicago time (03:24Z to 04:28Z on the 11th),
+// two on the 11th (16:46Z).
+const MERGED = [
+  { number: 129, mergedAt: '2026-09-11T02:24:04Z' },
+  { number: 131, mergedAt: '2026-09-11T04:26:33Z' },
+  { number: 130, mergedAt: '2026-09-11T04:27:40Z' },
+  { number: 135, mergedAt: '2026-09-11T04:28:51Z' },
+  { number: 133, mergedAt: '2026-09-11T16:46:24Z' },
+  { number: 134, mergedAt: '2026-09-11T16:46:59Z' },
+]
+
+const parts = (v: string): number[] => v.split('.').map(Number)
+const before = (a: string, b: string): boolean => {
+  const [x, y] = [parts(a), parts(b)]
+  for (let i = 0; i < x.length; i++) if (x[i] !== y[i]) return x[i] < y[i]
+  return false
+}
+
+describe('the build version', () => {
+  it('reads the PR number off a squash-merge subject', () => {
+    expect(headPrOf('LOOT lands holding the cubes around the destination (#134)')).toBe(134)
+    expect(headPrOf('LOOT lands holding the cubes (#134)\n\nbody mentioning (#7)')).toBe(134)
+    expect(headPrOf('Merge v2 into feat/experience')).toBeNull()
+    expect(headPrOf(undefined)).toBeNull()
+  })
+
+  it('counts the day in Chicago, where a merge at 04:28Z is still the night before', () => {
+    expect(dayOf('2026-09-11T04:28:51Z')).toBe('20260910')
+    expect(dayOf('2026-09-11T16:46:59Z')).toBe('20260911')
+  })
+
+  it('is 2.20260911.2.134 for the second merge of the 11th, #134', () => {
+    expect(versionOf(MERGED, 134)).toBe('2.20260911.2.134')
+  })
+
+  it('gives an older commit its own number again: #135 was the fourth of the 10th, #131 the second', () => {
+    expect(versionOf(MERGED, 135)).toBe('2.20260910.4.135')
+    expect(versionOf(MERGED, 131)).toBe('2.20260910.2.131')
+  })
+
+  it('versions a build that is not a merge as the newest merge', () => {
+    expect(versionOf(MERGED, null)).toBe('2.20260911.2.134')
+    expect(versionOf(MERGED, 999)).toBe('2.20260911.2.134')
+  })
+
+  it('only goes up across the merges, day boundary included', () => {
+    const order = [129, 131, 130, 135, 133, 134].map((n) => versionOf(MERGED, n))
+    for (let i = 1; i < order.length; i++) expect(before(order[i - 1], order[i]), `${order[i - 1]} < ${order[i]}`).toBe(true)
+  })
+
+  it('says so rather than inventing a number when there is nothing to count', () => {
+    expect(versionOf([], 134)).toBe(UNVERSIONED)
+  })
+
+  it('resolves from the environment first, then GitHub, and never throws', async () => {
+    expect(await resolveVersion({ VITE_ONOSENDAI_VERSION: '2.1.1.1' }, null)).toBe('2.1.1.1')
+    const ok = (async () => ({ ok: true, status: 200, json: async () => MERGED.map((p) => ({ number: p.number, merged_at: p.mergedAt })) })) as unknown as typeof fetch
+    expect(await resolveVersion({}, 'x (#133)', ok)).toBe('2.20260911.1.133')
+    const down = (async () => { throw new Error('offline') }) as unknown as typeof fetch
+    expect(await resolveVersion({}, 'x (#133)', down)).toBe(UNVERSIONED)
+  })
+})

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,92 @@
+/**
+ * The build's version: `2.YYYYMMDD.N.PR`.
+ *
+ *   2         the major, this is v2
+ *   YYYYMMDD  the day the PR being built was merged into v2, in arkinox's
+ *             day (America/Chicago), which is the day the merge commit
+ *             already carries in its own timestamp
+ *   N         how many PRs had been merged into v2 that day, this one
+ *             included, counted in merge order
+ *   PR        the number of the PR being built
+ *
+ * Read left to right as numbers it only ever goes up: a new day beats any
+ * count, and within a day every merge adds one to N. The PR number is the
+ * tail and may go down within a day when a lower-numbered PR merges later;
+ * N has already gone up by then. Rebuilding an older commit gives that
+ * commit's own number again, since N counts only the merges up to it.
+ *
+ * Where the pieces come from at build time: the PR number from the commit
+ * message of the commit being built (a squash merge ends its subject in
+ * "(#N)"), which Vercel hands over as VERCEL_GIT_COMMIT_MESSAGE and a local
+ * build reads from git; the merge days from GitHub's list of closed PRs on
+ * v2, since a Vercel build has no git history to count from. A build that
+ * is not a merge (a branch, a dev server) shows the version of the newest
+ * merge, which is what production is running. No data at all shows
+ * "unversioned build" rather than a number that would read as one.
+ */
+export interface MergedPr {
+  number: number
+  /** ISO 8601 merge time, as GitHub reports it (UTC). */
+  mergedAt: string
+}
+
+export const MAJOR = 2
+export const VERSION_ZONE = 'America/Chicago'
+export const UNVERSIONED = 'unversioned build'
+
+/** The PR number a squash-merge subject ends with, or null: "Title (#134)" gives 134. */
+export function headPrOf(message: string | undefined | null): number | null {
+  const first = (message ?? '').split('\n')[0]
+  const m = /\(#(\d+)\)\s*$/.exec(first)
+  return m ? Number(m[1]) : null
+}
+
+/** The calendar day of an instant in the zone, as YYYYMMDD. */
+export function dayOf(iso: string, zone: string = VERSION_ZONE): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: zone, year: 'numeric', month: '2-digit', day: '2-digit' })
+    .format(new Date(iso)).replace(/-/g, '')
+}
+
+/**
+ * The version for `head` given the merged PRs. A head that is not among
+ * them, or no head at all, is versioned as the newest merge. No merges at
+ * all gives UNVERSIONED.
+ */
+export function versionOf(merged: MergedPr[], head: number | null, zone: string = VERSION_ZONE): string {
+  const inOrder = merged
+    .filter((p) => Number.isFinite(Date.parse(p.mergedAt)))
+    .sort((a, b) => Date.parse(a.mergedAt) - Date.parse(b.mergedAt))
+  if (inOrder.length === 0) return UNVERSIONED
+  const at = (head !== null && inOrder.find((p) => p.number === head)) || inOrder[inOrder.length - 1]
+  const day = dayOf(at.mergedAt, zone)
+  const t = Date.parse(at.mergedAt)
+  const n = inOrder.filter((p) => dayOf(p.mergedAt, zone) === day && Date.parse(p.mergedAt) <= t).length
+  return `${MAJOR}.${day}.${n}.${at.number}`
+}
+
+const PULLS_URL = 'https://api.github.com/repos/arkin0x/ONOSENDAI/pulls?state=closed&base=v2&sort=updated&direction=desc&per_page=100'
+
+/** GitHub's closed PRs on v2 that were merged, newest first as listed. */
+export async function fetchMergedPrs(fetchFn: typeof fetch = fetch, token?: string, timeoutMs = 8000): Promise<MergedPr[]> {
+  const headers: Record<string, string> = { accept: 'application/vnd.github+json', 'user-agent': 'onosendai-build' }
+  if (token) headers.authorization = `Bearer ${token}`
+  const res = await fetchFn(PULLS_URL, { headers, signal: AbortSignal.timeout(timeoutMs) })
+  if (!res.ok) throw new Error(`GitHub pulls: HTTP ${res.status}`)
+  const list = (await res.json()) as Array<{ number: number; merged_at: string | null }>
+  return list.filter((p) => p.merged_at !== null).map((p) => ({ number: p.number, mergedAt: p.merged_at as string }))
+}
+
+/**
+ * The version for this build, from the environment and GitHub. Never
+ * throws: a build with no network is still a build.
+ */
+export async function resolveVersion(env: Record<string, string | undefined>, message: string | null, fetchFn: typeof fetch = fetch): Promise<string> {
+  if (env.VITE_ONOSENDAI_VERSION) return env.VITE_ONOSENDAI_VERSION
+  try {
+    const merged = await fetchMergedPrs(fetchFn, env.GITHUB_TOKEN)
+    return versionOf(merged, headPrOf(message))
+  } catch (err) {
+    console.warn(`[version] ${err instanceof Error ? err.message : String(err)}; building as "${UNVERSIONED}"`)
+    return UNVERSIONED
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -103,6 +103,18 @@ body {
   width: 300px;
   align-items: stretch;
 }
+/* The build version at the foot of the menu, with room around it so it
+   reads as a signature and not as one more panel. */
+.hud__version {
+  flex: 0 0 auto;
+  padding: 36px 0 44px;
+  text-align: center;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  color: var(--dim);
+  font-variant-numeric: tabular-nums;
+  user-select: all;
+}
 
 /* ---------- Panels ---------- */
 

--- a/src/version.d.ts
+++ b/src/version.d.ts
@@ -1,0 +1,2 @@
+/** The build's version, `2.YYYYMMDD.N.PR`, defined by vite.config.ts at build time (see src/lib/version.ts). */
+declare const __ONOSENDAI_VERSION__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,21 @@
+import { execSync } from 'node:child_process'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolveVersion, UNVERSIONED } from './src/lib/version'
 
-export default defineConfig({
+/** The subject of the commit being built: Vercel's variable, else git's. */
+function commitMessage(): string | null {
+  if (process.env.VERCEL_GIT_COMMIT_MESSAGE) return process.env.VERCEL_GIT_COMMIT_MESSAGE
+  try { return execSync('git log -1 --format=%s', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim() } catch { return null }
+}
+
+export default defineConfig(async () => ({
   plugins: [react()],
+  define: {
+    // Tests never reach the network for a number; the build and the dev
+    // server ask GitHub once (see src/lib/version.ts).
+    __ONOSENDAI_VERSION__: JSON.stringify(process.env.VITEST ? UNVERSIONED : await resolveVersion(process.env, commitMessage())),
+  },
   // cyberspace-core is a file: dependency, so it resolves through a symlink.
   // Excluding it from pre-bundling keeps edits to the core package live in dev
   // instead of being frozen into an optimized bundle.
@@ -23,4 +36,4 @@ export default defineConfig({
   worker: {
     format: 'es',
   },
-})
+}))


### PR DESCRIPTION
Under RELAYS, centered, with room around it: 2.20260911.2.134. Four
parts, read left to right as numbers so it only ever goes up:

  2         this is v2
  20260911  the day the PR being built was merged, in arkinox's day
            (America/Chicago), the day the merge commit already carries
  2         how many PRs had merged into v2 that day, this one included
  134       the PR being built

A new day beats any count; within a day every merge adds one. The PR
number is the tail and may dip when a lower-numbered PR merges later,
by which time the count has already risen. Rebuilding an older commit
gives that commit's own number, since the count stops at it.

Where it comes from. Production builds on Vercel, which has no git
history to count from, so vite.config.ts asks two things at build time:
the commit message (Vercel's VERCEL_GIT_COMMIT_MESSAGE, or git locally),
whose squash subject ends in "(#N)", and GitHub's list of closed PRs on
v2 for the merge times. A build that is not a merge, a branch or the dev
server, shows the newest merge's number, which is what production runs.
VITE_ONOSENDAI_VERSION in the environment overrides everything; GitHub
unreachable builds as "unversioned build" rather than a number that
would read as one. Tests never touch the network. GITHUB_TOKEN, if set
on Vercel, lifts the unauthenticated limit of 60 requests an hour.

Tests: the subject parser, the Chicago day, 2.20260911.2.134 for #134,
older commits keeping their numbers, the non-merge case, strict
ordering across the six real merges of 09-10 and 09-11, the empty case,
and the resolve order env then GitHub then unversioned.
The first production number after this merges will be 2.20260911.3.<this PR>, since it counts itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz