### PR TITLE
Three signals: the cursor's distance, the proof panel's place, and when the HOSAKA mark breathes

### DIFF
--- a/src/hud/HosakaPulse.tsx
+++ b/src/hud/HosakaPulse.tsx
@@ -3,16 +3,18 @@
  * while a job is under way, the width of that button and on its axis. The
  * job itself lives in the Cloud compute panel, so App mounts this only while
  * the panels are closed: it is the one sign on the scene that something is
- * being computed for you elsewhere.
+ * being computed for you elsewhere. Elsewhere is the point, so it breathes
+ * only while HOSAKA computes, not for every stage of a route that happens to
+ * include a paid step (hosakaComputing).
  */
 
-import { jobInProgress } from '../lib/cloud'
+import { hosakaComputing } from '../lib/cloud'
 import { useCyberspace } from '../store/useCyberspace'
 
 export function HosakaPulse(): JSX.Element | null {
   const status = useCyberspace((s) => s.cloud.status)
   const provider = useCyberspace((s) => s.cloud.provider)
-  if (!jobInProgress(status)) return null
+  if (!hosakaComputing(status)) return null
   return (
     <img
       className="hosaka-pulse"

--- a/src/hud/Hud.tsx
+++ b/src/hud/Hud.tsx
@@ -344,10 +344,15 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
   // HOSAKA outranks even that: while a payment is awaited or a job is under
   // way the cloud panel takes the first panel position, under the brand.
   const cloudLeads = useCyberspace((s) => s.cloud.status === 'awaiting_payment' || jobInProgress(s.cloud.status))
+  // A move being computed outranks everything: wherever the work is happening,
+  // the proof panel is the thing you are watching, so it takes the first
+  // position and HOSAKA falls in behind it rather than above it.
+  const proofLeads = useCyberspace((s) => s.proof.status === 'computing')
   return (
     <div className={menuOpen ? 'hud hud--menu' : 'hud'}>
       <div className="hud__col hud__col--left">
         <Brand />
+        {proofLeads && <ProofPanel />}
         {cloudLeads && <CloudPanel />}
         {rideSet && <HyperspacePanel />}
         <IdentityPanel />
@@ -360,7 +365,7 @@ export function Hud({ menuOpen = false }: { menuOpen?: boolean }): JSX.Element {
       <div className="hud__col hud__col--right">
         <ScalePanel />
         <PositionPanel />
-        <ProofPanel />
+        {!proofLeads && <ProofPanel />}
         {!cloudLeads && <CloudPanel />}
         <ChainPanel />
         {!rideSet && <HyperspacePanel />}

--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -21,6 +21,7 @@ import {
   driveCloudJob,
   formatClock,
   jobInProgress,
+  hosakaComputing,
   loadBalance,
   loadCloudJob,
   loadCloudPrefs,
@@ -275,6 +276,15 @@ describe('jobInProgress', () => {
   it('is paid, computing or verifying, and no other status', () => {
     for (const st of ['paid', 'computing', 'verifying'] as const) expect(jobInProgress(st)).toBe(true)
     for (const st of ['idle', 'quoting', 'confirm', 'funding', 'awaiting_payment', 'error'] as const) expect(jobInProgress(st)).toBe(false)
+  })
+})
+
+describe('hosakaComputing', () => {
+  it('is computing alone: a funded route between local steps is not HOSAKA working', () => {
+    expect(hosakaComputing('computing')).toBe(true)
+    for (const st of ['paid', 'verifying', 'idle', 'quoting', 'confirm', 'funding', 'awaiting_payment', 'error'] as const) {
+      expect(hosakaComputing(st), st).toBe(false)
+    }
   })
 })
 

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -590,6 +590,20 @@ export function jobInProgress(status: CloudStatus): boolean {
   return status === 'paid' || status === 'computing' || status === 'verifying'
 }
 
+/**
+ * HOSAKA is doing the work right now.
+ *
+ * Narrower than `jobInProgress`, which also counts `paid`: a route is marked
+ * paid the moment it is funded and stays that way between its steps, so a
+ * mixed route computing a local step on this machine reads as in progress
+ * while HOSAKA is idle. `verifying` is this machine checking the result that
+ * came back, which is also not HOSAKA working. Only `computing` is, which is
+ * what the breathing mark over the menu button says.
+ */
+export function hosakaComputing(status: CloudStatus): boolean {
+  return status === 'computing'
+}
+
 // ---------------------------------------------------------------------------
 // The prepaid balance, remembered per identity
 // ---------------------------------------------------------------------------

--- a/src/scene/Cursor.tsx
+++ b/src/scene/Cursor.tsx
@@ -15,7 +15,8 @@
 
 import { useLayoutEffect, useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
-import { formatCellSize } from '../lib/scale'
+import { formatDistance } from '../lib/scale'
+import { axisDistance } from '../lib/nearby'
 import { WorldLabel } from './WorldLabel'
 import {
   BufferGeometry,
@@ -283,13 +284,16 @@ export function Cursor({ axes }: Props): JSX.Element | null {
   return (
     <group position={[0, 0, 0.04]}>
       {/*
-        The scale reading rides the cursor, and shows once the cursor has left
-        the avatar's cell: parked on the avatar it read as a label on you, and
-        the SCALE panel already answers "how big is a gibson here" at rest.
-        Off your own head it stays up, since nothing else there names the size.
+        How far the cursor is from your avatar, riding the cursor itself, and
+        shown once it has left the avatar's cell: parked on the avatar the
+        answer is zero. It reads as the largest of the three axis distances,
+        the same measure the presence chip and the Nearby Loot list use, so
+        "12 km away" means the same thing everywhere. In history there is no
+        cursor and the label rides the anchor, saying how far that link is
+        from your head. The SCALE panel answers how big a cell is.
       */}
       {!focused && (!home || active) && <WorldLabel
-        text={formatCellSize(scaleExp)}
+        text={formatDistance(axisDistance(target, position))}
         color={active ? targetColor : ACCENT}
         offset={[1.5, 0.7, 0]}
         opacity={active ? 1 : 0.75}


### PR DESCRIPTION
Three small things, one per commit, all verified in a browser against this branch.

**The cursor's yellow label reads distance, not cell size.** It was saying how big a cell is, which the SCALE panel already answers and which does not change as the cursor moves. It now reads the largest of the three axis distances from your avatar to the cursor, the same measure the presence chip and the Nearby Loot list use. Measured on the dev build: the cursor three cells out at 2^40 reads 384 m, which is 3 times 2^40 gibsons over 2^33 gibsons per meter.

**A computing movement proof leads the menu, above HOSAKA.** Wherever the work is happening, the panel with the progress bar takes the first position under the brand. Measured, as the first panels of the left column:

| State | Order |
|---|---|
| idle | Identity, Loot, Stash (proof sits in the right column) |
| local proof computing | Movement proof, Identity, Loot |
| HOSAKA computing | Movement proof, Cloud compute, Identity |

**The HOSAKA mark breathes only while HOSAKA computes.** It asked `jobInProgress`, which counts `paid`, and a route stays paid between its steps, so a local step of a mixed route breathed the mark while HOSAKA was idle. Measured after the change: paid false, verifying false, computing true. The Cloud panel still leads the menu for the whole funded stretch, which is correct.

Suite 786 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz