### PR TITLE
The cubes arrive on their own; the hop no longer waits for them

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,9 @@ export default function App(): JSX.Element {
   // A cloud job paid or computing when the tab last closed is picked up here,
   // if the chain head is still the one it was bound to. Also fetches the caps.
   useEffect(() => { void useCyberspace.getState().resumeCloudJob() }, [])
+  // Cubes from a staged hop whose move landed before they finished: the
+  // ticket outlives the tab, so a phone put away mid job collects on return.
+  useEffect(() => { void useCyberspace.getState().collectCloudKeys() }, [])
   // Back from the wallet: a phone suspends the tab while another app is up,
   // so the invoice poll's timer is still counting when the tab returns. Ask
   // HOSAKA at once instead of waiting the interval out; harmless otherwise.

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -32,7 +32,7 @@ import {
   type HosakaJob,
   type HosakaLimits,
   type Waker,
-} from './hosaka'
+  keysPending } from './hosaka'
 import type { Position } from './space'
 
 export type CloudMode = 'auto' | 'ask' | 'off'
@@ -63,6 +63,7 @@ export function defaultCloudPrefs(): CloudPrefs {
 const PREFS_KEY = 'onosendai:cloud'
 const JOB_KEY = 'onosendai:cloudJob'
 const REGION_KEYS_KEY = 'onosendai:cloudRegionKeys'
+const KEYS_TICKET_KEY = 'onosendai:cloudKeys'
 
 export function loadCloudPrefs(): CloudPrefs {
   const d = defaultCloudPrefs()
@@ -195,6 +196,50 @@ export function saveCloudJob(record: PendingCloudJob): void {
 
 export function clearCloudJob(): void {
   try { localStorage.removeItem(JOB_KEY) } catch { /* private mode */ }
+}
+
+/**
+ * The ticket for cubes still being computed after their hop has landed.
+ *
+ * A hop with destination cubes is delivered in two stages: the hop's own
+ * proof first, which is what the avatar needs to move, and the cubes after.
+ * Once the move is signed the pending job record is gone, so this small
+ * ticket is what remains to collect the second stage: the job it belongs to,
+ * the token that reads it, and where the hop landed, which is what the cubes
+ * are held against. It survives a reload, so a phone put away mid job still
+ * collects its cubes when it comes back.
+ */
+export interface PendingKeys {
+  version: 1
+  jobId: string
+  pollToken: string
+  /** Where the hop landed: the cubes are around this point. */
+  to: WirePosition
+  plane: Plane
+  /** Date.now() when the hop landed and the wait for cubes began. */
+  at: number
+}
+
+export function loadKeysTicket(): PendingKeys | null {
+  try {
+    const raw = localStorage.getItem(KEYS_TICKET_KEY)
+    if (!raw) return null
+    const r = JSON.parse(raw) as Partial<PendingKeys>
+    if (r.version !== 1 || typeof r.jobId !== 'string' || typeof r.pollToken !== 'string') return null
+    if (!r.to || (r.plane !== 0 && r.plane !== 1)) return null
+    positionFromWire(r.to)
+    return { version: 1, jobId: r.jobId, pollToken: r.pollToken, to: r.to, plane: r.plane, at: typeof r.at === 'number' ? r.at : Date.now() }
+  } catch {
+    return null
+  }
+}
+
+export function saveKeysTicket(t: PendingKeys): void {
+  try { localStorage.setItem(KEYS_TICKET_KEY, JSON.stringify(t)) } catch { /* private mode */ }
+}
+
+export function clearKeysTicket(): void {
+  try { localStorage.removeItem(KEYS_TICKET_KEY) } catch { /* private mode */ }
 }
 
 /**
@@ -413,9 +458,14 @@ export async function driveCloudJob(
     // The clock for the experience record starts here, after any payment wait.
     if (record.computingAt === undefined) { record = { ...record, computingAt: Date.now() }; hooks.onRecord(record) }
     hooks.onStage('computing', { invoice: null, progress: null, message: null })
+    // A staged hop ends the wait here: its own proof is whole, so the move is
+    // signed now rather than after the destination cubes finish, which is
+    // work the avatar does not need in order to move. The caller collects the
+    // cubes from the same job afterwards (loadKeysTicket).
     const job = await client.waitForJob(record.jobId, record.pollToken, {
       signal,
       onPoll: (j) => hooks.onStage('computing', { progress: progressOf(j) }),
+      stopWhen: keysPending,
     })
     return { job, record }
   }

--- a/src/lib/hosaka.test.ts
+++ b/src/lib/hosaka.test.ts
@@ -21,8 +21,7 @@ import {
   jsonWithBigints,
   type HosakaDeposit,
   type HosakaJob,
-  SIGN_TIMEOUT_MS,
-} from './hosaka'
+  SIGN_TIMEOUT_MS, keysPending } from './hosaka'
 
 const sk = generateSecretKey()
 const pubkey = getPublicKey(sk)
@@ -73,6 +72,36 @@ describe('jsonWithBigints', () => {
     expect(jsonWithBigints({ v: { x: (1n << 84n) + 5n, plane: 0 }, id: 'ab' })).toBe(
       `{"v":{"x":${((1n << 84n) + 5n).toString()},"plane":0},"id":"ab"}`,
     )
+  })
+})
+
+describe('a staged hop', () => {
+  it('is pending cubes only while computing, never once completed', () => {
+    const job = (status: string, result: unknown): never => ({ id: 'j', status, cost_msats: 1, result, error: null } as never)
+    expect(keysPending(job('computing', { keys_pending: true }))).toBe(true)
+    expect(keysPending(job('pending', { keys_pending: true }))).toBe(true)
+    expect(keysPending(job('computing', { keys_pending: false }))).toBe(false)
+    expect(keysPending(job('computing', null))).toBe(false)
+    expect(keysPending(job('completed', { keys_pending: true }))).toBe(false)
+    expect(keysPending(job('failed', null))).toBe(false)
+  })
+
+  it('ends waitForJob at the staged answer, and without stopWhen waits for completed', async () => {
+    const staged = { id: 'job-1', status: 'computing', cost_msats: 1000, result: { keys_pending: true, destination_keys: null }, error: null }
+    const done = { id: 'job-1', status: 'completed', cost_msats: 1000, result: { keys_pending: false, destination_keys: [{ height: 13, secret_key: 'ab', lookup_id: 'cd' }] }, error: null }
+    let polls = 0
+    const { fetch } = scripted({ 'GET /api/v1/jobs/job-1': () => ({ body: ++polls === 1 ? staged : done }) })
+    const c = createHosaka({ apiUrl: API, sign, fetch })
+    const first = await c.waitForJob('job-1', 'tok', { stopWhen: keysPending })
+    expect(first.status).toBe('computing')
+    expect((first.result as { keys_pending?: boolean }).keys_pending).toBe(true)
+    expect(polls).toBe(1)
+
+    // The same client with no stopWhen returns the finished job, not the
+    // staged one: the early stop is the caller's to ask for.
+    polls = 1
+    const whole = await c.waitForJob('job-1', 'tok')
+    expect(whole.status).toBe('completed')
   })
 })
 

--- a/src/lib/hosaka.ts
+++ b/src/lib/hosaka.ts
@@ -163,8 +163,19 @@ export interface CloudHopResult {
   max_height: number
   compute_msats: number
   storage_msats_24h?: number
-  /** The cubes around the destination, one per height, when the hop asked for them. */
-  destination_keys?: Array<{ height: number; secret_key: string; lookup_id: string; base?: { x: string; y: string; z: string } }>
+  /**
+   * The cubes around the destination, one per height, when the hop asked for
+   * them. Null while they are still being computed: the hop above is whole
+   * and can be verified and signed at once, and the cubes follow on the same
+   * job (`keys_pending`).
+   */
+  destination_keys?: Array<{ height: number; secret_key: string; lookup_id: string; base?: { x: string; y: string; z: string } }> | null
+  /** This result is the hop alone; the cubes are still being computed. */
+  keys_pending?: boolean
+  /** The cubes failed while the hop stands. The hop is yours; the surcharge came back. */
+  keys_error?: string | null
+  /** What HOSAKA credited back when the cubes failed, in millisats. */
+  keys_credit_msats?: number
 }
 
 /** `result` of a completed sidestep job (spec 6.8 and 6.10). */
@@ -331,6 +342,23 @@ export interface WaitForJobOptions {
   /** Every poll's answer, for progress. */
   onPoll?: (job: HosakaJob) => void
   maxWaitMs?: number
+  /**
+   * Stop early on a job that is not finished but has delivered what the
+   * caller was waiting for. A staged hop is the case: its own proof is whole
+   * while the destination cubes are still being computed, so the move can be
+   * signed now and the cubes collected later on the same job.
+   */
+  stopWhen?: (job: HosakaJob) => boolean
+}
+
+/**
+ * A job whose hop is deliverable but whose cubes are not: the staged first
+ * answer. `completed` is not staged, whatever else it says, since everything
+ * that job will ever hold is already in it.
+ */
+export function keysPending(job: HosakaJob): boolean {
+  if (job.status !== 'computing' && job.status !== 'pending') return false
+  return (job.result as CloudHopResult | null)?.keys_pending === true
 }
 
 /**
@@ -555,6 +583,7 @@ export function createHosaka(opts: HosakaClientOptions): HosakaClient {
           failures = 0
           o.onPoll?.(job)
           if (job.status === 'completed' || job.status === 'failed') return job
+          if (o.stopWhen?.(job)) return job
         } catch (err) {
           if (err instanceof HosakaError && err.code === 'aborted') throw err
           // A 404 right after completion is the volume syncing (contract);

--- a/src/store/cloud.test.ts
+++ b/src/store/cloud.test.ts
@@ -54,6 +54,7 @@ import type { Position } from '../lib/space'
 import { postProof } from '../lib/workers'
 import { useCyberspace } from './useCyberspace'
 import { useToast } from './useToast'
+import { useSecrets } from './useSecrets'
 
 const LIMITS: HosakaLimits = { max_hop_height: 25, max_sidestep_height: 29, hop_min_msats: 1000, deposit_min_msats: 1000, deposit_max_msats: 5e9, invoice_ttl_seconds: 3600 }
 
@@ -139,6 +140,53 @@ describe('cloud routes', () => {
     S().cancelPlan()
     S().cancelCloud()
     S().discardCloudJob()
+  })
+
+  it('a staged hop moves the avatar at once and takes the cubes when they land', async () => {
+    useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, profile: 'loot' } })
+    const head = S().prevEventId
+    const to = lineUpH13()
+    const from = S().position
+    const hop = hopResult(from, to, S().plane, head)
+    const cubes = [{ height: 13, secret_key: 'ab'.repeat(32), lookup_id: 'cd'.repeat(32) }]
+    fake.quote.mockResolvedValue(quote('hop'))
+    fake.submitHop.mockResolvedValue(funded())
+    // First answer: the hop alone, the cubes still computing. Second: the cubes.
+    fake.waitForJob
+      .mockResolvedValueOnce({ id: 'job-1', status: 'computing', cost_msats: 1000, result: { ...hop, keys_pending: true, destination_keys: null }, error: null } as HosakaJob)
+      .mockResolvedValueOnce(completed({ ...hop, keys_pending: false, destination_keys: cubes }))
+
+    await S().commit()
+    await idle()
+
+    // The move landed on the staged answer, without waiting for the cubes.
+    expect(S().position).toEqual(to)
+    expect(fake.waitForJob).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => { expect(useSecrets.getState().keys['cd'.repeat(32)]).toBeTruthy() })
+    expect(useSecrets.getState().keys['cd'.repeat(32)].height).toBe(13)
+    expect(storage.getItem('onosendai:cloudKeys')).toBeNull()
+    expect(useToast.getState().toast?.label).toBe('1 REGION KEYS FROM HOSAKA')
+  })
+
+  it('a staged hop whose cubes fail keeps the move and says what came back', async () => {
+    useCyberspace.setState({ cloudPrefs: { ...S().cloudPrefs, profile: 'loot' } })
+    const head = S().prevEventId
+    const to = lineUpH13()
+    const from = S().position
+    const hop = hopResult(from, to, S().plane, head)
+    fake.quote.mockResolvedValue(quote('hop'))
+    fake.submitHop.mockResolvedValue(funded())
+    fake.waitForJob
+      .mockResolvedValueOnce({ id: 'job-1', status: 'computing', cost_msats: 1000, result: { ...hop, keys_pending: true, destination_keys: null }, error: null } as HosakaJob)
+      .mockResolvedValueOnce(completed({ ...hop, keys_pending: false, destination_keys: null, keys_error: 'the pairing container died', keys_credit_msats: 2000 }))
+
+    await S().commit()
+    await idle()
+
+    expect(S().position).toEqual(to)
+    await vi.waitFor(() => { expect(useToast.getState().toast?.label).toBe('CUBES NOT COMPUTED') })
+    expect(useToast.getState().toast?.meta).toContain('2 sats came back')
+    expect(storage.getItem('onosendai:cloudKeys')).toBeNull()
   })
 
   it('under LOOT the hop is quoted and submitted asking for the destination cubes; COST asks for nothing extra', async () => {

--- a/src/store/useCyberspace.ts
+++ b/src/store/useCyberspace.ts
@@ -92,9 +92,12 @@ import {
   type HosakaClient,
   type HosakaJob,
   type HosakaLimits,
-  type Waker, type HosakaProvider, type HopWants } from '../lib/hosaka'
+  type Waker, type HosakaProvider, type HopWants, keysPending } from '../lib/hosaka'
 import {
   clearCloudJob,
+  clearKeysTicket,
+  loadKeysTicket,
+  saveKeysTicket,
   cloudProofResponse,
   describeCloudError,
   driveCloudJob,
@@ -594,6 +597,8 @@ export interface CyberspaceState {
    * its invoice expired. Also fetches the caps when cloud mode is on.
    */
   resumeCloudJob: () => Promise<void>
+  /** Collect the destination cubes of a staged hop whose move has already landed. */
+  collectCloudKeys: () => Promise<void>
   /** Forget a kept job without finishing it. */
   discardCloudJob: () => void
   /** Ask HOSAKA about the invoice now rather than at the next poll. */
@@ -972,6 +977,8 @@ let requestId = 0
 
 /** The cloud flow in progress: its fetches, and the claim-poll sleep a button can cut short. */
 let cloudAbort: AbortController | null = null
+// One collector at a time: the startup call and a just-landed hop can both ask.
+let collectingKeys = false
 let cloudWaker: Waker | null = null
 let hosaka: { url: string; client: HosakaClient } | null = null
 /** The caps request out right now, and the API URL it was sent to. */
@@ -1353,7 +1360,11 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
 
     const { job } = outcome
     const final = outcome.record
-    if (job.status !== 'completed') {
+    // A staged hop is not a finished job and is not a failed one: its own
+    // proof is whole and the destination cubes are still being computed, so
+    // it is verified and signed exactly like a finished one and the cubes are
+    // collected afterwards (collectCloudKeys).
+    if (job.status !== 'completed' && !keysPending(job)) {
       clearCloudJob()
       cloudFail(`HOSAKA job failed: ${job.error ?? 'no reason given'}. The charge was refunded to your HOSAKA balance.`, false)
       return
@@ -1383,6 +1394,8 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       return
     }
 
+    // Set by the hop below when HOSAKA is still computing its cubes.
+    let stagedCubes = false
     const msg = cloudProofResponse(id, final, job, Date.now() - (get().cloud.startedAt ?? final.createdAt))
     if (msg.type === 'done' && msg.mode === 'hop' && msg.lookupId) {
       // The region key of the region entered (spec 7.2), which this machine could not derive.
@@ -1417,6 +1430,10 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
         const sent = r.destination_keys ? holdCloudDestinationKeys(r.destination_keys, move.to, move.plane) : 0
         const top = sent > 0 ? Math.min(...r.destination_keys!.map((k) => k.height)) - 1 : localKeyCeiling()
         void holdDestinationCubes(move.to, move.plane, destinationHeights(Math.min(r.max_height, top), localKeyCeiling()), MAX_COMPUTE_HEIGHT, 'cloud')
+        // Staged delivery: this result is the hop alone and the cubes are
+        // still being computed on the same job. Noted here, taken up once the
+        // move itself has landed, since the cubes are the lesser half.
+        stagedCubes = r.keys_pending === true
       }
     }
     const before = get().events.length
@@ -1428,6 +1445,13 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
       return
     }
     useToast.getState().show({ label: `CLOUD COMPUTE JOB COMPLETE - ${final.jobId.slice(0, 8)}`, meta: 'Thanks for using HOSAKA!', mark: 'hosaka' })
+    // The move is signed and the toast for it has been shown; now the cubes,
+    // which arrive on the same job minutes later. The ticket outlives this
+    // tab, so a phone put away mid job collects them when it comes back.
+    if (stagedCubes) {
+      saveKeysTicket({ version: 1, jobId: final.jobId, pollToken: final.pollToken, to: wirePosition(move.to), plane: move.plane, at: Date.now() })
+      void get().collectCloudKeys()
+    }
     // The event landed, and a route may already have moved on to its next
     // step (which bumps the request id): the bookkeeping below is about the
     // step that landed, so it runs regardless.
@@ -2556,6 +2580,39 @@ export const useCyberspace = create<CyberspaceState>((set, get) => {
             : null,
       },
     })
+  },
+
+  collectCloudKeys: async () => {
+    const ticket = loadKeysTicket()
+    if (!ticket || collectingKeys) return
+    collectingKeys = true
+    try {
+      const job = await cloudClient(get().cloudPrefs.apiUrl).waitForJob(ticket.jobId, ticket.pollToken)
+      const r = job.result as CloudHopResult | null
+      if (job.status === 'completed' && r?.destination_keys && r.destination_keys.length > 0) {
+        const n = holdCloudDestinationKeys(r.destination_keys, positionFromWire(ticket.to), ticket.plane)
+        clearKeysTicket()
+        if (n > 0) useToast.getState().show({ label: `${n} REGION KEYS FROM HOSAKA`, meta: 'The cubes around your paid hop are open. Anything hidden in them is yours to find.', mark: 'hosaka' })
+      } else if (r?.keys_error) {
+        // The hop stands and is already signed: only the extra work failed,
+        // and HOSAKA credited its surcharge back.
+        clearKeysTicket()
+        const back = Math.round((r.keys_credit_msats ?? 0) / 1000)
+        useToast.getState().show({
+          label: 'CUBES NOT COMPUTED',
+          meta: back > 0 ? `Your hop stands. ${back} sats came back to your HOSAKA balance.` : 'Your hop stands. Nothing extra was charged.',
+          mark: 'hosaka',
+        })
+      } else if (job.status === 'completed' || job.status === 'failed') {
+        // Nothing is coming on this job.
+        clearKeysTicket()
+      }
+    } catch {
+      // A dropped socket or a tab put away: the ticket keeps, and the next
+      // load picks it up again.
+    } finally {
+      collectingKeys = false
+    }
   },
 
   resumeCloudJob: async () => {


### PR DESCRIPTION
The client half of the staged hop. Pairs with hosaka-api #14 and hosaka-modal #7, and is safe to merge before or after them: a HOSAKA that never stages returns one completed answer as before and nothing here changes.

**Why.** Job cc78faeb, a real h20 hop bought this afternoon, took 845 seconds against a 103 second quote. Its own axis tree was done 25 seconds in. The rest was the cube arithmetic, which the avatar does not need in order to move, and the customer stood still for all of it.

**What this side does now.**

| Moment | Behavior |
|---|---|
| HOSAKA answers with the hop and `keys_pending: true` | `waitForJob` stops early (the driver passes `keysPending` as `stopWhen`), the proof is verified and signed, the avatar moves |
| the move lands | a ticket goes to disk: job id, poll token, where the hop landed |
| the cubes arrive on the same job | held, which scans them, and a toast says how many |
| the cubes fail while the hop stands | the move keeps, and the toast names the sats HOSAKA credited back |
| the tab was closed in between | App asks for waiting cubes on load, so the ticket is picked up on return |

One thing worth flagging in review: a staged job is not a finished job and is not a failed one. The store used to treat any non-completed job as a failure, which would have rejected the staged answer outright, and the new store test is what caught it.

Suite 789 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz