### PR TITLE
A copied vertex brings its ticks with it

### DIFF
--- a/src/lib/shards.ts
+++ b/src/lib/shards.ts
@@ -28,6 +28,19 @@ export interface ShardVertex {
 }
 
 /**
+ * A vertex copied whole, ticks included.
+ *
+ * The two halves of a position, whole units in `p` and the remainder in `t`,
+ * have to travel together. A copy that takes `p` and `c` and forgets `t`
+ * silently moves every sub-unit vertex onto the corner of its cell, and
+ * vertices that shared a cell land on each other, which turns their faces
+ * into triangles with no area that draw nothing at all.
+ */
+export function cloneVertex(v: ShardVertex): ShardVertex {
+  return { p: [...v.p], ...(v.t ? { t: [...v.t] as ShardVertex['t'] } : {}), c: [...v.c] }
+}
+
+/**
  * Ticks to a grid unit. A position is stored as whole ticks, so a third, a
  * quarter or a fifth of a unit is exact and they mix freely in one shard:
  * 120 is divisible by every division the workshop offers and by eighths.

--- a/src/store/useWorkshop.test.ts
+++ b/src/store/useWorkshop.test.ts
@@ -11,10 +11,52 @@ import { DEFAULT_PALETTE, useWorkshop } from './useWorkshop'
 
 const w = () => useWorkshop.getState()
 
+/**
+ * arkinox's Crucifix, exactly as the workshop exports it. The corpus arm
+ * (vertices 24 to 37) is drawn inside single cells: fourteen vertices share
+ * six whole positions between them and are told apart only by their ticks.
+ * Duplicate used to copy `p` and `c` and drop `t`, which landed those
+ * fourteen on six points and left every one of the arm's ten triangles
+ * without area, so the copy showed the cross and nothing else.
+ */
+const CRUCIFIX = "{\"v\":1,\"type\":\"shard\",\"name\":\"Crucifix\",\"unit\":0,\"extent\":15,\"mode\":\"solid\",\"vertices\":[[0,0,0],[-1,0,0],[0,7,0],[-1,7,0],[-1,7,-1],[0,7,-1],[2,7,0],[2,7,-1],[-3,7,0],[-3,7,-1],[-3,8,-1],[-1,8,-1],[0,8,-1],[2,8,-1],[2,8,0],[0,8,0],[-1,8,0],[-3,8,0],[0,0,-1],[-1,0,-1],[0,10,-1],[0,10,0],[-1,10,-1],[-1,10,0],[-3,7,-1],[-2,7,-1],[-2,7,-1],[-3,7,-1],[-3,7,-1],[-2,7,-1],[-1,7,-1],[0,7,-1],[0,6,-1],[-1,6,-1],[-2,7,-1],[-1,7,-1],[-1,7,-1],[-2,7,-1]],\"ticks\":[[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[60,0,60],[108,36,48],[24,60,48],[48,48,48],[108,72,48],[96,60,48],[12,36,48],[60,24,48],[60,24,48],[72,108,48],[48,108,48],[108,36,48],[24,36,48],[0,0,48],[48,24,48]],\"colors\":[[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[1,0.8352941176470589,0],[1,0.8352941176470589,0],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[1,0.8352941176470589,0],[1,0.8352941176470589,0],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[0.9686274509803922,0.5764705882352941,0.10196078431372549],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1],[1,1,1]],\"faces\":[[1,0,2],[2,3,1],[18,5,4],[19,4,18],[1,19,4],[3,4,1],[2,5,0],[0,18,5],[0,1,19],[0,18,19],[11,13,7],[11,7,5],[11,5,4],[11,4,9],[9,10,11],[3,6,14],[3,14,15],[3,15,16],[3,16,17],[17,8,3],[14,6,7],[7,13,14],[17,9,8],[9,17,10],[11,17,16],[17,11,10],[12,14,13],[14,12,15],[22,21,20],[21,22,23],[23,15,21],[15,23,16],[23,11,16],[11,23,22],[12,22,20],[12,11,22],[21,15,12],[12,20,21],[5,7,6],[6,2,5],[9,8,4],[3,4,8],[28,24,27],[27,25,29],[24,29,27],[25,29,26],[29,26,37],[26,34,37],[37,36,34],[34,36,35],[35,36,33],[35,30,33]]}"
+
 describe('workshop', () => {
   beforeEach(() => {
     useWorkshop.setState({ shards: [], currentId: null, selection: [], selectedFace: null, facePick: [], palette: [...DEFAULT_PALETTE], level: 0, color: [0, 0.9, 1], past: [], future: [], aim: null, notice: null, tool: 'stamp', stampKind: 'block', stampSize: 1, stampFacing: 0 })
     w().create('t')
+  })
+
+  it('duplicating the crucifix keeps all 38 vertices, ticks and all, and no face loses its area', () => {
+    const id = w().importText(CRUCIFIX)
+    expect(id).not.toBeNull()
+    const src = w().shards.find((s) => s.id === id)!
+    expect(src.vertices).toHaveLength(38)
+    // Fourteen arm vertices on five whole positions: the ticks are the only
+    // thing keeping them apart, which is what made this bug invisible on the
+    // cross and total on the arm.
+    const arm = src.vertices.slice(24)
+    expect(new Set(arm.map((v) => v.p.join(','))).size).toBe(6)
+    expect(new Set(arm.map((v) => ticksOf(v).join(','))).size).toBe(14)
+
+    const copyId = w().duplicate(id!)
+    const copy = w().shards.find((s) => s.id === copyId)!
+    expect(copy.vertices).toEqual(src.vertices)
+    expect(copy.vertices).not.toBe(src.vertices)
+    expect(copy.vertices[24]).not.toBe(src.vertices[24])
+    for (const [a, b, c] of copy.faces) {
+      const at = (i: number): string => ticksOf(copy.vertices[i]).join(',')
+      expect(new Set([at(a), at(b), at(c)]).size, `face ${a},${b},${c} has corners on top of each other`).toBe(3)
+    }
+  })
+
+  it('taking a found shard into the stash keeps its sub-unit vertices too', () => {
+    const id = w().importText(CRUCIFIX)!
+    const found = w().shards.find((s) => s.id === id)!
+    const takenId = w().importShard(found)
+    const taken = w().shards.find((s) => s.id === takenId)!
+    expect(taken.vertices).toEqual(found.vertices)
+    expect(taken.id).not.toBe(found.id)
   })
 
   it('starts a new shard in LINES with the stamp tool', () => {

--- a/src/store/useWorkshop.ts
+++ b/src/store/useWorkshop.ts
@@ -45,8 +45,7 @@ import {
   validPoint,
   type ShardMode,
   type ShardModel,
-  type ShardVertex,
-} from '../lib/shards'
+  type ShardVertex, cloneVertex } from '../lib/shards'
 import { FLOOR, MAX_SIZE, MIN_SIZE, stamp, type Facing, type StampKind, type WorkPlane } from '../lib/stamps'
 import { newell, triangulate } from '../lib/triangulate'
 import { Vector3 } from 'three'
@@ -359,7 +358,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     duplicate: (id) => {
       const src = get().shards.find((s) => s.id === id)
       if (!src) return id
-      const copy: ShardModel = { ...src, id: uuid(), name: `${src.name} copy`, vertices: src.vertices.map((v) => ({ p: [...v.p] as P3, c: [...v.c] as ShardVertex['c'] })), faces: src.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
+      const copy: ShardModel = { ...src, id: uuid(), name: `${src.name} copy`, vertices: src.vertices.map(cloneVertex), faces: src.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
       const list = [...get().shards, copy]
       set({ shards: list, currentId: copy.id, selection: [], selectedFace: null, facePick: [], past: [], future: [], notice: null }); save(list)
       return copy.id
@@ -674,7 +673,7 @@ export const useWorkshop = create<WorkshopState>((set, get) => {
     importShard: (model) => {
       const taken = new Set(get().shards.map((s) => s.name))
       const name = taken.has(model.name) ? `${model.name} copy` : model.name
-      const copy: ShardModel = { ...model, id: uuid(), name, vertices: model.vertices.map((v) => ({ p: [...v.p] as ShardVertex['p'], c: [...v.c] as ShardVertex['c'] })), faces: model.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
+      const copy: ShardModel = { ...model, id: uuid(), name, vertices: model.vertices.map(cloneVertex), faces: model.faces.map((f) => [...f] as [number, number, number]), updatedAt: Date.now() }
       const list = [...get().shards, copy]
       set({ shards: list }); save(list)
       return copy.id


### PR DESCRIPTION
Duplicating the Crucifix produced a cross with no corpus. Here is why.

A vertex is two halves: whole units in `p`, and the rest of the way in `t`, 120 ticks to a unit. DUPLICATE and the loot import both rebuilt each vertex by hand as `{ p, c }`, dropping `t`, so every sub-unit vertex moved to the corner of its cell.

On a shard whose vertices sit on distinct whole units that is a uniform half-cell shift and invisible. On one with detail inside a cell it is fatal. The Crucifix draws the corpus with fourteen vertices sharing six whole positions between them, told apart only by ticks:

| Whole position | Vertices there |
|---|---|
| -2, 7, -1 | 25, 26, 29, 34, 37 |
| -3, 7, -1 | 24, 27, 28 |
| -1, 7, -1 | 30, 35, 36 |
| 0, 7, -1 / 0, 6, -1 / -1, 6, -1 | one each |

With the ticks gone, all ten of the arm's triangles have at least two corners at the same point. A triangle with no area draws nothing. The other 42 faces, the cross itself, were untouched, which is why the copy looked like a cross and nothing else.

`cloneVertex` copies a vertex whole and both paths use it. The wire format was never wrong: the payload carries ticks and always did, so saved and shared shards were fine, and this only ever affected the in-app copy.

Tests run on the Crucifix payload exactly as the workshop exports it: the arm sits on six whole positions and fourteen distinct tick positions; the duplicate matches vertex for vertex while being genuinely new objects; no face in the copy has two corners on one point; and a shard taken into the stash from loot keeps its sub-unit vertices too.

Suite 793 passing, tsc and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169pUQPTjJrpzxEWhoQ3Faz