### PR TITLE
The client waits as long as the job it bought, not a flat hour

### DIFF
--- a/src/lib/cloud.test.ts
+++ b/src/lib/cloud.test.ts
@@ -38,7 +38,7 @@ import {
   type PendingCloudJob,
   wirePosition,
   formatWait,
-} from './cloud'
+  jobPatienceMs } from './cloud'
 import { HosakaError, type HosakaClient, type HosakaDeposit, type HosakaJob, type HosakaLimits } from './hosaka'
 
 const LIMITS: HosakaLimits = { max_hop_height: 25, max_sidestep_height: 29, hop_min_msats: 1000, deposit_min_msats: 1000, deposit_max_msats: 5_000_000_000, invoice_ttl_seconds: 3600 }
@@ -276,6 +276,25 @@ describe('jobInProgress', () => {
   it('is paid, computing or verifying, and no other status', () => {
     for (const st of ['paid', 'computing', 'verifying'] as const) expect(jobInProgress(st)).toBe(true)
     for (const st of ['idle', 'quoting', 'confirm', 'funding', 'awaiting_payment', 'error'] as const) expect(jobInProgress(st)).toBe(false)
+  })
+})
+
+describe('jobPatienceMs', () => {
+  it('waits three times the quote plus ten minutes, between twenty minutes and six hours', () => {
+    const min = 60_000
+    // A two minute hop: the floor, since three times two minutes is under it.
+    expect(jobPatienceMs(103)).toBe(20 * min)
+    // A ten minute hop: 3 x 565 s is 28.25 min, plus 10.
+    expect(jobPatienceMs(565)).toBe(565 * 3_000 + 10 * min)
+    // An h30 hop sold at about 4.2 hours: the cap, which is still longer
+    // than the quote, so it is not abandoned while it could still land.
+    expect(jobPatienceMs(15_120)).toBe(6 * 60 * min)
+    expect(jobPatienceMs(15_120)).toBeGreaterThan(15_120 * 1000)
+    // No quote on the record, and nonsense on it, both get the floor.
+    expect(jobPatienceMs(undefined)).toBe(20 * min)
+    expect(jobPatienceMs(0)).toBe(20 * min)
+    expect(jobPatienceMs(Number.NaN)).toBe(20 * min)
+    expect(jobPatienceMs(-5)).toBe(20 * min)
   })
 })
 

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -404,6 +404,31 @@ export interface CloudDriverHooks {
 /** Rounds of "pay, start" tolerated: a short payment can ask once more. */
 const PAYMENT_ROUNDS = 3
 
+const MINUTE = 60_000
+
+/**
+ * How long to keep polling one job before handing it back for RESUME.
+ *
+ * It used to be a flat hour for every job, which is two wrong answers at
+ * once: a two minute hop that dies in its first second held the screen for
+ * an hour, and an h30 hop sold at about 4.2 hours was abandoned long before
+ * it could possibly land. Patience is the job's own quote times three, plus
+ * ten minutes for the queue and the cold starts, floored at twenty minutes
+ * so a tiny job still gets a fair wait, and capped at six hours, past which
+ * HOSAKA's own reaper has long since marked the job failed and refunded it.
+ *
+ *   a 103 s hop     the floor, 20 minutes
+ *   a 565 s hop     3 x 565 s + 10 min, about 38 minutes
+ *   an h30 at 4.2 h the cap, 6 hours
+ *
+ * Handing it back is not losing it: the record stays on disk and RESUME
+ * picks the same job up by its id and token.
+ */
+export function jobPatienceMs(estSeconds?: number): number {
+  const est = typeof estSeconds === 'number' && Number.isFinite(estSeconds) && estSeconds > 0 ? estSeconds : 0
+  return Math.min(6 * 60 * MINUTE, Math.max(20 * MINUTE, est * 3_000 + 10 * MINUTE))
+}
+
 function progressOf(job: HosakaJob): number | null {
   const r = job.result as { progress_percent?: unknown } | null
   return r && typeof r.progress_percent === 'number' ? Math.min(1, Math.max(0, r.progress_percent / 100)) : null
@@ -466,6 +491,7 @@ export async function driveCloudJob(
       signal,
       onPoll: (j) => hooks.onStage('computing', { progress: progressOf(j) }),
       stopWhen: keysPending,
+      maxWaitMs: jobPatienceMs(record.estSeconds),
     })
     return { job, record }
   }


### PR DESCRIPTION
The client half of last night's stall. Pairs with the HOSAKA reaper, which is a separate PR on hosaka-api, and stands on its own.

**What went wrong.** Job b6fefc78 was charged 116 sats at 01:19:49 and its row was never touched again: a worker pulled it off the queue and died without writing a word. The client polled it for a full hour before handing it back, because patience was a flat hour for every job regardless of what the job was quoted at. The same flat hour abandons an h30 hop, sold at about 4.2 hours, long before it could land.

**Patience now follows the quote:** three times the job's own `est_seconds`, plus ten minutes for the queue and cold starts, floored at twenty minutes and capped at six hours.

| Job | Patience |
|---|---|
| 103 s hop | 20 minutes, the floor |
| 565 s hop | about 38 minutes |
| h30 at 4.2 hours | 6 hours, the cap, still longer than the quote |

The quote already travels on the pending record as `estSeconds`, so nothing new is stored. Handing a job back is not losing it: the record stays on disk and RESUME picks it up by id and token, and once the reaper ships, a stalled job comes back as a failure with the refund named.

Suite 790 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz