### PR TITLE
The compose box reads a token once the text holds still, and says what it found

### DIFF
--- a/src/hud/ShardsPanel.tsx
+++ b/src/hud/ShardsPanel.tsx
@@ -13,7 +13,8 @@
 import { useState } from 'react'
 import { formatCellSize } from '../lib/scale'
 import { cashuLabel } from '../lib/cashu'
-import { cashuStateLabel, useCashu } from './useCashu'
+import { cashuStateLabel, composeVerdict, SETTLE_MS, useCashu } from './useCashu'
+import { useSettled } from './useSettled'
 import { messagePreview, MAX_MESSAGE_LENGTH } from '../lib/hidden'
 import { useCyberspace } from '../store/useCyberspace'
 import { useShards, type MyDeployment } from '../store/useShards'
@@ -73,6 +74,12 @@ export function ShardsPanel(): JSX.Element {
   const scanning = useShards((s) => s.scanning)
   const [composing, setComposing] = useState(false)
   const [message, setMessage] = useState('')
+  // The token is read, and its mint asked, only once the text has held
+  // still for SETTLE_MS: not on every keystroke through a token thousands
+  // of characters long. Until then PLACE MESSAGE waits.
+  const settled = useSettled(message, SETTLE_MS) === message
+  const cashu = useCashu(settled ? message : null)
+  const verdict = composeVerdict(settled, cashu)
 
   const hiddenCount = mine.length
   const live = useCyberspace((s) => s.live)
@@ -123,9 +130,10 @@ export function ShardsPanel(): JSX.Element {
               rows={3}
               autoFocus
             />
+            {verdict.note && <span className={`shards__compose-note shards__compose-note--${verdict.tone}`} role="status">{verdict.note}</span>}
             <div className="shards__actions">
               <button className="avatars__go" onClick={() => { setComposing(false); setMessage('') }}>CANCEL</button>
-              <button className="avatars__go" disabled={!message.trim()} onClick={placeMessage}>PLACE MESSAGE ▸</button>
+              <button className="avatars__go" disabled={!message.trim() || !verdict.ready} onClick={placeMessage}>PLACE MESSAGE ▸</button>
             </div>
           </div>
         ) : (

--- a/src/hud/composeVerdict.test.ts
+++ b/src/hud/composeVerdict.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { composeVerdict, type CashuView } from './useCashu'
+
+const token = { mint: 'https://mint.minibits.cash/Bitcoin', unit: 'sat', memo: null, amount: 21, proofs: [{ amount: 21, secret: 's' }], version: 4 as const }
+const view = (v: Partial<CashuView>): CashuView => ({ found: false, token: null, state: 'unknown', ...v })
+
+describe('placing a composed message', () => {
+  it('waits while the text is still moving, whatever it holds', () => {
+    expect(composeVerdict(false, view({})).ready).toBe(false)
+    expect(composeVerdict(false, view({ found: true, token, state: 'unclaimed' })).ready).toBe(false)
+  })
+
+  it('is ready at once for a message without a token, with nothing to say', () => {
+    expect(composeVerdict(true, view({}))).toEqual({ ready: true, note: null, tone: 'dim' })
+  })
+
+  it('refuses a token that will not decode and says so', () => {
+    const v = composeVerdict(true, view({ found: true, token: null, state: 'unreadable' }))
+    expect(v.ready).toBe(false)
+    expect(v.tone).toBe('warn')
+    expect(v.note).toMatch(/will not decode/)
+  })
+
+  it('waits for the mint, then goes by its answer', () => {
+    expect(composeVerdict(true, view({ found: true, token, state: 'checking' })).ready).toBe(false)
+    const ok = composeVerdict(true, view({ found: true, token, state: 'unclaimed' }))
+    expect(ok).toEqual({ ready: true, tone: 'ok', note: '21 sat, unclaimed at mint.minibits.cash.' })
+    expect(composeVerdict(true, view({ found: true, token, state: 'redeemed' }))).toMatchObject({ ready: false, tone: 'warn' })
+    expect(composeVerdict(true, view({ found: true, token, state: 'pending' }))).toMatchObject({ ready: false, tone: 'warn' })
+  })
+
+  it('lets an unverifiable token through with a warning', () => {
+    const v = composeVerdict(true, view({ found: true, token, state: 'unknown' }))
+    expect(v.ready).toBe(true)
+    expect(v.tone).toBe('warn')
+    expect(v.note).toMatch(/could not be reached/)
+  })
+})

--- a/src/hud/useCashu.ts
+++ b/src/hud/useCashu.ts
@@ -46,7 +46,9 @@ export function useCashu(text: string | null | undefined): CashuView {
     if (!token) return
     let live = true
     const cached = cache.get(raw)
+    // A new token starts from CHECKING, not from the last token's answer.
     if (cached && cached.at > 0) setState(cached.state)
+    else setState('checking')
     void stateOf(raw, token).then((s) => { if (live) setState(s) })
     return () => { live = false }
   }, [raw])
@@ -57,4 +59,46 @@ export function useCashu(text: string | null | undefined): CashuView {
 /** UNCLAIMED, REDEEMED, PENDING, CHECKING, UNREADABLE, or nothing to say. */
 export function cashuStateLabel(state: CashuView['state']): string {
   return state === 'unclaimed' ? 'UNCLAIMED' : state === 'redeemed' ? 'REDEEMED' : state === 'pending' ? 'PENDING' : state === 'checking' ? 'CHECKING' : state === 'unreadable' ? 'UNREADABLE' : 'MINT?'
+}
+
+/** How long the compose box waits for the text to hold still before reading a token. */
+export const SETTLE_MS = 500
+
+export interface ComposeVerdict {
+  /** The message may be placed. */
+  ready: boolean
+  /** What to say under the box, or nothing. */
+  note: string | null
+  tone: 'ok' | 'warn' | 'dim'
+}
+
+function hostOf(mint: string): string {
+  try { return new URL(mint).host } catch { return mint }
+}
+
+/**
+ * Whether a composed message may be placed, and what to say under the box.
+ *
+ * Nothing is decided while the text is still moving (`settled` false): the
+ * button waits for the timer. Once still, a message without a token is
+ * ready at once. One with a token is ready only if the token decodes and
+ * its mint does not call it spent: a token that will not decode, or one
+ * already redeemed or being spent, would publish a coin nobody can claim,
+ * so the button stays off and the note says why. A mint that cannot be
+ * reached is a warning, not a stop: the token reads, and placing it is the
+ * writer's call.
+ */
+export function composeVerdict(settled: boolean, view: CashuView): ComposeVerdict {
+  if (!settled) return { ready: false, note: null, tone: 'dim' }
+  if (!view.found) return { ready: true, note: null, tone: 'dim' }
+  if (!view.token) return { ready: false, tone: 'warn', note: 'This cashu token will not decode: it is cut short or malformed. Fix it or take it out before placing.' }
+  const sats = `${view.token.amount.toLocaleString()} ${view.token.unit}`
+  const host = hostOf(view.token.mint)
+  switch (view.state) {
+    case 'checking': return { ready: false, tone: 'dim', note: `Asking ${host} about this ${sats} token…` }
+    case 'unclaimed': return { ready: true, tone: 'ok', note: `${sats}, unclaimed at ${host}.` }
+    case 'redeemed': return { ready: false, tone: 'warn', note: `This ${sats} token was already redeemed at ${host}. Nobody could claim it.` }
+    case 'pending': return { ready: false, tone: 'warn', note: `${host} says this ${sats} token is being spent right now. Wait, or use another.` }
+    default: return { ready: true, tone: 'warn', note: `A ${sats} token that reads, but ${host} could not be reached to verify it. Placing it anyway is your call.` }
+  }
 }

--- a/src/hud/useSettled.ts
+++ b/src/hud/useSettled.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * The value once it has held still for `ms`: a debounce. The result equals
+ * `value` only when the value has settled, so `settled === value` is the
+ * test for "the timer has run out".
+ */
+export function useSettled<T>(value: T, ms: number): T {
+  const [settled, setSettled] = useState(value)
+  useEffect(() => {
+    const t = window.setTimeout(() => setSettled(value), ms)
+    return () => window.clearTimeout(t)
+  }, [value, ms])
+  return settled
+}

--- a/src/lib/hidden.ts
+++ b/src/lib/hidden.ts
@@ -44,8 +44,14 @@ export const SHARD_KIND = 3330
 /** A plain note, inside the envelope. */
 export const MESSAGE_KIND = 1
 
-/** Longest hidden message; the whole event still has to fit a relay's limit. */
-export const MAX_MESSAGE_LENGTH = 2000
+/**
+ * Longest hidden message. The relay is the only hard limit and it is far
+ * off: cyberspace.nostr1.com (strfry) takes 262,140 bytes of content, and
+ * the sealed envelope of a 10,000-character message is under 15 KB. Two
+ * thousand was a placeholder, and it cut a Cashu token of six proofs in
+ * half as it was pasted; ten thousand leaves room for thirty.
+ */
+export const MAX_MESSAGE_LENGTH = 10_000
 
 export type HiddenType = 'shard' | 'message'
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1799,6 +1799,15 @@ kbd {
   border-color: var(--accent);
 }
 
+/* What the compose box says about a token in the text, under the textarea. */
+.shards__compose-note {
+  font-size: 9px;
+  line-height: 1.5;
+  color: var(--dim);
+}
+.shards__compose-note--ok { color: #52e39f; }
+.shards__compose-note--warn { color: var(--warn); }
+
 .shards__compose-open {
   width: 100%;
 }


### PR DESCRIPTION
Stacked on #137 (it uses its token reader); merge #137 first and this retargets to v2.

A Cashu token pasted into a hidden message was only ever looked at
after it was published: the STASH showed a coin or, since #137, an
UNREADABLE one, but nothing stopped a cut or fake token from going out
as loot nobody could claim.

Now the box waits for the text to hold still for 500 ms (useSettled, a
debounce), and only then reads the token and asks its mint; not on
every keystroke through a token thousands of characters long. Until it
settles PLACE MESSAGE is off. Settled, the verdict (composeVerdict) is:

  no token            ready, nothing said
  token will not      off, in orange: cut short or malformed, fix it or
  decode              take it out
  mint asked          off, dim: asking <mint> about this N sat token
  unclaimed           ready, green: N sat, unclaimed at <mint>
  redeemed / pending  off, orange: already redeemed, or being spent
  mint unreachable    ready, orange: reads, but could not be verified,
                      placing it is your call

A new token in the box starts from CHECKING rather than inheriting the
last token's answer.

The 2,000-character cap goes to 10,000. The relay (strfry) takes
262,140 bytes of content and the sealed envelope of a 10,000-character
message is under 15 KB, so the cap was never about the relay; it was a
placeholder that cut a six-proof token in half as it was pasted.

Tests: the verdict in every state, and the wait while typing.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz