### PR TITLE
A find you wrote joins the Stash's DEPLOYED list on every device you sign in on

### DIFF
--- a/src/lib/hidden.test.ts
+++ b/src/lib/hidden.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { bytesToHex } from './events'
 import { regionKeyAt } from './shardCrypto'
 import { newShard, type ShardModel } from './shards'
 import {
@@ -58,6 +59,11 @@ describe('unbag', () => {
     expect(msgItem.text).toBe('meet at the black sun')
     expect(msgItem.plane).toBe(1)
     expect(msgItem.at.x).toBe(at.x + 1n)
+    // Each find carries the event it was made of and the key that opened it,
+    // so a find of your own can become a deployment on this device.
+    expect(shardItem.inner).toEqual(s)
+    expect(msgItem.inner).toEqual(m)
+    expect(msgItem.keyHex).toBe(bytesToHex(rk.key))
   })
 
   it('stays shut to the wrong region', async () => {

--- a/src/lib/hidden.ts
+++ b/src/lib/hidden.ts
@@ -22,7 +22,7 @@
 
 import { verifyEvent } from 'nostr-tools/pure'
 import { coordToXyz, hexToCoord, type Plane } from 'cyberspace-core'
-import { positionHex, type EventTemplate, type NostrEvent } from './events'
+import { bytesToHex, positionHex, type EventTemplate, type NostrEvent } from './events'
 import { fromPayload, toPayload, type ShardModel } from './shards'
 import { ALGO, decryptForRegion, encryptForRegion } from './shardCrypto'
 import type { Position } from './space'
@@ -59,6 +59,14 @@ export function messagePreview(text: string, max = 32): string {
 export interface Hidden {
   /** The item's stable identity: its inner event id. */
   eventId: string
+  /**
+   * The signed inner event itself, verified, and the region key that opened
+   * its bag, as hex. Together they let a find of your own become a deployment
+   * on this device: enough to rebuild, broadcast or delete the bag from here.
+   * Absent on the ceremony's preview items, which came out of no bag.
+   */
+  inner?: NostrEvent
+  keyHex?: string
   /** The envelope (bag) currently holding it; changes when the bag is rewritten. */
   bagId: string
   /** The bag's `d` tag (spec §8.6 lookup id): with the author it is the bag's address. */
@@ -156,8 +164,8 @@ export function heightHint(ev: NostrEvent): number {
   return Number.isInteger(n) && n >= 0 ? n : 0
 }
 
-/** One inner event of a bag -> a Hidden, or null if it does not verify. */
-function fromInner(inner: NostrEvent, outer: NostrEvent): Hidden | null {
+/** One inner event of a bag -> a Hidden, or null if it does not verify. `keyHex` is the key that opened the bag. */
+function fromInner(inner: NostrEvent, outer: NostrEvent, keyHex: string): Hidden | null {
   // The inner event must be genuinely signed, and by the same key that wrapped
   // it: an envelope carrying someone else's event is not theirs to place.
   if (!inner || typeof inner.kind !== 'number' || inner.pubkey !== outer.pubkey) return null
@@ -168,6 +176,8 @@ function fromInner(inner: NostrEvent, outer: NostrEvent): Hidden | null {
   const { x, y, z, plane } = coordToXyz(hexToCoord(coordHex))
   const base = {
     eventId: inner.id,
+    inner,
+    keyHex,
     bagId: outer.id,
     lookupId: tag(outer, 'd') ?? '',
     author: outer.pubkey,
@@ -206,9 +216,10 @@ export async function unbag(outer: NostrEvent, regionKey: Uint8Array): Promise<H
   let inners: unknown
   try { inners = JSON.parse(json) } catch { return [] }
   if (!Array.isArray(inners)) return []
+  const keyHex = bytesToHex(regionKey)
   const out: Hidden[] = []
   for (const inner of inners) {
-    const h = fromInner(inner as NostrEvent, outer)
+    const h = fromInner(inner as NostrEvent, outer, keyHex)
     if (h) out.push(h)
   }
   return out

--- a/src/store/ownFinds.test.ts
+++ b/src/store/ownFinds.test.ts
@@ -1,0 +1,137 @@
+/**
+ * ownFinds.test.ts - a find this identity wrote joins the Stash's DEPLOYED
+ * list, whichever device placed it.
+ *
+ * `mine` is per device and was written only at deploy time, so a bag hidden
+ * from the phone and opened by a scan on the desktop reached `discovered` and
+ * no further. The bag here is built and signed as a deploy builds it, opened
+ * with the real region key as a scan opens it, and filed through
+ * addDiscovered, the one door every scan goes through.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The store keeps deployments in localStorage; the test runs where there is none.
+if (typeof localStorage === 'undefined') {
+  const mem = new Map<string, string>()
+  ;(globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, String(v)) },
+    removeItem: (k: string) => { mem.delete(k) },
+    clear: () => { mem.clear() },
+  }
+}
+
+vi.mock('../lib/relay', () => ({
+  publishMany: vi.fn(async () => ({ ok: true })),
+  query: vi.fn(async () => []),
+  relaySet: () => ['wss://relay.test'],
+}))
+
+import { finalizeEvent, generateSecretKey } from 'nostr-tools/pure'
+import { bytesToHex, type NostrEvent } from '../lib/events'
+import { bagTemplate, messageInnerTemplate, unbag, type Hidden } from '../lib/hidden'
+import { regionKeyAt } from '../lib/shardCrypto'
+import { useCyberspace } from './useCyberspace'
+import { useShards, type MyDeployment } from './useShards'
+
+const at = { x: 90_000n, y: 4_000n, z: 71n }
+const HEIGHT = 5
+const rk = regionKeyAt(at, HEIGHT, 20)
+const MADE_AT = 1_800_000_000
+
+/** A bag as the phone published it: one message, sealed to the region, signed by this identity. */
+async function ownBag(text: string): Promise<{ outer: NostrEvent; inner: NostrEvent }> {
+  const cs = useCyberspace.getState()
+  const inner = await cs.signEvent(messageInnerTemplate(text, at, 0, MADE_AT))
+  const outer = await cs.signEvent(await bagTemplate([inner], rk.key, rk.lookupId, HEIGHT, MADE_AT + 1))
+  return { outer, inner }
+}
+
+/** The same bag from a stranger. */
+async function strangerBag(text: string): Promise<NostrEvent> {
+  const sk = generateSecretKey()
+  const inner = finalizeEvent(messageInnerTemplate(text, at, 0, MADE_AT), sk)
+  return finalizeEvent(await bagTemplate([inner], rk.key, rk.lookupId, HEIGHT, MADE_AT + 1), sk)
+}
+
+describe('a find this identity wrote', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useShards.setState({ mine: [], discovered: {}, deleted: {} })
+  })
+
+  it('joins DEPLOYED as a published deployment, and is saved for the next load', async () => {
+    const { outer, inner } = await ownBag('left from the phone')
+    const found = await unbag(outer, rk.key)
+    expect(found).toHaveLength(1)
+    useShards.getState().addDiscovered(found)
+
+    const { mine, discovered } = useShards.getState()
+    expect(mine).toHaveLength(1)
+    expect(mine[0]).toMatchObject({
+      eventId: inner.id,
+      lookupId: rk.lookupId,
+      height: HEIGHT,
+      type: 'message',
+      text: 'left from the phone',
+      bagId: outer.id,
+      keyHex: bytesToHex(rk.key),
+      at: { x: '90000', y: '4000', z: '71' },
+      plane: 0,
+      createdAt: MADE_AT,
+      relays: ['wss://relay.test'],
+      published: true,
+    })
+    expect(mine[0].inner).toEqual(inner)
+    // Still a discovery too, as a find of your own always was on the device that placed it.
+    expect(discovered[inner.id]).toBeDefined()
+    // And on disk, where loadMine reads it from on the next page load.
+    const saved = JSON.parse(localStorage.getItem('onosendai:deployments') ?? '[]') as MyDeployment[]
+    expect(saved.map((d) => d.eventId)).toEqual([inner.id])
+    // JSON keeps the event, not the Symbol(verified) nostr-tools stamps on it.
+    expect(saved[0].inner).toMatchObject({ id: inner.id, sig: inner.sig })
+  })
+
+  it("leaves a stranger's find in Loot only", async () => {
+    const found = await unbag(await strangerBag('not yours'), rk.key)
+    expect(found).toHaveLength(1)
+    useShards.getState().addDiscovered(found)
+    expect(useShards.getState().mine).toHaveLength(0)
+    expect(Object.keys(useShards.getState().discovered)).toEqual([found[0].eventId])
+  })
+
+  it('is not listed twice when DEPLOYED already has it, and the row it has is kept', async () => {
+    const { outer, inner } = await ownBag('placed from here')
+    // What this device's own deploy recorded, before any relay took it.
+    const local: MyDeployment = {
+      eventId: inner.id, inner, bagId: 'ff'.repeat(32), type: 'message', text: 'placed from here',
+      at: { x: '90000', y: '4000', z: '71' }, plane: 0, height: HEIGHT, lookupId: rk.lookupId,
+      keyHex: bytesToHex(rk.key), relays: [], createdAt: MADE_AT, published: false,
+    }
+    useShards.setState({ mine: [local] })
+    const found = await unbag(outer, rk.key)
+    useShards.getState().addDiscovered(found)
+    useShards.getState().addDiscovered(found) // the next scan of the same region
+    expect(useShards.getState().mine).toHaveLength(1)
+    expect(useShards.getState().mine[0]).toBe(local)
+  })
+
+  it('does not resurrect what was deleted here', async () => {
+    const { outer, inner } = await ownBag('gone')
+    useShards.setState({ deleted: { [inner.id]: true } })
+    useShards.getState().addDiscovered(await unbag(outer, rk.key))
+    expect(useShards.getState().mine).toHaveLength(0)
+    expect(useShards.getState().discovered[inner.id]).toBeUndefined()
+    expect(localStorage.getItem('onosendai:deployments')).toBeNull()
+  })
+
+  it('needs the find to have come out of a bag', () => {
+    // The ceremony's preview items are Hiddens made from no envelope: no inner event, no key.
+    const me = useCyberspace.getState().identity.pubkey
+    const preview: Hidden = { eventId: 'preview', bagId: 'b', lookupId: rk.lookupId, author: me, at, plane: 0, height: HEIGHT, createdAt: 1, type: 'message', text: 'preview' }
+    useShards.getState().addDiscovered([preview])
+    expect(useShards.getState().mine).toHaveLength(0)
+    expect(useShards.getState().discovered.preview).toBeDefined()
+  })
+})

--- a/src/store/useShards.ts
+++ b/src/store/useShards.ts
@@ -9,9 +9,10 @@
  * per-item tags. Height is the discovery radius (spec §7.3): 0 is a single
  * gibson; higher hides it across a wider aligned cube that costs more to find.
  *
- * `mine` is what this device deployed, kept with each item's signed inner event
- * so a bag can be rebuilt without the relay; `discovered` is what a scan turned
- * up near you and could decrypt and verify.
+ * `mine` is what this identity deployed, placed from this device or found by a
+ * scan after another device placed it, kept with each item's signed inner
+ * event so a bag can be rebuilt without the relay; `discovered` is what a scan
+ * turned up near you and could decrypt and verify.
  */
 
 import { normalizeStored } from '../lib/shards'
@@ -132,6 +133,7 @@ interface ShardsState {
   rescan: (lookupId: string, keyHex: string) => Promise<number>
   inspect: (eventId: string | null) => void
   selectSecret: (eventId: string | null) => void
+  /** File what a scan opened. A find this identity wrote joins `mine` as well, whichever device placed it. */
   addDiscovered: (items: Hidden[]) => void
   setScanning: (scanning: boolean) => void
   testDiscovery: (eventId: string) => Promise<boolean>
@@ -174,6 +176,11 @@ function saveDeleted(deleted: Record<string, true>): void {
 
 export function positionOf(d: { at: { x: string; y: string; z: string } }): Position {
   return { x: BigInt(d.at.x), y: BigInt(d.at.y), z: BigInt(d.at.z) }
+}
+
+/** The reverse: a position as the decimal strings a deployment keeps. */
+function storedAt(p: Position): { x: string; y: string; z: string } {
+  return { x: p.x.toString(), y: p.y.toString(), z: p.z.toString() }
 }
 
 /** Union of inner events by id, order preserved. */
@@ -220,6 +227,38 @@ export const useShards = create<ShardsState>((set, get) => {
     } catch {
       return local
     }
+  }
+
+  /**
+   * A find this identity wrote is a deployment, whichever device placed it.
+   *
+   * `mine` lives in this device's localStorage and was written only at deploy
+   * time, so a bag hidden from the phone and opened by a scan on the desktop
+   * went into `discovered` and no further: the Stash's DEPLOYED list stayed
+   * empty there. The author is proven (unbag verified the inner signature
+   * against the envelope's pubkey), and the find carries the inner event and
+   * the key that opened it, which is everything a row needs to be rescanned,
+   * broadcast or deleted from here. The relays are the set the scan asked.
+   * What is already listed or deleted here stays as it is.
+   */
+  function claimOwn(items: Hidden[]): void {
+    const me = cyber().identity.pubkey
+    const { mine, deleted } = get()
+    const have = new Set(mine.map((d) => d.eventId))
+    const own: MyDeployment[] = []
+    for (const h of items) {
+      if (h.author !== me || !h.inner || !h.keyHex || have.has(h.eventId) || deleted[h.eventId]) continue
+      have.add(h.eventId)
+      own.push({
+        eventId: h.eventId, inner: h.inner, bagId: h.bagId, type: h.type, shard: h.shard, text: h.text,
+        at: storedAt(h.at), plane: h.plane, height: h.height, lookupId: h.lookupId, keyHex: h.keyHex,
+        relays: relaySet(), createdAt: h.createdAt, published: true,
+      })
+    }
+    if (own.length === 0) return
+    const next = [...mine, ...own]
+    set({ mine: next })
+    saveMine(next)
   }
 
   return {
@@ -320,7 +359,7 @@ export const useShards = create<ShardsState>((set, get) => {
           type: pending.type,
           shard,
           text,
-          at: { x: at.x.toString(), y: at.y.toString(), z: at.z.toString() },
+          at: storedAt(at),
           plane,
           height: deployHeight,
           lookupId: rk.lookupId,
@@ -454,6 +493,7 @@ export const useShards = create<ShardsState>((set, get) => {
       let changed = false
       for (const h of items) if (!discovered[h.eventId] && !deleted[h.eventId]) { discovered[h.eventId] = h; changed = true }
       if (changed) set({ discovered })
+      claimOwn(items)
     },
 
     setScanning: (scanning) => set({ scanning }),


### PR DESCRIPTION
Arkinox, on production: a hidden message placed from the phone, visited on the desktop with the same identity, opens (the loot record even says YOURS) but never appears under DEPLOYED in the Stash.

**Why.** DEPLOYED renders `mine` (store/useShards), and `mine` lives in this device's localStorage (`onosendai:deployments`), written in one place: the deploy itself, on the device that placed the bag. A scan on any device goes through `unbag` (lib/hidden), which decrypts the region envelope, verifies each inner event's signature against the envelope's pubkey, and hands the finds to `addDiscovered`, which files them in `discovered` (the Loot list) without ever asking who wrote them. On the desktop the phone's bag reached Loot and stopped there.

**The fix.** `addDiscovered`, the one door every scan goes through (the passive scan in useDiscovery, and `rescan` from the Region keys list, a hop's key and a HOSAKA purchase), now also claims what this identity wrote. The author is proven: `unbag` only returns an inner whose signature verifies and whose pubkey is the envelope's.

| Find | What happens |
|---|---|
| Author is `identity.pubkey`, not in `mine` by inner event id, not in `deleted` | Becomes a published deployment (bagId = the envelope it came out of, relays = the set the scan asked) and is saved with the rest; stays in `discovered` too, as a find of your own always did on the device that placed it |
| Author is someone else | Loot only, as before |
| Already in `mine` (this device's own deploy, LOCAL or LIVE) | The existing row is kept exactly as it was; a second scan of the same region changes nothing |
| In `deleted` | Not resurrected, not listed |
| Came out of no bag (the ceremony's preview items) | Never claimed |

A deployment row needs two things the find did not carry: the signed inner event (`loadMine` drops any stored row without one on the next page load; `gatherInners` and `broadcast` rebuild the bag from it) and the region key as hex (`deleteInstance` and `broadcast` rewrite the bag with it; the Region keys list rescans with it). Both are in hand at the moment of the find, so `unbag` stamps each `Hidden` with `inner` and `keyHex`. A claimed row can be rescanned, broadcast or deleted from any device, the same as one deployed there.

`worldItems` lists `mine` first and skips a discovered item with the same inner event id, so the world, Nearby Loot and its counts show the thing once, as before. The ceremony (the found chip and the decode) is untouched.

**Not changed here, and the follow-up.** `mine` is still per device, not per identity, so switching identities on one device keeps every row listed. A bag this device cannot decrypt yet (a region it has not scanned or been given the key to) is still not listed: listing those would take a relay query for the identity's own kind 33330 envelopes by author, and their contents would stay sealed until the region is scanned. That is a separate decision.

**Tests.** `store/ownFinds.test.ts` builds a bag exactly as a deploy does (`messageInnerTemplate`, `bagTemplate`, signed by the store's identity), opens it with the real region key as a scan does, and files it through `addDiscovered`: the five rows of the table above, including the localStorage write with its inner event. `lib/hidden.test.ts` checks `unbag` stamps `inner` and `keyHex`. tsc, 780 vitest tests and the build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz
