### PR TITLE
The STASH shows the coin for any message that carries a token, readable or not

### DIFF
--- a/src/hud/LootDetail.tsx
+++ b/src/hud/LootDetail.tsx
@@ -10,7 +10,7 @@
  * VIEW button that flies the scene to each.
  */
 
-import { cashuLabel, decodeCashuToken, findCashuToken } from '../lib/cashu'
+import { cashuLabel, readCashuToken } from '../lib/cashu'
 import { nip19 } from 'nostr-tools'
 import type { Plane } from 'cyberspace-core'
 import { useState } from 'react'
@@ -40,11 +40,10 @@ interface OpenedItem {
   text?: string
 }
 
-/** A message's preview, or what its Cashu token holds when it carries one. */
+/** A message's preview, or what its Cashu token holds when it carries one; a coin that cannot be read is still a coin. */
 function cashuOrPreview(text: string | undefined): string {
-  const raw = findCashuToken(text)
-  const token = raw ? decodeCashuToken(raw) : null
-  return token ? `₿ ${cashuLabel(token)} hidden here` : messagePreview(text ?? '', 48)
+  const { raw, token } = readCashuToken(text)
+  return token ? `₿ ${cashuLabel(token)} hidden here` : raw ? '₿ cashu token hidden here' : messagePreview(text ?? '', 48)
 }
 
 function safeNpub(pubkey: string): string {

--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -32,10 +32,13 @@ function depName(d: MyDeployment): string {
  * One hidden thing in the STASH. A message carrying a Cashu token shows the
  * coin instead of the pen, what it holds, and whether anyone has taken it:
  * the mint says which proofs are spent (useCashu), so REDEEMED means found.
+ * The coin is decided by the token being there, not by its being readable:
+ * one this client cannot decode still shows the mark, reads "cashu token",
+ * and says UNREADABLE, the same rule the world and the loot list follow.
  */
 function DeployedRow({ d, viewing, onGo }: { d: MyDeployment; viewing: boolean; onGo: () => void }): JSX.Element {
   const cashu = useCashu(d.type === 'message' ? d.text : null)
-  const coin = cashu.token !== null
+  const coin = cashu.found
   const live = useCyberspace((s) => s.live)
   const broadcasting = useShards((s) => s.broadcasting) === d.lookupId
   return (
@@ -43,7 +46,7 @@ function DeployedRow({ d, viewing, onGo }: { d: MyDeployment; viewing: boolean; 
       <button className="shards__goto" onClick={onGo} title="Fly to it and see its wire record">
         <span className="avatars__who">
           <span className={`shards__type shards__type--${coin ? 'cashu' : d.type}`}>{coin ? '₿' : d.type === 'message' ? '✎' : '◇'}</span>
-          {coin && cashu.token ? cashuLabel(cashu.token) : depName(d)}
+          {coin ? (cashu.token ? cashuLabel(cashu.token) : 'cashu token') : depName(d)}
         </span>
         <span className="shards__meta">
           {d.height === 0 ? 'exact gibson' : formatCellSize(d.height)} · {d.published ? 'LIVE' : 'LOCAL'}{d.plane === 1 ? ' · ideaspace' : ''}

--- a/src/hud/useCashu.test.ts
+++ b/src/hud/useCashu.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The STASH row's coin decision, rendered through the hook itself. Rendered
+ * to a string so the first render is what is checked: what the row shows
+ * before the mint has answered, which is the render that decides pen or coin.
+ */
+import { describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { renderToString } from 'react-dom/server'
+import { cashuStateLabel, useCashu, type CashuView } from './useCashu'
+
+const V3 = 'cashuA' + btoa(JSON.stringify({ token: [{ mint: 'https://mint.example', proofs: [{ id: '00ad', amount: 16, secret: 'a', C: '02aa' }, { id: '00ad', amount: 5, secret: 'b', C: '02bb' }] }], unit: 'sat' }))
+
+function view(text: string | null): CashuView {
+  let out: CashuView | null = null
+  renderToString(createElement(() => { out = useCashu(text); return null }))
+  return out!
+}
+
+describe('useCashu', () => {
+  it('a message carrying a token is a coin, and says what it holds', () => {
+    const v = view(`for the drinks ${V3}`)
+    expect(v.found).toBe(true)
+    expect(v.token?.amount).toBe(21)
+    expect(cashuStateLabel(v.state)).toBe('CHECKING')
+  })
+  it('a token this reader cannot decode is still a coin, marked UNREADABLE', () => {
+    const v = view(`for the drinks ${V3.slice(0, 40)}`)
+    expect(v.found).toBe(true)
+    expect(v.token).toBeNull()
+    expect(cashuStateLabel(v.state)).toBe('UNREADABLE')
+  })
+  it('a plain message is not a coin', () => {
+    const v = view('just a note')
+    expect(v.found).toBe(false)
+    expect(v.token).toBeNull()
+  })
+  it('no text is not a coin', () => {
+    expect(view(null).found).toBe(false)
+  })
+})

--- a/src/hud/useCashu.ts
+++ b/src/hud/useCashu.ts
@@ -4,17 +4,26 @@
  * The STASH and the loot list ask this per message. The token is read once
  * per text; the mint is asked once a minute at most, shared across every
  * place the same token shows.
+ *
+ * Found and read are two different questions. A message is a coin when a
+ * token is in it (`found`), whether or not this reader can decode it; what
+ * it holds (`token`) and the mint's answer (`state`) come only from a token
+ * that reads. One that does not is UNREADABLE, never a plain message.
  */
 
 import { useEffect, useState } from 'react'
-import { checkCashuState, decodeCashuToken, findCashuToken, type CashuState, type CashuToken } from '../lib/cashu'
+import { checkCashuState, decodeCashuToken, readCashuToken, type CashuState, type CashuToken } from '../lib/cashu'
 
 const RECHECK_MS = 60_000
 const cache = new Map<string, { state: CashuState; at: number; pending: Promise<CashuState> | null }>()
 
 export interface CashuView {
+  /** A token is in the text: this message is a coin, readable or not. */
+  found: boolean
+  /** What the coin holds; null when found but this reader cannot decode it. */
   token: CashuToken | null
-  state: CashuState | 'checking'
+  /** `unreadable`: a token is there but cannot be decoded, so the mint cannot be asked. */
+  state: CashuState | 'checking' | 'unreadable'
 }
 
 /** Ask the mint, no more than once a minute per token. */
@@ -29,23 +38,23 @@ function stateOf(raw: string, token: CashuToken): Promise<CashuState> {
 }
 
 export function useCashu(text: string | null | undefined): CashuView {
-  const raw = findCashuToken(text)
+  const { raw, token } = readCashuToken(text)
   const [state, setState] = useState<CashuState | 'checking'>('checking')
   useEffect(() => {
     if (!raw) return
     const token = decodeCashuToken(raw)
-    if (!token) { setState('unknown'); return }
+    if (!token) return
     let live = true
     const cached = cache.get(raw)
     if (cached && cached.at > 0) setState(cached.state)
     void stateOf(raw, token).then((s) => { if (live) setState(s) })
     return () => { live = false }
   }, [raw])
-  if (!raw) return { token: null, state: 'unknown' }
-  return { token: decodeCashuToken(raw), state }
+  if (!raw) return { found: false, token: null, state: 'unknown' }
+  return { found: true, token, state: token ? state : 'unreadable' }
 }
 
-/** UNCLAIMED, REDEEMED, PENDING, CHECKING, or nothing to say. */
+/** UNCLAIMED, REDEEMED, PENDING, CHECKING, UNREADABLE, or nothing to say. */
 export function cashuStateLabel(state: CashuView['state']): string {
-  return state === 'unclaimed' ? 'UNCLAIMED' : state === 'redeemed' ? 'REDEEMED' : state === 'pending' ? 'PENDING' : state === 'checking' ? 'CHECKING' : 'MINT?'
+  return state === 'unclaimed' ? 'UNCLAIMED' : state === 'redeemed' ? 'REDEEMED' : state === 'pending' ? 'PENDING' : state === 'checking' ? 'CHECKING' : state === 'unreadable' ? 'UNREADABLE' : 'MINT?'
 }

--- a/src/lib/cashu.test.ts
+++ b/src/lib/cashu.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { bytesToHex, hexToBytes } from 'cyberspace-core'
-import { cashuLabel, checkCashuState, decodeCashuToken, decodeCbor, findCashuToken, hashToCurve, textWithoutToken } from './cashu'
+import { cashuLabel, checkCashuState, decodeCashuToken, decodeCbor, findCashuToken, hashToCurve, readCashuToken, textWithoutToken } from './cashu'
 
 const b64url = (bytes: Uint8Array): string => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 
@@ -108,5 +108,29 @@ describe('a token among words', () => {
   it('leaves an ordinary message alone', () => {
     expect(findCashuToken('just a note')).toBeNull()
     expect(textWithoutToken('just a note')).toBe('just a note')
+  })
+})
+
+describe('readCashuToken: a coin is a coin whether or not it can be read', () => {
+  it('reads a whole token: found, and what it holds', () => {
+    const r = readCashuToken(`for the drinks ${V4}`)
+    expect(r.raw).toBe(V4)
+    expect(r.token?.amount).toBe(9)
+  })
+  it('a token cut short is still found, with nothing readable in it', () => {
+    // What the 2000-character compose cap does to a token longer than the room
+    // left after the words: the prefix survives, the tail does not.
+    const r = readCashuToken(`for the drinks ${V4.slice(0, V4.length - 20)}`)
+    expect(r.raw).not.toBeNull()
+    expect(r.token).toBeNull()
+  })
+  it('a token fused with the word after it is found and unreadable, not a plain message', () => {
+    const r = readCashuToken(`${V4}enjoy`)
+    expect(r.raw).not.toBeNull()
+    expect(r.token).toBeNull()
+  })
+  it('a plain message is neither', () => {
+    expect(readCashuToken('just a note')).toEqual({ raw: null, token: null })
+    expect(readCashuToken(undefined)).toEqual({ raw: null, token: null })
   })
 })

--- a/src/lib/cashu.ts
+++ b/src/lib/cashu.ts
@@ -45,6 +45,20 @@ export function findCashuToken(text: string | null | undefined): string | null {
   return m ? m[0].replace(/=+$/, '') : null
 }
 
+/**
+ * A message's token, found and read, as one answer. `raw` is the token as it
+ * sits in the text, or null when the message carries none: it decides whether
+ * the message is a coin. `token` is what the coin holds, or null when the
+ * token is there but this reader cannot read it: cut short (the compose cap
+ * or a paste that lost its tail), fused with the word after it, or a shape
+ * this decoder does not know. A coin that cannot be read is still a coin, so
+ * every surface keys the mark on `raw` and the amount on `token`.
+ */
+export function readCashuToken(text: string | null | undefined): { raw: string | null; token: CashuToken | null } {
+  const raw = findCashuToken(text)
+  return { raw, token: raw ? decodeCashuToken(raw) : null }
+}
+
 function base64ToBytes(s: string): Uint8Array {
   const std = s.replace(/-/g, '+').replace(/_/g, '/')
   const padded = std + '='.repeat((4 - (std.length % 4)) % 4)

--- a/src/styles.css
+++ b/src/styles.css
@@ -1773,6 +1773,7 @@ kbd {
 .shards__cashu--unclaimed { color: #52e39f; }
 .shards__cashu--redeemed { color: #f7931a; }
 .shards__cashu--pending, .shards__cashu--checking, .shards__cashu--unknown { opacity: 0.7; }
+.shards__cashu--unreadable { color: var(--warn); }
 
 .shards__compose {
   display: flex;


### PR DESCRIPTION
## The report

Arkinox, on production (onosendai.tech, 2026-09-11): messages in the Stash that hold a Cashu token no longer show the Bitcoin mark and no longer behave as bitcoin. They render as plain messages.

## Where the coin decision lived, surface by surface

| Surface | File | Question asked of the message | Result for a token that is there but does not decode |
| --- | --- | --- | --- |
| World label | `src/scene/WorldMessages.tsx` | is a token in it (`findCashuToken`) | coin |
| Loot list | `src/hud/LootPanel.tsx` | is a token in it | coin |
| Nearby Loot list | `src/hud/NearbyLootModal.tsx` | is a token in it | coin, "cashu token" |
| Loot record | `src/hud/LootDetail.tsx` | does it decode (`decodeCashuToken`) | message preview |
| **Stash row** | `src/hud/ShardsPanel.tsx` via `useCashu` | does it decode: `coin = cashu.token !== null` | **pen, and the note's first words** |

`findCashuToken` is the `cashuA` / `cashuB` prefix plus its base64, anywhere in the text. `decodeCashuToken` reads a v3 JSON or v4 CBOR token and returns what it holds, or null. The Stash, since the coin arrived in #102 (`3e3ffdb`), keyed the mark on the second answer. Nothing on that path changed after #102; the decoder is sound (checked below). What changed is the tokens the Stash gets: a token that is found but does not read is a pen in the Stash and a coin everywhere else.

## Why a real token stops decoding

| Way it happens | Mechanism | `findCashuToken` | `decodeCashuToken` |
| --- | --- | --- | --- |
| Cut by the compose cap | The textarea slices what you paste at 2000 characters (`MAX_MESSAGE_LENGTH`). A v4 token with DLEQ proofs is about 330 characters per proof; six proofs plus a few words before the token go past 2000 and the tail of the token is silently dropped. | found (prefix survives) | null (CBOR short) |
| Fused with the next word | `cashuB...enjoy` with no space: the base64 class swallows the word. | found, with the word inside it | null (bad base64 or trailing bytes) |
| A shape this decoder does not know | Not observed. Five published NUT-00 vectors and cashu-ts 3.3.0 tokens with memo, DLEQ, witness and large amounts all decode. | found | reads |

Reproduced against the dev build and the production build of `e22b8a7` (the same asset hash production serves, `index-IDeJyXb4.js`): a whole 994-character cashu-ts v4 token in `mine` renders as "₿ 21 sats"; the same message doubled and cut at 2000 rendered as a pen with "for the drinks cashuBpGF..." before this change.

## The fix

| File | Change |
| --- | --- |
| `src/lib/cashu.ts` | `readCashuToken(text)`: found and read as one answer, `{ raw, token }`. `raw` decides that the message is a coin; `token` decides the amount and whether the mint can be asked. |
| `src/hud/useCashu.ts` | `CashuView` gains `found`; a found token that does not read has state `unreadable`; `cashuStateLabel` says UNREADABLE. The effect no longer asks the mint for a token it cannot read. |
| `src/hud/ShardsPanel.tsx` | `coin = cashu.found`. An unreadable coin shows the mark, "cashu token" where the amount would be, and UNREADABLE beside LIVE. |
| `src/hud/LootDetail.tsx` | Same rule: "₿ cashu token hidden here" instead of the message preview. |
| `src/styles.css` | `.shards__cashu--unreadable` in the warn color. |

A token that reads is unchanged: the amount, and UNCLAIMED, REDEEMED or PENDING from the mint.

**Not changed here:** the 2000-character cap still cuts a long token as it is pasted. UNREADABLE now says so in the Stash, where before the row looked like a note. Whether the compose should refuse a message that would cut its token (the published token is unredeemable by anyone) is a separate decision for arkinox.

## Measured after the fix (dev build, Playwright)

| Row text | Glyph | Label | State |
| --- | --- | --- | --- |
| "for the drinks" + whole v4 token | ₿ | 21 sats | CHECKING, then the mint's answer |
| same, doubled and cut at 2000 | ₿ | cashu token | UNREADABLE (warn color) |
| "just a note" | ✎ | just a note | none |

## Tests

- `src/lib/cashu.test.ts`: `readCashuToken` on a whole token (found, 9 sats), a cut token (found, unreadable), a token fused with the next word (found, unreadable), and a plain note and `undefined` (neither).
- `src/hud/useCashu.test.ts`: the hook rendered through `react-dom/server`, so the first render is what is checked: a coin that reads (found, 21 sats, CHECKING), one that does not (found, no token, UNREADABLE), a plain message and no text (not a coin).

## Gate

| Step | Exit |
| --- | --- |
| `npx tsc --noEmit` | 0 |
| `npx vitest run` (83 files, 767 tests) | 0 |
| `npm run build` | 0 |

Not merged: ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
