### PR TITLE
The eight divisions fit the panel, five to a line

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2274,7 +2274,19 @@ kbd {
 
 .workshop__modes {
   display: flex;
+  flex-wrap: wrap;
   gap: 3px;
+}
+
+/* The eight divisions do not fit one line beside their label, and a flex row
+   that could not wrap ran off the panel. Five to a line, on one column
+   rhythm, so 1/6 begins the second line under 1 and the two lines read as
+   one block. */
+.workshop__modes--divisions {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  flex: 1 1 200px;
+  max-width: 260px;
 }
 
 .workshop__list {

--- a/src/workshop/Workshop.tsx
+++ b/src/workshop/Workshop.tsx
@@ -569,7 +569,7 @@ export function Workshop(): JSX.Element | null {
           </div>
           <div className="workshop__row" role="group" aria-label="Grid division">
             <span className="workshop__label">DIVISION</span>
-            <div className="workshop__modes">
+            <div className="workshop__modes workshop__modes--divisions">
               {DIVISIONS.map((d) => (
                 <button key={d} className={`workshop__mode ${division === d ? 'is-on' : ''}`} aria-pressed={division === d} onClick={() => w().setDivision(d)} title={d === 1 ? 'Snap to whole units' : `Snap to 1/${d} of a unit`}>{d === 1 ? '1' : `1/${d}`}</button>
               ))}


### PR DESCRIPTION
DIVISION was a flex row that could not wrap, so its eight buttons ran off the right edge of the workshop panel and the last of them could not be reached.

They are a five column grid now, so 1/6 begins the second line under 1, and the two lines share one column rhythm. Measured on the dev build with the GRID panel open:

| Viewport | Lines | Rightmost button vs the row's edge |
|---|---|---|
| 1400 wide | `1 1/2 1/3 1/4 1/5` then `1/6 1/8 1/10` | 39 px inside |
| 390 wide | the same two lines | 37 px inside |

The base mode row also wraps now rather than overflowing, which is the same bug waiting for the next mode someone adds.

Suite 789 passing, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz